### PR TITLE
Fix v1.1.3: Graph viz class filter and dead code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralfbecher/orionbelt-ontology-builder?style=social)](https://github.com/ralfbecher/orionbelt-ontology-builder)
-[![Version 1.1.2](https://img.shields.io/badge/version-1.1.2-purple.svg)](https://github.com/ralfbecher/orionbelt-ontology-builder/releases)
+[![Version 1.1.3](https://img.shields.io/badge/version-1.1.3-purple.svg)](https://github.com/ralfbecher/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralfbecher/orionbelt-ontology-builder/blob/main/LICENSE)
 [![Streamlit](https://img.shields.io/badge/Streamlit-1.28+-FF4B4B.svg?logo=streamlit&logoColor=white)](https://streamlit.io)

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import streamlit as st
 import traceback
 from datetime import datetime
 
-APP_VERSION = "1.1.2"
+APP_VERSION = "1.1.3"
 
 GITHUB_ISSUES_URL = "https://github.com/ralfbecher/orionbelt-ontology-builder/issues"
 
@@ -226,59 +226,6 @@ def build_class_options(classes: list, include_none: bool = False) -> tuple:
     options.extend(items)
     return options, lookup
 
-
-def build_property_options(properties: list, include_none: bool = False) -> tuple:
-    """Build property dropdown options with 'Label (name)' format, sorted by display text.
-
-    Returns:
-        tuple: (display_options, name_lookup_dict)
-    """
-    options = []
-    lookup = {}
-
-    # Build display strings and sort
-    items = []
-    for p in properties:
-        display = format_label_name(p["name"], p.get("label"))
-        items.append(display)
-        lookup[display] = p["name"]
-
-    # Sort alphabetically by display text (case-insensitive)
-    items.sort(key=lambda x: x.lower())
-
-    if include_none:
-        options.append("None")
-        lookup["None"] = None
-
-    options.extend(items)
-    return options, lookup
-
-
-def build_individual_options(individuals: list, include_none: bool = False) -> tuple:
-    """Build individual dropdown options with 'Label (name)' format, sorted by display text.
-
-    Returns:
-        tuple: (display_options, name_lookup_dict)
-    """
-    options = []
-    lookup = {}
-
-    # Build display strings and sort
-    items = []
-    for i in individuals:
-        display = format_label_name(i["name"], i.get("label"))
-        items.append(display)
-        lookup[display] = i["name"]
-
-    # Sort alphabetically by display text (case-insensitive)
-    items.sort(key=lambda x: x.lower())
-
-    if include_none:
-        options.append("None")
-        lookup["None"] = None
-
-    options.extend(items)
-    return options, lookup
 
 
 def render_dashboard():
@@ -1411,7 +1358,7 @@ def render_restrictions():
                     st.write(f"**Applied to Classes:** {', '.join(rest['applied_to'])}")
 
                     if rest['applied_to']:
-                        if st.button(f"Delete", key=f"del_rest_{i}"):
+                        if st.button("Delete", key=f"del_rest_{i}"):
                             ont.delete_restriction(rest['applied_to'][0],
                                                   rest['property'],
                                                   rest['type'])
@@ -2344,7 +2291,7 @@ def render_import_export():
                 st.metric("Total Triples", incoming_stats["total_triples"])
 
             # Apply / Cancel buttons (compact, above the change report)
-            col_apply, col_cancel, col_spacer = st.columns([1, 1, 4])
+            col_apply, col_cancel, _ = st.columns([1, 1, 4])
             with col_apply:
                 if st.button("Apply Import", type="primary"):
                     try:

--- a/app.py
+++ b/app.py
@@ -2869,8 +2869,14 @@ def render_visualization():
 
         # Class filter
         all_class_names = [c["name"] for c in classes] if classes else []
+        all_class_set = set(all_class_names)
         if "_viz_cfg_selected_classes" not in st.session_state:
             st.session_state["_viz_cfg_selected_classes"] = all_class_names
+        else:
+            valid = [c for c in st.session_state["_viz_cfg_selected_classes"] if c in all_class_set]
+            if not valid and all_class_names:
+                valid = all_class_names
+            st.session_state["_viz_cfg_selected_classes"] = valid
         st.session_state["viz_selected_classes"] = st.session_state["_viz_cfg_selected_classes"]
         with st.expander("Filter Classes", expanded=False):
             selected_classes = st.multiselect(
@@ -2883,7 +2889,7 @@ def render_visualization():
 
         # Store graph settings in session state for caching
         selected_classes_key = "_".join(sorted(selected_classes)) if selected_classes else "none"
-        _graph_ver = 14  # Bump to invalidate cached graph data after code changes
+        _graph_ver = 15  # Bump to invalidate cached graph data after code changes
         graph_key = f"v{_graph_ver}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{height}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}"
         if "last_graph_key" not in st.session_state:
             st.session_state.last_graph_key = None

--- a/ontology_manager.py
+++ b/ontology_manager.py
@@ -1835,14 +1835,6 @@ class OntologyManager:
                         })
         return relations
 
-    def get_all_relations(self) -> Dict[str, List[Dict[str, str]]]:
-        """Get all relations organized by type."""
-        return {
-            "class_relations": self.get_class_relations(),
-            "property_relations": self.get_property_relations(),
-            "individual_relations": self.get_individual_relations()
-        }
-
     # ==================== ADVANCED OWL FEATURES ====================
 
     def add_property_chain(self, property_name: str, chain_properties: List[str]):
@@ -2303,10 +2295,6 @@ class OntologyManager:
     def export_to_string(self, format: str = "turtle") -> str:
         """Export ontology to a string."""
         return self.graph.serialize(format=format)
-
-    def export_to_file(self, file_path: str, format: str = "turtle"):
-        """Export ontology to a file."""
-        self.graph.serialize(destination=file_path, format=format)
 
     # ==================== SEARCH ====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.1.2"
+version = "1.1.3"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
## Summary
- **Fix graph viz class filter**: When loading a new ontology, the persisted class filter retained class names from the previous ontology, causing all class nodes to disappear from the graph visualization. The filter now validates against the current class list and resets when stale.
- **Remove dead code**: Cleaned up unused functions, methods, and fixed lint issues.

## Test plan
- [ ] Load an ontology with classes, verify classes appear in Visualization graph
- [ ] Load a different ontology, verify the new classes appear (not the old ones)
- [ ] Verify class filter multiselect shows correct class names after switching ontologies

🤖 Generated with [Claude Code](https://claude.com/claude-code)