### PR TITLE
v1.3.0: gUFO, Reference Ontologies tab, cross-namespace duplicate handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralfbecher/orionbelt-ontology-builder?style=social)](https://github.com/ralfbecher/orionbelt-ontology-builder)
-[![Version 1.2.1](https://img.shields.io/badge/version-1.2.1-purple.svg)](https://github.com/ralfbecher/orionbelt-ontology-builder/releases)
+[![Version 1.3.0](https://img.shields.io/badge/version-1.3.0-purple.svg)](https://github.com/ralfbecher/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralfbecher/orionbelt-ontology-builder/blob/main/LICENSE)
 [![Streamlit](https://img.shields.io/badge/Streamlit-1.28+-FF4B4B.svg?logo=streamlit&logoColor=white)](https://streamlit.io)
@@ -27,7 +27,7 @@
 
 OrionBelt lets you build, edit, and maintain OWL ontologies and SKOS vocabularies in your browser. No Java, no desktop install - just `pip install` and go.
 
-It works with **OWL ontologies** (classes as `owl:Class`, properties as `owl:ObjectProperty` / `owl:DatatypeProperty`). Pure RDFS vocabularies like Schema.org that use `rdfs:Class` and `rdf:Property` are not supported.
+It works with **OWL ontologies** (classes as `owl:Class`, properties as `owl:ObjectProperty` / `owl:DatatypeProperty`). Pure RDFS vocabularies like schema.org that use `rdfs:Class` and `rdf:Property` can be imported via the Reference Ontologies tab — their triples land in the graph and show up in the Source view, but they will not appear in the OWL Classes / Properties panels.
 
 It's not trying to be Protégé. It's meant for people who want something lighter: a workbench that's easy to pick up, hard to break things with, and good enough for real ontology work.
 
@@ -75,7 +75,14 @@ Five starter templates you can merge into or replace your current ontology: Orga
 
 ### Upper Ontologies
 
-Start from a professionally built upper ontology instead of redefining foundational concepts for every project. Currently ships with [**gist**](https://www.semanticarts.com/gist/) by Semantic Arts — a minimalist upper ontology covering ~100 classes (Event, Person, Organization, Agreement, Specification, etc.) and ~100 properties. Select which modules to load (Core, RDFS Annotations, SubClass Assertions, Media Types) and merge or replace your current ontology.
+Start from a professionally built upper ontology instead of redefining foundational concepts for every project. Two options ship in the box:
+
+- [**gist**](https://www.semanticarts.com/gist/) by Semantic Arts — a minimalist upper ontology covering ~100 classes (Event, Person, Organization, Agreement, Specification, etc.) and ~100 properties. Select which modules to load (Core, RDFS Annotations, SubClass Assertions, Media Types) and merge or replace your current ontology.
+- [**gUFO**](https://nemo-ufes.github.io/gufo/) (gentle UFO) — a lightweight OWL implementation of the Unified Foundational Ontology, suitable for OntoUML-style conceptual modeling with kinds, roles, phases, events, situations, qualities, and relators.
+
+### Reference Ontologies
+
+A separate tab for importing widely-used domain and reference vocabularies. Bundled vocabularies load instantly; remote vocabularies are downloaded once on first use, verified against a pinned SHA256, and cached on disk. Currently includes [**schema.org**](https://schema.org/) (downloaded), [**PROV-O**](https://www.w3.org/TR/prov-o/), [**FOAF**](http://xmlns.com/foaf/spec/), and [**GoodRelations**](http://www.heppnetz.de/ontologies/goodrelations/) (bundled).
 
 ### Import & export
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 OrionBelt lets you build, edit, and maintain OWL ontologies and SKOS vocabularies in your browser. No Java, no desktop install - just `pip install` and go.
 
-It works with **OWL ontologies** (classes as `owl:Class`, properties as `owl:ObjectProperty` / `owl:DatatypeProperty`). Pure RDFS vocabularies like schema.org that use `rdfs:Class` and `rdf:Property` can be imported via the Reference Ontologies tab — their triples land in the graph and show up in the Source view, but they will not appear in the OWL Classes / Properties panels.
+It works with **OWL ontologies** (classes as `owl:Class`, properties as `owl:ObjectProperty` / `owl:DatatypeProperty`). Pure RDFS vocabularies like schema.org that use `rdfs:Class` and `rdf:Property` are not currently surfaced in the Classes / Properties panels.
 
 It's not trying to be Protégé. It's meant for people who want something lighter: a workbench that's easy to pick up, hard to break things with, and good enough for real ontology work.
 
@@ -82,7 +82,7 @@ Start from a professionally built upper ontology instead of redefining foundatio
 
 ### Reference Ontologies
 
-A separate tab for importing widely-used domain and reference vocabularies. Bundled vocabularies load instantly; remote vocabularies are downloaded once on first use, verified against a pinned SHA256, and cached on disk. Currently includes [**schema.org**](https://schema.org/) (downloaded), [**PROV-O**](https://www.w3.org/TR/prov-o/), [**FOAF**](http://xmlns.com/foaf/spec/), and [**GoodRelations**](http://www.heppnetz.de/ontologies/goodrelations/) (bundled).
+A separate tab for importing widely-used domain and reference vocabularies. The loader supports both bundled vocabularies (instant) and on-demand downloads (verified against a pinned SHA256 and cached on disk). Currently ships with [**PROV-O**](https://www.w3.org/TR/prov-o/), [**FOAF**](http://xmlns.com/foaf/spec/), and [**GoodRelations**](http://www.heppnetz.de/ontologies/goodrelations/) — all bundled.
 
 ### Import & export
 

--- a/app.py
+++ b/app.py
@@ -3319,18 +3319,22 @@ def render_visualization():
             max_nodes = 500
             node_count = 0
 
-            # Build set of class names for edge validation (only selected classes)
-            class_names = set(selected_classes) if selected_classes else set()
+            # Build sets for node existence checks (URI-keyed for cross-namespace safety)
+            cls_collisions = _build_name_collision_set(classes)
+            selected_class_names = set(selected_classes) if selected_classes else set()
+            displayed_class_uris: set = set()
 
             # Add classes as nodes (only selected classes)
             if show_classes and selected_classes:
                 for cls in classes:
                     if node_count >= max_nodes:
                         break
-                    if cls["name"] not in selected_classes:
+                    if cls["name"] not in selected_class_names:
                         continue
-                    label = cls["label"] if cls["label"] else cls["name"]
-                    title = f"Class: {cls['name']}"
+                    cls_node_id = _uid(cls["uri"])
+                    disp_cls_name = _disambiguated_name(cls, cls_collisions)
+                    label = cls["label"] if cls["label"] else disp_cls_name
+                    title = f"Class: {disp_cls_name}"
                     if cls["label"]:
                         title += f"\nLabel: {cls['label']}"
                     if cls["comment"]:
@@ -3343,34 +3347,44 @@ def render_visualization():
                     border_width = 3 if has_issue else 1
                     if has_issue:
                         title += "\n⚠ Has validation issues"
-                    net.add_node(cls["name"], label=label, title=title,
+                    net.add_node(cls_node_id, label=label, title=title,
                                color=node_color, borderWidth=border_width,
                                shape="box", size=25,
-                               ntype="Class", ename=cls["name"])
+                               ntype="Class", ename=cls_node_id)
+                    displayed_class_uris.add(cls["uri"])
                     node_count += 1
 
-                # Add class hierarchy edges (only if parent node exists in graph)
+                # Add class hierarchy edges (URI-based so cross-namespace collisions don't merge)
                 for cls in classes:
-                    for parent in cls["parents"]:
-                        if parent in class_names:
-                            net.add_edge(cls["name"], parent, label="subClassOf",
-                                       title=f"Subclass relation:\n{cls['name']} is a subclass of {parent}",
+                    if cls["uri"] not in displayed_class_uris:
+                        continue
+                    cls_node_id = _uid(cls["uri"])
+                    for parent_uri in cls.get("parent_uris", []):
+                        if parent_uri in displayed_class_uris:
+                            parent_node_id = _uid(parent_uri)
+                            net.add_edge(cls_node_id, parent_node_id, label="subClassOf",
+                                       title=f"Subclass relation:\n{cls['name']} is a subclass of {parent_uri.rsplit('#', 1)[-1].rsplit('/', 1)[-1]}",
                                        color="#81C784", arrows="to")
 
             # Add object properties as labeled edges between domain and range
             if show_properties and object_props and show_classes:
                 for prop in object_props:
-                    # Only show if both domain and range exist as class nodes
-                    if prop["domain"] and prop["range"] and prop["domain"] in class_names and prop["range"] in class_names:
+                    # Only show if both domain and range exist as class nodes (URI-keyed)
+                    dom_uri = prop.get("domain_uri", "")
+                    rng_uri = prop.get("range_uri", "")
+                    if (dom_uri and rng_uri
+                            and dom_uri in displayed_class_uris
+                            and rng_uri in displayed_class_uris):
+                        prop_node_id = _uid(prop["uri"])
                         label = prop["label"] if prop["label"] else prop["name"]
                         title = f"Object Property: {prop['name']}"
                         if prop["label"]:
                             title += f"\nLabel: {prop['label']}"
-                        net.add_edge(prop["domain"], prop["range"],
+                        net.add_edge(_uid(dom_uri), _uid(rng_uri),
                                    label=label,
                                    title=title,
                                    color="#2196F3", arrows="to",
-                                   ntype="Object Property", ename=prop["name"])
+                                   ntype="Object Property", ename=prop_node_id)
 
             # Add data properties (connected to displayed classes, or standalone if no domain)
             if show_data_props and data_props and node_count < max_nodes:
@@ -3378,9 +3392,11 @@ def render_visualization():
                     if node_count >= max_nodes:
                         break
                     # Skip if domain is set but the class node isn't displayed
-                    if prop["domain"] and show_classes and prop["domain"] not in class_names:
+                    dom_uri = prop.get("domain_uri", "")
+                    if dom_uri and show_classes and dom_uri not in displayed_class_uris:
                         continue
 
+                    prop_node_id = f"dprop_{_uid(prop['uri'])}"
                     label = prop["label"] if prop["label"] else prop["name"]
                     title = f"Data Property: {prop['name']}"
                     if prop["domain"]:
@@ -3390,15 +3406,15 @@ def render_visualization():
                     if prop["functional"]:
                         title += "\nFunctional: Yes"
 
-                    net.add_node(f"dprop_{prop['name']}", label=label, title=title,
+                    net.add_node(prop_node_id, label=label, title=title,
                                color={"background": "#9C27B0", "border": "#7B1FA2"},
                                shape="box", size=12, font={"color": "#f0f0f0"},
-                               ntype="Data Property", ename=prop["name"])
+                               ntype="Data Property", ename=_uid(prop["uri"]))
                     node_count += 1
 
                     # Connect to domain class
-                    if prop["domain"]:
-                        net.add_edge(prop["domain"], f"dprop_{prop['name']}",
+                    if dom_uri and dom_uri in displayed_class_uris:
+                        net.add_edge(_uid(dom_uri), prop_node_id,
                                    title=f"Domain:\n{prop['name']} has domain {prop['domain']}",
                                    color="#CE93D8", arrows="to", dashes=True)
 
@@ -3407,6 +3423,7 @@ def render_visualization():
                 for ind in individuals:
                     if node_count >= max_nodes:
                         break
+                    ind_node_id = f"ind_{_uid(ind['uri'])}"
                     label = ind["label"] if ind["label"] else ind["name"]
                     title = f"Individual: {ind['name']}"
                     if ind["classes"]:
@@ -3419,44 +3436,52 @@ def render_visualization():
                     border_width = 3 if has_issue else 1
                     if has_issue:
                         title += "\n⚠ Has validation issues"
-                    net.add_node(f"ind_{ind['name']}", label=label, title=title,
+                    net.add_node(ind_node_id, label=label, title=title,
                                color=ind_color, borderWidth=border_width,
                                shape="box", size=20,
-                               ntype="Individual", ename=ind["name"])
+                               ntype="Individual", ename=_uid(ind["uri"]))
                     node_count += 1
 
-                    # Connect to classes (only if class node is in the graph)
+                    # Connect to classes (only if class node is displayed)
                     if show_classes:
+                        # Map local class names to displayed URIs once per individual
                         for cls_name in ind["classes"]:
-                            if cls_name in class_names:
-                                net.add_edge(f"ind_{ind['name']}", cls_name,
-                                           label="type",
-                                           title=f"Instance of:\n{ind['name']} is an instance of {cls_name}",
-                                           color="#FFB74D", arrows="to")
+                            for c in classes:
+                                if c["name"] == cls_name and c["uri"] in displayed_class_uris:
+                                    net.add_edge(ind_node_id, _uid(c["uri"]),
+                                               label="type",
+                                               title=f"Instance of:\n{ind['name']} is an instance of {cls_name}",
+                                               color="#FFB74D", arrows="to")
+                                    break
 
                 # Add edges between individuals (object property assertions)
                 if show_ind_edges:
-                    ind_names = {ind["name"] for ind in individuals}
+                    ind_uri_by_name: dict[str, str] = {ind["name"]: ind["uri"] for ind in individuals}
                     for ind in individuals:
                         for prop in ind.get("properties", []):
-                            if prop["value"] in ind_names:
-                                net.add_edge(f"ind_{ind['name']}", f"ind_{prop['value']}",
+                            target_uri = ind_uri_by_name.get(prop["value"])
+                            if target_uri:
+                                net.add_edge(f"ind_{_uid(ind['uri'])}", f"ind_{_uid(target_uri)}",
                                            label=prop["property"],
                                            title=f"{prop['property']}:\n{ind['name']} → {prop['value']}",
                                            color="#FF9800", arrows="to")
 
-            # Add class relations (only if both nodes exist)
+            # Add class relations (only if both nodes exist) — URI-keyed
             class_relations = ont.get_class_relations()
             if show_classes and classes:
                 for rel in class_relations:
-                    if rel["subject"] in class_names and rel["object"] in class_names:
+                    subj_uri = rel.get("subject_uri", "")
+                    obj_uri = rel.get("object_uri", "")
+                    if subj_uri in displayed_class_uris and obj_uri in displayed_class_uris:
+                        subj_node = _uid(subj_uri)
+                        obj_node = _uid(obj_uri)
                         if rel["relation"] == "equivalentClass":
-                            net.add_edge(rel["subject"], rel["object"],
+                            net.add_edge(subj_node, obj_node,
                                        label="equivalentClass",
                                        title=f"Equivalent classes:\n{rel['subject']} and {rel['object']} represent the same concept",
                                        color="#9C27B0", arrows="to")
                         elif rel["relation"] == "disjointWith":
-                            net.add_edge(rel["subject"], rel["object"],
+                            net.add_edge(subj_node, obj_node,
                                        label="disjointWith",
                                        title=f"Disjoint classes:\n{rel['subject']} and {rel['object']} cannot share instances",
                                        color="#F44336", arrows="to")

--- a/app.py
+++ b/app.py
@@ -117,6 +117,8 @@ def save_checkpoint(label: str = "Edit"):
     """Save a snapshot to the undo history after a mutation."""
     if st.session_state.get("undo_manager"):
         st.session_state.undo_manager.checkpoint(label)
+    # Bump mutation counter so derived UI caches (e.g. graph viz) invalidate
+    st.session_state["_ont_mutation_count"] = st.session_state.get("_ont_mutation_count", 0) + 1
 
 
 def log_error(error: Exception, context: str = ""):
@@ -3128,9 +3130,11 @@ def render_visualization():
         # Store graph settings in session state for caching
         selected_classes_key = "_".join(sorted(selected_classes)) if selected_classes else "none"
         _graph_ver = 15  # Bump to invalidate cached graph data after code changes
-        # Include the ontology's triple count so an import/replace/undo invalidates the cached graph
-        ont_fingerprint = len(ont.graph)
-        graph_key = f"v{_graph_ver}_{ont_fingerprint}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{height}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}"
+        # Include a mutation counter that bumps on every checkpoint / undo / redo,
+        # so any change to the ontology — even one that preserves triple count —
+        # invalidates the cached graph data and the iframe re-renders.
+        ont_mutation = st.session_state.get("_ont_mutation_count", 0)
+        graph_key = f"v{_graph_ver}_m{ont_mutation}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{height}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}"
         if "last_graph_key" not in st.session_state:
             st.session_state.last_graph_key = None
             st.session_state.last_graph_data = None
@@ -3535,6 +3539,8 @@ def render_visualization():
                     "edges": edges_json,
                     "options": options_json,
                 }
+                # Bump seq so the iframe component re-initialises with the new data
+                st.session_state.viz_render_seq += 1
                 status.empty()
 
             except Exception as e:
@@ -3767,11 +3773,13 @@ def main():
         with undo_col:
             if st.button("Undo", disabled=not um.can_undo(), use_container_width=True, key="btn_undo"):
                 label = um.undo()
+                st.session_state["_ont_mutation_count"] = st.session_state.get("_ont_mutation_count", 0) + 1
                 set_flash_message(f"Undid: {label}", "info")
                 st.rerun()
         with redo_col:
             if st.button("Redo", disabled=not um.can_redo(), use_container_width=True, key="btn_redo"):
                 label = um.redo()
+                st.session_state["_ont_mutation_count"] = st.session_state.get("_ont_mutation_count", 0) + 1
                 set_flash_message(f"Redid: {label}", "info")
                 st.rerun()
 

--- a/app.py
+++ b/app.py
@@ -3128,7 +3128,9 @@ def render_visualization():
         # Store graph settings in session state for caching
         selected_classes_key = "_".join(sorted(selected_classes)) if selected_classes else "none"
         _graph_ver = 15  # Bump to invalidate cached graph data after code changes
-        graph_key = f"v{_graph_ver}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{height}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}"
+        # Include the ontology's triple count so an import/replace/undo invalidates the cached graph
+        ont_fingerprint = len(ont.graph)
+        graph_key = f"v{_graph_ver}_{ont_fingerprint}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{height}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}"
         if "last_graph_key" not in st.session_state:
             st.session_state.last_graph_key = None
             st.session_state.last_graph_data = None

--- a/app.py
+++ b/app.py
@@ -811,31 +811,41 @@ def render_properties():
 
             st.caption(f"Showing {len(filtered_obj_props)} of {len(object_props)} properties")
 
-            _active_op = next((p for p in filtered_obj_props if st.session_state.get(f"view_objprop_{p['name']}", False) or st.session_state.get(f"edit_objprop_{p['name']}", False)), None)
+            op_collisions = _build_name_collision_set(object_props)
+            _active_op = next(
+                (p for p in filtered_obj_props
+                 if st.session_state.get(f"view_objprop_{_uid(p['uri'])}", False)
+                 or st.session_state.get(f"edit_objprop_{_uid(p['uri'])}", False)),
+                None,
+            )
             if _active_op:
+                _active_op_uid = _uid(_active_op["uri"])
                 for p in filtered_obj_props:
-                    if p["name"] != _active_op["name"]:
-                        st.session_state.pop(f"view_objprop_{p['name']}", None)
-                        st.session_state.pop(f"edit_objprop_{p['name']}", None)
+                    p_uid = _uid(p["uri"])
+                    if p_uid != _active_op_uid:
+                        st.session_state.pop(f"view_objprop_{p_uid}", None)
+                        st.session_state.pop(f"edit_objprop_{p_uid}", None)
 
             for prop in filtered_obj_props:
-                _op_expanded = st.session_state.get(f"view_objprop_{prop['name']}", False) or st.session_state.get(f"edit_objprop_{prop['name']}", False)
-                with st.expander(f"🔗 **{prop['name']}** ({prop['domain'] or '?'} → {prop['range'] or '?'})", expanded=_op_expanded):
+                prop_uid = _uid(prop["uri"])
+                disp_name = _disambiguated_name(prop, op_collisions)
+                _op_expanded = st.session_state.get(f"view_objprop_{prop_uid}", False) or st.session_state.get(f"edit_objprop_{prop_uid}", False)
+                with st.expander(f"🔗 **{disp_name}** ({prop['domain'] or '?'} → {prop['range'] or '?'})", expanded=_op_expanded):
                     st.write(f"**URI:** `{prop['uri']}`" if prop['uri'].startswith("http://example.org/") else f"**URI:** {prop['uri']}")
 
                     btn_view, btn_edit, btn_del, _ = st.columns([1, 1, 1, 4])
                     with btn_view:
-                        st.button("👁️ View", key=f"btn_view_objprop_{prop['name']}", use_container_width=True,
-                                  on_click=_cb_toggle_view, args=("objprop", prop['name']))
+                        st.button("👁️ View", key=f"btn_view_objprop_{prop_uid}", use_container_width=True,
+                                  on_click=_cb_toggle_view, args=("objprop", prop_uid))
                     with btn_edit:
-                        st.button("✏️ Edit", key=f"btn_edit_objprop_{prop['name']}", use_container_width=True,
-                                  on_click=_cb_toggle_edit, args=("objprop", prop['name']))
+                        st.button("✏️ Edit", key=f"btn_edit_objprop_{prop_uid}", use_container_width=True,
+                                  on_click=_cb_toggle_edit, args=("objprop", prop_uid))
                     with btn_del:
-                        st.button("🗑️ Delete", key=f"btn_del_objprop_{prop['name']}", use_container_width=True,
-                                  on_click=_cb_confirm_delete, args=(f"objprop_{prop['name']}",))
+                        st.button("🗑️ Delete", key=f"btn_del_objprop_{prop_uid}", use_container_width=True,
+                                  on_click=_cb_confirm_delete, args=(f"objprop_{prop_uid}",))
 
                     # View details
-                    if st.session_state.get(f"view_objprop_{prop['name']}", False):
+                    if st.session_state.get(f"view_objprop_{prop_uid}", False):
                         st.divider()
                         st.write(f"**Name:** {prop['name']}")
                         st.write(f"**Label:** {prop['label'] or '—'}")
@@ -844,53 +854,52 @@ def render_properties():
                         st.write(f"**Range:** {prop['range'] or '—'}")
                         st.write(f"**Characteristics:** {', '.join(prop['characteristics']) if prop['characteristics'] else '—'}")
                         st.write(f"**Inverse of:** {prop.get('inverse_of') or '—'}")
-                        st.button("✏️ Edit", key=f"btn_view_to_edit_objprop_{prop['name']}",
-                                  on_click=_cb_view_to_edit, args=("objprop", prop['name']))
+                        st.button("✏️ Edit", key=f"btn_view_to_edit_objprop_{prop_uid}",
+                                  on_click=_cb_view_to_edit, args=("objprop", prop_uid))
 
-                    if confirm_delete(prop["name"], "property", f"objprop_{prop['name']}"):
-                        ont.delete_property(prop["name"])
+                    if confirm_delete(prop["uri"], "property", f"objprop_{prop_uid}"):
+                        ont.delete_property(prop["uri"])
                         save_checkpoint("Delete property")
-                        set_flash_message(f"Property '{prop['name']}' deleted!", "success")
+                        set_flash_message(f"Property '{disp_name}' deleted!", "success")
                         st.rerun()
 
                     # Inline edit form
-                    if st.session_state.get(f"edit_objprop_{prop['name']}", False):
+                    if st.session_state.get(f"edit_objprop_{prop_uid}", False):
                         st.divider()
-                        with st.form(f"edit_objprop_form_{prop['name']}"):
-                            new_name = st.text_input("Name (URI local part)", value=prop["name"], key=f"objp_name_{prop['name']}")
-                            new_label = st.text_input("Label", value=prop["label"], key=f"objp_lbl_{prop['name']}")
-                            new_comment = st.text_area("Comment", value=prop["comment"], key=f"objp_cmt_{prop['name']}")
+                        with st.form(f"edit_objprop_form_{prop_uid}"):
+                            new_name = st.text_input("Name (URI local part)", value=prop["name"], key=f"objp_name_{prop_uid}")
+                            new_label = st.text_input("Label", value=prop["label"], key=f"objp_lbl_{prop_uid}")
+                            new_comment = st.text_area("Comment", value=prop["comment"], key=f"objp_cmt_{prop_uid}")
                             col1, col2 = st.columns(2)
                             with col1:
                                 new_domain = st.selectbox("Domain", options=["None"] + class_names,
                                     index=0 if not prop["domain"] else (class_names.index(prop["domain"]) + 1 if prop["domain"] in class_names else 0),
-                                    key=f"objp_dom_{prop['name']}")
+                                    key=f"objp_dom_{prop_uid}")
                             with col2:
                                 new_range = st.selectbox("Range", options=["None"] + class_names,
                                     index=0 if not prop["range"] else (class_names.index(prop["range"]) + 1 if prop["range"] in class_names else 0),
-                                    key=f"objp_rng_{prop['name']}")
+                                    key=f"objp_rng_{prop_uid}")
 
                             if st.form_submit_button("Save Changes"):
-                                # Handle rename first
+                                # Handle rename first — pass URI for cross-namespace safety
+                                current_ref = prop["uri"]
                                 if new_name and new_name != prop["name"]:
-                                    if ont.rename_property(prop["name"], new_name):
-                                        current_name = new_name
+                                    if ont.rename_property(prop["uri"], new_name):
+                                        current_ref = new_name
                                         save_checkpoint("Rename property")
                                         show_message(f"Property renamed to '{new_name}'", "success")
                                     else:
                                         show_message(f"Cannot rename: '{new_name}' already exists!", "error")
                                         st.rerun()
-                                else:
-                                    current_name = prop["name"]
 
-                                ont.update_property(current_name,
+                                ont.update_property(current_ref,
                                     new_label=new_label,
                                     new_comment=new_comment,
                                     new_domain=new_domain if new_domain != "None" else "",
                                     new_range=new_range if new_range != "None" else "")
                                 save_checkpoint("Update property")
-                                st.session_state[f"edit_objprop_{prop['name']}"] = False
-                                show_message(f"Property '{current_name}' updated!", "success")
+                                st.session_state[f"edit_objprop_{prop_uid}"] = False
+                                show_message(f"Property updated!", "success")
                                 st.rerun()
 
     if _prop_tab == "Data Properties":
@@ -915,31 +924,41 @@ def render_properties():
 
             datatypes = list(get_ontology_manager_class().XSD_DATATYPES.keys())
 
-            _active_dp = next((p for p in filtered_data_props if st.session_state.get(f"view_dataprop_{p['name']}", False) or st.session_state.get(f"edit_dataprop_{p['name']}", False)), None)
+            dp_collisions = _build_name_collision_set(data_props)
+            _active_dp = next(
+                (p for p in filtered_data_props
+                 if st.session_state.get(f"view_dataprop_{_uid(p['uri'])}", False)
+                 or st.session_state.get(f"edit_dataprop_{_uid(p['uri'])}", False)),
+                None,
+            )
             if _active_dp:
+                _active_dp_uid = _uid(_active_dp["uri"])
                 for p in filtered_data_props:
-                    if p["name"] != _active_dp["name"]:
-                        st.session_state.pop(f"view_dataprop_{p['name']}", None)
-                        st.session_state.pop(f"edit_dataprop_{p['name']}", None)
+                    p_uid = _uid(p["uri"])
+                    if p_uid != _active_dp_uid:
+                        st.session_state.pop(f"view_dataprop_{p_uid}", None)
+                        st.session_state.pop(f"edit_dataprop_{p_uid}", None)
 
             for prop in filtered_data_props:
-                _dp_expanded = st.session_state.get(f"view_dataprop_{prop['name']}", False) or st.session_state.get(f"edit_dataprop_{prop['name']}", False)
-                with st.expander(f"📝 **{prop['name']}** ({prop['domain'] or '?'} → {prop['range']})", expanded=_dp_expanded):
+                prop_uid = _uid(prop["uri"])
+                disp_name = _disambiguated_name(prop, dp_collisions)
+                _dp_expanded = st.session_state.get(f"view_dataprop_{prop_uid}", False) or st.session_state.get(f"edit_dataprop_{prop_uid}", False)
+                with st.expander(f"📝 **{disp_name}** ({prop['domain'] or '?'} → {prop['range']})", expanded=_dp_expanded):
                     st.write(f"**URI:** `{prop['uri']}`" if prop['uri'].startswith("http://example.org/") else f"**URI:** {prop['uri']}")
 
                     btn_view, btn_edit, btn_del, _ = st.columns([1, 1, 1, 4])
                     with btn_view:
-                        st.button("👁️ View", key=f"btn_view_dataprop_{prop['name']}", use_container_width=True,
-                                  on_click=_cb_toggle_view, args=("dataprop", prop['name']))
+                        st.button("👁️ View", key=f"btn_view_dataprop_{prop_uid}", use_container_width=True,
+                                  on_click=_cb_toggle_view, args=("dataprop", prop_uid))
                     with btn_edit:
-                        st.button("✏️ Edit", key=f"btn_edit_dataprop_{prop['name']}", use_container_width=True,
-                                  on_click=_cb_toggle_edit, args=("dataprop", prop['name']))
+                        st.button("✏️ Edit", key=f"btn_edit_dataprop_{prop_uid}", use_container_width=True,
+                                  on_click=_cb_toggle_edit, args=("dataprop", prop_uid))
                     with btn_del:
-                        st.button("🗑️ Delete", key=f"btn_del_dataprop_{prop['name']}", use_container_width=True,
-                                  on_click=_cb_confirm_delete, args=(f"dataprop_{prop['name']}",))
+                        st.button("🗑️ Delete", key=f"btn_del_dataprop_{prop_uid}", use_container_width=True,
+                                  on_click=_cb_confirm_delete, args=(f"dataprop_{prop_uid}",))
 
                     # View details
-                    if st.session_state.get(f"view_dataprop_{prop['name']}", False):
+                    if st.session_state.get(f"view_dataprop_{prop_uid}", False):
                         st.divider()
                         st.write(f"**Name:** {prop['name']}")
                         st.write(f"**Label:** {prop['label'] or '—'}")
@@ -947,54 +966,53 @@ def render_properties():
                         st.write(f"**Domain:** {prop['domain'] or '—'}")
                         st.write(f"**Range (Datatype):** {prop['range']}")
                         st.write(f"**Functional:** {'Yes' if prop['functional'] else 'No'}")
-                        st.button("✏️ Edit", key=f"btn_view_to_edit_dataprop_{prop['name']}",
-                                  on_click=_cb_view_to_edit, args=("dataprop", prop['name']))
+                        st.button("✏️ Edit", key=f"btn_view_to_edit_dataprop_{prop_uid}",
+                                  on_click=_cb_view_to_edit, args=("dataprop", prop_uid))
 
-                    if confirm_delete(prop["name"], "property", f"dataprop_{prop['name']}"):
-                        ont.delete_property(prop["name"])
+                    if confirm_delete(prop["uri"], "property", f"dataprop_{prop_uid}"):
+                        ont.delete_property(prop["uri"])
                         save_checkpoint("Delete property")
-                        set_flash_message(f"Property '{prop['name']}' deleted!", "success")
+                        set_flash_message(f"Property '{disp_name}' deleted!", "success")
                         st.rerun()
 
                     # Inline edit form
-                    if st.session_state.get(f"edit_dataprop_{prop['name']}", False):
+                    if st.session_state.get(f"edit_dataprop_{prop_uid}", False):
                         st.divider()
-                        with st.form(f"edit_dataprop_form_{prop['name']}"):
-                            new_name = st.text_input("Name (URI local part)", value=prop["name"], key=f"dp_name_{prop['name']}")
-                            new_label = st.text_input("Label", value=prop["label"], key=f"dp_lbl_{prop['name']}")
-                            new_comment = st.text_area("Comment", value=prop["comment"], key=f"dp_cmt_{prop['name']}")
+                        with st.form(f"edit_dataprop_form_{prop_uid}"):
+                            new_name = st.text_input("Name (URI local part)", value=prop["name"], key=f"dp_name_{prop_uid}")
+                            new_label = st.text_input("Label", value=prop["label"], key=f"dp_lbl_{prop_uid}")
+                            new_comment = st.text_area("Comment", value=prop["comment"], key=f"dp_cmt_{prop_uid}")
                             col1, col2 = st.columns(2)
                             with col1:
                                 new_domain = st.selectbox("Domain", options=["None"] + class_names,
                                     index=0 if not prop["domain"] else (class_names.index(prop["domain"]) + 1 if prop["domain"] in class_names else 0),
-                                    key=f"dp_dom_{prop['name']}")
+                                    key=f"dp_dom_{prop_uid}")
                             with col2:
                                 current_range = prop["range"] if prop["range"] in datatypes else "string"
                                 new_range = st.selectbox("Range (Datatype)", options=datatypes,
                                     index=datatypes.index(current_range) if current_range in datatypes else 0,
-                                    key=f"dp_rng_{prop['name']}")
+                                    key=f"dp_rng_{prop_uid}")
 
                             if st.form_submit_button("Save Changes"):
-                                # Handle rename first
+                                # Handle rename first — pass URI for cross-namespace safety
+                                current_ref = prop["uri"]
                                 if new_name and new_name != prop["name"]:
-                                    if ont.rename_property(prop["name"], new_name):
-                                        current_name = new_name
+                                    if ont.rename_property(prop["uri"], new_name):
+                                        current_ref = new_name
                                         save_checkpoint("Rename property")
                                         show_message(f"Property renamed to '{new_name}'", "success")
                                     else:
                                         show_message(f"Cannot rename: '{new_name}' already exists!", "error")
                                         st.rerun()
-                                else:
-                                    current_name = prop["name"]
 
-                                ont.update_property(current_name,
+                                ont.update_property(current_ref,
                                     new_label=new_label,
                                     new_comment=new_comment,
                                     new_domain=new_domain if new_domain != "None" else "",
                                     new_range=new_range)
                                 save_checkpoint("Update property")
-                                st.session_state[f"edit_dataprop_{prop['name']}"] = False
-                                show_message(f"Property '{current_name}' updated!", "success")
+                                st.session_state[f"edit_dataprop_{prop_uid}"] = False
+                                show_message(f"Property updated!", "success")
                                 st.rerun()
 
     if _prop_tab == "Add Object Property":
@@ -1190,22 +1208,29 @@ def render_individuals():
         if not individuals:
             st.info("No individuals defined yet.")
         else:
-            # Use URI hash for unique widget keys (name may not be unique across classes)
-            def _ind_key(ind):
-                return str(abs(hash(ind['uri'])))[:8]
+            # Use URI hash for unique widget keys (name may not be unique across namespaces)
+            ind_collisions = _build_name_collision_set(individuals)
 
-            _active_ind = next((i for i in individuals if st.session_state.get(f"view_ind_{_ind_key(i)}", False) or st.session_state.get(f"edit_ind_{_ind_key(i)}", False)), None)
+            _active_ind = next(
+                (i for i in individuals
+                 if st.session_state.get(f"view_ind_{_uid(i['uri'])}", False)
+                 or st.session_state.get(f"edit_ind_{_uid(i['uri'])}", False)),
+                None,
+            )
             if _active_ind:
+                _active_ind_uid = _uid(_active_ind["uri"])
                 for i in individuals:
-                    if i["uri"] != _active_ind["uri"]:
-                        st.session_state.pop(f"view_ind_{_ind_key(i)}", None)
-                        st.session_state.pop(f"edit_ind_{_ind_key(i)}", None)
+                    i_uid = _uid(i["uri"])
+                    if i_uid != _active_ind_uid:
+                        st.session_state.pop(f"view_ind_{i_uid}", None)
+                        st.session_state.pop(f"edit_ind_{i_uid}", None)
 
             for ind in individuals:
                 classes_str = ", ".join(ind["classes"]) if ind["classes"] else "No class"
-                _ik = _ind_key(ind)
+                _ik = _uid(ind["uri"])
+                disp_ind_name = _disambiguated_name(ind, ind_collisions)
                 _ind_expanded = st.session_state.get(f"view_ind_{_ik}", False) or st.session_state.get(f"edit_ind_{_ik}", False)
-                with st.expander(f"👤 **{ind['name']}** ({classes_str})", expanded=_ind_expanded):
+                with st.expander(f"👤 **{disp_ind_name}** ({classes_str})", expanded=_ind_expanded):
                     st.write(f"**URI:** `{ind['uri']}`" if ind['uri'].startswith("http://example.org/") else f"**URI:** {ind['uri']}")
 
                     btn_view, btn_edit, btn_del, _ = st.columns([1, 1, 1, 4])
@@ -1235,15 +1260,15 @@ def render_individuals():
                         st.button("✏️ Edit", key=f"btn_view_to_edit_ind_{_ik}",
                                   on_click=_cb_view_to_edit, args=("ind", _ik))
 
-                    if confirm_delete(ind["name"], "individual", f"ind_{_ik}"):
-                        ont.delete_individual(ind["name"])
+                    if confirm_delete(ind["uri"], "individual", f"ind_{_ik}"):
+                        ont.delete_individual(ind["uri"])
                         save_checkpoint("Delete individual")
-                        set_flash_message(f"Individual '{ind['name']}' deleted!", "success")
+                        set_flash_message(f"Individual '{disp_ind_name}' deleted!", "success")
                         st.rerun()
 
                     # Resource usages
                     with st.expander("Show Usages", expanded=False):
-                        usages = ont.get_resource_usages(ind["name"])
+                        usages = ont.get_resource_usages(ind["uri"])
                         if usages["inbound"]:
                             st.markdown("**Referenced by:**")
                             for u in usages["inbound"]:
@@ -1278,26 +1303,25 @@ def render_individuals():
                                     key=f"ind_rem_cls_{_ik}")
 
                             if st.form_submit_button("Save Changes"):
-                                # Handle rename first
+                                # Handle rename first — pass URI for cross-namespace safety
+                                current_ref = ind["uri"]
                                 if new_name and new_name != ind["name"]:
-                                    if ont.rename_individual(ind["name"], new_name):
-                                        current_name = new_name
+                                    if ont.rename_individual(ind["uri"], new_name):
+                                        current_ref = new_name
                                         save_checkpoint("Rename individual")
                                         show_message(f"Individual renamed to '{new_name}'", "success")
                                     else:
                                         show_message(f"Cannot rename: '{new_name}' already exists!", "error")
                                         st.rerun()
-                                else:
-                                    current_name = ind["name"]
 
-                                ont.update_individual(current_name,
+                                ont.update_individual(current_ref,
                                     new_label=new_label,
                                     new_comment=new_comment,
                                     add_class=add_class if add_class != "None" else None,
                                     remove_class=remove_class if remove_class != "None" else None)
                                 save_checkpoint("Update individual")
                                 st.session_state[f"edit_ind_{_ik}"] = False
-                                show_message(f"Individual '{current_name}' updated!", "success")
+                                show_message(f"Individual updated!", "success")
                                 st.rerun()
 
     if _ind_tab == "Add Individual":
@@ -1546,6 +1570,9 @@ def render_relations():
         if class_relations:
             st.write("**Class Relations:**")
             for rel in class_relations:
+                subj_uri = rel.get("subject_uri", rel["subject"])
+                obj_uri = rel.get("object_uri", rel["object"])
+                rel_uid = _uid(f"{subj_uri}|{rel['relation']}|{obj_uri}")
                 col1, col2, col3, col4 = st.columns([3, 2, 3, 1])
                 with col1:
                     st.write(f"📦 {rel['subject']}")
@@ -1554,8 +1581,8 @@ def render_relations():
                 with col3:
                     st.write(f"📦 {rel['object']}")
                 with col4:
-                    if st.button("🗑️", key=f"del_crel_{rel['subject']}_{rel['relation']}_{rel['object']}"):
-                        ont.remove_class_relation(rel['subject'], rel['relation'], rel['object'])
+                    if st.button("🗑️", key=f"del_crel_{rel_uid}"):
+                        ont.remove_class_relation(subj_uri, rel['relation'], obj_uri)
                         save_checkpoint("Delete class relation")
                         show_message("Relation deleted!", "success")
                         st.rerun()
@@ -1577,8 +1604,11 @@ def render_relations():
                 with col3:
                     st.write(f"🔗 {rel['object']}")
                 with col4:
-                    if st.button("🗑️", key=f"del_prel_{rel['subject']}_{rel['relation']}_{rel['object']}"):
-                        ont.remove_property_relation(rel['subject'], rel['relation'], rel['object'])
+                    subj_uri = rel.get("subject_uri", rel["subject"])
+                    obj_uri = rel.get("object_uri", rel["object"])
+                    rel_uid = _uid(f"{subj_uri}|{rel['relation']}|{obj_uri}")
+                    if st.button("🗑️", key=f"del_prel_{rel_uid}"):
+                        ont.remove_property_relation(subj_uri, rel['relation'], obj_uri)
                         save_checkpoint("Delete property relation")
                         show_message("Relation deleted!", "success")
                         st.rerun()
@@ -1600,8 +1630,11 @@ def render_relations():
                 with col3:
                     st.write(f"👤 {rel['object']}")
                 with col4:
-                    if st.button("🗑️", key=f"del_irel_{rel['subject']}_{rel['relation']}_{rel['object']}"):
-                        ont.remove_individual_relation(rel['subject'], rel['relation'], rel['object'])
+                    subj_uri = rel.get("subject_uri", rel["subject"])
+                    obj_uri = rel.get("object_uri", rel["object"])
+                    rel_uid = _uid(f"{subj_uri}|{rel['relation']}|{obj_uri}")
+                    if st.button("🗑️", key=f"del_irel_{rel_uid}"):
+                        ont.remove_individual_relation(subj_uri, rel['relation'], obj_uri)
                         save_checkpoint("Delete individual relation")
                         show_message("Relation deleted!", "success")
                         st.rerun()

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 
+import hashlib
 import logging
 import streamlit as st
 import traceback
@@ -185,20 +186,87 @@ def format_label_name(name: str, label: str) -> str:
     return name
 
 
-def _cb_toggle_view(prefix, name):
-    """Callback: open view panel, close edit."""
-    st.session_state[f"view_{prefix}_{name}"] = True
-    st.session_state[f"edit_{prefix}_{name}"] = False
+def _uid(uri: str) -> str:
+    """Stable short identifier for a URI — used as Streamlit key suffix.
 
-def _cb_toggle_edit(prefix, name):
-    """Callback: open edit panel, close view."""
-    st.session_state[f"edit_{prefix}_{name}"] = True
-    st.session_state[f"view_{prefix}_{name}"] = False
+    The local name of an imported resource may collide across namespaces
+    (e.g., gist:Organization and foaf:Organization both have local name
+    'Organization'). Using a hash of the full URI guarantees a unique key
+    per resource regardless of name collisions.
+    """
+    return hashlib.md5(uri.encode("utf-8")).hexdigest()[:12]
 
-def _cb_view_to_edit(prefix, name):
-    """Callback: switch from view to edit."""
-    st.session_state[f"view_{prefix}_{name}"] = False
-    st.session_state[f"edit_{prefix}_{name}"] = True
+
+def _prefix_for_uri(uri: str) -> str:
+    """Return the prefix bound to the namespace of a URI, or empty string.
+
+    Used by display disambiguation to surface the namespace when a local
+    name appears in more than one namespace.
+    """
+    ont = st.session_state.get("ontology")
+    if ont is None:
+        return ""
+    # Find the longest namespace whose URI is a prefix of the resource URI
+    best_prefix = ""
+    best_ns_len = 0
+    for prefix, ns in ont.graph.namespaces():
+        ns_str = str(ns)
+        if uri.startswith(ns_str) and len(ns_str) > best_ns_len:
+            best_prefix = prefix
+            best_ns_len = len(ns_str)
+    return best_prefix
+
+
+def _build_name_collision_set(items: list) -> set:
+    """Return the set of local names that appear under more than one URI.
+
+    `items` is a list of dicts each with 'name' and 'uri' fields. Result is
+    used by `_disambiguated_name` so single-namespace names render as just
+    the name and ambiguous names render with a namespace tag.
+    """
+    seen: dict[str, str] = {}
+    collisions: set[str] = set()
+    for it in items:
+        name = it.get("name")
+        uri = it.get("uri")
+        if not name or not uri:
+            continue
+        if name in seen:
+            if seen[name] != uri:
+                collisions.add(name)
+        else:
+            seen[name] = uri
+    return collisions
+
+
+def _disambiguated_name(item: dict, collisions: set) -> str:
+    """Return a display name that includes a namespace prefix when ambiguous.
+
+    `Organization` stays `Organization` if it's the only one; otherwise it
+    becomes `Organization (foaf)` / `Organization (gist)` etc.
+    """
+    name = item.get("name", "")
+    if name in collisions:
+        prefix = _prefix_for_uri(item.get("uri", ""))
+        if prefix:
+            return f"{name} ({prefix})"
+    return name
+
+
+def _cb_toggle_view(prefix, uid):
+    """Callback: open view panel, close edit. `uid` must be unique per resource."""
+    st.session_state[f"view_{prefix}_{uid}"] = True
+    st.session_state[f"edit_{prefix}_{uid}"] = False
+
+def _cb_toggle_edit(prefix, uid):
+    """Callback: open edit panel, close view. `uid` must be unique per resource."""
+    st.session_state[f"edit_{prefix}_{uid}"] = True
+    st.session_state[f"view_{prefix}_{uid}"] = False
+
+def _cb_view_to_edit(prefix, uid):
+    """Callback: switch from view to edit. `uid` must be unique per resource."""
+    st.session_state[f"view_{prefix}_{uid}"] = False
+    st.session_state[f"edit_{prefix}_{uid}"] = True
 
 def _cb_confirm_delete(key_suffix):
     """Callback: trigger delete confirmation."""
@@ -206,20 +274,29 @@ def _cb_confirm_delete(key_suffix):
 
 
 def build_class_options(classes: list, include_none: bool = False) -> tuple:
-    """Build class dropdown options with 'Label (name)' format, sorted by display text.
+    """Build class dropdown options with 'Label (disambiguated name)' format.
+
+    Display strings include a namespace tag when local names collide across
+    namespaces (e.g. 'Organization (foaf)' / 'Organization (gist)'), so the
+    dropdown never shows two visually identical entries. The lookup maps each
+    display string to the resource's full URI — pass this URI to ont methods
+    (`add_class`, `delete_class`, etc.) which already accept URIs via `_uri()`.
 
     Returns:
-        tuple: (display_options, name_lookup_dict)
+        tuple: (display_options, uri_lookup_dict). For the 'None' entry the
+        lookup value is None.
     """
     options = []
     lookup = {}
+    collisions = _build_name_collision_set(classes)
 
     # Build display strings and sort
     items = []
     for c in classes:
-        display = format_label_name(c["name"], c.get("label"))
+        disp_name = _disambiguated_name(c, collisions)
+        display = format_label_name(disp_name, c.get("label"))
         items.append(display)
-        lookup[display] = c["name"]
+        lookup[display] = c["uri"]
 
     # Sort alphabetically by display text (case-insensitive)
     items.sort(key=lambda x: x.lower())
@@ -410,34 +487,48 @@ def render_classes():
             # Class hierarchy view
             st.subheader("Class Hierarchy")
 
+            collisions = _build_name_collision_set(classes)
+
             # Sort classes by display name, but put actively viewed class first
-            sorted_classes = sorted(classes, key=lambda c: format_label_name(c['name'], c.get('label')).lower())
-            _active_cls = next((c for c in sorted_classes if st.session_state.get(f"view_class_{c['name']}", False) or st.session_state.get(f"edit_class_{c['name']}", False)), None)
+            sorted_classes = sorted(
+                classes,
+                key=lambda c: format_label_name(_disambiguated_name(c, collisions), c.get('label')).lower(),
+            )
+            _active_cls = next(
+                (c for c in sorted_classes
+                 if st.session_state.get(f"view_class_{_uid(c['uri'])}", False)
+                 or st.session_state.get(f"edit_class_{_uid(c['uri'])}", False)),
+                None,
+            )
             if _active_cls:
+                _active_uid = _uid(_active_cls["uri"])
                 for c in sorted_classes:
-                    if c["name"] != _active_cls["name"]:
-                        st.session_state.pop(f"view_class_{c['name']}", None)
-                        st.session_state.pop(f"edit_class_{c['name']}", None)
+                    c_uid = _uid(c["uri"])
+                    if c_uid != _active_uid:
+                        st.session_state.pop(f"view_class_{c_uid}", None)
+                        st.session_state.pop(f"edit_class_{c_uid}", None)
 
             for cls in sorted_classes:
-                display_name = format_label_name(cls['name'], cls.get('label'))
-                _cls_expanded = st.session_state.get(f"view_class_{cls['name']}", False) or st.session_state.get(f"edit_class_{cls['name']}", False)
+                cls_uid = _uid(cls["uri"])
+                disp_name = _disambiguated_name(cls, collisions)
+                display_name = format_label_name(disp_name, cls.get('label'))
+                _cls_expanded = st.session_state.get(f"view_class_{cls_uid}", False) or st.session_state.get(f"edit_class_{cls_uid}", False)
                 with st.expander(f"📦 **{display_name}**", expanded=_cls_expanded):
                     st.write(f"**URI:** `{cls['uri']}`" if cls['uri'].startswith("http://example.org/") else f"**URI:** {cls['uri']}")
 
                     btn_view, btn_edit, btn_del, _ = st.columns([1, 1, 1, 4])
                     with btn_view:
-                        st.button("👁️ View", key=f"btn_view_class_{cls['name']}", use_container_width=True,
-                                  on_click=_cb_toggle_view, args=("class", cls['name']))
+                        st.button("👁️ View", key=f"btn_view_class_{cls_uid}", use_container_width=True,
+                                  on_click=_cb_toggle_view, args=("class", cls_uid))
                     with btn_edit:
-                        st.button("✏️ Edit", key=f"btn_edit_class_{cls['name']}", use_container_width=True,
-                                  on_click=_cb_toggle_edit, args=("class", cls['name']))
+                        st.button("✏️ Edit", key=f"btn_edit_class_{cls_uid}", use_container_width=True,
+                                  on_click=_cb_toggle_edit, args=("class", cls_uid))
                     with btn_del:
-                        st.button("🗑️ Delete", key=f"btn_del_class_{cls['name']}", use_container_width=True,
-                                  on_click=_cb_confirm_delete, args=(f"class_{cls['name']}",))
+                        st.button("🗑️ Delete", key=f"btn_del_class_{cls_uid}", use_container_width=True,
+                                  on_click=_cb_confirm_delete, args=(f"class_{cls_uid}",))
 
                     # View details
-                    if st.session_state.get(f"view_class_{cls['name']}", False):
+                    if st.session_state.get(f"view_class_{cls_uid}", False):
                         st.divider()
                         st.write(f"**Name:** {cls['name']}")
                         st.write(f"**Label:** {cls['label'] or '—'}")
@@ -445,52 +536,51 @@ def render_classes():
                         st.write(f"**Parent Class:** {', '.join(cls['parents']) if cls['parents'] else '—'}")
                         if cls["children"]:
                             st.write(f"**Children:** {', '.join(cls['children'])}")
-                        st.button("✏️ Edit", key=f"btn_view_to_edit_class_{cls['name']}",
-                                  on_click=_cb_view_to_edit, args=("class", cls['name']))
+                        st.button("✏️ Edit", key=f"btn_view_to_edit_class_{cls_uid}",
+                                  on_click=_cb_view_to_edit, args=("class", cls_uid))
 
-                    if confirm_delete(cls["name"], "class", f"class_{cls['name']}"):
-                        ont.delete_class(cls["name"])
+                    if confirm_delete(cls["uri"], "class", f"class_{cls_uid}"):
+                        ont.delete_class(cls["uri"])
                         save_checkpoint("Delete class")
-                        set_flash_message(f"Class '{cls['name']}' deleted!", "success")
+                        set_flash_message(f"Class '{disp_name}' deleted!", "success")
                         st.rerun()
 
                     # Inline edit form
-                    if st.session_state.get(f"edit_class_{cls['name']}", False):
+                    if st.session_state.get(f"edit_class_{cls_uid}", False):
                         st.divider()
-                        with st.form(f"edit_class_form_{cls['name']}"):
-                            new_name = st.text_input("Name (URI local part)", value=cls["name"], key=f"name_{cls['name']}")
-                            new_label = st.text_input("Label", value=cls["label"], key=f"lbl_{cls['name']}")
-                            new_comment = st.text_area("Comment", value=cls["comment"], key=f"cmt_{cls['name']}")
+                        with st.form(f"edit_class_form_{cls_uid}"):
+                            new_name = st.text_input("Name (URI local part)", value=cls["name"], key=f"name_{cls_uid}")
+                            new_label = st.text_input("Label", value=cls["label"], key=f"lbl_{cls_uid}")
+                            new_comment = st.text_area("Comment", value=cls["comment"], key=f"cmt_{cls_uid}")
                             other_classes = [c for c in class_names if c != cls["name"]]
                             current_parent = cls["parents"][0] if cls["parents"] else "None"
                             new_parent = st.selectbox("Parent Class",
                                 options=["None"] + other_classes,
                                 index=0 if current_parent == "None" else
                                       (other_classes.index(current_parent) + 1 if current_parent in other_classes else 0),
-                                key=f"par_{cls['name']}")
+                                key=f"par_{cls_uid}")
 
                             if st.form_submit_button("Save Changes"):
-                                # Handle rename first
+                                # Handle rename first — pass URI so cross-namespace duplicates resolve correctly
+                                current_ref = cls["uri"]
                                 if new_name and new_name != cls["name"]:
-                                    if ont.rename_class(cls["name"], new_name):
-                                        current_name = new_name
+                                    if ont.rename_class(cls["uri"], new_name):
+                                        current_ref = new_name  # post-rename, the resource lives in the base namespace
                                         save_checkpoint("Rename class")
                                         show_message(f"Class renamed to '{new_name}'", "success")
                                     else:
                                         show_message(f"Cannot rename: '{new_name}' already exists!", "error")
                                         st.rerun()
-                                else:
-                                    current_name = cls["name"]
 
                                 if cls["parents"] and new_parent != cls["parents"][0]:
-                                    ont.update_class(current_name, remove_parent=cls["parents"][0])
-                                ont.update_class(current_name,
+                                    ont.update_class(current_ref, remove_parent=cls["parents"][0])
+                                ont.update_class(current_ref,
                                     new_label=new_label,
                                     new_comment=new_comment,
                                     new_parent=new_parent if new_parent != "None" else None)
                                 save_checkpoint("Update class")
-                                st.session_state[f"edit_class_{cls['name']}"] = False
-                                show_message(f"Class '{current_name}' updated!", "success")
+                                st.session_state[f"edit_class_{cls_uid}"] = False
+                                show_message(f"Class updated!", "success")
                                 st.rerun()
 
             # Table view
@@ -536,62 +626,62 @@ def render_classes():
         if not classes:
             st.info("No classes to edit.")
         else:
-            # Build options with Label (name) format
+            # Build options with Label (disambiguated name) format; lookup is by URI
             class_options, class_lookup = build_class_options(classes)
             selected_display = st.selectbox("Select Class", options=class_options, key="edit_class_select")
-            selected_class = class_lookup.get(selected_display)
+            selected_uri = class_lookup.get(selected_display)
+            class_info = next((c for c in classes if c["uri"] == selected_uri), None) if selected_uri else None
 
-            if selected_class:
-                class_info = next((c for c in classes if c["name"] == selected_class), None)
+            if class_info:
+                selected_uid = _uid(class_info["uri"])
+                selected_class = class_info["name"]  # local-name shorthand for messaging
+                st.subheader(f"Edit: {selected_display}")
 
-                if class_info:
-                    st.subheader(f"Edit: {selected_class}")
+                with st.form("edit_class_form"):
+                    new_label = st.text_input("Label", value=class_info["label"])
+                    new_comment = st.text_area("Comment", value=class_info["comment"])
 
-                    with st.form("edit_class_form"):
-                        new_label = st.text_input("Label", value=class_info["label"])
-                        new_comment = st.text_area("Comment", value=class_info["comment"])
+                    other_classes = [c for c in class_names if c != selected_class]
+                    current_parent = class_info["parents"][0] if class_info["parents"] else "None"
+                    new_parent = st.selectbox("Parent Class",
+                                              options=["None"] + other_classes,
+                                              index=0 if current_parent == "None"
+                                              else (other_classes.index(current_parent) + 1
+                                                   if current_parent in other_classes else 0))
 
-                        other_classes = [c for c in class_names if c != selected_class]
-                        current_parent = class_info["parents"][0] if class_info["parents"] else "None"
-                        new_parent = st.selectbox("Parent Class",
-                                                  options=["None"] + other_classes,
-                                                  index=0 if current_parent == "None"
-                                                  else (other_classes.index(current_parent) + 1
-                                                       if current_parent in other_classes else 0))
+                    col1, col2 = st.columns(2)
+                    with col1:
+                        update_btn = st.form_submit_button("Update Class")
+                    with col2:
+                        delete_btn = st.form_submit_button("Delete Class", type="secondary")
 
-                        col1, col2 = st.columns(2)
-                        with col1:
-                            update_btn = st.form_submit_button("Update Class")
-                        with col2:
-                            delete_btn = st.form_submit_button("Delete Class", type="secondary")
+                    if update_btn:
+                        # Remove old parent if changed
+                        if class_info["parents"] and new_parent != class_info["parents"][0]:
+                            ont.update_class(class_info["uri"],
+                                             remove_parent=class_info["parents"][0])
 
-                        if update_btn:
-                            # Remove old parent if changed
-                            if class_info["parents"] and new_parent != class_info["parents"][0]:
-                                ont.update_class(selected_class,
-                                               remove_parent=class_info["parents"][0])
+                        ont.update_class(class_info["uri"],
+                                         new_label=new_label,
+                                         new_comment=new_comment,
+                                         new_parent=new_parent if new_parent != "None" else None)
+                        save_checkpoint("Update class")
+                        show_message(f"Class '{selected_display}' updated!", "success")
+                        st.rerun()
 
-                            ont.update_class(selected_class,
-                                           new_label=new_label,
-                                           new_comment=new_comment,
-                                           new_parent=new_parent if new_parent != "None" else None)
-                            save_checkpoint("Update class")
-                            show_message(f"Class '{selected_class}' updated!", "success")
-                            st.rerun()
+                    if delete_btn:
+                        st.session_state[f"confirm_delete_class_detail_{selected_uid}"] = True
+                        st.rerun()
 
-                        if delete_btn:
-                            st.session_state[f"confirm_delete_class_detail_{selected_class}"] = True
-                            st.rerun()
-
-                if confirm_delete(selected_class, "class", f"class_detail_{selected_class}"):
-                    ont.delete_class(selected_class)
+                if confirm_delete(class_info["uri"], "class", f"class_detail_{selected_uid}"):
+                    ont.delete_class(class_info["uri"])
                     save_checkpoint("Delete class")
-                    set_flash_message(f"Class '{selected_class}' deleted!", "success")
+                    set_flash_message(f"Class '{selected_display}' deleted!", "success")
                     st.rerun()
 
                 # Resource usages / backlinks
                 with st.expander("Show Usages"):
-                    usages = ont.get_resource_usages(selected_class)
+                    usages = ont.get_resource_usages(class_info["uri"])
                     if usages["inbound"]:
                         st.markdown("**Referenced by:**")
                         for u in usages["inbound"]:

--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ import traceback
 from datetime import datetime
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.2.1"
+APP_VERSION = "1.3.0"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -2156,7 +2156,7 @@ def render_import_export():
 
     ont = st.session_state.ontology
 
-    _ie_tabs = ["Import", "Export", "New Ontology", "Templates", "Upper Ontologies"]
+    _ie_tabs = ["Import", "Export", "New Ontology", "Templates", "Upper Ontologies", "Reference Ontologies"]
     _ie_tab = st.segmented_control("Section", _ie_tabs, default="Import",
                                    key="ie_active_tab", label_visibility="collapsed")
     if not _ie_tab:
@@ -2605,6 +2605,106 @@ def render_import_export():
             st.button("Load Upper Ontology", type="primary",
                       key="apply_upper_ontology_btn",
                       on_click=_on_load_upper_ontology, args=(upper,))
+
+    if _ie_tab == "Reference Ontologies":
+        from templates import (get_reference_ontology_names,
+                               get_reference_ontology,
+                               load_reference_ontology_module)
+
+        def _on_load_reference_ontology(ref):
+            selected_modules = []
+            for mod in ref["modules"]:
+                if st.session_state.get(f"ref_mod_{mod['name']}", False):
+                    selected_modules.append(mod)
+
+            if not selected_modules:
+                st.session_state["_ref_onto_err"] = "Select at least one module."
+                return
+
+            try:
+                mode = st.session_state.ref_apply_mode
+                with st.spinner(f"Loading {ref['name']}…"):
+                    first = True
+                    for mod in selected_modules:
+                        fmt = mod.get("format", "turtle")
+                        content = load_reference_ontology_module(mod)
+                        if first and mode == "Replace current":
+                            ont.load_from_string(content, fmt)
+                            first = False
+                        else:
+                            ont.merge_from_string(content, fmt)
+                mod_names = ", ".join(m["name"] for m in selected_modules)
+                save_checkpoint(
+                    f"Load reference ontology: {ref['name']} ({mod_names})"
+                )
+                s = ont.get_statistics()
+                st.session_state["_ref_onto_msg"] = (
+                    f"Loaded {ref['name']} ({mod_names})! "
+                    f"— {s['classes']} classes, {s['object_properties']} obj props, "
+                    f"{s['data_properties']} data props, {s['content_triples']} triples"
+                )
+            except Exception as e:
+                st.session_state["_ref_onto_err"] = (
+                    f"Error loading reference ontology: {str(e)}"
+                )
+
+        st.subheader("Reference Ontologies")
+        st.caption(
+            "Import widely-used domain and reference vocabularies into the "
+            "current ontology. Bundled vocabularies load instantly; remote "
+            "vocabularies are downloaded once on first use and cached locally."
+        )
+
+        if "_ref_onto_msg" in st.session_state:
+            st.success(st.session_state.pop("_ref_onto_msg"))
+        if "_ref_onto_err" in st.session_state:
+            st.error(st.session_state.pop("_ref_onto_err"))
+
+        ref_names = get_reference_ontology_names()
+        selected_ref = st.selectbox("Select Reference Ontology", ref_names,
+                                    key="reference_ontology_select")
+
+        if selected_ref:
+            ref = get_reference_ontology(selected_ref)
+            st.write(f"**{ref['name']}** v{ref['version']}")
+            st.write(ref["description"])
+            st.caption(f"License: {ref['license']} — Attribution: {ref['attribution']}")
+            if ref.get("url"):
+                st.caption(f"More info: {ref['url']}")
+
+            has_remote = any("url" in m for m in ref["modules"])
+            if has_remote:
+                st.caption(
+                    "📡 Source: downloaded on first use, cached locally. "
+                    "Requires network access on first load."
+                )
+            else:
+                st.caption("💾 Source: bundled with the application (offline-ready).")
+
+            st.write("**Modules:**")
+            for mod in ref["modules"]:
+                default_on = mod.get("required", False) or mod.get("default", False)
+                st.checkbox(
+                    f"**{mod['name']}** — {mod['description']}",
+                    value=default_on,
+                    disabled=mod.get("required", False),
+                    key=f"ref_mod_{mod['name']}",
+                )
+
+            st.radio(
+                "Apply Mode",
+                ["Merge into current", "Replace current"],
+                horizontal=True,
+                key="ref_apply_mode",
+            )
+
+            st.button(
+                "Load Reference Ontology",
+                type="primary",
+                key="apply_reference_ontology_btn",
+                on_click=_on_load_reference_ontology,
+                args=(ref,),
+            )
 
 
 def render_advanced():

--- a/app.py
+++ b/app.py
@@ -3230,11 +3230,19 @@ def render_visualization():
             issues = ont.validate()
             validation_subjects = {i["subject"] for i in issues}
 
-        # Class filter
+        # Class filter — reset to "all selected" whenever the ontology mutates
+        # (load, import, replace, undo) so a previously narrowed filter doesn't
+        # silently hide most of the newly loaded content.
         all_class_names = [c["name"] for c in classes] if classes else []
         all_class_set = set(all_class_names)
-        if "_viz_cfg_selected_classes" not in st.session_state:
+        current_mutation = st.session_state.get("_ont_mutation_count", 0)
+        last_seen_mutation = st.session_state.get("_viz_cfg_classes_at_mutation")
+        if (
+            "_viz_cfg_selected_classes" not in st.session_state
+            or last_seen_mutation != current_mutation
+        ):
             st.session_state["_viz_cfg_selected_classes"] = all_class_names
+            st.session_state["_viz_cfg_classes_at_mutation"] = current_mutation
         else:
             valid = [c for c in st.session_state["_viz_cfg_selected_classes"] if c in all_class_set]
             if not valid and all_class_names:

--- a/ontology_manager.py
+++ b/ontology_manager.py
@@ -485,7 +485,13 @@ class OntologyManager:
         self.graph.remove((None, None, class_uri))
 
     def get_classes(self) -> List[Dict[str, Any]]:
-        """Get all classes with their details."""
+        """Get all classes with their details.
+
+        Each entry includes both local-name lists (`parents`, `children`) and
+        URI lists (`parent_uris`, `child_uris`). The local-name lists keep
+        existing callers working; consumers that need to disambiguate across
+        namespaces (e.g. the graph visualizer) should use the URI lists.
+        """
         classes = []
         for class_uri in self.graph.subjects(RDF.type, OWL.Class):
             if isinstance(class_uri, BNode):
@@ -497,18 +503,22 @@ class OntologyManager:
                 "label": str(self.graph.value(class_uri, RDFS.label) or ""),
                 "comment": str(self.graph.value(class_uri, RDFS.comment) or ""),
                 "parents": [],
-                "children": []
+                "parent_uris": [],
+                "children": [],
+                "child_uris": [],
             }
 
             # Get parent classes
             for parent in self.graph.objects(class_uri, RDFS.subClassOf):
                 if isinstance(parent, URIRef):
                     class_info["parents"].append(self._local_name(parent))
+                    class_info["parent_uris"].append(str(parent))
 
             # Get child classes
             for child in self.graph.subjects(RDFS.subClassOf, class_uri):
                 if isinstance(child, URIRef):
                     class_info["children"].append(self._local_name(child))
+                    class_info["child_uris"].append(str(child))
 
             classes.append(class_info)
 
@@ -889,7 +899,9 @@ class OntologyManager:
                 "label": str(self.graph.value(prop_uri, RDFS.label) or ""),
                 "comment": str(self.graph.value(prop_uri, RDFS.comment) or ""),
                 "domain": "",
+                "domain_uri": "",
                 "range": "",
+                "range_uri": "",
                 "characteristics": []
             }
 
@@ -901,6 +913,7 @@ class OntologyManager:
                         break
             if domain and isinstance(domain, URIRef):
                 prop_info["domain"] = self._local_name(domain)
+                prop_info["domain_uri"] = str(domain)
 
             range_ = self.graph.value(prop_uri, RDFS.range)
             if not range_ or not isinstance(range_, URIRef):
@@ -910,6 +923,7 @@ class OntologyManager:
                         break
             if range_ and isinstance(range_, URIRef):
                 prop_info["range"] = self._local_name(range_)
+                prop_info["range_uri"] = str(range_)
 
             # Check characteristics
             if (prop_uri, RDF.type, OWL.FunctionalProperty) in self.graph:
@@ -948,6 +962,7 @@ class OntologyManager:
                 "label": str(self.graph.value(prop_uri, RDFS.label) or ""),
                 "comment": str(self.graph.value(prop_uri, RDFS.comment) or ""),
                 "domain": "",
+                "domain_uri": "",
                 "range": "",
                 "functional": False
             }
@@ -960,6 +975,7 @@ class OntologyManager:
                         break
             if domain and isinstance(domain, URIRef):
                 prop_info["domain"] = self._local_name(domain)
+                prop_info["domain_uri"] = str(domain)
 
             range_ = self.graph.value(prop_uri, RDFS.range)
             if range_:

--- a/ontology_manager.py
+++ b/ontology_manager.py
@@ -1756,7 +1756,12 @@ class OntologyManager:
             self.graph.remove((class1_uri, relation, class2_uri))
 
     def get_class_relations(self, class_name: str = None) -> List[Dict[str, str]]:
-        """Get all class relations, optionally filtered by class."""
+        """Get all class relations, optionally filtered by class.
+
+        Each result dict includes both local names (subject/object) and full
+        URIs (subject_uri/object_uri) so callers can disambiguate when local
+        names collide across namespaces.
+        """
         relations = []
         for rel_name, rel_pred in self.CLASS_RELATIONS.items():
             for subj, obj in self.graph.subject_objects(rel_pred):
@@ -1766,8 +1771,10 @@ class OntologyManager:
                     if class_name is None or class_name in [subj_name, obj_name]:
                         relations.append({
                             "subject": subj_name,
+                            "subject_uri": str(subj),
                             "relation": rel_name,
-                            "object": obj_name
+                            "object": obj_name,
+                            "object_uri": str(obj),
                         })
         return relations
 
@@ -1788,7 +1795,10 @@ class OntologyManager:
             self.graph.remove((prop1_uri, relation, prop2_uri))
 
     def get_property_relations(self, prop_name: str = None) -> List[Dict[str, str]]:
-        """Get all property relations, optionally filtered by property."""
+        """Get all property relations, optionally filtered by property.
+
+        Each result dict includes both local names and full URIs.
+        """
         relations = []
         for rel_name, rel_pred in self.PROPERTY_RELATIONS.items():
             for subj, obj in self.graph.subject_objects(rel_pred):
@@ -1798,8 +1808,10 @@ class OntologyManager:
                     if prop_name is None or prop_name in [subj_name, obj_name]:
                         relations.append({
                             "subject": subj_name,
+                            "subject_uri": str(subj),
                             "relation": rel_name,
-                            "object": obj_name
+                            "object": obj_name,
+                            "object_uri": str(obj),
                         })
         return relations
 
@@ -1820,7 +1832,10 @@ class OntologyManager:
             self.graph.remove((ind1_uri, relation, ind2_uri))
 
     def get_individual_relations(self, ind_name: str = None) -> List[Dict[str, str]]:
-        """Get all individual relations (sameAs, differentFrom)."""
+        """Get all individual relations (sameAs, differentFrom).
+
+        Each result dict includes both local names and full URIs.
+        """
         relations = []
         for rel_name, rel_pred in self.INDIVIDUAL_RELATIONS.items():
             for subj, obj in self.graph.subject_objects(rel_pred):
@@ -1830,8 +1845,10 @@ class OntologyManager:
                     if ind_name is None or ind_name in [subj_name, obj_name]:
                         relations.append({
                             "subject": subj_name,
+                            "subject_uri": str(subj),
                             "relation": rel_name,
-                            "object": obj_name
+                            "object": obj_name,
+                            "object_uri": str(obj),
                         })
         return relations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.2.1"
+version = "1.3.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/samples/gufo/LICENSE-CC-BY-4.0.txt
+++ b/samples/gufo/LICENSE-CC-BY-4.0.txt
@@ -1,0 +1,398 @@
+Copyright (c) 2020 João Paulo A. Almeida, Giancarlo Guizzardi, Tiago Sales, Ricardo Falbo
+
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/samples/gufo/gufo.ttl
+++ b/samples/gufo/gufo.ttl
@@ -1,0 +1,1474 @@
+@prefix : <http://purl.org/nemo/gufo#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix gufo: <http://purl.org/nemo/gufo#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@base <http://purl.org/nemo/gufo#> .
+
+<http://purl.org/nemo/gufo#> rdf:type owl:Ontology ;
+                              owl:versionIRI <http://purl.org/nemo/gufo#/1.0.0> ;
+                              owl:versionInfo "1.0.0"@en ;
+                              dc:creator "Almeida, João Paulo A." ,
+                                         "Falbo, Ricardo A." ,
+                                         "Guizzardi, Giancarlo" ,
+                                         "Sales, Tiago P." ;
+                              dc:title "gUFO: A Lightweight Implementation of the Unified Foundational Ontology (UFO)"@en ;
+                              dct:bibliographicCitation "J. P. A. Almeida, G. Guizzardi, T. P. Sales, R. A. Falbo, \"gUFO: A Lightweight Implementation of the Unified Foundational Ontology (UFO)\", 2019, http://purl.org/nemo/doc/gufo"@en ;
+                              dct:created "2019-11-11"^^xsd:date ;
+                              dct:modified "2021-11-01"^^xsd:date ;
+                              dct:license <https://creativecommons.org/licenses/by/4.0/legalcode> ;
+                              vann:preferredNamespacePrefix "gufo"@en ;
+                              vann:preferredNamespaceUri "http://purl.org/nemo/gufo#"^^xsd:anyURI ;
+                              rdfs:comment """The objective of gUFO is to provide a lightweight implementation of the Unified Foundational Ontology (UFO) [1-5] suitable for Semantic Web OWL 2 DL applications. 
+
+Intended users are those implementing UFO-based lightweight ontologies that reuse gUFO by specializing and instantiating its elements.
+
+There are three implications of the use of the term lightweight. First of all, we have employed little expressive means in an effort to retain computational properties for the resulting OWL ontology. Second, we have selected a subset of UFO-A [1, 2] and UFO-B [3] to include here. In particular, there is minimalistic support for UFO-B (only that which is necessary to establish the participation of objects in events and to capture historical dependence between events). Third, a lightweight ontology, differently from a reference ontology, is designed with the purpose of providing an implementation artifact to structure a knowledge base (or knowledge graph). This has driven a number of pragmatic implementation choices which are discussed in comments annotated to the various elements of this implementation. 
+
+The 'g' in gUFO stands for gentle. At the same time, \"gufo\" is the Italian word for \"owl\".
+
+For background information on the reference ontology on which this implementation is based, see: 
+
+1. G. Guizzardi, G. Wagner, J. P. A. Almeida, R. S. S. Guizzardi, “Towards ontological foundations for conceptual modeling: The unified foundational ontology (UFO) story,” Applied Ontology (Online), vol. 10, p. 259–271, 2015. <http://dx.doi.org/10.3233/ao-150157>
+2. G. Guizzardi, Ontological Foundations for Structural Conceptual Models,
+PhD Thesis, University of Twente, The Netherlands, 2005. <https://research.utwente.nl/en/publications/ontological-foundations-for-structural-conceptual-models>
+3. G. Guizzardi, G. Wagner, R. A. Falbo, R. S. S. Guizzardi, and J. P. A. Almeida, “Towards Ontological Foundations for the Conceptual Modeling of Events,” in Proc. 32th International Conference, ER 2013, 2013, p. 327–341. <https://doi.org/10.1007/978-3-642-41924-9_27>
+4. G. Guizzardi, C. M. Fonseca, A. B. Benevides, J. P. A. Almeida, D. Porello, T. P. Sales, “Endurant Types in Ontology-Driven Conceptual Modeling: Towards OntoUML 2.0,” in Conceptual Modeling – 37th International Conference, ER 2018, 2018, p. 136–150. <https://doi.org/10.1007/978-3-030-00847-5_12>
+5. C. M. Fonseca, D. Porello, G. Guizzardi, J. P. A. Almeida, and N. Guarino, “Relations in ontology-driven conceptual modeling,” in 38th International Conference on Conceptual Modeling (ER 2019), LNCS, 2019. v. 11788, 2019, p. 1–15. <http://dx.doi.org/10.1007/978-3-030-33223-5_4>
+
+Cite this work as: 
+
+J. P. A. Almeida, G. Guizzardi, T. P. Sales, R. A. Falbo, \"gUFO: A Lightweight Implementation of the Unified Foundational Ontology (UFO)\", 2019, http://purl.org/nemo/doc/gufo
+
+This work is distributed under Creative Commons Attribution License CC BY 4.0 <https://creativecommons.org/licenses/by/4.0/legalcode>.
+
+For the source repository, see: <https://github.com/nemo-ufes/gufo>"""@en .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/elements/1.1/creator
+dc:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+dc:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/bibliographicCitation
+dct:bibliographicCitation rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/created
+dct:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+dct:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/modified
+dct:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+vann:preferredNamespacePrefix rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceUri
+vann:preferredNamespaceUri rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Datatypes
+#################################################################
+
+###  http://www.w3.org/2001/XMLSchema#date
+xsd:date rdf:type rdfs:Datatype .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://purl.org/nemo/gufo#broughtAbout
+gufo:broughtAbout rdf:type owl:ObjectProperty ;
+                  rdfs:domain gufo:Event ;
+                  rdfs:range gufo:Situation ;
+                  rdfs:comment """Identifies a gufo:Situation that is brought about by the gufo:Event.
+
+Guizzardi et al. (2013) included a notion of \"brings-about\" that related events to a single (\"maximal\") situation, embodying all the effects of the event at the time it ends. This implementation of gufo:broughtAbout diverges from \"brings-about\" in that work because gufo:broughtAbout can be used to relate events to more than one gufo:Situation. Each gufo:Situation identified through gufo:broughtAbout should be understood as an (improper) part of the maximal situation."""@en ;
+                  rdfs:label "broughtAbout"@en .
+
+
+###  http://purl.org/nemo/gufo#categorizes
+gufo:categorizes rdf:type owl:ObjectProperty ;
+                 rdfs:domain [ owl:intersectionOf ( gufo:Type
+                                                    [ rdf:type owl:Class ;
+                                                      owl:complementOf gufo:AbstractIndividualType
+                                                    ]
+                                                    [ rdf:type owl:Class ;
+                                                      owl:complementOf gufo:ConcreteIndividualType
+                                                    ]
+                                                  ) ;
+                               rdf:type owl:Class
+                             ] ;
+                 rdfs:range gufo:Type ;
+                 rdfs:comment """Identifies a gufo:Type whose instances may be classified by instances of the categorizing higher-order type.
+
+For example, \"ShipType\" gufo:categorizes \"Ship\". Instances of \"ShipType\" such as \"Supercarrier\" and \"Cargoship\" should be declared subclasses of \"Ship\". OWL 2 punning should be used to capture the two facets of \"Supercarrier\" and \"Cargoship\" in this example: (i) as instances of \"ShipType\", and (ii) as subclasses of \"Ship\".
+
+The categorized type is termed the \"base type\" in the \"powertype pattern\" see Carvalho et al (2017), the higher-order type is often called the \"powertype\".  
+
+gufo:categorizes is the general (unspecific) form of categorization. See  gufo:partitions for a more specific form, in which instances of the categorized type are classified by exactly one instance of the higher-order type. 
+
+The domain is gufo:Type excluding gufo:AbstractIndividualType as well as gufo:ConcreteIndividualTypes because those types are first-order types (their instances are individuals). Only instances of gufo:Type representing higher-order types can categorize a base type.
+
+For further details and formalization of \"categorization\", see Carvalho et al (2017) which combines UFO with MLT (a multi-level modeling theory).  
+
+V. A. Carvalho, J. P. A. Almeida, C. M. Fonseca, and G. Guizzardi, “Multi-level ontology-based conceptual modeling,” Data & Knowledge Engineering, vol. 109, p. 3–24, 2017. <http://dx.doi.org/10.1016/j.datak.2017.03.002>"""@en ;
+                 rdfs:label "categorizes"@en .
+
+
+###  http://purl.org/nemo/gufo#concernsConstitutedEndurant
+gufo:concernsConstitutedEndurant rdf:type owl:ObjectProperty ;
+                                 rdfs:domain gufo:TemporaryConstitutionSituation ;
+                                 rdfs:range gufo:Endurant ;
+                                 rdfs:comment "Identifies the constituted gufo:Endurant in the gufo:TemporaryConstitutionSituation."@en ;
+                                 rdfs:label "concernsConstitutedEndurant"@en .
+
+
+###  http://purl.org/nemo/gufo#concernsNonRigidType
+gufo:concernsNonRigidType rdf:type owl:ObjectProperty ,
+                                   owl:FunctionalProperty ;
+                          rdfs:domain gufo:TemporaryInstantiationSituation ;
+                          rdfs:range gufo:NonRigidType ;
+                          rdfs:comment "Identifies the gufo:NonRigidType that is instantiated by the endurant that stands in a gufo:TemporaryInstantiationSituation."@en ;
+                          rdfs:label "concernsNonRigidType"@en .
+
+
+###  http://purl.org/nemo/gufo#concernsQualityType
+gufo:concernsQualityType rdf:type owl:ObjectProperty ,
+                                  owl:FunctionalProperty ;
+                         rdfs:domain gufo:QualityValueAttributionSituation ;
+                         rdfs:range gufo:EndurantType ;
+                         rdfs:comment "Identifies the quality type (a gufo:EndurantType subclassing gufo:Quality) whose value is attributed in the gufo:QualityValueAttributionSituation."@en ;
+                         rdfs:label "concernsQualityType"@en .
+
+
+###  http://purl.org/nemo/gufo#concernsReifiedQualityValue
+gufo:concernsReifiedQualityValue rdf:type owl:ObjectProperty ,
+                                          owl:FunctionalProperty ;
+                                 rdfs:domain gufo:QualityValueAttributionSituation ;
+                                 rdfs:range gufo:QualityValue ;
+                                 rdfs:comment gufo:concernsQualityValue ,
+                                              "Identifies the gufo:QualityValue (i.e., the reified quality value) associated with the endurant that stands in the gufo:QualityValueAttributionSituation."@en ;
+                                 rdfs:label "concernsReifiedQualityValue"@en .
+
+
+###  http://purl.org/nemo/gufo#concernsRelatedEndurant
+gufo:concernsRelatedEndurant rdf:type owl:ObjectProperty ,
+                                      owl:FunctionalProperty ;
+                             rdfs:domain gufo:TemporaryRelationshipSituation ;
+                             rdfs:range gufo:Endurant ;
+                             rdfs:comment "Identifies the related gufo:Endurant in the gufo:TemporaryRelationshipSituation."@en ;
+                             rdfs:label "concernsRelatedEndurant"@en .
+
+
+###  http://purl.org/nemo/gufo#concernsRelationshipType
+gufo:concernsRelationshipType rdf:type owl:ObjectProperty ,
+                                       owl:FunctionalProperty ;
+                              rdfs:domain gufo:TemporaryRelationshipSituation ;
+                              rdfs:range gufo:RelationshipType ;
+                              rdfs:comment "Identifies the gufo:RelationshipType instantiated in the gufo:TemporaryRelationshipSituation."@en ;
+                              rdfs:label "concernsRelationshipType"@en .
+
+
+###  http://purl.org/nemo/gufo#concernsTemporaryWhole
+gufo:concernsTemporaryWhole rdf:type owl:ObjectProperty ,
+                                     owl:FunctionalProperty ;
+                            rdfs:domain gufo:TemporaryParthoodSituation ;
+                            rdfs:range gufo:Endurant ;
+                            rdfs:comment "Identifies the whole (a gufo:Endurant) of which the endurant that stands in the gufo:TemporaryParthoodSituation is part."@en ;
+                            rdfs:label "concernsTemporaryWhole"@en .
+
+
+###  http://purl.org/nemo/gufo#constitutes
+gufo:constitutes rdf:type owl:ObjectProperty ;
+                 rdfs:domain gufo:ConcreteIndividual ;
+                 rdfs:range gufo:ConcreteIndividual ;
+                 rdfs:comment """Identifies a gufo:ConcreteIndividual that is constituted (partially) by the constituent individual.
+
+For example, the gufo:Collection of persons whose members are John, Paul, George, Ringo constituted the beatles, the gufo:Quantity of marble that constitutes the statue of Venus de Milo, and the gufo:Event of Paul raising his arm in a meeting that constitutes his voting (also a gufo:Event).
+
+In case constitution changes in time, see gufo:standsInQualifiedConstitution."""@en ;
+                 rdfs:label "constitutes"@en ;
+                 rdfs:seeAlso gufo:standsInQualifiedConstitution .
+
+
+###  http://purl.org/nemo/gufo#contributedToTrigger
+gufo:contributedToTrigger rdf:type owl:ObjectProperty ;
+                          rdfs:domain gufo:Situation ;
+                          rdfs:range gufo:Event ;
+                          rdfs:comment """Identifies a gufo:Event that the gufo:Situation contributed to trigger.
+
+Guizzardi et al. (2013) defined a notion of \"triggers\" to relate the situation satisfying all the sufficient and necessary conditions with the triggered  event. This implementation differs from  \"triggers\" as defined in that work because gufo:contributedToTrigger can be used to relate more than one gufo:Situation to a gufo:Event. Each gufo:Situation identified through gufo:contributedToTrigger should be understood as an (improper) part of the situation that triggered the event."""@en ;
+                          rdfs:label "contributedToTrigger"@en .
+
+
+###  http://purl.org/nemo/gufo#externallyDependsOn
+gufo:externallyDependsOn rdf:type owl:ObjectProperty ,
+                                  owl:IrreflexiveProperty ;
+                         rdfs:domain gufo:ExtrinsicMode ;
+                         rdfs:range gufo:Endurant ;
+                         rdfs:comment """Identifies a gufo:Endurant on which the gufo:ExtrinsicMode depends.
+
+For example, John's duty to return the book he borrowed from Mary (a gufo:ExtrinsicMode) depends externally on Mary.
+
+The identifed gufo:Endurant should  be external to the bearer of the extrinsic mode (see Guizzardi, 2005, p. 239). In other words, the identified endurant should not be a part or an intrisic aspect of the bearer of the extrinsic mode."""@en ;
+                         rdfs:label "externallyDependsOn"@en .
+
+
+###  http://purl.org/nemo/gufo#hasAssociatedQualityValueType
+gufo:hasAssociatedQualityValueType rdf:type owl:ObjectProperty ;
+                                   rdfs:domain gufo:EndurantType ;
+                                   rdfs:range gufo:AbstractIndividualType ;
+                                   rdfs:comment """Identifies a quality value type to which the quality type is associated. 
+
+For example, a \"Color\" quality type may be associated with a \"ColorValueInRGB\" quality value type.
+
+It relates a specialization of gufo:Quality (an instance of gufo:EndurantType) to a specialization of gufo:QualityValue  (an instance of gufo:AbstractIndividualType).
+
+To be used only when quality values are reified."""@en ;
+                                   rdfs:label "hasAssociatedQualityValueType"@en .
+
+
+###  http://purl.org/nemo/gufo#hasBeginPoint
+gufo:hasBeginPoint rdf:type owl:ObjectProperty ;
+                   rdfs:domain gufo:ConcreteIndividual ;
+                   rdfs:range time:Instant ;
+                   rdfs:comment """Identifies the begin point for a gufo:ConcreteIndividual, in the case in which time instants are reified. 
+
+In the case of endurants, this identifies the time point when the endurant comes into existence. In the case of events, this identifies the time point when the event starts to take place. In the case of situation, this identifies the time point when the situation begins to hold.
+
+If time instants are not reified, use gufo:hasBeginPointInXSDDate or gufo:hasBeginPointInXSDDateTimeStamp."""@en ;
+                   rdfs:label "hasBeginPoint"@en ;
+                   rdfs:seeAlso gufo:hasBeginPointInXSDDate ,
+                                gufo:hasBeginPointInXSDDateTimeStamp .
+
+
+###  http://purl.org/nemo/gufo#hasEndPoint
+gufo:hasEndPoint rdf:type owl:ObjectProperty ;
+                 rdfs:domain gufo:ConcreteIndividual ;
+                 rdfs:range time:Instant ;
+                 rdfs:comment """Identifies the end point for a gufo:ConcreteIndividual, in the case in which time instants are reified.
+
+In the case of endurants, this identifies the time point when the endurant ceases to exist. In the case of events, this identifies the time point when the event ends. In the case of situation, this identifies the time point when the situation ceases to hold."""@en ;
+                 rdfs:label "hasEndPoint"@en ;
+                 rdfs:seeAlso gufo:hasEndPointInXSDDate ,
+                              gufo:hasEndPointInXSDDateTimeStamp .
+
+
+###  http://purl.org/nemo/gufo#hasReifiedQualityValue
+gufo:hasReifiedQualityValue rdf:type owl:ObjectProperty ;
+                            rdfs:domain gufo:ConcreteIndividual ;
+                            rdfs:range gufo:QualityValue ;
+                            rdfs:comment """Identifies an instance of gufo:QualityValue to reflect the perception or conception of a quality in a certain value space. 
+
+Use this property only for quality values that are to be reified in the A-box and associated with a gufo:ConcreteIndividual. Otherwise, use the gufo:hasQualityValue data property and a literal to determine the quality value.
+
+The full representation pattern for quality values involves first identifying a gufo:Quality that inheres in a concrete individual and then associating it with a reified quality value. For example, let us consider the color of Yves Klein's \"Blue Monochrome\" painting made in 1961 (MoMA's object with number 618.1967). In the full pattern, an instance of gufo:Quality that inheres in the physical object (the color of that painting) is associated with a gufo:QualityValue (say the triplet <0, 47, 167> for that painting) through gufo:hasReifiedQualityValue. The full pattern is recommended when different quality spaces are expected to be used for the same quality. For example, the color of that painting could also be associated with a quadruple <100, 72, 0, 35> representing the same color in a CMYK space.
+
+When the full pattern is not required, gufo:hasReifiedQualityValue can also be used to directly associate a concrete individual (without identifying the quality) with a quality value."""@en ;
+                            rdfs:label "hasReifiedQualityValue"@en ;
+                            rdfs:seeAlso gufo:hasQualityValue .
+
+
+###  http://purl.org/nemo/gufo#historicallyDependsOn
+gufo:historicallyDependsOn rdf:type owl:ObjectProperty ,
+                                    owl:TransitiveProperty ;
+                           rdfs:domain gufo:ConcreteIndividual ;
+                           rdfs:range gufo:ConcreteIndividual ;
+                           rdfs:comment """Identifies a gufo:ConcreteIndividual on which the concrete individual depends historically. 
+
+For example, a person is historically dependent on his/her ancestors.
+
+When used between events, historical dependence encompasses causation (when the event is caused by the other), but also other cases where there is dependence but not causation (when the event brings about a situation that is either insufficient or more than sufficient to trigger the historically dependent event).
+
+For example, Real Madrid's goal in the 60th minute of the 2016 FIFA Club World Cup Final is historically dependent on (and in this case caused by) a penalty kick by Cristiano Ronaldo. The penalty kick itself is historically dependent on (but not caused by) a penalty (the occurrence of the penalty is necessary but not sufficient to cause the penalty kick as authorization of the referee is required). 
+
+Historical dependence is transitive. Hence, in the example above, Real Madrid's goal is historically dependent on the penalty."""@en ;
+                           rdfs:label "historicallyDependsOn"@en .
+
+
+###  http://purl.org/nemo/gufo#inheresIn
+gufo:inheresIn rdf:type owl:ObjectProperty ,
+                        owl:FunctionalProperty ,
+                        owl:AsymmetricProperty ,
+                        owl:IrreflexiveProperty ;
+               rdfs:domain gufo:Aspect ;
+               rdfs:range gufo:ConcreteIndividual ;
+               rdfs:comment """Identifies the gufo:ConcreteIndividual in which the gufo:Aspect inheres. Inherence is a sort of existential dependence. The identified concrete individual is the \"bearer\" of the aspect.
+
+For example, the color of an object inheres in the object and the average speed of a flight inheres in the flight."""@en ;
+               rdfs:label "inheresIn"@en .
+
+
+###  http://purl.org/nemo/gufo#isAspectProperPartOf
+gufo:isAspectProperPartOf rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf gufo:isProperPartOf ;
+                          rdf:type owl:TransitiveProperty ;
+                          rdfs:domain gufo:Aspect ;
+                          rdfs:range gufo:Aspect ;
+                          rdfs:comment """Identifies a gufo:Aspect of which the aspect is a proper part.
+
+For example, John's obligations towards Mary in the scope of their marriage is an aspect proper part of their marriage  (and same can be said of Mary's extrinsic aspects in the scope of their marriage.)
+
+This property can be used to represent the composition of a relator from extrisinc aspects, but also to represent complex extrisinc aspects.
+
+gufo:isAspectProperPartOf is transitive."""@en ;
+                          rdfs:label "isAspectProperPartOf"@en .
+
+
+###  http://purl.org/nemo/gufo#isCollectionMemberOf
+gufo:isCollectionMemberOf rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf gufo:isObjectProperPartOf ;
+                          rdfs:domain gufo:Object ;
+                          rdfs:range gufo:Collection ;
+                          rdfs:comment """Identifies a gufo:Collection of which the object is a member. 
+
+This is the relation between John and a group of persons, and between a cow and its herd.
+
+gufo:isCollectionMemberOf is intransitive (Guizzardi, 2005, p. 185).
+
+For membership in a gufo:VariableCollection, see gufo:standsInQualifiedParthood."""@en ;
+                          rdfs:label "isCollectionMemberOf"@en ;
+                          rdfs:seeAlso gufo:standsInQualifiedParthood .
+
+
+###  http://purl.org/nemo/gufo#isComponentOf
+gufo:isComponentOf rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf gufo:isObjectProperPartOf ;
+                   rdfs:domain gufo:Object ;
+                   rdfs:range gufo:FunctionalComplex ;
+                   rdfs:comment """Identifies a gufo:FunctionalComplex of which the object is a component.
+
+For example, the habitation module is a component of the International Space Station, and so are each of the solar panels; Obama's brain is a component of his body, and so is his heart; the engine is a component of the HMS Queen Elizabeth (R08).
+
+gufo:isComponentOf is not transitive in the general case. Particular sub-properties may be transitive (Guizzardi, 2005, p. 183).
+
+When a component may change its relation to be whole, see gufo:standsInQualifiedParthood."""@en ;
+                   rdfs:label "isComponentOf"@en ;
+                   rdfs:seeAlso gufo:standsInQualifiedParthood .
+
+
+###  http://purl.org/nemo/gufo#isDerivedFrom
+gufo:isDerivedFrom rdf:type owl:ObjectProperty ;
+                   rdfs:domain [ rdf:type owl:Class ;
+                                 owl:unionOf ( gufo:ComparativeRelationshipType
+                                               gufo:MaterialRelationshipType
+                                             )
+                               ] ;
+                   rdfs:range gufo:EndurantType ;
+                   rdfs:comment """Identifies a gufo:EndurantType from which the material or comparative relation can be derived. The identified gufo:EndurantType should be a subclass of gufo:Aspect, more specifically a subclass of gufo:ExtrinsicAspect in the case of a gufo:MaterialRelationshipType, and a subclass of gufo:IntrinsicAspect in the case of a gufo:ComparativeRelationshipType.
+
+For example, \"marriedWith\" can be derived from \"Marriage\", \"heavierThan\" can be derived from \"Weight\".
+
+See Fonseca et al. (2019)."""@en ;
+                   rdfs:label "isDerivedFrom"@en .
+
+
+###  http://purl.org/nemo/gufo#isEventProperPartOf
+gufo:isEventProperPartOf rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf gufo:isProperPartOf ;
+                         rdf:type owl:TransitiveProperty ;
+                         rdfs:domain gufo:Event ;
+                         rdfs:range gufo:Event ;
+                         rdfs:comment """Identifies a gufo:Event of which the event is part. 
+
+For example, Cristiano Ronaldo's penalty kick is an event proper part of the 2016 FIFA Club World Cup Final, having ocurred in the 60th minute of that match. That match is itself an event proper part of the 2016 FIFA Club World Cup.
+
+The match can be decomposed in different ways. For example, we can identify the participation of each player in the match (instances of gufo:Participation that are proper parts of the match) or decomposed the match using some temporal segmentation (each minute of the match, each of which is a proper part of the match).
+
+gufo:isEventProperPartOf is transitive."""@en ;
+                         rdfs:label "isEventProperPartOf"@en .
+
+
+###  http://purl.org/nemo/gufo#isObjectProperPartOf
+gufo:isObjectProperPartOf rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf gufo:isProperPartOf ;
+                          rdf:type owl:TransitiveProperty ;
+                          rdfs:domain gufo:Object ;
+                          rdfs:range gufo:Object ;
+                          rdfs:comment """Identifies a gufo:Object of which the object is a part.
+
+This is a general parthood relation between objects. Use the various sub-properties provided in order to represent specific types of parthood, each of which has specialized semantics (and different formal properties in this implementation, in particular, transitivity (Guizzardi, 2005, section 5.6)."""@en ;
+                          rdfs:label "isObjectProperPartOf"@en .
+
+
+###  http://purl.org/nemo/gufo#isProperPartOf
+gufo:isProperPartOf rdf:type owl:ObjectProperty ,
+                             owl:TransitiveProperty ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range owl:Thing ;
+                    rdfs:comment """Identifies a whole of which the entity is a proper part.
+
+gufo:isProperPartOf is the most generic parthood relation in this implementation. Use the various sub-properties provided in order to represent specific types of parthood.
+
+Proper parthood (and each of its sub-properties) is asymmetric and irreflexive. Nevertheless, these characteristics are not declared in this implementation since that would violate rules of OWL 2 DL that guarantee decidability of reasoning. Instead, we have focused only on declaring transitivity where applicable.
+
+Note that gufo:isProperPartOf (as the most general notion of parthood) is transitive, although the various sub-properties may not be transitive."""@en ;
+                    rdfs:label "isProperPartOf"@en .
+
+
+###  http://purl.org/nemo/gufo#isSituationProperPartOf
+gufo:isSituationProperPartOf rdf:type owl:ObjectProperty ;
+                             rdfs:subPropertyOf gufo:isProperPartOf ;
+                             rdfs:domain gufo:Situation ;
+                             rdfs:range gufo:Situation ;
+                             rdfs:comment """Identifies a gufo:Situation of which the situation is a part.
+
+Examples include: the situation in which John has influenza is part of the situation in which John has influenza and he is tired; the situation in which John is friends with Mary is part of the situation in which he is friends with Mary and Alice; the situation in which John is married to Alice is part of the situation in which John is married to Alice, while she works at the Free University of Bozen-Bolzano."""@en ;
+                             rdfs:label "isSituationProperPartOf"@en .
+
+
+###  http://purl.org/nemo/gufo#isSubCollectionOf
+gufo:isSubCollectionOf rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf gufo:isObjectProperPartOf ;
+                       rdf:type owl:TransitiveProperty ;
+                       rdfs:domain gufo:Collection ;
+                       rdfs:range gufo:Collection ;
+                       rdfs:comment """Identifies a gufo:Collection of which the collection is a sub-collection. All members of the sub-collection are members of the identified super-collection.
+
+gufo:isSubCollectionOf is transitive (Guizzardi, 2005, p. 186).
+
+For parthood involving one or more varied collections, see gufo:standsInQualifiedParthood."""@en ;
+                       rdfs:label "isSubCollectionOf"@en ;
+                       rdfs:seeAlso gufo:standsInQualifiedParthood .
+
+
+###  http://purl.org/nemo/gufo#isSubQuantityOf
+gufo:isSubQuantityOf rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf gufo:isObjectProperPartOf ;
+                     rdf:type owl:TransitiveProperty ;
+                     rdfs:domain gufo:Quantity ;
+                     rdfs:range gufo:Quantity ;
+                     rdfs:comment """Identifies a gufo:Quantity of which the quantity is a part.
+
+For example, the quantity of water in a wine glass is a sub-quantity of the wine in that glass.
+
+gufo:isSubQuantityOf is transitive (Guizzardi, 2005, p. 184).
+
+Sub-quantities are always essential parts of their wholes. Thus, gufo:standsInQualifiedParthood is not applicable for sub-quantities."""@en ;
+                     rdfs:label "isSubQuantityOf"@en .
+
+
+###  http://purl.org/nemo/gufo#manifestedIn
+gufo:manifestedIn rdf:type owl:ObjectProperty ;
+                  rdfs:domain gufo:Aspect ;
+                  rdfs:range gufo:Event ;
+                  rdfs:comment """Identifies a gufo:Event in which the gufo:Aspect is manifested.
+
+For example, the passing of an electrical current in a conductor is an event that encompasses the manifestation of an aspect inhering in a copper wire (the wire's  electrical conductivity)."""@en ;
+                  rdfs:label "manifestedIn"@en .
+
+
+###  http://purl.org/nemo/gufo#mediates
+gufo:mediates rdf:type owl:ObjectProperty ,
+                       owl:AsymmetricProperty ,
+                       owl:IrreflexiveProperty ;
+              rdfs:domain gufo:Relator ;
+              rdfs:range gufo:Endurant ;
+              rdfs:comment """Identifies the endurants mediated by a gufo:Relator.
+
+For example, John and Mary's marriage mediates John and Mary."""@en ;
+              rdfs:label "mediates"@en .
+
+
+###  http://purl.org/nemo/gufo#participatedIn
+gufo:participatedIn rdf:type owl:ObjectProperty ;
+                    rdfs:domain gufo:Object ;
+                    rdfs:range gufo:Event ;
+                    rdfs:comment """Identifies a gufo:Event in which the gufo:Object participated.
+
+Examples include the participation of Freddy Mercury in Queen's Live Aid Concert and the participation of an airplane in a flight."""@en ;
+                    rdfs:label "participatedIn"@en .
+
+
+###  http://purl.org/nemo/gufo#partitions
+gufo:partitions rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf gufo:categorizes ;
+                rdfs:domain [ owl:intersectionOf ( gufo:Type
+                                                   [ rdf:type owl:Class ;
+                                                     owl:complementOf gufo:AbstractIndividualType
+                                                   ]
+                                                   [ rdf:type owl:Class ;
+                                                     owl:complementOf gufo:ConcreteIndividualType
+                                                   ]
+                                                 ) ;
+                              rdf:type owl:Class
+                            ] ;
+                rdfs:comment """Identifies a gufo:Type whose instances are classified by exactly one instance of the partitioning higher-order type.
+
+For example, \"AnimalSpecies\" gufo:partitions \"Animal\". Instances of \"AnimalSpecies\" such as \"Lion\", \"Hiena\" must be disjoint subclasses of \"Animal\". OWL 2 punning should be used to capture the two facets of \"Lion\" and \"Hiena\" in this example: (i) as instances of \"AnimalSpecies\", and (ii) as  subclasses of \"Animal\".
+
+Note that the partitioned type (in the example \"Animal\") may or may not be declared to be a disjoint union of the explicitly enumerated subclasses (such as \"Lion\", \"Hiena\"). This is because other instances of the higher-order type (\"AnimalSpecies\") may exist that are not explicitly enumerated in the ontology.
+
+The partitioned type is termed the \"base type\" in the \"powertype pattern\" see Carvalho et al (2017), the higher-order type is often called the \"powertype\".  
+
+For further details and formalization of \"partitioning\", see Carvalho et al (2017) which combines UFO with MLT (a multi-level modeling theory).  
+
+V. A. Carvalho, J. P. A. Almeida, C. M. Fonseca, and G. Guizzardi, “Multi-level ontology-based conceptual modeling,” Data & Knowledge Engineering, vol. 109, p. 3–24, 2017. <http://dx.doi.org/10.1016/j.datak.2017.03.002>"""@en ;
+                rdfs:label "partitions"@en .
+
+
+###  http://purl.org/nemo/gufo#standsIn
+gufo:standsIn rdf:type owl:ObjectProperty ;
+              rdfs:domain owl:Thing ;
+              rdfs:range gufo:Situation ;
+              rdfs:comment """Identifies a gufo:Situation in which the entity stands. 
+
+This implementation includes sub-properties of gufo:standsIn to identify situations concerning the attribution of (mutable) values to qualities, variable relationships, the instantiation of non-contingent types, temporary parthood and temporary constitution."""@en ;
+              rdfs:label "standsIn"@en .
+
+
+###  http://purl.org/nemo/gufo#standsInQualifiedAttribution
+gufo:standsInQualifiedAttribution rdf:type owl:ObjectProperty ;
+                                  rdfs:subPropertyOf gufo:standsIn ;
+                                  rdfs:domain gufo:Endurant ;
+                                  rdfs:range gufo:QualityValueAttributionSituation ;
+                                  rdfs:comment "Identifies a gufo:QualityValueAttributionSituation in which the endurant stands. The identified gufo:QualityValueAttributionSituation is then used with the gufo:concernsQualityValue data property or the gufo:concernsReifiedQualityValue object property to indicate a quality value attributed to the gufo:Endurant standing in the situation. This forms a pattern to represent that quality values may differ in different situations."@en ;
+                                  rdfs:label "standsInQualifiedAttribution"@en ;
+                                  rdfs:seeAlso gufo:QualityValueAttributionSituation .
+
+
+###  http://purl.org/nemo/gufo#standsInQualifiedConstitution
+gufo:standsInQualifiedConstitution rdf:type owl:ObjectProperty ;
+                                   rdfs:subPropertyOf gufo:standsIn ;
+                                   rdfs:domain gufo:Endurant ;
+                                   rdfs:range gufo:TemporaryConstitutionSituation ;
+                                   rdfs:comment """Identifies a gufo:TemporaryConstitutionSituation in which an endurant stands temporarily (as a constituent). The identified gufo:TemporaryConstitutionSituation is further related with an endurant (the whole) through the gufo:concernsConstitutedEndurant object property. This forms a pattern to represent temporary constitution, in which the relationships between constituents and constituted endurant vary in different situations.
+
+Consider, for example, a group of people (understood as a gufo:FixedCollection) constituting a band (understood as a gufo:FunctionalComplex). In this case, any change in the membership of the group (e.g., the replacement of one person) creates a different group of people. Therefore, the band's constitution can change in time, and the pattern using gufo:TemporaryConstitutionSituation is applicable."""@en ;
+                                   rdfs:label "standsInQualifiedConstitution"@en ;
+                                   rdfs:seeAlso gufo:TemporaryConstitutionSituation .
+
+
+###  http://purl.org/nemo/gufo#standsInQualifiedInstantiation
+gufo:standsInQualifiedInstantiation rdf:type owl:ObjectProperty ;
+                                    rdfs:subPropertyOf gufo:standsIn ;
+                                    rdfs:domain gufo:Endurant ;
+                                    rdfs:range gufo:TemporaryInstantiationSituation ;
+                                    rdfs:comment "Identifies a gufo:TemporaryInstantiationSituation in which the endurant stands. The identified gufo:TemporaryInstantiationSituation is further related with a gufo:NonRigidType through the gufo:concernsNonRigidType object property. This forms a pattern to represent the contigent instantiation of a non-rigid type by the endurant, in which case instantiation may vary in different situations."@en ;
+                                    rdfs:label "standsInQualifiedInstantiation"@en ;
+                                    rdfs:seeAlso gufo:TemporaryInstantiationSituation .
+
+
+###  http://purl.org/nemo/gufo#standsInQualifiedParthood
+gufo:standsInQualifiedParthood rdf:type owl:ObjectProperty ;
+                               rdfs:subPropertyOf gufo:standsIn ;
+                               rdfs:domain gufo:Endurant ;
+                               rdfs:range gufo:TemporaryParthoodSituation ;
+                               rdfs:comment "Identifies a gufo:TemporaryParthoodSituation in which the endurant stands (as a temporary part). The identified gufo:TemporaryParthoodSituation is further related with an endurant (the whole) through the gufo:concernsTemporaryWhole object property. This forms a pattern to represent temporary parthood, in which the relationships between parts and wholes vary in different situations. In particular, this pattern is useful in case parts may be separated from their wholes, attached to other wholes, replaced."@en ;
+                               rdfs:label "standsInQualifiedParthood"@en ;
+                               rdfs:seeAlso gufo:TemporaryParthoodSituation .
+
+
+###  http://purl.org/nemo/gufo#standsInQualifiedRelationship
+gufo:standsInQualifiedRelationship rdf:type owl:ObjectProperty ;
+                                   rdfs:subPropertyOf gufo:standsIn ;
+                                   rdfs:domain gufo:Endurant ;
+                                   rdfs:range gufo:TemporaryRelationshipSituation ;
+                                   rdfs:comment """Identifies a gufo:TemporaryRelationshipSituation in which the endurant stands. The identified gufo:TemporaryRelationshipSituation is then used with the gufo:concernsRelatedEndurant and the gufo:concernsRelationshipType object properties to indicate the related element and the type of relationship that applies. This forms a pattern to represent that relationships that may change in different situations. For example, \"heavierThan\" may change when the objects involved gain or lose weight.
+
+For material relations, prefer the use of gufo:Relator."""@en ;
+                                   rdfs:label "standsInQualifiedRelationship"@en ;
+                                   rdfs:seeAlso gufo:Relator ,
+                                                gufo:TemporaryRelationshipSituation .
+
+
+###  http://purl.org/nemo/gufo#wasCreatedIn
+gufo:wasCreatedIn rdf:type owl:ObjectProperty ;
+                  rdfs:domain gufo:Endurant ;
+                  rdfs:range gufo:Event ;
+                  rdfs:comment """Identifies the gufo:Event which brought the gufo:Endurant into existence. 
+
+For example, a musical piece is created in an act of composition (or in an event that is part of it), a piece of legislation is created in a complex legislative process.
+
+Benevides et al. (2019) only discussed creation of objects; gufo:wasCreatedIn is extended to endurants in general. Further, in that work \"createdBy\" required the event to \"bring about\" a situation in which the created object is present. We relax this requirement here, such that the object may be created and terminated in the scope of the identified gufo:Event.
+
+A. B. Benevides, J. R. Bourguet, G. Guizzardi, R. Penãloza, and J. P. A. Almeida, “Representing a reference foundational ontology of events in SROIQ,” Applied ontology, vol. 14, iss. 3, p. 293–334, 2019. <http://dx.doi.org/10.3233/AO-190214>"""@en ;
+                  rdfs:label "wasCreatedIn"@en .
+
+
+###  http://purl.org/nemo/gufo#wasTerminatedIn
+gufo:wasTerminatedIn rdf:type owl:ObjectProperty ;
+                     rdfs:domain gufo:Endurant ;
+                     rdfs:range gufo:Event ;
+                     rdfs:comment """Identifies the gufo:Event in which the gufo:Endurant was brought to an end. 
+
+For example, the Space Shuttle Challenger (OV-099) (a gufo:FunctionalComplex) was destroyed during the launch of its tenth flight (a gufo:Event). 
+
+Benevides et al. (2019) only discussed termination of objects; gufo:wasCreatedIn is extended to endurants in general. This means that a gufo:Relator (such as a marriage) can be declared terminated. Further, in that work \"terminatedBy\" required the event to be \"triggered\" by a situation in which the terminated object is present. We relax this requirement here, such that the object may be created and terminated in the scope of the identified gufo:Event.
+
+A. B. Benevides, J. R. Bourguet, G. Guizzardi, R. Penãloza, and J. P. A. Almeida, “Representing a reference foundational ontology of events in SROIQ,” Applied ontology, vol. 14, iss. 3, p. 293–334, 2019. <http://dx.doi.org/10.3233/AO-190214>"""@en ;
+                     rdfs:label "wasTerminatedIn"@en .
+
+
+#################################################################
+#    Data properties
+#################################################################
+
+###  http://purl.org/nemo/gufo#concernsQualityValue
+gufo:concernsQualityValue rdf:type owl:DatatypeProperty ;
+                          rdfs:domain gufo:QualityValueAttributionSituation ;
+                          rdfs:comment """Determines a quality value associated with the gufo:ConcreteIndividual that stands in the gufo:QualityValueAttributionSituation.
+
+Use gufo:concernsReifiedQualityValue instead when quality values are refied.
+
+It is recommended that subproperties of gufo:concernsQualityValue are created, possibly identifying the datatype to be used. For example, \"concernsTemperatureValue\" could be defined as a sub-property of gufo:concernsQualityValue with range xsd:double."""@en ;
+                          rdfs:label "concernsQualityValue"@en ;
+                          rdfs:seeAlso gufo:concernsReifiedQualityValue .
+
+
+###  http://purl.org/nemo/gufo#hasBeginPointInXSDDate
+gufo:hasBeginPointInXSDDate rdf:type owl:DatatypeProperty ,
+                                     owl:FunctionalProperty ;
+                            rdfs:domain gufo:ConcreteIndividual ;
+                            rdfs:range xsd:date ;
+                            rdfs:comment """Determines the begin point for a gufo:ConcreteIndividual, using a xsd:date literal.
+
+In the case of endurants, gufo:asBeginPointInXSDDate determines the time point when the endurant comes into existence. In the case of events, this data property determines the time point when the event starts to take place. In the case of situation, it determines the time point when the situation begins to hold.
+
+Use gufo:hasBeginPoint instead when temporal entities are reified."""@en ;
+                            rdfs:label "hasBeginPointInXSDDate"@en ;
+                            rdfs:seeAlso gufo:hasBeginPoint ,
+                                         gufo:hasBeginPointInXSDDateTimeStamp .
+
+
+###  http://purl.org/nemo/gufo#hasBeginPointInXSDDateTimeStamp
+gufo:hasBeginPointInXSDDateTimeStamp rdf:type owl:DatatypeProperty ,
+                                              owl:FunctionalProperty ;
+                                     rdfs:domain gufo:ConcreteIndividual ;
+                                     rdfs:range xsd:dateTimeStamp ;
+                                     rdfs:comment """Determines the begin point for a gufo:ConcreteIndividual, using a xsd:dateTimeStamp literal.
+
+In the case of endurants, gufo:hasBeginPointInXSDDateTimeStamp determines the time point when the endurant comes into existence. In the case of events, this data property determines the time point when the event starts to take place. In the case of situation, it determines the time point when the situation begins to hold.
+
+Use gufo:hasBeginPoint instead when temporal entities are reified."""@en ;
+                                     rdfs:label "hasBeginPointInXSDDateTimeStamp"@en ;
+                                     rdfs:seeAlso gufo:hasBeginPoint ,
+                                                  gufo:hasBeginPointInXSDDate .
+
+
+###  http://purl.org/nemo/gufo#hasEndPointInXSDDate
+gufo:hasEndPointInXSDDate rdf:type owl:DatatypeProperty ,
+                                   owl:FunctionalProperty ;
+                          rdfs:domain gufo:ConcreteIndividual ;
+                          rdfs:range xsd:date ;
+                          rdfs:comment """Determines the end point for a gufo:ConcreteIndividual using a xsd:date literal.
+ 
+In the case of endurants, gufo:hasEndPointInXSDDate determines the time point when the endurant ceases to exist. In the case of events, this data property determines the time point when the event ends. In the case of situation, it determines the time point when the situation ceases to hold.
+
+Use gufo:hasEndPoint instead when temporal entities are reified."""@en ;
+                          rdfs:label "hasEndPointInXSDDate"@en ;
+                          rdfs:seeAlso gufo:hasEndPoint ,
+                                       gufo:hasEndPointInXSDDateTimeStamp .
+
+
+###  http://purl.org/nemo/gufo#hasEndPointInXSDDateTimeStamp
+gufo:hasEndPointInXSDDateTimeStamp rdf:type owl:DatatypeProperty ,
+                                            owl:FunctionalProperty ;
+                                   rdfs:domain gufo:ConcreteIndividual ;
+                                   rdfs:range xsd:dateTimeStamp ;
+                                   rdfs:comment """Determines the end point for a gufo:ConcreteIndividual using a xsd:dateTimeStamp literal.
+ 
+In the case of endurants, gufo:hasEndPointInXSDDateTimeStamp determines the time point when the endurant ceases to exist. In the case of events, this data property determines the time point when the event ends. In the case of situation, it determines the time point when the situation ceases to hold.
+
+Use gufo:hasEndPoint instead when temporal entities are reified."""@en ;
+                                   rdfs:label "hasEndPointInXSDDateTimeStamp"@en ;
+                                   rdfs:seeAlso gufo:hasEndPoint ,
+                                                gufo:hasEndPointInXSDDate .
+
+
+###  http://purl.org/nemo/gufo#hasQualityValue
+gufo:hasQualityValue rdf:type owl:DatatypeProperty ;
+                     rdfs:domain gufo:ConcreteIndividual ;
+                     rdfs:comment """Determines a quality value associated with the concrete individual.
+
+Use gufo:hasReifiedQualityValue instead when quality values are reified.
+
+It is recommended that subproperties of gufo:hasQualityValue are created, possibly identifying the datatype to be used. For example, \"hasTemperatureValue\" could be defined as a sub-property of gufo:hasQualityValue whose domain is \"Temperature\" (specializing gufo:Quality) and whose range is xsd:double."""@en ;
+                     rdfs:label "hasQualityValue"@en ;
+                     rdfs:seeAlso gufo:hasReifiedQualityValue .
+
+
+###  http://purl.org/nemo/gufo#hasValueComponent
+gufo:hasValueComponent rdf:type owl:DatatypeProperty ;
+                       rdfs:domain gufo:QualityValue ;
+                       rdfs:comment """This property is used for quality values that are defined in terms of a multidimensional quality structure (such as color conceived in terms of hue, saturation and brightness). Each value component of a quality value (a particular value for hue, a particular value for saturation, a particular value for brightness) is determined with this property. 
+
+It is recommended that subproperties of gufo:hasValueComponent are created to indicate values for particular dimensions, possibly identifying the datatype to be used. For example \"hasHueComponent\", \"hasSaturationComponent\" and \"hasBrightnessComponent\" could be used as data properties specializing gufo:hasValueComponent with the xsd:double datatype."""@en ;
+                       rdfs:label "hasValueComponent"@en .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://purl.org/nemo/gufo#AbstractIndividual
+gufo:AbstractIndividual rdf:type owl:Class ;
+                        rdfs:subClassOf gufo:Individual ;
+                        owl:disjointWith gufo:ConcreteIndividual ;
+                        rdfs:comment """A gufo:Individual that does not exist in space-time in the same way as a gufo:ConcreteIndividual does. A gufo:AbstractIndividual has no spatiotemporal qualities in its own right. Hence, it does not make sense to ask how much space it now occupies (Gideon, 2018) and when it was created or destroyed.
+
+Examples include the number ten, the null set, and the proposition that 'Obama was the president of the United States'.
+
+Rosen, Gideon, \"Abstract Objects\", The Stanford Encyclopedia of Philosophy (Winter 2018 Edition), Edward N. Zalta (ed.), <https://plato.stanford.edu/archives/win2018/entries/abstract-objects/>"""@en ;
+                        rdfs:label "AbstractIndividual"@en .
+
+
+###  http://purl.org/nemo/gufo#AbstractIndividualType
+gufo:AbstractIndividualType rdf:type owl:Class ;
+                            rdfs:subClassOf gufo:Type ;
+                            owl:disjointWith gufo:ConcreteIndividualType ,
+                                             gufo:RelationshipType ;
+                            rdfs:comment """A gufo:Type whose instances are abstract individuals.
+
+Instances of gufo:AbstractIndividualType are subclasses of gufo:AbstractIndividual.
+
+Examples include the types \"NaturalNumber\", \"Set\", \"Proposition\"."""@en ;
+                            rdfs:label "AbstractIndividualType"@en .
+
+
+###  http://purl.org/nemo/gufo#AntiRigidType
+gufo:AntiRigidType rdf:type owl:Class ;
+                   rdfs:subClassOf gufo:NonRigidType ;
+                   owl:disjointWith gufo:SemiRigidType ;
+                   rdfs:comment """A gufo:NonRigidType that applies contingently to all its instances (see Guizzardi, 2005, chapter 4).
+
+Examples include the gufo:Phase \"Child\", the gufo:PhaseMixin \"InfantAnimal\", the gufo:Role \"Student\", and the gufo:RoleMixin \"Customer\"."""@en ;
+                   rdfs:label "AntiRigidType"@en .
+
+
+###  http://purl.org/nemo/gufo#Aspect
+gufo:Aspect rdf:type owl:Class ;
+            rdfs:subClassOf gufo:Endurant ;
+            owl:disjointWith gufo:Object ;
+            owl:disjointUnionOf ( gufo:ExtrinsicAspect
+                                  gufo:IntrinsicAspect
+                                ) ;
+            rdfs:comment """A gufo:Endurant that depends on at least one other concrete individual for its existence. A gufo:Aspect is a characteristic or trait of a concrete individual that is itself conceived as an individual. 
+
+Examples include: intrinsic physical aspects, such as the Moon's mass, Lassie's fur color; mental dispositions, such as Bob's math skills, his belief that the number one is odd; as well as relational aspects, such as John's love for Mary and the marriage between John and Mary. 
+
+The specific sort of existential dependence connecting aspects to their bearers is called inherence.
+
+Corresponds to \"Moment\" in Guizzardi (2005). 
+
+Also termed \"property instance\", \"particularized property\", \"individual accident\", or \"(variable) trope\" in the philosophical literature."""@en ;
+            rdfs:label "Aspect"@en .
+
+
+###  http://purl.org/nemo/gufo#Category
+gufo:Category rdf:type owl:Class ;
+              rdfs:subClassOf gufo:NonSortal ,
+                              gufo:RigidType ;
+              rdfs:comment """A gufo:EndurantType that is both non-sortal and rigid. It captures essential properties that apply to instances of different kinds.
+
+For example, \"PhysicalObject\" may be considered a gufo:Category, encompassing objects such as cars, planets, trees. \"Agent\" may be a gufo:Category that classifies both people and organizations."""@en ;
+              rdfs:label "Category"@en .
+
+
+###  http://purl.org/nemo/gufo#Collection
+gufo:Collection rdf:type owl:Class ;
+                rdfs:subClassOf gufo:Object ;
+                owl:disjointUnionOf ( gufo:FixedCollection
+                                      gufo:VariableCollection
+                                    ) ;
+                rdfs:comment """A complex gufo:Object whose parts (the members of the collection) have a uniform structure (i.e., members are conceived as playing the same role in the collection). Collections may have a fixed or variable membership, which can be asserted using gufo:FixedCollection and gufo:VariableCollection respectively.
+
+Examples include a deck of cards, a pile of bricks, a forest (conceived as a collection of trees), and a group of people.
+
+Collections in many cases constitute a functional complex. For example, a pile of bricks may constitute a wall, a group of people may constitute a football team.
+
+A gufo:Collection may be decomposed into \"smaller\" collections. For instance, a group of people may be decomposed into a group of English speakers and a group of Italian speakers. Sub collections may or may not share members among them."""@en ;
+                rdfs:label "Collection"@en .
+
+
+###  http://purl.org/nemo/gufo#ComparativeRelationshipType
+gufo:ComparativeRelationshipType rdf:type owl:Class ;
+                                 rdfs:subClassOf gufo:RelationshipType ;
+                                 owl:disjointWith gufo:MaterialRelationshipType ;
+                                 rdfs:comment """A gufo:RelationshipType derived from intrinsic aspects of the related entities.
+
+For example, \"heavierThan\", \"olderThan\". 
+
+For a gufo:ComparativeRelationshipType it is recommended to identify the types of intrinsic aspects from which it is derived (see gufo:isDerivedFrom). For example \"heavierThan\" is derived from the \"Weight\" quality type.
+
+Note that, in the case of relationships that may change in different circumstances or times, the use of a qualified relation pattern enables indicating the period of time in which the relationship holds. See gufo:TemporaryRelationshipSituation.
+
+Corresponds to \"comparative formal relation\" in Guizzardi (2005) and \"Comparative Relation\" in Fonseca et al. (2019)."""@en ;
+                                 rdfs:label "ComparativeRelationshipType"@en ;
+                                 rdfs:seeAlso gufo:isDerivedFrom .
+
+
+###  http://purl.org/nemo/gufo#ConcreteIndividual
+gufo:ConcreteIndividual rdf:type owl:Class ;
+                        rdfs:subClassOf gufo:Individual ;
+                        owl:disjointUnionOf ( gufo:Endurant
+                                              gufo:Event
+                                              gufo:Situation
+                                            ) ;
+                        rdfs:comment """A gufo:Individual that exists in space-time. 
+
+Concrete individuals comprise not only object-like entities (a car, a mountain, a person, a marriage, a belief), but also events (a business meeting, a soccer match) and situations (the situation in which a person weighs 80 kilograms, the situation in which a bank account is overdrawn)."""@en ;
+                        rdfs:label "ConcreteIndividual"@en .
+
+
+###  http://purl.org/nemo/gufo#ConcreteIndividualType
+gufo:ConcreteIndividualType rdf:type owl:Class ;
+                            rdfs:subClassOf gufo:Type ;
+                            owl:disjointWith gufo:RelationshipType ;
+                            rdfs:comment """A gufo:Type whose instances are concrete individuals.
+
+Instances of gufo:ConcreteIndividualType are subclasses of gufo:ConcreteIndividual.
+
+Examples include the gufo:Kind \"Person\", the gufo:Category \"Physical Object\", the gufo:EventType \"Business Meeting\"."""@en ;
+                            rdfs:label "ConcreteIndividualType"@en .
+
+
+###  http://purl.org/nemo/gufo#Endurant
+gufo:Endurant rdf:type owl:Class ;
+              rdfs:subClassOf gufo:ConcreteIndividual ;
+              owl:disjointUnionOf ( gufo:Aspect
+                                    gufo:Object
+                                  ) ;
+              rdfs:comment """A gufo:ConcreteIndividual that endures in time and may change qualitatively while keeping its identity. 
+
+Examples include: ordinary objects of everyday experience, such as a person, a house, and a car; reified relationships, such as a marriage, a rental contract, and a person's love for another; and existentially-dependent aspects of objects, such as a car's weight, a person's language skills, and a house's color. 
+
+Also termed \"continuant\" in the philosophical literature."""@en ;
+              rdfs:label "Endurant"@en .
+
+
+###  http://purl.org/nemo/gufo#EndurantType
+gufo:EndurantType rdf:type owl:Class ;
+                  rdfs:subClassOf gufo:ConcreteIndividualType ;
+                  owl:disjointWith gufo:EventType ,
+                                   gufo:SituationType ;
+                  owl:disjointUnionOf ( gufo:NonRigidType
+                                        gufo:RigidType
+                                      ) ,
+                                      ( gufo:NonSortal
+                                        gufo:Sortal
+                                      ) ;
+                  rdfs:comment """A gufo:Type whose instances are endurants. 
+
+Instances of gufo:EndurantType are subclasses of gufo:Endurant.
+
+Examples include the object kind \"Person\", the phase \"Child\", the relator kind \"Marriage\".
+
+See Guizzardi et al. (2018) for details concerning the taxonomy of endurant types included here."""@en ;
+                  rdfs:label "EndurantType"@en .
+
+
+###  http://purl.org/nemo/gufo#Event
+gufo:Event rdf:type owl:Class ;
+           rdfs:subClassOf gufo:ConcreteIndividual ;
+           rdfs:comment """A gufo:ConcreteIndividual that 'occurs' or 'happens' in time. They may be instantaneous or long-running. Events are those \"things that happen to or are performed by\" (Casati and Varzi, 2015) endurants. 
+
+Examples include actions and processes, such as a business meeting, a communicative act, a soccer match, a goal kick, the clicking of a mouse button; as well as natural occurrences such as an earthquake, the fall of the meteor that caused the extinction of the dinosaurs.
+
+Also termed \"happening\", \"occurrence\", \"perdurant\" or \"occurrent\" in the philosophical literature.
+
+Casati, R. & Varzi, A. (2015). Events. In E.N. Zalta (Ed.), The Stanford Encyclopedia of Philosophy (Winter 2015 ed.). 19 Metaphysics Research Lab, Stanford University. https://plato.stanford.edu/archives/win2015/entries/events/"""@en ;
+           rdfs:label "Event"@en ;
+           rdfs:seeAlso gufo:participatedIn .
+
+
+###  http://purl.org/nemo/gufo#EventType
+gufo:EventType rdf:type owl:Class ;
+               rdfs:subClassOf gufo:ConcreteIndividualType ;
+               owl:disjointWith gufo:SituationType ;
+               rdfs:comment """A gufo:Type whose instances are events.
+
+Instances of gufo:EventType are subclasses of gufo:Event.
+
+Examples include \"Business Meeting\", \"Birth\", \"Musical Performance\"."""@en ;
+               rdfs:label "EventType"@en .
+
+
+###  http://purl.org/nemo/gufo#ExtrinsicAspect
+gufo:ExtrinsicAspect rdf:type owl:Class ;
+                     rdfs:subClassOf gufo:Aspect ;
+                     owl:disjointWith gufo:IntrinsicAspect ;
+                     owl:disjointUnionOf ( gufo:ExtrinsicMode
+                                           gufo:Relator
+                                         ) ;
+                     rdfs:comment """A gufo:Aspect that depends on one or more concrete individuals.
+
+Extrinsic (or \"relational\") aspects are reified relationships, e.g., John and Mary's marriage, Mary's employment contract at Nasa, or parts of those relationships, e.g., John's obligations towards Mary in the scope of the marriage, Mary's reciprocal claims, Mary's obligations towards John, John's reciprocal claims. Extrinsic aspects can also be reified one-sided relationships, e.g., John's admiration for Obama (which depends on Obama but does not characterize him).
+
+Corresponds to \"Extrinsic Moment\" in Fonseca et al (2019). Encompasses \"Externally Depedent Mode\", \"Qua Individual\" and \"Relator\" in Guizzardi (2005)."""@en ;
+                     rdfs:label "ExtrinsicAspect"@en .
+
+
+###  http://purl.org/nemo/gufo#ExtrinsicMode
+gufo:ExtrinsicMode rdf:type owl:Class ;
+                   rdfs:subClassOf gufo:ExtrinsicAspect ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty gufo:externallyDependsOn ;
+                                     owl:someValuesFrom gufo:ConcreteIndividual
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty gufo:inheresIn ;
+                                     owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass gufo:ConcreteIndividual
+                                   ] ;
+                   owl:disjointWith gufo:Relator ;
+                   rdfs:comment """A gufo:ExtrinsicAspect that inheres in a concrete individual and depends on others for its existence.
+
+A gufo:ExtrinsicMode can be understood as a reified one-sided relationship, such as John's admiration for Mary.
+
+Corresponds to \"Extrinsic Moment\" in Fonseca et al (2019). Encompasses what \"Externally Dependent Mode\", \"Qua Individual\" and \"Relator\" in Guizzardi (2005)."""@en ;
+                   rdfs:label "ExtrinsicMode"@en ;
+                   rdfs:seeAlso gufo:externallyDependsOn ,
+                                gufo:inheresIn .
+
+
+###  http://purl.org/nemo/gufo#FixedCollection
+gufo:FixedCollection rdf:type owl:Class ;
+                     rdfs:subClassOf gufo:Collection ;
+                     owl:disjointWith gufo:VariableCollection ;
+                     rdfs:comment """A gufo:Collection for which no change in membership is possible.
+
+Such a collection obeys an extensional principle of identity, i.e., two fixed collections are the same if, and only if, they have the same members.
+
+Consider, for example, a group of people understood as a gufo:FixedCollection. In this case, any change in the membership of the group (e.g., the addition of one person) would in fact create a different group of people. In this case, the gufo:FixedCollection may be contrasted with the complexes they constitute. For instance, The Beatles (the band conceived as a gufo:FunctionalComplex) was in a certain circumstance constituted by the collection {John, Paul, George, Pete} and in another one constituted by the collection {John, Paul, George, Ringo}. The replacement of Pete Best by Ringo Star does not alter the identity of the band, but creates a  different group of people."""@en ;
+                     rdfs:label "FixedCollection"@en ;
+                     rdfs:seeAlso gufo:isCollectionMemberOf ,
+                                  gufo:isSubCollectionOf .
+
+
+###  http://purl.org/nemo/gufo#FunctionalComplex
+gufo:FunctionalComplex rdf:type owl:Class ;
+                       rdfs:subClassOf gufo:Object ;
+                       rdfs:comment gufo:isComponentOf ,
+                                    """A complex gufo:Object whose parts (components) play different roles in its composition. 
+
+For example, a person could be considered a gufo:FunctionalComplex with the various organs (heart, brain, lungs, etc.) playing different roles. Another example is a scrum team, which is composed by people playing the roles of scrum master, product owner, developer, etc.
+
+To explicitly capture temporary components, use gufo:TemporaryParthoodSituation."""@en ;
+                       rdfs:label "FunctionalComplex"@en ;
+                       rdfs:seeAlso gufo:TemporaryParthoodSituation .
+
+
+###  http://purl.org/nemo/gufo#Individual
+gufo:Individual rdf:type owl:Class ;
+                owl:disjointWith gufo:Type ;
+                owl:disjointUnionOf ( gufo:AbstractIndividual
+                                      gufo:ConcreteIndividual
+                                    ) ;
+                rdfs:comment """An entity that (unlike a gufo:Type) cannot be instantiated.
+
+Individuals may be either concrete (e.g., the Earth, Mick Jagger, Brazil, the 1985 Mexico City Earthquake) or abstract (e.g., the number two, the proposition that 'three is a prime number').
+
+Also known as \"particular\" in the philosophical literature."""@en ;
+                rdfs:label "Individual"@en .
+
+
+###  http://purl.org/nemo/gufo#IntrinsicAspect
+gufo:IntrinsicAspect rdf:type owl:Class ;
+                     rdfs:subClassOf gufo:Aspect ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty gufo:inheresIn ;
+                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                       owl:onClass gufo:ConcreteIndividual
+                                     ] ;
+                     owl:disjointUnionOf ( gufo:IntrinsicMode
+                                           gufo:Quality
+                                         ) ;
+                     rdfs:comment """A gufo:Aspect that depends on a single concrete individual in which it inheres. 
+
+Examples include intrinsic physical aspects, such as the Moon's mass, Lassie's fur color; the fragility of John Lennon's glasses; mental dispositions, such as Bob's math skills, his belief that the number one is odd.
+
+A gufo:IntrinsicAspect is classified as a gufo:Quality (e.g., an apple's weight, the height of the Statue of Liberty) if it is measurable by a certain value space, or as a gufo:IntrinsicMode (e.g. Bob's belief that the Eiffel Tower is in Paris) otherwise.
+
+Corresponds to \"Intrinsic Moment\" in Guizzardi (2005). Different from Guizzardi (2005), here we consider that aspects can inhere in concrete individuals in general, and not only in endurants."""@en ;
+                     rdfs:label "IntrinsicAspect"@en ;
+                     rdfs:seeAlso gufo:inheresIn .
+
+
+###  http://purl.org/nemo/gufo#IntrinsicMode
+gufo:IntrinsicMode rdf:type owl:Class ;
+                   rdfs:subClassOf gufo:IntrinsicAspect ;
+                   owl:disjointWith gufo:Quality ;
+                   rdfs:comment """A gufo:IntrinsicAspect that is not measurable.
+
+For example, Bob's belief that the Eiffel Tower is in Paris, his math skills, his headache.
+
+Corresponds to \"Mode\" in Guizzardi (2005)."""@en ;
+                   rdfs:label "IntrinsicMode"@en .
+
+
+###  http://purl.org/nemo/gufo#Kind
+gufo:Kind rdf:type owl:Class ;
+          rdfs:subClassOf gufo:RigidType ,
+                          gufo:Sortal ;
+          owl:disjointWith gufo:SubKind ;
+          rdfs:comment """A gufo:EndurantType that is both sortal and rigid. It provides a uniform principle of identity for its instances. Every gufo:Endurant instantiates one and only one gufo:Kind. 
+
+Examples include kinds of ordinary objects of everyday experience, such as: \"Person\", \"House\", \"Car\"; kinds of relators, such as \"Marriage\", \"RentalContract\"; kinds of existentially-dependent aspects of objects, such as \"Weight\", \"Belief\", \"Vulnerability\"."""@en ;
+          rdfs:label "Kind"@en .
+
+
+###  http://purl.org/nemo/gufo#MaterialRelationshipType
+gufo:MaterialRelationshipType rdf:type owl:Class ;
+                              rdfs:subClassOf gufo:RelationshipType ;
+                              rdfs:comment """A gufo:RelationshipType derived from extrinsic aspects of the related entities.
+
+For example, \"marriedWith\", \"employedBy\", \"enrolledIn\", \"admires\". 
+
+For a gufo:MaterialRelationshipType it is recommended to identify the type of extrinsic aspect from which the material relationship type is derived (see gufo:isDerivedFrom). For example \"marriedWith\" can be derived from the \"Marriage\" relator type, \"employedBy\" can be derived from the \"Employment\" relator type.
+
+Encompasses \"Material Relation\" in Guizzardi (2005) and corresponds to \"Material Relation\" in Fonseca et al. (2019)."""@en ;
+                              rdfs:label "MaterialRelationshipType"@en ;
+                              rdfs:seeAlso gufo:isDerivedFrom .
+
+
+###  http://purl.org/nemo/gufo#Mixin
+gufo:Mixin rdf:type owl:Class ;
+           rdfs:subClassOf gufo:NonSortal ,
+                           gufo:SemiRigidType ;
+           rdfs:comment """A gufo:EndurantType that is both non-sortal and semi-rigid. As a semi-rigid type, it applies necessarily to some of its instances and contingently to some others. As a non-sortal, it captures properties shared by instances of different kinds.
+
+For example, the type \"FemaleAnimal\" may be considered a gufo:Mixin as it applies necessarily to animals of certain species, e.g., lions and sharks, while it applies contingently to animals of other species such as clownfish and mushroom corals (which may change sex given certain conditions)."""@en ;
+           rdfs:label "Mixin"@en .
+
+
+###  http://purl.org/nemo/gufo#NonRigidType
+gufo:NonRigidType rdf:type owl:Class ;
+                  rdfs:subClassOf gufo:EndurantType ;
+                  owl:disjointWith gufo:RigidType ;
+                  owl:disjointUnionOf ( gufo:AntiRigidType
+                                        gufo:SemiRigidType
+                                      ) ;
+                  rdfs:comment """A gufo:EndurantType that does not apply necessarily to at least one of its instances (see Guizzardi, 2005, chapter 4).
+
+Examples include anti-rigid types, such as the role \"Student\" and the phase \"Child\", and semi-rigid types, such as the mixin \"MusicalArtist\" (which necessarily characterizes bands, but contingently characterizes people) and the mixin \"FemaleAnimal\" (which is necessarily characterizes female dogs, but contigently characterizes clownfish)."""@en ;
+                  rdfs:label "NonRigidType"@en .
+
+
+###  http://purl.org/nemo/gufo#NonSortal
+gufo:NonSortal rdf:type owl:Class ;
+               rdfs:subClassOf gufo:EndurantType ;
+               owl:disjointWith gufo:Sortal ;
+               rdfs:comment """A gufo:EndurantType that applies to individuals of different kinds (see Guizzardi, 2005, chapter 4).
+
+Non-sortals do not provide a uniform principle of identity for their instances; instead, they just classify things that share common properties but which obey different principles of identity.
+
+Also termed \"dispersive\" types in the philosophical literature."""@en ;
+               rdfs:label "NonSortal"@en .
+
+
+###  http://purl.org/nemo/gufo#Object
+gufo:Object rdf:type owl:Class ;
+            rdfs:subClassOf gufo:Endurant ;
+            rdfs:comment """A gufo:Endurant that does not depend on another endurant for its existence (excluding its essential parts and aspects). 
+
+Examples of objects include ordinary physical entities, such as a dog, a house, a tomato, a car, Alan Turing, but also socially-defined entities such as The Rolling Stones, the European Union, the Brazilian 1988 Constitution.
+
+Guizzardi (2005) also included the more abstract notion of \"Substantial\", which generalizes both objects and amounts of matter. That notion was left out from this implementation, together with the notion of amount of matter. Support for the representation of maximally-self-connected amounts of matter is given by gufo:Quantity."""@en ;
+            rdfs:label "Object"@en .
+
+
+###  http://purl.org/nemo/gufo#Participation
+gufo:Participation rdf:type owl:Class ;
+                   rdfs:subClassOf gufo:Event ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty [ owl:inverseOf gufo:participatedIn
+                                                    ] ;
+                                     owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                     owl:onClass gufo:Object
+                                   ] ;
+                   rdfs:comment """A gufo:Event that depends on a single object. 
+
+Participations can be used to partition an event into portions, each of which depend exclusively on a single object. Consider a business meeting with multiple participants, including John and Mary. John's participation in the meeting encompasses all events that are part of the meeting and that depend solely on him. Likewise, Mary's participation encompasses all events that are part of the meeting and that depend solely on her. Similarly, in Brutus’ stabbing of Caesar, we may identify the participations of Brutus, of Caesar, and of the dagger."""@en ;
+                   rdfs:label "Participation"@en ;
+                   rdfs:seeAlso gufo:participatedIn .
+
+
+###  http://purl.org/nemo/gufo#Phase
+gufo:Phase rdf:type owl:Class ;
+           rdfs:subClassOf gufo:AntiRigidType ,
+                           gufo:Sortal ;
+           owl:disjointWith gufo:Role ;
+           rdfs:comment """A gufo:EndurantType that is both sortal and anti-rigid. It is defined by intrinsic but contingent instantiation conditions. Phases are relationally independent types that capturec intrinsic properties shared by instances of a given kind.
+
+For example, \"Child\" may be considered a gufo:Phase as a subclass of the gufo:Kind \"Person\", instantiated by persons younger than 12. Another example is the type \"IllPerson\", which may be considered a gufo:Phase that is instantiated whenever an instance of \"Disease\" (a gufo:IntrinsicMode) inheres in a person."""@en ;
+           rdfs:label "Phase"@en .
+
+
+###  http://purl.org/nemo/gufo#PhaseMixin
+gufo:PhaseMixin rdf:type owl:Class ;
+                rdfs:subClassOf gufo:AntiRigidType ,
+                                gufo:NonSortal ;
+                owl:disjointWith gufo:RoleMixin ;
+                rdfs:comment """A gufo:EndurantType that is both non-sortal and anti-rigid. It is defined by intrinsic but contingent instantiation conditions. Phase mixins are relationally independent types that capture intrinsic properties shared by instances of different kinds.
+
+For example, \"LivingAnimal\" may be considered a gufo:PhaseMixin as a superclass of the phases \"LivingPerson\" (specializing the gufo:Kind \"Person\") and \"LivingDog\" (specializing the gufo:Kind \"Dog\")."""@en ;
+                rdfs:label "PhaseMixin"@en .
+
+
+###  http://purl.org/nemo/gufo#Quality
+gufo:Quality rdf:type owl:Class ;
+             rdfs:subClassOf gufo:IntrinsicAspect ;
+             rdfs:comment """A gufo:IntrinsicAspect that is measurable by some value spaces. A quality may be used to compare individuals, on the basis of the value it takes in a certain quality space (for instance, a position within the RGB spectrum).
+
+Examples include the weight of a person, the name of organization, the color of a car, and the duration of a concert."""@en ;
+             rdfs:label "Quality"@en .
+
+
+###  http://purl.org/nemo/gufo#QualityValue
+gufo:QualityValue rdf:type owl:Class ;
+                  rdfs:subClassOf gufo:AbstractIndividual ;
+                  rdfs:comment """A gufo:AbstractIndividual that can be associated with a gufo:Quality reflecting the perception or conception of the quality in a certain value space. 
+
+Instances of gufo:QualityValue include the rational number 2.5 when used to conceive of the acidity of a portion of wine (in a pH scale), the tuple <38.8897,-77.0089> when used to conceive of the location of a building (in a space formed by latitude and longitude), or the triplet <0,0,0> when used to conceive of the color of a physical object (in a trimensional space formed by red, green and blue color components).  
+
+Corresponds to \"Quale\" in Guizzardi (2005). 
+
+Use this class only for quality values (qualia) that are to be reified in the A-box and associated with a gufo:ConcreteIndividual through the object property gufo:hasReifiedQualityValue. Otherwise, use the gufo:hasQualityValue data property and a literal to determine the quality value."""@en ;
+                  rdfs:label "QualityValue"@en ;
+                  rdfs:seeAlso gufo:hasReifiedQualityValue .
+
+
+###  http://purl.org/nemo/gufo#QualityValueAttributionSituation
+gufo:QualityValueAttributionSituation rdf:type owl:Class ;
+                                      rdfs:subClassOf gufo:Situation ,
+                                                      [ rdf:type owl:Class ;
+                                                        owl:unionOf ( [ rdf:type owl:Restriction ;
+                                                                        owl:onProperty gufo:concernsReifiedQualityValue ;
+                                                                        owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                                        owl:onClass gufo:QualityValue
+                                                                      ]
+                                                                      [ rdf:type owl:Restriction ;
+                                                                        owl:onProperty gufo:concernsQualityValue ;
+                                                                        owl:cardinality "1"^^xsd:nonNegativeInteger
+                                                                      ]
+                                                                    )
+                                                      ] ,
+                                                      [ rdf:type owl:Restriction ;
+                                                        owl:onProperty gufo:concernsQualityType ;
+                                                        owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                        owl:onClass gufo:EndurantType
+                                                      ] ,
+                                                      [ rdf:type owl:Restriction ;
+                                                        owl:onProperty [ owl:inverseOf gufo:standsInQualifiedAttribution
+                                                                       ] ;
+                                                        owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                        owl:onClass gufo:Endurant
+                                                      ] ;
+                                      owl:disjointWith gufo:TemporaryConstitutionSituation ,
+                                                       gufo:TemporaryInstantiationSituation ,
+                                                       gufo:TemporaryParthoodSituation ,
+                                                       gufo:TemporaryRelationshipSituation ;
+                                      rdfs:comment """A gufo:Situation in which a quality value is temporarily attributed to a gufo:Endurant.
+
+A gufo:QualityValueAttributionSituation should be used only for mutable qualities, i.e. those whose value can vary in time.
+
+Examples include: the situation in which the value of a bitcoin in Euros is 6.526,12, which lasted from 10/12/2019 to 11/12/2019; the situation in which the weight of Mike Tyson was 100 kg; and the situation in which the color of Einstein' hair was grey.
+
+This is a reification of the quality value attribution (in a solution that is similar to the qualified relation pattern  http://patterns.dataincubator.org/book/qualified-relation.html )"""@en ;
+                                      rdfs:label "QualityValueAttributionSituation"@en ;
+                                      rdfs:seeAlso gufo:concernsQualityValue ,
+                                                   gufo:concernsReifiedQualityValue .
+
+
+###  http://purl.org/nemo/gufo#Quantity
+gufo:Quantity rdf:type owl:Class ;
+              rdfs:subClassOf gufo:Object ;
+              rdfs:comment """A complex gufo:Object that is a maximally-connected portion of stuff. A gufo:Quantity has a fixed constitution, and thus, removing or adding a sub-quantity would result in a different quantity.
+
+Examples include the portion of wine in a wine tank, a lump of clay, the gold that constitutes a wedding ring.
+
+Also termed \"quantity of matter\", \"objectified portion of matter\", \"piece\" in the philosophical literature."""@en ;
+              rdfs:label "Quantity"@en ;
+              rdfs:seeAlso gufo:isSubQuantityOf .
+
+
+###  http://purl.org/nemo/gufo#RelationshipType
+gufo:RelationshipType rdf:type owl:Class ;
+                      rdfs:subClassOf gufo:Type ;
+                      rdfs:comment """A gufo:Type whose instances are ordered pairs of related entities. Instances of gufo:RelationshipType are object properties in UFO-based ontologies.
+
+The object properties \"marriedWith\" and \"enrolledIn\" are examples of material relationship types. The object properties \"heavierThan\", \"olderThan\" are examples of comparative relationship types.
+
+The use of gufo:RelationshipType and its subclasses requires OWL 2 punning.
+
+Corresponds to \"Relation\" in Guizzardi (2005) and Fonseca et al. (2019)."""@en ;
+                      rdfs:label "RelationshipType"@en .
+
+
+###  http://purl.org/nemo/gufo#Relator
+gufo:Relator rdf:type owl:Class ;
+             rdfs:subClassOf gufo:ExtrinsicAspect ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty gufo:mediates ;
+                               owl:minQualifiedCardinality "2"^^xsd:nonNegativeInteger ;
+                               owl:onClass gufo:Endurant
+                             ] ;
+             rdfs:comment """A gufo:ExtrinsicAspect that connects (involves, mediates) two or more concrete individuals. Relators are reified relationships composed of reciprocal extrinsic modes.
+
+Examples of relators include John and Mary's marriage (composed of John's obligations towards Mary in the scope of the marriage, Mary's reciprocal claims, Mary's obligations towards John, John's reciprocal claims), Mary's employment contract at Nasa, a covalent bond between two atoms."""@en ;
+             rdfs:label "Relator"@en ;
+             rdfs:seeAlso gufo:mediates .
+
+
+###  http://purl.org/nemo/gufo#RigidType
+gufo:RigidType rdf:type owl:Class ;
+               rdfs:subClassOf gufo:EndurantType ;
+               rdfs:comment """A gufo:EndurantType which applies necessarily to its instances (see Guizzardi, 2005, chapter 4).
+
+Examples include the types \"Agent\", \"Person\", \"Animal\", \"PhysicalObject\", \"Car\", and \"Tree\"."""@en ;
+               rdfs:label "RigidType"@en .
+
+
+###  http://purl.org/nemo/gufo#Role
+gufo:Role rdf:type owl:Class ;
+          rdfs:subClassOf gufo:AntiRigidType ,
+                          gufo:Sortal ;
+          rdfs:comment """A gufo:EndurantType that both sortal and anti-rigid. It is defined by relational instantiation conditions. Roles are relationally dependent types, capturing relational properties shared by instances of a given kind.
+
+For example, \"Student\" may be considered a gufo:Role as a subclass of the gufo:Kind \"Person\", instantiated by all persons enrolled in a school."""@en ;
+          rdfs:label "Role"@en .
+
+
+###  http://purl.org/nemo/gufo#RoleMixin
+gufo:RoleMixin rdf:type owl:Class ;
+               rdfs:subClassOf gufo:AntiRigidType ,
+                               gufo:NonSortal ;
+               rdfs:comment """A gufo:EndurantType that is both non-sortal and anti-rigid. It is defined by relational instantiation conditions. Role mixins are relationally dependent types, capturing relational properties shared by instances of different kinds.
+
+For example, \"Customer\" may be considered a gufo:RoleMixin as a superclass of the roles \"CorporateCustomer\" (specializing the gufo:Kind \"BusinessOrganization\") and \"PersonalCustomer\" (specializing the gufo:Kind \"Person\")."""@en ;
+               rdfs:label "RoleMixin"@en .
+
+
+###  http://purl.org/nemo/gufo#SemiRigidType
+gufo:SemiRigidType rdf:type owl:Class ;
+                   rdfs:subClassOf gufo:NonRigidType ;
+                   rdfs:comment "A gufo:NonRigidType that applies necessarily to some of its instances and contingently to some others (see Guizzardi, 2005, chapter 4)."@en ;
+                   rdfs:label "SemiRigidType"@en .
+
+
+###  http://purl.org/nemo/gufo#Situation
+gufo:Situation rdf:type owl:Class ;
+               rdfs:subClassOf gufo:ConcreteIndividual ;
+               rdfs:comment """A gufo:ConcreteIndividual that is a particular configuration of a part of reality which can be understood as a whole and in which entities stand in relations. A situation may be counterfactual or actual. An actual situation (or in other words, a \"fact\") \"obtains\" in a certain time instant or during a time interval.
+
+Note that, in Guizzardi et al. (2013), situations were considered to obtain at a specific point in time. Here, instead, they obtain in a time interval when begin and end points differ.
+
+The various subclasses of Situation in this implementation are used to capture \"mutable\" facts which obtain during some time and fail to obtain at other times. This includes the contingent instantiation of non-rigid types (e.g., as someone is a child at one point in time and a teenager later), the attribution of value to mutable qualities (such as a person's weight) and temporary participation in part-whole relations for replaceable parts (such as a car's tires). Other subclasses may be created to capture domain-specific notions such as \"HazardousSituation\", \"PersonHasFever\"."""@en ;
+               rdfs:label "Situation"@en .
+
+
+###  http://purl.org/nemo/gufo#SituationType
+gufo:SituationType rdf:type owl:Class ;
+                   rdfs:subClassOf gufo:ConcreteIndividualType ;
+                   rdfs:comment """A gufo:Type whose instances are situations.
+
+Instances of gufo:SituationType are subclasses of gufo:Situation.
+
+Examples include \"HazardousSituation\", \"PersonHasFever\",  \"PersonIsStudent\"."""@en ;
+                   rdfs:label "SituationType"@en .
+
+
+###  http://purl.org/nemo/gufo#Sortal
+gufo:Sortal rdf:type owl:Class ;
+            rdfs:subClassOf gufo:EndurantType ;
+            rdfs:comment "A gufo:EndurantType which carries (or supplies) a principle of identity for its instances  (see Guizzardi, 2005, chapter 4)."@en ;
+            rdfs:label "Sortal"@en .
+
+
+###  http://purl.org/nemo/gufo#SubKind
+gufo:SubKind rdf:type owl:Class ;
+             rdfs:subClassOf gufo:RigidType ,
+                             gufo:Sortal ;
+             rdfs:comment """A gufo:EndurantType that is both sortal and rigid. It specializes a gufo:Kind carrying the principle of identity supplied by that kind. Every gufo:SubKind should directly or indirectly specialize a gufo:Kind.
+
+For example, the gufo:Kind \"Lion\" may be specialized into the \"Lionness\" and \"Male Lion\" subkinds, while the gufo:Kind \"Computer\" may be specialized into the \"Laptop\" and \"Desktop\" subkinds."""@en ;
+             rdfs:label "SubKind"@en .
+
+
+###  http://purl.org/nemo/gufo#TemporaryConstitutionSituation
+gufo:TemporaryConstitutionSituation rdf:type owl:Class ;
+                                    rdfs:subClassOf gufo:Situation ,
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty gufo:concernsConstitutedEndurant ;
+                                                      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                      owl:onClass gufo:Object
+                                                    ] ,
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty [ owl:inverseOf gufo:standsInQualifiedConstitution
+                                                                     ] ;
+                                                      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                      owl:onClass gufo:Object
+                                                    ] ;
+                                    owl:disjointWith gufo:TemporaryInstantiationSituation ,
+                                                     gufo:TemporaryRelationshipSituation ;
+                                    rdfs:comment """A gufo:Situation in which a gufo:Endurant temporarly constitutes another gufo:Endurant.
+
+When constitution of an object may change in time, it may be qualified by the period in time in which the relation applies. 
+
+Examples include: the situation in which the Beatles is constituted by the group composed of {John,Paul,Ringo,George}; and the situation in which the statue of Venus de Milo was constituted by its original quantity of marble (including its arms).
+
+This is a reification of constitution (in a solution that is similar to the qualified relation pattern  http://patterns.dataincubator.org/book/qualified-relation.html)"""@en ;
+                                    rdfs:label "TemporaryConstitutionSituation"@en .
+
+
+###  http://purl.org/nemo/gufo#TemporaryInstantiationSituation
+gufo:TemporaryInstantiationSituation rdf:type owl:Class ;
+                                     rdfs:subClassOf gufo:Situation ,
+                                                     [ rdf:type owl:Restriction ;
+                                                       owl:onProperty gufo:concernsNonRigidType ;
+                                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                       owl:onClass gufo:NonRigidType
+                                                     ] ,
+                                                     [ rdf:type owl:Restriction ;
+                                                       owl:onProperty [ owl:inverseOf gufo:standsInQualifiedInstantiation
+                                                                      ] ;
+                                                       owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                       owl:onClass gufo:Endurant
+                                                     ] ;
+                                     owl:disjointWith gufo:TemporaryParthoodSituation ,
+                                                      gufo:TemporaryRelationshipSituation ;
+                                     rdfs:comment """A gufo:Situation in which a gufo:Endurant temporarily instantiates a gufo:NonRigidType.
+
+A gufo:TemporaryInstantiationSituation can account for the time period in which a particular instantiation holds.
+
+Examples include: the situation in which Obama instantiates the role of president, which began in 20/01/2009 and lasted until 20/01/2017; the situation in which Coatria instantiates the role of EU Member, which began in 01/07/2013 (and is still on-going); and the situation in which Steve Jobs instantiates the child phase, which began in 24/02/1955 and lasted until 24/02/1965.
+
+This solution is inspired in the qualified relation pattern (http://patterns.dataincubator.org/book/qualified-relation.html)."""@en ;
+                                     rdfs:label "TemporaryInstantiationSituation"@en .
+
+
+###  http://purl.org/nemo/gufo#TemporaryParthoodSituation
+gufo:TemporaryParthoodSituation rdf:type owl:Class ;
+                                rdfs:subClassOf gufo:Situation ,
+                                                [ rdf:type owl:Restriction ;
+                                                  owl:onProperty gufo:concernsTemporaryWhole ;
+                                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                  owl:onClass gufo:Endurant
+                                                ] ,
+                                                [ rdf:type owl:Restriction ;
+                                                  owl:onProperty [ owl:inverseOf gufo:standsInQualifiedParthood
+                                                                 ] ;
+                                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                  owl:onClass gufo:Endurant
+                                                ] ;
+                                owl:disjointWith gufo:TemporaryRelationshipSituation ;
+                                rdfs:comment """A gufo:Situation in which a gufo:Endurant is temporarily a part of another gufo:Endurant.
+
+A gufo:TemporaryParthoodSituation should only be used for mutable parts. It may be qualified by the period in time in which the relation applies. 
+
+Examples include: the situation in which the United Kingdom is a member of the European Union; the situation in which Messi is a a member of the Barcelona FC squad; the situation in which an engine is part of a car; and the situation in which a transplanted heart is part of a person.
+
+Note that, since every instance of gufo:Quantity or gufo:FixedCollection only has essential parts, the gufo:TemporaryParthoodSituation should not be used to represent these parthood relations.
+ 
+This solution is inspired in the qualified relation pattern (http://patterns.dataincubator.org/book/qualified-relation.html)."""@en ;
+                                rdfs:label "TemporaryParthoodSituation"@en .
+
+
+###  http://purl.org/nemo/gufo#TemporaryRelationshipSituation
+gufo:TemporaryRelationshipSituation rdf:type owl:Class ;
+                                    rdfs:subClassOf gufo:Situation ,
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty gufo:concernsRelatedEndurant ;
+                                                      owl:someValuesFrom gufo:Endurant
+                                                    ] ,
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty gufo:concernsRelationshipType ;
+                                                      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                      owl:onClass gufo:RelationshipType
+                                                    ] ,
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty [ owl:inverseOf gufo:standsInQualifiedRelationship
+                                                                     ] ;
+                                                      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                                      owl:onClass gufo:Endurant
+                                                    ] ;
+                                    rdfs:comment """A gufo:Situation in which a gufo:Endurant temporarily stands in a relation with another gufo:Endurant (or other endurants in the case of n-ary relationships). 
+
+Reification of a gufo:TemporaryRelationshipSituation allows qualification of the relationship with the period in time in which it applies. 
+
+Examples include: the situation in which Einstein works at the Swiss Patent Office in Bern; the situation in which Elon Musk studies at the University of Pennsylvania; the situation in which John Lennon is married to Yoko Ono; and the situation in which Facebook has a lower market value than Amazon.
+
+For material relationships, prefer the use of gufo:Relator.
+
+This is a reification of the relationship (in a solution that is similar to the qualified relation pattern  http://patterns.dataincubator.org/book/qualified-relation.html)."""@en ;
+                                    rdfs:label "TemporaryRelationshipSituation"@en .
+
+
+###  http://purl.org/nemo/gufo#Type
+gufo:Type rdf:type owl:Class ;
+          rdfs:comment """An entity that may be instantiated by (or predicated over) other entities. Types encompass what we often call \"sorts\", \"kinds\", \"categories\", etc. 
+
+Examples include the kind \"Person\", the event type \"Earthquake\", and the abstract individual type \"NaturalNumber\". Relations, such as \"marriedTo\" and \"olderThan\", are also considered as types.
+
+Instances of gufo:Type are classes, and should specialize the taxonomy of individuals of gUFO. For example, \"Person\" is a gufo:Type (more specifically a gufo:Kind), specializing gufo:Object. The mechanism that allows for this is called punning in OWL 2.
+
+Encompasses the notion of \"Universal\" in Guizzardi (2005)."""@en ;
+          rdfs:label "Type"@en .
+
+
+###  http://purl.org/nemo/gufo#VariableCollection
+gufo:VariableCollection rdf:type owl:Class ;
+                        rdfs:subClassOf gufo:Collection ;
+                        rdfs:comment gufo:TemporaryParthoodSituation ,
+                                     """A gufo:Collection for which change in membership is possible.
+
+Such a collection obeys an intensional principle of identity, i.e., change in membership does not necessarily create a different collection.
+
+For example, KLM's fleet of airplanes could be understood as a gufo:VariableCollection. In this case, when the company acquires (or retires) an airplane, the fleet changes. Note that, in this case, the airplanes are conceptualized as playing the role of \"member of a fleet\". If various roles for the parts of a fleet were envisioned (such as \"cargo airplane\", \"passenger airplane\"), then a fleet would be best understood as a gufo:FunctionalComplex.
+
+See gufo:TemporaryParthoodSituation for the pattern to represent the relation of a variable collection to its temporary parts."""@en ;
+                        rdfs:label "VariableCollection"@en .
+
+
+###  http://www.w3.org/2006/time#Instant
+time:Instant rdf:type owl:Class ;
+             rdfs:subClassOf gufo:AbstractIndividual ;
+             rdfs:comment "An gufo:AbstractIndividual that reifies time instants. It is used as a target of the gufo:hasBeginPoint and gufo:hasEndPoint object properties."@en ;
+             rdfs:label "Instant"@en .
+
+
+#################################################################
+#    General axioms
+#################################################################
+
+[ rdf:type owl:AllDisjointClasses ;
+  owl:members ( gufo:Collection
+                gufo:FunctionalComplex
+                gufo:Quantity
+              )
+] .
+
+
+[ rdf:type owl:AllDisjointClasses ;
+  owl:members ( gufo:Endurant
+                gufo:Event
+                gufo:Situation
+              )
+] .
+
+
+###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/templates.py
+++ b/templates.py
@@ -434,34 +434,6 @@ CACHE_DIR = Path.home() / ".cache" / "orionbelt" / "ontologies"
 
 REFERENCE_ONTOLOGIES = [
     {
-        "name": "schema.org",
-        "version": "30.0",
-        "description": (
-            "The schema.org vocabulary — types and properties used by major "
-            "search engines for structured data on the web. Around 800 types "
-            "and 1,400 properties covering persons, organizations, events, "
-            "products, creative works, and more. Note: schema.org uses "
-            "rdfs:Class / rdf:Property (not OWL); imported types appear in "
-            "the Source view but not in the OWL Classes panel."
-        ),
-        "url": "https://schema.org/",
-        "license": "Creative Commons Attribution-ShareAlike 3.0 (CC BY-SA 3.0)",
-        "attribution": "Schema.org Community Group",
-        "modules": [
-            {
-                "name": "schema-org-core",
-                "url": "https://schema.org/version/30.0/schemaorg-current-https.ttl",
-                "sha256": "320938f0945d717fc317f822c707f10944e7a7a0097018665a3b95dcf475b39d",
-                "format": "turtle",
-                "description": (
-                    "schema.org v30.0 core vocabulary "
-                    "(~1.1 MB, downloaded on first use)"
-                ),
-                "required": True,
-            },
-        ],
-    },
-    {
         "name": "PROV-O",
         "version": "W3C Recommendation 2013-04-30",
         "description": (

--- a/templates.py
+++ b/templates.py
@@ -378,6 +378,33 @@ UPPER_ONTOLOGIES = [
             },
         ],
     },
+    {
+        "name": "gUFO (UFO / OntoUML)",
+        "version": "1.0.0",
+        "description": (
+            "A lightweight OWL 2 DL implementation of the Unified Foundational "
+            "Ontology (UFO). Designed for ontologically precise modeling of "
+            "kinds, roles, phases, events, situations, qualities, and relators. "
+            "Suitable for OntoUML-style conceptual modeling. Licensed under CC BY 4.0."
+        ),
+        "url": "https://nemo-ufes.github.io/gufo/",
+        "license": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
+        "attribution": (
+            "Almeida, J.P.A.; Guizzardi, G.; Sales, T.P.; Falbo, R.A. — "
+            "NEMO, Federal University of Espírito Santo"
+        ),
+        "modules": [
+            {
+                "name": "gufo",
+                "file": "gufo/gufo.ttl",
+                "description": (
+                    "Core gUFO ontology — foundational UFO classes (Endurant, "
+                    "Event, Situation, Quality, Relator, etc.) and properties"
+                ),
+                "required": True,
+            },
+        ],
+    },
 ]
 
 

--- a/templates.py
+++ b/templates.py
@@ -1,5 +1,8 @@
 """Built-in ontology templates for bootstrapping new ontologies."""
 
+import hashlib
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 TEMPLATES = [
@@ -425,3 +428,167 @@ def load_upper_ontology_module(module: dict) -> str:
     """Load a module's Turtle content from file."""
     file_path = SAMPLES_DIR / module["file"]
     return file_path.read_text(encoding="utf-8")
+
+
+CACHE_DIR = Path.home() / ".cache" / "orionbelt" / "ontologies"
+
+REFERENCE_ONTOLOGIES = [
+    {
+        "name": "schema.org",
+        "version": "30.0",
+        "description": (
+            "The schema.org vocabulary — types and properties used by major "
+            "search engines for structured data on the web. Around 800 types "
+            "and 1,400 properties covering persons, organizations, events, "
+            "products, creative works, and more. Note: schema.org uses "
+            "rdfs:Class / rdf:Property (not OWL); imported types appear in "
+            "the Source view but not in the OWL Classes panel."
+        ),
+        "url": "https://schema.org/",
+        "license": "Creative Commons Attribution-ShareAlike 3.0 (CC BY-SA 3.0)",
+        "attribution": "Schema.org Community Group",
+        "modules": [
+            {
+                "name": "schema-org-core",
+                "url": "https://schema.org/version/30.0/schemaorg-current-https.ttl",
+                "sha256": "320938f0945d717fc317f822c707f10944e7a7a0097018665a3b95dcf475b39d",
+                "format": "turtle",
+                "description": (
+                    "schema.org v30.0 core vocabulary "
+                    "(~1.1 MB, downloaded on first use)"
+                ),
+                "required": True,
+            },
+        ],
+    },
+    {
+        "name": "PROV-O",
+        "version": "W3C Recommendation 2013-04-30",
+        "description": (
+            "The W3C PROV Ontology for representing provenance: agents, "
+            "activities, entities, and how they were generated, derived, and "
+            "used. The standard vocabulary for tracking 'who did what when' "
+            "in any domain."
+        ),
+        "url": "https://www.w3.org/TR/prov-o/",
+        "license": "W3C Document License (royalty-free)",
+        "attribution": "W3C Provenance Working Group",
+        "modules": [
+            {
+                "name": "prov-o",
+                "file": "prov-o.ttl",
+                "format": "turtle",
+                "description": "PROV-O ontology (bundled, offline-ready)",
+                "required": True,
+            },
+        ],
+    },
+    {
+        "name": "FOAF (Friend of a Friend)",
+        "version": "0.99",
+        "description": (
+            "Friend of a Friend — a Linked Data vocabulary for describing "
+            "people, organizations, social networks, and online identity. "
+            "One of the original Linked Data vocabularies and widely embedded "
+            "in other ontologies."
+        ),
+        "url": "http://xmlns.com/foaf/spec/",
+        "license": "Creative Commons Attribution 1.0",
+        "attribution": "Dan Brickley, Libby Miller",
+        "modules": [
+            {
+                "name": "foaf",
+                "file": "foaf.rdf",
+                "format": "xml",
+                "description": "FOAF specification (bundled, RDF/XML)",
+                "required": True,
+            },
+        ],
+    },
+    {
+        "name": "GoodRelations",
+        "version": "1.0",
+        "description": (
+            "GoodRelations — an OWL ontology for e-commerce: products, "
+            "offers, prices, payment methods, and business entities. Underlies "
+            "much of the schema.org Product/Offer model."
+        ),
+        "url": "http://www.heppnetz.de/ontologies/goodrelations/v1.html",
+        "license": "Creative Commons Attribution 3.0",
+        "attribution": "Martin Hepp",
+        "modules": [
+            {
+                "name": "goodrelations",
+                "file": "goodrelations.owl",
+                "format": "xml",
+                "description": "GoodRelations e-commerce vocabulary (bundled, RDF/XML)",
+                "required": True,
+            },
+        ],
+    },
+]
+
+
+def get_reference_ontology_names() -> list:
+    """Return list of reference ontology names."""
+    return [o["name"] for o in REFERENCE_ONTOLOGIES]
+
+
+def get_reference_ontology(name: str) -> dict:
+    """Return a reference ontology definition by name, or None if not found."""
+    for o in REFERENCE_ONTOLOGIES:
+        if o["name"] == name:
+            return o
+    return None
+
+
+def load_reference_ontology_module(module: dict) -> str:
+    """Load a reference-ontology module from bundle (file:) or HTTPS (url:).
+
+    Downloaded files are cached on disk under CACHE_DIR keyed by SHA256 (or by
+    URL hash when no SHA256 is pinned). When a SHA256 is provided, the
+    downloaded bytes are verified against it before caching — a mismatch
+    raises rather than silently loading altered content.
+    """
+    if "file" in module:
+        return (SAMPLES_DIR / module["file"]).read_text(encoding="utf-8")
+    if "url" in module:
+        return _fetch_with_cache(module["url"], module.get("sha256"))
+    raise ValueError(
+        f"Module '{module.get('name')}' has neither 'file' nor 'url'"
+    )
+
+
+def _fetch_with_cache(url: str, expected_sha256: str | None = None) -> str:
+    """Download a URL with on-disk caching and optional SHA256 verification."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache_key = expected_sha256 or hashlib.sha256(url.encode("utf-8")).hexdigest()
+    cache_file = CACHE_DIR / f"{cache_key}.dat"
+
+    if cache_file.exists():
+        return cache_file.read_text(encoding="utf-8")
+
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "orionbelt-ontology-builder/1.3"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = resp.read()
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f"Could not download ontology from {url}: {e.reason}"
+        ) from e
+
+    if expected_sha256:
+        actual = hashlib.sha256(data).hexdigest()
+        if actual != expected_sha256:
+            raise RuntimeError(
+                f"SHA256 mismatch for {url}: expected {expected_sha256}, "
+                f"got {actual}. The remote file may have been updated; "
+                "please verify and update the registry."
+            )
+
+    text = data.decode("utf-8")
+    cache_file.write_text(text, encoding="utf-8")
+    return text

--- a/templates.py
+++ b/templates.py
@@ -412,8 +412,8 @@ UPPER_ONTOLOGIES = [
 
 
 def get_upper_ontology_names() -> list:
-    """Return list of upper ontology names."""
-    return [o["name"] for o in UPPER_ONTOLOGIES]
+    """Return upper ontology names, sorted alphabetically."""
+    return sorted(o["name"] for o in UPPER_ONTOLOGIES)
 
 
 def get_upper_ontology(name: str) -> dict:
@@ -502,8 +502,8 @@ REFERENCE_ONTOLOGIES = [
 
 
 def get_reference_ontology_names() -> list:
-    """Return list of reference ontology names."""
-    return [o["name"] for o in REFERENCE_ONTOLOGIES]
+    """Return reference ontology names, sorted alphabetically."""
+    return sorted(o["name"] for o in REFERENCE_ONTOLOGIES)
 
 
 def get_reference_ontology(name: str) -> dict:

--- a/templates.py
+++ b/templates.py
@@ -412,8 +412,8 @@ UPPER_ONTOLOGIES = [
 
 
 def get_upper_ontology_names() -> list:
-    """Return upper ontology names, sorted alphabetically."""
-    return sorted(o["name"] for o in UPPER_ONTOLOGIES)
+    """Return upper ontology names, sorted alphabetically (case-insensitive)."""
+    return sorted((o["name"] for o in UPPER_ONTOLOGIES), key=str.lower)
 
 
 def get_upper_ontology(name: str) -> dict:
@@ -502,8 +502,8 @@ REFERENCE_ONTOLOGIES = [
 
 
 def get_reference_ontology_names() -> list:
-    """Return reference ontology names, sorted alphabetically."""
-    return sorted(o["name"] for o in REFERENCE_ONTOLOGIES)
+    """Return reference ontology names, sorted alphabetically (case-insensitive)."""
+    return sorted((o["name"] for o in REFERENCE_ONTOLOGIES), key=str.lower)
 
 
 def get_reference_ontology(name: str) -> dict:

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -44,3 +44,76 @@ def test_get_class_hierarchy(populated_om):
     hierarchy = populated_om.get_class_hierarchy()
     assert "Person" in hierarchy
     assert "Employee" in hierarchy["Person"]
+
+
+def test_get_classes_includes_parent_uris(populated_om):
+    """Regression: graph viewer needs URI-keyed parent links to disambiguate
+    cross-namespace duplicates without local-name lookup."""
+    classes = {c["name"]: c for c in populated_om.get_classes()}
+    employee = classes["Employee"]
+    assert employee["parents"] == ["Person"]
+    assert len(employee["parent_uris"]) == 1
+    assert employee["parent_uris"][0].endswith("Person")
+
+
+class TestCrossNamespaceDuplicates:
+    """Regression tests for the v1.3.0 'duplicate local name' fix.
+
+    When two ontologies are merged that both define a class with the same
+    local name (e.g. gist:Organization and foaf:Organization), the URI-based
+    operations must address them independently.
+    """
+
+    def _make_two_orgs(self):
+        from rdflib import Graph, RDF, OWL, RDFS, Literal, URIRef
+        from ontology_manager import OntologyManager
+
+        om = OntologyManager(base_uri="http://example.org/myont#")
+
+        # Inject FOAF-style and gist-style 'Organization' classes directly,
+        # since add_class would put both in the base namespace and collapse them.
+        foaf_org = URIRef("http://xmlns.com/foaf/0.1/Organization")
+        gist_org = URIRef("https://w3id.org/semanticarts/ns/ontology/gist/Organization")
+        om.graph.add((foaf_org, RDF.type, OWL.Class))
+        om.graph.add((foaf_org, RDFS.label, Literal("FOAF Organization")))
+        om.graph.add((gist_org, RDF.type, OWL.Class))
+        om.graph.add((gist_org, RDFS.label, Literal("gist Organization")))
+        om.graph.bind("foaf", "http://xmlns.com/foaf/0.1/")
+        om.graph.bind("gist", "https://w3id.org/semanticarts/ns/ontology/gist/")
+        return om, str(foaf_org), str(gist_org)
+
+    def test_get_classes_returns_both_with_distinct_uris(self):
+        om, foaf_uri, gist_uri = self._make_two_orgs()
+        classes = om.get_classes()
+        orgs = [c for c in classes if c["name"] == "Organization"]
+        assert len(orgs) == 2
+        uris = {c["uri"] for c in orgs}
+        assert uris == {foaf_uri, gist_uri}
+
+    def test_delete_by_uri_only_affects_one(self):
+        om, foaf_uri, gist_uri = self._make_two_orgs()
+        om.delete_class(foaf_uri)
+        remaining = [c for c in om.get_classes() if c["name"] == "Organization"]
+        assert len(remaining) == 1
+        assert remaining[0]["uri"] == gist_uri
+
+    def test_rename_by_uri_only_affects_one(self):
+        om, foaf_uri, gist_uri = self._make_two_orgs()
+        result = om.rename_class(foaf_uri, "SocialOrganization")
+        assert result is True
+        names = sorted(c["name"] for c in om.get_classes())
+        # gist's Organization untouched, foaf's renamed (now in base namespace)
+        assert "Organization" in names  # still has gist's
+        assert "SocialOrganization" in names
+
+    def test_class_relations_expose_uris(self):
+        """Regression for Relations tab key collisions."""
+        from rdflib import URIRef, RDF, OWL
+        om, foaf_uri, gist_uri = self._make_two_orgs()
+        om.graph.add((URIRef(foaf_uri), OWL.equivalentClass, URIRef(gist_uri)))
+        rels = om.get_class_relations()
+        equiv = [r for r in rels if r["relation"] == "equivalentClass"]
+        assert len(equiv) == 1
+        assert "subject_uri" in equiv[0]
+        assert "object_uri" in equiv[0]
+        assert {equiv[0]["subject_uri"], equiv[0]["object_uri"]} == {foaf_uri, gist_uri}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,10 +1,17 @@
 """Tests for ontology templates."""
 
+import hashlib
+from unittest.mock import patch
+
 import pytest
 from rdflib import Graph
+import templates as templates_module
 from templates import (get_template_names, get_template, render_template,
                        get_upper_ontology_names, get_upper_ontology,
-                       load_upper_ontology_module)
+                       load_upper_ontology_module,
+                       get_reference_ontology_names, get_reference_ontology,
+                       load_reference_ontology_module,
+                       _fetch_with_cache)
 from ontology_manager import OntologyManager
 
 
@@ -158,3 +165,113 @@ class TestUpperOntologies:
         assert "Event" in classes
         assert "Kind" in classes
         assert "Relator" in classes
+
+
+class TestReferenceOntologies:
+    def test_reference_names(self):
+        names = get_reference_ontology_names()
+        assert "schema.org" in names
+        assert "PROV-O" in names
+        assert "FOAF (Friend of a Friend)" in names
+        assert "GoodRelations" in names
+
+    def test_get_reference_ontology(self):
+        ref = get_reference_ontology("schema.org")
+        assert ref is not None
+        assert ref["version"] == "30.0"
+        assert ref["modules"][0].get("url", "").startswith("https://")
+        assert ref["modules"][0].get("sha256")
+
+    def test_get_nonexistent_reference(self):
+        assert get_reference_ontology("Nonexistent") is None
+
+    def test_load_bundled_prov_o(self):
+        ref = get_reference_ontology("PROV-O")
+        mod = ref["modules"][0]
+        content = load_reference_ontology_module(mod)
+        g = Graph()
+        g.parse(data=content, format=mod.get("format", "turtle"))
+        assert len(g) > 100
+
+    def test_load_bundled_foaf_xml(self):
+        ref = get_reference_ontology("FOAF (Friend of a Friend)")
+        mod = ref["modules"][0]
+        content = load_reference_ontology_module(mod)
+        g = Graph()
+        g.parse(data=content, format=mod.get("format", "xml"))
+        assert len(g) > 50
+
+    def test_merge_prov_o_into_ontology(self):
+        om = OntologyManager(base_uri="http://test.org/myont#")
+        om.add_class("MyClass")
+        ref = get_reference_ontology("PROV-O")
+        mod = ref["modules"][0]
+        content = load_reference_ontology_module(mod)
+        om.merge_from_string(content, mod.get("format", "turtle"))
+        classes = [c["name"] for c in om.get_classes()]
+        assert "MyClass" in classes
+        assert any(c in classes for c in ("Activity", "Agent", "Entity"))
+
+    def test_module_without_file_or_url_raises(self):
+        with pytest.raises(ValueError):
+            load_reference_ontology_module({"name": "broken"})
+
+    def test_fetch_uses_disk_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(templates_module, "CACHE_DIR", tmp_path)
+        payload = b"@prefix : <http://test/> . :A a :B ."
+        sha = hashlib.sha256(payload).hexdigest()
+
+        # Pre-seed cache so no network call should happen
+        cache_file = tmp_path / f"{sha}.dat"
+        cache_file.write_bytes(payload)
+
+        with patch("templates.urllib.request.urlopen") as mock_urlopen:
+            result = _fetch_with_cache("https://example.invalid/x", sha)
+            mock_urlopen.assert_not_called()
+        assert result == payload.decode("utf-8")
+
+    def test_fetch_verifies_sha256_mismatch(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(templates_module, "CACHE_DIR", tmp_path)
+        payload = b"actual content"
+        wrong_sha = "0" * 64
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return payload
+
+        with patch("templates.urllib.request.urlopen", return_value=_Resp()):
+            with pytest.raises(RuntimeError, match="SHA256 mismatch"):
+                _fetch_with_cache("https://example.invalid/x", wrong_sha)
+
+        # Mismatched fetch must NOT poison the cache
+        assert not (tmp_path / f"{wrong_sha}.dat").exists()
+
+    def test_fetch_caches_after_download(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(templates_module, "CACHE_DIR", tmp_path)
+        payload = b"valid content here"
+        sha = hashlib.sha256(payload).hexdigest()
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return payload
+
+        with patch("templates.urllib.request.urlopen", return_value=_Resp()) as mock:
+            result1 = _fetch_with_cache("https://example.invalid/x", sha)
+            result2 = _fetch_with_cache("https://example.invalid/x", sha)
+            # Second call should hit the cache, not the network
+            assert mock.call_count == 1
+
+        assert result1 == result2 == payload.decode("utf-8")
+        assert (tmp_path / f"{sha}.dat").exists()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -170,17 +170,14 @@ class TestUpperOntologies:
 class TestReferenceOntologies:
     def test_reference_names(self):
         names = get_reference_ontology_names()
-        assert "schema.org" in names
         assert "PROV-O" in names
         assert "FOAF (Friend of a Friend)" in names
         assert "GoodRelations" in names
 
     def test_get_reference_ontology(self):
-        ref = get_reference_ontology("schema.org")
+        ref = get_reference_ontology("PROV-O")
         assert ref is not None
-        assert ref["version"] == "30.0"
-        assert ref["modules"][0].get("url", "").startswith("https://")
-        assert ref["modules"][0].get("sha256")
+        assert ref["modules"][0].get("file") == "prov-o.ttl"
 
     def test_get_nonexistent_reference(self):
         assert get_reference_ontology("Nonexistent") is None

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -122,3 +122,39 @@ class TestUpperOntologies:
         required = [m for m in upper["modules"] if m.get("required")]
         assert len(required) == 1
         assert required[0]["name"] == "gistCore"
+
+    def test_gufo_listed(self):
+        names = get_upper_ontology_names()
+        assert "gUFO (UFO / OntoUML)" in names
+
+    def test_get_gufo_upper_ontology(self):
+        upper = get_upper_ontology("gUFO (UFO / OntoUML)")
+        assert upper is not None
+        assert upper["version"] == "1.0.0"
+        assert "CC BY 4.0" in upper["license"]
+        assert len(upper["modules"]) == 1
+        assert upper["modules"][0]["name"] == "gufo"
+        assert upper["modules"][0].get("required") is True
+
+    def test_gufo_core_valid_turtle(self):
+        upper = get_upper_ontology("gUFO (UFO / OntoUML)")
+        core = upper["modules"][0]
+        content = load_upper_ontology_module(core)
+        g = Graph()
+        g.parse(data=content, format="turtle")
+        assert len(g) > 100
+
+    def test_merge_gufo_into_ontology(self):
+        om = OntologyManager(base_uri="http://test.org/myont#")
+        om.add_class("MyClass")
+        upper = get_upper_ontology("gUFO (UFO / OntoUML)")
+        for mod in upper["modules"]:
+            if mod.get("required") or mod.get("default"):
+                content = load_upper_ontology_module(mod)
+                om.merge_from_string(content, "turtle")
+        classes = [c["name"] for c in om.get_classes()]
+        assert "MyClass" in classes
+        assert "Endurant" in classes
+        assert "Event" in classes
+        assert "Kind" in classes
+        assert "Relator" in classes


### PR DESCRIPTION
## Summary

- **gUFO** added as a second upper ontology option (NEMO/UFES, CC BY 4.0) alongside gist
- New **Reference Ontologies** tab with PROV-O, FOAF, GoodRelations bundled and a download-on-demand loader (SHA256-pinned, disk-cached, urllib stdlib only)
- **Cross-namespace duplicate handling**: when reference vocabularies introduce class/property/individual local names that collide with existing ones (e.g. `gist:Organization` + `foaf:Organization`), the UI no longer crashes with `multiple elements with the same key` and the graph viewer no longer collapses duplicates into a single node

## Bug fixes covered in this PR

- Visualization cache stayed stale on import / replace / undo — now invalidated by an `_ont_mutation_count` counter that bumps on every checkpoint and undo/redo (replaces the brittle triple-count fingerprint)
- Graph viewer iframe didn't always re-mount when content changed — `viz_render_seq` now bumps on every rebuild
- Streamlit duplicate-key crashes in Classes / Properties / Individuals / Relations tabs after merging a reference vocabulary
- Graph viz showed fewer classes than the stats panel because vis-network deduplicated nodes by local-name ID

## Architecture changes

- `_uid(uri)` helper for stable per-resource Streamlit key suffixes
- `_build_name_collision_set()` + `_disambiguated_name()` so display names get a namespace prefix only when ambiguous (`Organization (foaf)` / `Organization (gist)`)
- `OntologyManager` getters extended with URI fields used by disambiguation: `parent_uris`, `child_uris`, `domain_uri`, `range_uri`, `subject_uri`, `object_uri`
- All `delete_class` / `rename_class` / `update_class` / `delete_property` / `delete_individual` etc. callsites now pass URIs (existing methods already accepted URIs via `_uri()`)
- Graph viewer node IDs are URI-hash-based; `ename` round-trips as URI hash so the post-click navigation lands on the correct resource

## Out of scope (deferred)

- **schema.org** — pure RDFS, the loader works but classes don't surface in OWL panels; deferred until `get_classes()` is extended to recognize `rdfs:Class`
- **Validation noise from imported vocabularies** — current default validates everything in the graph; a `filter to user namespace` toggle is a v1.3.1 follow-up
- **FIBO** — needs `owl:imports` resolution against the local samples library; separate ticket

## Test plan

- [x] 230 unit tests pass (`pytest tests/`) — up from 215 baseline (+15 new tests)
- [x] New `TestCrossNamespaceDuplicates` regression suite covers `get_classes` returning both Organizations with distinct URIs, URI-based delete/rename, and URI exposure on relations
- [x] New tests for Reference Ontologies registry + fetch/cache/SHA256 verification (10 tests)
- [x] New tests for gUFO upper-ontology integration (4 tests)
- [x] Manual UI smoke test: load gist, then load FOAF in Merge mode → verify Classes, Properties, Individuals tabs render without errors and show disambiguated names
- [x] Manual UI smoke test: open Visualization with both `Organization` classes selected → verify both nodes appear

## Commit list

11 commits on the branch. Notable ones:

- `a3c50eb` Add gUFO as upper ontology option
- `71ef061` Add Reference Ontologies tab and bump version to 1.3.0
- `c5f7f27` Use mutation counter for viz cache invalidation
- `4b1eb6f` Disambiguate Classes view by URI
- `357cb3b` Disambiguate Properties / Individuals / Relations by URI
- `0c5e196` Make graph viewer node identity URI-based
- `0899277` Test cross-namespace duplicate handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)