### PR TITLE
chore: update repo links to ralforion org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-ontology-builder/main/orionbelt_ontology_builder/assets/ORIONBELT_Logo.png" alt="OrionBelt Logo" width="400">
+  <img src="https://raw.githubusercontent.com/ralforion/orionbelt-ontology-builder/main/orionbelt_ontology_builder/assets/ORIONBELT_Logo.png" alt="OrionBelt Logo" width="400">
 </p>
 
 <h1 align="center">OrionBelt Ontology Builder</h1>
 
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
-[![GitHub stars](https://img.shields.io/github/stars/ralfbecher/orionbelt-ontology-builder?style=social)](https://github.com/ralfbecher/orionbelt-ontology-builder)
-[![Version 1.3.2](https://img.shields.io/badge/version-1.3.2-purple.svg)](https://github.com/ralfbecher/orionbelt-ontology-builder/releases)
+[![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
+[![Version 1.3.2](https://img.shields.io/badge/version-1.3.2-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralfbecher/orionbelt-ontology-builder/blob/main/LICENSE)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 [![Streamlit](https://img.shields.io/badge/Streamlit-1.28+-FF4B4B.svg?logo=streamlit&logoColor=white)](https://streamlit.io)
 [![rdflib](https://img.shields.io/badge/rdflib-7.0+-2E86C1.svg)](https://rdflib.readthedocs.io)
 [![OWL-RL](https://img.shields.io/badge/OWL--RL-reasoning-green.svg)](https://owl-rl.readthedocs.io)
@@ -18,7 +18,7 @@
 **Try it now:** [orionbelt.streamlit.app](https://orionbelt.streamlit.app/)
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-ontology-builder/main/orionbelt_ontology_builder/assets/OrionBelt_Ontology_Builder.png" alt="OrionBelt Ontology Builder Screenshot" width="800">
+  <img src="https://raw.githubusercontent.com/ralforion/orionbelt-ontology-builder/main/orionbelt_ontology_builder/assets/OrionBelt_Ontology_Builder.png" alt="OrionBelt Ontology Builder Screenshot" width="800">
 </p>
 
 ---
@@ -121,7 +121,7 @@ Interactive vis-network graph with class filtering, configurable node limits, cl
 
 ```bash
 # Clone and install
-git clone https://github.com/ralfbecher/orionbelt-ontology-builder.git
+git clone https://github.com/ralforion/orionbelt-ontology-builder.git
 cd orionbelt-ontology-builder
 pip install -r requirements.txt
 
@@ -195,6 +195,6 @@ By contributing to this project, you agree to the [Contributor License Agreement
 
 <p align="center">
   <a href="https://ralforion.com">
-    <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-ontology-builder/main/orionbelt_ontology_builder/assets/RALFORION_doo_Logo.png" alt="RALFORION d.o.o." width="200">
+    <img src="https://raw.githubusercontent.com/ralforion/orionbelt-ontology-builder/main/orionbelt_ontology_builder/assets/RALFORION_doo_Logo.png" alt="RALFORION d.o.o." width="200">
   </a>
 </p>

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -16,7 +16,7 @@ APP_VERSION = "1.3.2"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-GITHUB_ISSUES_URL = "https://github.com/ralfbecher/orionbelt-ontology-builder/issues"
+GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"
 
 _FAVICON = _Path(__file__).parent / "favicon.png"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/ralfbecher/orionbelt-ontology-builder"
-Repository = "https://github.com/ralfbecher/orionbelt-ontology-builder"
-Issues = "https://github.com/ralfbecher/orionbelt-ontology-builder/issues"
+Homepage = "https://github.com/ralforion/orionbelt-ontology-builder"
+Repository = "https://github.com/ralforion/orionbelt-ontology-builder"
+Issues = "https://github.com/ralforion/orionbelt-ontology-builder/issues"
 Demo = "https://orionbelt.streamlit.app"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Repository was transferred from `ralfbecher` to the **ralforion** org. This updates all references to the new owner:

- `pyproject.toml` — Homepage / Repository / Issues URLs
- `README.md` — logo + screenshot asset paths, stars/version/license badges, clone URL, RALFORION logo path
- `orionbelt_ontology_builder/app.py` — in-app `GITHUB_ISSUES_URL`

The `orionbelt-analytics` link is a separate repo and was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)