### PR TITLE
docs: add Docker pulls and image size badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 [![Streamlit](https://img.shields.io/badge/Streamlit-1.28+-FF4B4B.svg?logo=streamlit&logoColor=white)](https://streamlit.io)
 [![Docker Hub](https://img.shields.io/badge/Docker%20Hub-ralforion-2496ED.svg?logo=docker&logoColor=white)](https://hub.docker.com/r/ralforion/orionbelt-ontology-builder)
+[![Docker Pulls](https://img.shields.io/docker/pulls/ralforion/orionbelt-ontology-builder.svg?logo=docker&logoColor=white)](https://hub.docker.com/r/ralforion/orionbelt-ontology-builder)
+[![Docker Image Size](https://img.shields.io/docker/image-size/ralforion/orionbelt-ontology-builder/latest.svg?logo=docker&logoColor=white)](https://hub.docker.com/r/ralforion/orionbelt-ontology-builder/tags)
 [![rdflib](https://img.shields.io/badge/rdflib-7.0+-2E86C1.svg)](https://rdflib.readthedocs.io)
 [![OWL-RL](https://img.shields.io/badge/OWL--RL-reasoning-green.svg)](https://owl-rl.readthedocs.io)
 [![vis-network](https://img.shields.io/badge/vis--network-9.1-97C2FC.svg)](https://visjs.github.io/vis-network/docs/network/)


### PR DESCRIPTION
## Summary
- Add **Docker Pulls** and **Docker Image Size** shields.io badges next to the existing Docker Hub badge

Follows up #24 / #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)