### PR TITLE
ci: add CI workflow (ruff + mypy + pytest) and type the engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Lint (ruff)
+        run: uv run ruff check orionbelt_ontology_builder tests app.py ontology_manager.py templates.py
+
+      - name: Format check (ruff)
+        run: uv run ruff format --check orionbelt_ontology_builder tests app.py ontology_manager.py templates.py
+
+      - name: Type check (mypy)
+        run: uv run mypy orionbelt_ontology_builder
+
+      - name: Test (pytest)
+        run: uv run pytest

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -103,6 +103,7 @@ def _configure_page() -> None:
 def get_ontology_manager_class():
     """Lazy load the OntologyManager class."""
     from .ontology_manager import OntologyManager
+
     return OntologyManager
 
 
@@ -115,6 +116,7 @@ def init_session_state():
     if "undo_manager" not in st.session_state:
         try:
             from .ontology_manager import UndoManager
+
             st.session_state.undo_manager = UndoManager(st.session_state.ontology)
         except ImportError as e:
             st.error(f"Failed to load UndoManager: {e}")
@@ -127,7 +129,12 @@ def init_session_state():
     if "nav_radio" not in st.session_state:
         ont = st.session_state.ontology
         _s = ont.get_statistics()
-        if _s["classes"] == 0 and _s["object_properties"] == 0 and _s["data_properties"] == 0 and _s.get("concepts", 0) == 0:
+        if (
+            _s["classes"] == 0
+            and _s["object_properties"] == 0
+            and _s["data_properties"] == 0
+            and _s.get("concepts", 0) == 0
+        ):
             st.session_state["nav_radio"] = "Import / Export"
 
 
@@ -161,6 +168,7 @@ def _get_local_storage():
     if "_local_storage" not in st.session_state:
         try:
             from streamlit_local_storage import LocalStorage
+
             st.session_state["_local_storage"] = LocalStorage()
         except Exception as e:  # pragma: no cover - depends on browser/runtime
             logger.warning(f"localStorage autosave unavailable: {e}")
@@ -223,10 +231,13 @@ def maybe_restore_autosave():
     # Rebuild undo history so the restored graph becomes the baseline state.
     try:
         from .ontology_manager import UndoManager
+
         st.session_state.undo_manager = UndoManager(ont)
     except ImportError:
         pass
-    st.session_state["_ont_mutation_count"] = st.session_state.get("_ont_mutation_count", 0) + 1
+    st.session_state["_ont_mutation_count"] = (
+        st.session_state.get("_ont_mutation_count", 0) + 1
+    )
     # init_session_state parks empty sessions on Import/Export; with content
     # restored, the Dashboard is the more useful landing page.
     if st.session_state.get("nav_radio") == "Import / Export":
@@ -295,7 +306,9 @@ def render_autosave_sidebar():
         and not _ontology_is_empty(st.session_state.ontology)
     ):
         st.sidebar.caption("✓ Saved in this browser")
-    if st.sidebar.button("Discard saved session", key="_autosave_discard", use_container_width=True):
+    if st.sidebar.button(
+        "Discard saved session", key="_autosave_discard", use_container_width=True
+    ):
         # Reset the workspace to a clean slate. We deliberately don't call the
         # component's deleteItem (its delete path is unreliable); instead the
         # now-empty graph is mirrored out by persist_autosave on the rerun,
@@ -304,11 +317,14 @@ def render_autosave_sidebar():
         st.session_state.ontology = OntologyManager()
         try:
             from .ontology_manager import UndoManager
+
             st.session_state.undo_manager = UndoManager(st.session_state.ontology)
         except ImportError:
             st.session_state.undo_manager = None
         st.session_state["_autosave_last_hash"] = None
-        st.session_state["_ont_mutation_count"] = st.session_state.get("_ont_mutation_count", 0) + 1
+        st.session_state["_ont_mutation_count"] = (
+            st.session_state.get("_ont_mutation_count", 0) + 1
+        )
         st.toast("Cleared this browser's autosave and reset the workspace.", icon="🗑️")
         st.rerun()
 
@@ -318,7 +334,9 @@ def save_checkpoint(label: str = "Edit"):
     if st.session_state.get("undo_manager"):
         st.session_state.undo_manager.checkpoint(label)
     # Bump mutation counter so derived UI caches (e.g. graph viz) invalidate
-    st.session_state["_ont_mutation_count"] = st.session_state.get("_ont_mutation_count", 0) + 1
+    st.session_state["_ont_mutation_count"] = (
+        st.session_state.get("_ont_mutation_count", 0) + 1
+    )
 
 
 def log_error(error: Exception, context: str = ""):
@@ -457,15 +475,18 @@ def _cb_toggle_view(prefix, uid):
     st.session_state[f"view_{prefix}_{uid}"] = True
     st.session_state[f"edit_{prefix}_{uid}"] = False
 
+
 def _cb_toggle_edit(prefix, uid):
     """Callback: open edit panel, close view. `uid` must be unique per resource."""
     st.session_state[f"edit_{prefix}_{uid}"] = True
     st.session_state[f"view_{prefix}_{uid}"] = False
 
+
 def _cb_view_to_edit(prefix, uid):
     """Callback: switch from view to edit. `uid` must be unique per resource."""
     st.session_state[f"view_{prefix}_{uid}"] = False
     st.session_state[f"edit_{prefix}_{uid}"] = True
+
 
 def _cb_confirm_delete(key_suffix):
     """Callback: trigger delete confirmation."""
@@ -538,7 +559,6 @@ def build_class_options(classes: list, include_none: bool = False) -> tuple:
     return options, lookup
 
 
-
 def render_dashboard():
     """Render the dashboard/overview page."""
     st.header("Dashboard")
@@ -552,14 +572,22 @@ def render_dashboard():
     col1, col2 = st.columns(2)
 
     with col1:
-        base_uri = st.text_input("Base URI", value=ont.base_uri,
-                                 help="The namespace URI for your ontology (e.g., http://example.org/ontology#)")
+        base_uri = st.text_input(
+            "Base URI",
+            value=ont.base_uri,
+            help="The namespace URI for your ontology (e.g., http://example.org/ontology#)",
+        )
         label = st.text_input("Label (rdfs:label)", value=metadata.get("label", ""))
-        comment = st.text_area("Comment (rdfs:comment)", value=metadata.get("comment", ""))
+        comment = st.text_area(
+            "Comment (rdfs:comment)", value=metadata.get("comment", "")
+        )
 
     with col2:
-        version_iri = st.text_input("Version IRI", value=metadata.get("version_iri", ""),
-                                    help="Optional IRI identifying this version of the ontology")
+        version_iri = st.text_input(
+            "Version IRI",
+            value=metadata.get("version_iri", ""),
+            help="Optional IRI identifying this version of the ontology",
+        )
         creator = st.text_input("Creator", value=metadata.get("creator", ""))
 
         if st.button("Update Metadata"):
@@ -568,9 +596,12 @@ def render_dashboard():
                 ont.set_base_uri(base_uri)
                 show_message(f"Base URI updated to: {ont.base_uri}", "success")
 
-            ont.set_ontology_metadata(label=label, comment=comment,
-                                      creator=creator,
-                                      version_iri=version_iri if version_iri else None)
+            ont.set_ontology_metadata(
+                label=label,
+                comment=comment,
+                creator=creator,
+                version_iri=version_iri if version_iri else None,
+            )
             save_checkpoint("Update metadata")
             show_message("Metadata updated successfully!", "success")
             st.rerun()
@@ -590,7 +621,9 @@ def render_dashboard():
                     st.rerun()
 
     with st.expander("Add Import"):
-        new_import = st.text_input("Import URI", placeholder="http://example.org/other-ontology")
+        new_import = st.text_input(
+            "Import URI", placeholder="http://example.org/other-ontology"
+        )
         if st.button("Add Import"):
             if new_import:
                 ont.add_import(new_import)
@@ -614,11 +647,15 @@ def render_dashboard():
     with st.expander("Add Custom Prefix"):
         col_pfx, col_ns = st.columns(2)
         with col_pfx:
-            new_prefix = st.text_input("Prefix", placeholder="foaf", key="new_prefix_name")
+            new_prefix = st.text_input(
+                "Prefix", placeholder="foaf", key="new_prefix_name"
+            )
         with col_ns:
-            new_ns = st.text_input("Namespace URI",
-                                   placeholder="http://xmlns.com/foaf/0.1/",
-                                   key="new_prefix_ns")
+            new_ns = st.text_input(
+                "Namespace URI",
+                placeholder="http://xmlns.com/foaf/0.1/",
+                key="new_prefix_ns",
+            )
         if st.button("Add Prefix", key="add_prefix_btn"):
             if new_prefix and new_ns:
                 ont.add_prefix(new_prefix, new_ns)
@@ -692,7 +729,13 @@ def render_dashboard():
 
                 with st.expander("View Details"):
                     for issue in issues:
-                        icon = "❌" if issue["severity"] == "error" else "⚠️" if issue["severity"] == "warning" else "ℹ️"
+                        icon = (
+                            "❌"
+                            if issue["severity"] == "error"
+                            else "⚠️"
+                            if issue["severity"] == "warning"
+                            else "ℹ️"
+                        )
                         st.write(f"{icon} **{issue['subject']}**: {issue['message']}")
 
 
@@ -704,8 +747,13 @@ def render_classes():
     classes = ont.get_classes()
     class_names = [c["name"] for c in classes]
 
-    _cls_tab = st.segmented_control("Section", ["View Classes", "Add Class", "Edit/Delete Class", "Bulk Operations"],
-                                    default="View Classes", key="cls_active_tab", label_visibility="collapsed")
+    _cls_tab = st.segmented_control(
+        "Section",
+        ["View Classes", "Add Class", "Edit/Delete Class", "Bulk Operations"],
+        default="View Classes",
+        key="cls_active_tab",
+        label_visibility="collapsed",
+    )
     if not _cls_tab:
         _cls_tab = "View Classes"
 
@@ -721,12 +769,17 @@ def render_classes():
             # Sort classes by display name, but put actively viewed class first
             sorted_classes = sorted(
                 classes,
-                key=lambda c: format_label_name(_disambiguated_name(c, collisions), c.get('label')).lower(),
+                key=lambda c: format_label_name(
+                    _disambiguated_name(c, collisions), c.get("label")
+                ).lower(),
             )
             _active_cls = next(
-                (c for c in sorted_classes
-                 if st.session_state.get(f"view_class_{_uid(c['uri'])}", False)
-                 or st.session_state.get(f"edit_class_{_uid(c['uri'])}", False)),
+                (
+                    c
+                    for c in sorted_classes
+                    if st.session_state.get(f"view_class_{_uid(c['uri'])}", False)
+                    or st.session_state.get(f"edit_class_{_uid(c['uri'])}", False)
+                ),
                 None,
             )
             if _active_cls:
@@ -740,21 +793,42 @@ def render_classes():
             for cls in sorted_classes:
                 cls_uid = _uid(cls["uri"])
                 disp_name = _disambiguated_name(cls, collisions)
-                display_name = format_label_name(disp_name, cls.get('label'))
-                _cls_expanded = st.session_state.get(f"view_class_{cls_uid}", False) or st.session_state.get(f"edit_class_{cls_uid}", False)
+                display_name = format_label_name(disp_name, cls.get("label"))
+                _cls_expanded = st.session_state.get(
+                    f"view_class_{cls_uid}", False
+                ) or st.session_state.get(f"edit_class_{cls_uid}", False)
                 with st.expander(f"📦 **{display_name}**", expanded=_cls_expanded):
-                    st.write(f"**URI:** `{cls['uri']}`" if cls['uri'].startswith("http://example.org/") else f"**URI:** {cls['uri']}")
+                    st.write(
+                        f"**URI:** `{cls['uri']}`"
+                        if cls["uri"].startswith("http://example.org/")
+                        else f"**URI:** {cls['uri']}"
+                    )
 
                     btn_view, btn_edit, btn_del, _ = st.columns([1, 1, 1, 4])
                     with btn_view:
-                        st.button("👁️ View", key=f"btn_view_class_{cls_uid}", use_container_width=True,
-                                  on_click=_cb_toggle_view, args=("class", cls_uid))
+                        st.button(
+                            "👁️ View",
+                            key=f"btn_view_class_{cls_uid}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_view,
+                            args=("class", cls_uid),
+                        )
                     with btn_edit:
-                        st.button("✏️ Edit", key=f"btn_edit_class_{cls_uid}", use_container_width=True,
-                                  on_click=_cb_toggle_edit, args=("class", cls_uid))
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_edit_class_{cls_uid}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_edit,
+                            args=("class", cls_uid),
+                        )
                     with btn_del:
-                        st.button("🗑️ Delete", key=f"btn_del_class_{cls_uid}", use_container_width=True,
-                                  on_click=_cb_confirm_delete, args=(f"class_{cls_uid}",))
+                        st.button(
+                            "🗑️ Delete",
+                            key=f"btn_del_class_{cls_uid}",
+                            use_container_width=True,
+                            on_click=_cb_confirm_delete,
+                            args=(f"class_{cls_uid}",),
+                        )
 
                     # View details
                     if st.session_state.get(f"view_class_{cls_uid}", False):
@@ -762,11 +836,17 @@ def render_classes():
                         st.write(f"**Name:** {cls['name']}")
                         st.write(f"**Label:** {cls['label'] or '—'}")
                         st.write(f"**Comment:** {cls['comment'] or '—'}")
-                        st.write(f"**Parent Class:** {', '.join(cls['parents']) if cls['parents'] else '—'}")
+                        st.write(
+                            f"**Parent Class:** {', '.join(cls['parents']) if cls['parents'] else '—'}"
+                        )
                         if cls["children"]:
                             st.write(f"**Children:** {', '.join(cls['children'])}")
-                        st.button("✏️ Edit", key=f"btn_view_to_edit_class_{cls_uid}",
-                                  on_click=_cb_view_to_edit, args=("class", cls_uid))
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_view_to_edit_class_{cls_uid}",
+                            on_click=_cb_view_to_edit,
+                            args=("class", cls_uid),
+                        )
 
                     if confirm_delete(cls["uri"], "class", f"class_{cls_uid}"):
                         ont.delete_class(cls["uri"])
@@ -778,16 +858,33 @@ def render_classes():
                     if st.session_state.get(f"edit_class_{cls_uid}", False):
                         st.divider()
                         with st.form(f"edit_class_form_{cls_uid}"):
-                            new_name = st.text_input("Name (URI local part)", value=cls["name"], key=f"name_{cls_uid}")
-                            new_label = st.text_input("Label", value=cls["label"], key=f"lbl_{cls_uid}")
-                            new_comment = st.text_area("Comment", value=cls["comment"], key=f"cmt_{cls_uid}")
+                            new_name = st.text_input(
+                                "Name (URI local part)",
+                                value=cls["name"],
+                                key=f"name_{cls_uid}",
+                            )
+                            new_label = st.text_input(
+                                "Label", value=cls["label"], key=f"lbl_{cls_uid}"
+                            )
+                            new_comment = st.text_area(
+                                "Comment", value=cls["comment"], key=f"cmt_{cls_uid}"
+                            )
                             other_classes = [c for c in class_names if c != cls["name"]]
-                            current_parent = cls["parents"][0] if cls["parents"] else "None"
-                            new_parent = st.selectbox("Parent Class",
+                            current_parent = (
+                                cls["parents"][0] if cls["parents"] else "None"
+                            )
+                            new_parent = st.selectbox(
+                                "Parent Class",
                                 options=["None"] + other_classes,
-                                index=0 if current_parent == "None" else
-                                      (other_classes.index(current_parent) + 1 if current_parent in other_classes else 0),
-                                key=f"par_{cls_uid}")
+                                index=0
+                                if current_parent == "None"
+                                else (
+                                    other_classes.index(current_parent) + 1
+                                    if current_parent in other_classes
+                                    else 0
+                                ),
+                                key=f"par_{cls_uid}",
+                            )
 
                             if st.form_submit_button("Save Changes"):
                                 # Handle rename first — pass URI so cross-namespace duplicates resolve correctly
@@ -796,45 +893,67 @@ def render_classes():
                                     if ont.rename_class(cls["uri"], new_name):
                                         current_ref = new_name  # post-rename, the resource lives in the base namespace
                                         save_checkpoint("Rename class")
-                                        show_message(f"Class renamed to '{new_name}'", "success")
+                                        show_message(
+                                            f"Class renamed to '{new_name}'", "success"
+                                        )
                                     else:
-                                        show_message(f"Cannot rename: '{new_name}' already exists!", "error")
+                                        show_message(
+                                            f"Cannot rename: '{new_name}' already exists!",
+                                            "error",
+                                        )
                                         st.rerun()
 
                                 if cls["parents"] and new_parent != cls["parents"][0]:
-                                    ont.update_class(current_ref, remove_parent=cls["parents"][0])
-                                ont.update_class(current_ref,
+                                    ont.update_class(
+                                        current_ref, remove_parent=cls["parents"][0]
+                                    )
+                                ont.update_class(
+                                    current_ref,
                                     new_label=new_label,
                                     new_comment=new_comment,
-                                    new_parent=new_parent if new_parent != "None" else None)
+                                    new_parent=new_parent
+                                    if new_parent != "None"
+                                    else None,
+                                )
                                 save_checkpoint("Update class")
                                 st.session_state[f"edit_class_{cls_uid}"] = False
-                                show_message(f"Class updated!", "success")
+                                show_message("Class updated!", "success")
                                 st.rerun()
 
             # Table view
             st.subheader("All Classes")
             class_data = []
             for c in sorted_classes:
-                class_data.append({
-                    "Name": c["name"],
-                    "Label": c["label"],
-                    "Parents": ", ".join(c["parents"]),
-                    "Children": ", ".join(c["children"]),
-                    "Comment": c["comment"][:50] + "..." if len(c["comment"]) > 50 else c["comment"]
-                })
+                class_data.append(
+                    {
+                        "Name": c["name"],
+                        "Label": c["label"],
+                        "Parents": ", ".join(c["parents"]),
+                        "Children": ", ".join(c["children"]),
+                        "Comment": c["comment"][:50] + "..."
+                        if len(c["comment"]) > 50
+                        else c["comment"],
+                    }
+                )
             st.dataframe(class_data, width="stretch")
 
     if _cls_tab == "Add Class":
         st.subheader("Add New Class")
 
         with st.form("add_class_form"):
-            name = st.text_input("Class Name *", help="Local name for the class (e.g., 'Person')")
+            name = st.text_input(
+                "Class Name *", help="Local name for the class (e.g., 'Person')"
+            )
             label = st.text_input("Label", help="Human-readable label")
             comment = st.text_area("Comment", help="Description of the class")
-            parent_options, parent_lookup = build_class_options(classes, include_none=True)
-            parent_display = st.selectbox("Parent Class", options=parent_options,
-                                 help="Select a parent class for hierarchy")
+            parent_options, parent_lookup = build_class_options(
+                classes, include_none=True
+            )
+            parent_display = st.selectbox(
+                "Parent Class",
+                options=parent_options,
+                help="Select a parent class for hierarchy",
+            )
 
             submitted = st.form_submit_button("Add Class")
             if submitted:
@@ -857,13 +976,21 @@ def render_classes():
         else:
             # Build options with Label (disambiguated name) format; lookup is by URI
             class_options, class_lookup = build_class_options(classes)
-            selected_display = st.selectbox("Select Class", options=class_options, key="edit_class_select")
+            selected_display = st.selectbox(
+                "Select Class", options=class_options, key="edit_class_select"
+            )
             selected_uri = class_lookup.get(selected_display)
-            class_info = next((c for c in classes if c["uri"] == selected_uri), None) if selected_uri else None
+            class_info = (
+                next((c for c in classes if c["uri"] == selected_uri), None)
+                if selected_uri
+                else None
+            )
 
             if class_info:
                 selected_uid = _uid(class_info["uri"])
-                selected_class = class_info["name"]  # local-name shorthand for messaging
+                selected_class = class_info[
+                    "name"
+                ]  # local-name shorthand for messaging
                 st.subheader(f"Edit: {selected_display}")
 
                 with st.form("edit_class_form"):
@@ -871,38 +998,59 @@ def render_classes():
                     new_comment = st.text_area("Comment", value=class_info["comment"])
 
                     other_classes = [c for c in class_names if c != selected_class]
-                    current_parent = class_info["parents"][0] if class_info["parents"] else "None"
-                    new_parent = st.selectbox("Parent Class",
-                                              options=["None"] + other_classes,
-                                              index=0 if current_parent == "None"
-                                              else (other_classes.index(current_parent) + 1
-                                                   if current_parent in other_classes else 0))
+                    current_parent = (
+                        class_info["parents"][0] if class_info["parents"] else "None"
+                    )
+                    new_parent = st.selectbox(
+                        "Parent Class",
+                        options=["None"] + other_classes,
+                        index=0
+                        if current_parent == "None"
+                        else (
+                            other_classes.index(current_parent) + 1
+                            if current_parent in other_classes
+                            else 0
+                        ),
+                    )
 
                     col1, col2 = st.columns(2)
                     with col1:
                         update_btn = st.form_submit_button("Update Class")
                     with col2:
-                        delete_btn = st.form_submit_button("Delete Class", type="secondary")
+                        delete_btn = st.form_submit_button(
+                            "Delete Class", type="secondary"
+                        )
 
                     if update_btn:
                         # Remove old parent if changed
-                        if class_info["parents"] and new_parent != class_info["parents"][0]:
-                            ont.update_class(class_info["uri"],
-                                             remove_parent=class_info["parents"][0])
+                        if (
+                            class_info["parents"]
+                            and new_parent != class_info["parents"][0]
+                        ):
+                            ont.update_class(
+                                class_info["uri"],
+                                remove_parent=class_info["parents"][0],
+                            )
 
-                        ont.update_class(class_info["uri"],
-                                         new_label=new_label,
-                                         new_comment=new_comment,
-                                         new_parent=new_parent if new_parent != "None" else None)
+                        ont.update_class(
+                            class_info["uri"],
+                            new_label=new_label,
+                            new_comment=new_comment,
+                            new_parent=new_parent if new_parent != "None" else None,
+                        )
                         save_checkpoint("Update class")
                         show_message(f"Class '{selected_display}' updated!", "success")
                         st.rerun()
 
                     if delete_btn:
-                        st.session_state[f"confirm_delete_class_detail_{selected_uid}"] = True
+                        st.session_state[
+                            f"confirm_delete_class_detail_{selected_uid}"
+                        ] = True
                         st.rerun()
 
-                if confirm_delete(class_info["uri"], "class", f"class_detail_{selected_uid}"):
+                if confirm_delete(
+                    class_info["uri"], "class", f"class_detail_{selected_uid}"
+                ):
                     ont.delete_class(class_info["uri"])
                     save_checkpoint("Delete class")
                     set_flash_message(f"Class '{selected_display}' deleted!", "success")
@@ -924,18 +1072,29 @@ def render_classes():
 
     if _cls_tab == "Bulk Operations":
         import pandas as pd
-        bulk_op = st.radio("Operation", ["Add", "Edit", "Delete"], horizontal=True, key="bulk_class_op")
+
+        bulk_op = st.radio(
+            "Operation", ["Add", "Edit", "Delete"], horizontal=True, key="bulk_class_op"
+        )
 
         if bulk_op == "Add":
             st.subheader("Bulk Add Classes")
-            st.caption("Enter one class name per line, or use CSV format: Name, Label, Parent")
-            bulk_text = st.text_area("Class entries", height=200, key="bulk_classes_text",
-                                     placeholder="Dog\nCat\nBird\n\nor CSV:\nName, Label, Parent\nDog, A Dog, Animal\nCat, A Cat, Animal")
+            st.caption(
+                "Enter one class name per line, or use CSV format: Name, Label, Parent"
+            )
+            bulk_text = st.text_area(
+                "Class entries",
+                height=200,
+                key="bulk_classes_text",
+                placeholder="Dog\nCat\nBird\n\nor CSV:\nName, Label, Parent\nDog, A Dog, Animal\nCat, A Cat, Animal",
+            )
             if bulk_text:
                 entries = ont.parse_bulk_text(bulk_text)
                 if entries:
                     st.dataframe(pd.DataFrame(entries), width="stretch")
-                    if st.button("Create All Classes", type="primary", key="bulk_create_classes"):
+                    if st.button(
+                        "Create All Classes", type="primary", key="bulk_create_classes"
+                    ):
                         result = ont.bulk_add_classes(entries)
                         save_checkpoint("Bulk add classes")
                         parts = []
@@ -945,7 +1104,10 @@ def render_classes():
                             parts.append(f"Skipped {len(result['skipped'])} existing")
                         if result["errors"]:
                             parts.append(f"{len(result['errors'])} error(s)")
-                        show_message(". ".join(parts), "success" if result["created"] else "warning")
+                        show_message(
+                            ". ".join(parts),
+                            "success" if result["created"] else "warning",
+                        )
                         st.rerun()
 
         elif bulk_op == "Edit":
@@ -954,30 +1116,61 @@ def render_classes():
             if not classes:
                 st.info("No classes to edit.")
             else:
-                edit_data = [{"Name": c["name"], "Label": c.get("label") or "",
-                              "Comment": c.get("comment") or "",
-                              "Parent": c["parents"][0] if c.get("parents") else ""}
-                             for c in classes]
+                edit_data = [
+                    {
+                        "Name": c["name"],
+                        "Label": c.get("label") or "",
+                        "Comment": c.get("comment") or "",
+                        "Parent": c["parents"][0] if c.get("parents") else "",
+                    }
+                    for c in classes
+                ]
                 df = pd.DataFrame(edit_data)
-                edited_df = st.data_editor(df, key="bulk_edit_classes_editor", width="stretch",
-                                           disabled=["Name"])
+                edited_df = st.data_editor(
+                    df,
+                    key="bulk_edit_classes_editor",
+                    width="stretch",
+                    disabled=["Name"],
+                )
                 if st.button("Apply Changes", type="primary", key="bulk_apply_classes"):
                     changes = 0
                     for _, row in edited_df.iterrows():
-                        orig = next((c for c in classes if c["name"] == row["Name"]), None)
+                        orig = next(
+                            (c for c in classes if c["name"] == row["Name"]), None
+                        )
                         if not orig:
                             continue
-                        new_label = row["Label"] if row["Label"] != (orig.get("label") or "") else None
-                        new_comment = row["Comment"] if row["Comment"] != (orig.get("comment") or "") else None
+                        new_label = (
+                            row["Label"]
+                            if row["Label"] != (orig.get("label") or "")
+                            else None
+                        )
+                        new_comment = (
+                            row["Comment"]
+                            if row["Comment"] != (orig.get("comment") or "")
+                            else None
+                        )
                         old_parent = orig["parents"][0] if orig.get("parents") else ""
                         new_parent = row["Parent"]
-                        if new_label is not None or new_comment is not None or new_parent != old_parent:
+                        if (
+                            new_label is not None
+                            or new_comment is not None
+                            or new_parent != old_parent
+                        ):
                             ont.update_class(
                                 row["Name"],
-                                new_label=row["Label"] if new_label is not None else None,
-                                new_comment=row["Comment"] if new_comment is not None else None,
-                                remove_parent=old_parent if old_parent and new_parent != old_parent else None,
-                                new_parent=new_parent if new_parent and new_parent != old_parent else None,
+                                new_label=row["Label"]
+                                if new_label is not None
+                                else None,
+                                new_comment=row["Comment"]
+                                if new_comment is not None
+                                else None,
+                                remove_parent=old_parent
+                                if old_parent and new_parent != old_parent
+                                else None,
+                                new_parent=new_parent
+                                if new_parent and new_parent != old_parent
+                                else None,
                             )
                             changes += 1
                     if changes:
@@ -992,13 +1185,23 @@ def render_classes():
             if not classes:
                 st.info("No classes to delete.")
             else:
-                selected = st.multiselect("Select classes to delete", class_names, key="bulk_delete_classes_select")
+                selected = st.multiselect(
+                    "Select classes to delete",
+                    class_names,
+                    key="bulk_delete_classes_select",
+                )
                 if selected:
-                    st.warning(f"This will delete {len(selected)} class(es) and all their references.")
-                    if st.button("Delete Selected", type="primary", key="bulk_delete_classes_btn"):
+                    st.warning(
+                        f"This will delete {len(selected)} class(es) and all their references."
+                    )
+                    if st.button(
+                        "Delete Selected", type="primary", key="bulk_delete_classes_btn"
+                    ):
                         result = ont.bulk_delete_classes(selected)
                         save_checkpoint("Bulk delete classes")
-                        show_message(f"Deleted {len(result['deleted'])} class(es)", "success")
+                        show_message(
+                            f"Deleted {len(result['deleted'])} class(es)", "success"
+                        )
                         st.rerun()
 
 
@@ -1014,9 +1217,19 @@ def render_properties():
     obj_prop_names = [p["name"] for p in object_props]
     data_prop_names = [p["name"] for p in data_props]
 
-    _prop_tab = st.segmented_control("Section", ["Object Properties", "Data Properties",
-                                     "Add Object Property", "Add Data Property", "Bulk Operations"],
-                                    default="Object Properties", key="prop_active_tab", label_visibility="collapsed")
+    _prop_tab = st.segmented_control(
+        "Section",
+        [
+            "Object Properties",
+            "Data Properties",
+            "Add Object Property",
+            "Add Data Property",
+            "Bulk Operations",
+        ],
+        default="Object Properties",
+        key="prop_active_tab",
+        label_visibility="collapsed",
+    )
     if not _prop_tab:
         _prop_tab = "Object Properties"
 
@@ -1029,22 +1242,29 @@ def render_properties():
             filter_class_obj = st.selectbox(
                 "Filter by Domain Class",
                 options=["All"] + class_names + ["(No domain)"],
-                key="filter_obj_prop_class"
+                key="filter_obj_prop_class",
             )
 
             filtered_obj_props = object_props
             if filter_class_obj == "(No domain)":
                 filtered_obj_props = [p for p in object_props if not p["domain"]]
             elif filter_class_obj != "All":
-                filtered_obj_props = [p for p in object_props if p["domain"] == filter_class_obj]
+                filtered_obj_props = [
+                    p for p in object_props if p["domain"] == filter_class_obj
+                ]
 
-            st.caption(f"Showing {len(filtered_obj_props)} of {len(object_props)} properties")
+            st.caption(
+                f"Showing {len(filtered_obj_props)} of {len(object_props)} properties"
+            )
 
             op_collisions = _build_name_collision_set(object_props)
             _active_op = next(
-                (p for p in filtered_obj_props
-                 if st.session_state.get(f"view_objprop_{_uid(p['uri'])}", False)
-                 or st.session_state.get(f"edit_objprop_{_uid(p['uri'])}", False)),
+                (
+                    p
+                    for p in filtered_obj_props
+                    if st.session_state.get(f"view_objprop_{_uid(p['uri'])}", False)
+                    or st.session_state.get(f"edit_objprop_{_uid(p['uri'])}", False)
+                ),
                 None,
             )
             if _active_op:
@@ -1058,20 +1278,44 @@ def render_properties():
             for prop in filtered_obj_props:
                 prop_uid = _uid(prop["uri"])
                 disp_name = _disambiguated_name(prop, op_collisions)
-                _op_expanded = st.session_state.get(f"view_objprop_{prop_uid}", False) or st.session_state.get(f"edit_objprop_{prop_uid}", False)
-                with st.expander(f"🔗 **{disp_name}** ({prop['domain'] or '?'} → {prop['range'] or '?'})", expanded=_op_expanded):
-                    st.write(f"**URI:** `{prop['uri']}`" if prop['uri'].startswith("http://example.org/") else f"**URI:** {prop['uri']}")
+                _op_expanded = st.session_state.get(
+                    f"view_objprop_{prop_uid}", False
+                ) or st.session_state.get(f"edit_objprop_{prop_uid}", False)
+                with st.expander(
+                    f"🔗 **{disp_name}** ({prop['domain'] or '?'} → {prop['range'] or '?'})",
+                    expanded=_op_expanded,
+                ):
+                    st.write(
+                        f"**URI:** `{prop['uri']}`"
+                        if prop["uri"].startswith("http://example.org/")
+                        else f"**URI:** {prop['uri']}"
+                    )
 
                     btn_view, btn_edit, btn_del, _ = st.columns([1, 1, 1, 4])
                     with btn_view:
-                        st.button("👁️ View", key=f"btn_view_objprop_{prop_uid}", use_container_width=True,
-                                  on_click=_cb_toggle_view, args=("objprop", prop_uid))
+                        st.button(
+                            "👁️ View",
+                            key=f"btn_view_objprop_{prop_uid}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_view,
+                            args=("objprop", prop_uid),
+                        )
                     with btn_edit:
-                        st.button("✏️ Edit", key=f"btn_edit_objprop_{prop_uid}", use_container_width=True,
-                                  on_click=_cb_toggle_edit, args=("objprop", prop_uid))
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_edit_objprop_{prop_uid}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_edit,
+                            args=("objprop", prop_uid),
+                        )
                     with btn_del:
-                        st.button("🗑️ Delete", key=f"btn_del_objprop_{prop_uid}", use_container_width=True,
-                                  on_click=_cb_confirm_delete, args=(f"objprop_{prop_uid}",))
+                        st.button(
+                            "🗑️ Delete",
+                            key=f"btn_del_objprop_{prop_uid}",
+                            use_container_width=True,
+                            on_click=_cb_confirm_delete,
+                            args=(f"objprop_{prop_uid}",),
+                        )
 
                     # View details
                     if st.session_state.get(f"view_objprop_{prop_uid}", False):
@@ -1081,10 +1325,16 @@ def render_properties():
                         st.write(f"**Comment:** {prop['comment'] or '—'}")
                         st.write(f"**Domain:** {prop['domain'] or '—'}")
                         st.write(f"**Range:** {prop['range'] or '—'}")
-                        st.write(f"**Characteristics:** {', '.join(prop['characteristics']) if prop['characteristics'] else '—'}")
+                        st.write(
+                            f"**Characteristics:** {', '.join(prop['characteristics']) if prop['characteristics'] else '—'}"
+                        )
                         st.write(f"**Inverse of:** {prop.get('inverse_of') or '—'}")
-                        st.button("✏️ Edit", key=f"btn_view_to_edit_objprop_{prop_uid}",
-                                  on_click=_cb_view_to_edit, args=("objprop", prop_uid))
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_view_to_edit_objprop_{prop_uid}",
+                            on_click=_cb_view_to_edit,
+                            args=("objprop", prop_uid),
+                        )
 
                     if confirm_delete(prop["uri"], "property", f"objprop_{prop_uid}"):
                         ont.delete_property(prop["uri"])
@@ -1096,28 +1346,52 @@ def render_properties():
                     if st.session_state.get(f"edit_objprop_{prop_uid}", False):
                         st.divider()
                         with st.form(f"edit_objprop_form_{prop_uid}"):
-                            new_name = st.text_input("Name (URI local part)", value=prop["name"], key=f"objp_name_{prop_uid}")
-                            new_label = st.text_input("Label", value=prop["label"], key=f"objp_lbl_{prop_uid}")
-                            new_comment = st.text_area("Comment", value=prop["comment"], key=f"objp_cmt_{prop_uid}")
+                            new_name = st.text_input(
+                                "Name (URI local part)",
+                                value=prop["name"],
+                                key=f"objp_name_{prop_uid}",
+                            )
+                            new_label = st.text_input(
+                                "Label", value=prop["label"], key=f"objp_lbl_{prop_uid}"
+                            )
+                            new_comment = st.text_area(
+                                "Comment",
+                                value=prop["comment"],
+                                key=f"objp_cmt_{prop_uid}",
+                            )
                             # Build URI-keyed dropdowns for Domain/Range so a
                             # foaf:Organization domain isn't silently rewritten
                             # to myont:Organization on save.
-                            cls_opts, cls_lookup = build_class_options(classes, include_none=True)
+                            cls_opts, cls_lookup = build_class_options(
+                                classes, include_none=True
+                            )
                             cur_dom_uri = prop.get("domain_uri", "")
                             cur_rng_uri = prop.get("range_uri", "")
-                            cur_dom_disp = next((d for d, u in cls_lookup.items() if u == cur_dom_uri), "None")
-                            cur_rng_disp = next((d for d, u in cls_lookup.items() if u == cur_rng_uri), "None")
+                            cur_dom_disp = next(
+                                (d for d, u in cls_lookup.items() if u == cur_dom_uri),
+                                "None",
+                            )
+                            cur_rng_disp = next(
+                                (d for d, u in cls_lookup.items() if u == cur_rng_uri),
+                                "None",
+                            )
                             col1, col2 = st.columns(2)
                             with col1:
                                 dom_disp = st.selectbox(
-                                    "Domain", options=cls_opts,
-                                    index=cls_opts.index(cur_dom_disp) if cur_dom_disp in cls_opts else 0,
+                                    "Domain",
+                                    options=cls_opts,
+                                    index=cls_opts.index(cur_dom_disp)
+                                    if cur_dom_disp in cls_opts
+                                    else 0,
                                     key=f"objp_dom_{prop_uid}",
                                 )
                             with col2:
                                 rng_disp = st.selectbox(
-                                    "Range", options=cls_opts,
-                                    index=cls_opts.index(cur_rng_disp) if cur_rng_disp in cls_opts else 0,
+                                    "Range",
+                                    options=cls_opts,
+                                    index=cls_opts.index(cur_rng_disp)
+                                    if cur_rng_disp in cls_opts
+                                    else 0,
                                     key=f"objp_rng_{prop_uid}",
                                 )
 
@@ -1128,21 +1402,29 @@ def render_properties():
                                     if ont.rename_property(prop["uri"], new_name):
                                         current_ref = new_name
                                         save_checkpoint("Rename property")
-                                        show_message(f"Property renamed to '{new_name}'", "success")
+                                        show_message(
+                                            f"Property renamed to '{new_name}'",
+                                            "success",
+                                        )
                                     else:
-                                        show_message(f"Cannot rename: '{new_name}' already exists!", "error")
+                                        show_message(
+                                            f"Cannot rename: '{new_name}' already exists!",
+                                            "error",
+                                        )
                                         st.rerun()
 
                                 new_dom_uri = cls_lookup.get(dom_disp) or ""
                                 new_rng_uri = cls_lookup.get(rng_disp) or ""
-                                ont.update_property(current_ref,
+                                ont.update_property(
+                                    current_ref,
                                     new_label=new_label,
                                     new_comment=new_comment,
                                     new_domain=new_dom_uri,
-                                    new_range=new_rng_uri)
+                                    new_range=new_rng_uri,
+                                )
                                 save_checkpoint("Update property")
                                 st.session_state[f"edit_objprop_{prop_uid}"] = False
-                                show_message(f"Property updated!", "success")
+                                show_message("Property updated!", "success")
                                 st.rerun()
 
     if _prop_tab == "Data Properties":
@@ -1154,24 +1436,31 @@ def render_properties():
             filter_class_data = st.selectbox(
                 "Filter by Domain Class",
                 options=["All"] + class_names + ["(No domain)"],
-                key="filter_data_prop_class"
+                key="filter_data_prop_class",
             )
 
             filtered_data_props = data_props
             if filter_class_data == "(No domain)":
                 filtered_data_props = [p for p in data_props if not p["domain"]]
             elif filter_class_data != "All":
-                filtered_data_props = [p for p in data_props if p["domain"] == filter_class_data]
+                filtered_data_props = [
+                    p for p in data_props if p["domain"] == filter_class_data
+                ]
 
-            st.caption(f"Showing {len(filtered_data_props)} of {len(data_props)} properties")
+            st.caption(
+                f"Showing {len(filtered_data_props)} of {len(data_props)} properties"
+            )
 
             datatypes = list(get_ontology_manager_class().XSD_DATATYPES.keys())
 
             dp_collisions = _build_name_collision_set(data_props)
             _active_dp = next(
-                (p for p in filtered_data_props
-                 if st.session_state.get(f"view_dataprop_{_uid(p['uri'])}", False)
-                 or st.session_state.get(f"edit_dataprop_{_uid(p['uri'])}", False)),
+                (
+                    p
+                    for p in filtered_data_props
+                    if st.session_state.get(f"view_dataprop_{_uid(p['uri'])}", False)
+                    or st.session_state.get(f"edit_dataprop_{_uid(p['uri'])}", False)
+                ),
                 None,
             )
             if _active_dp:
@@ -1185,20 +1474,44 @@ def render_properties():
             for prop in filtered_data_props:
                 prop_uid = _uid(prop["uri"])
                 disp_name = _disambiguated_name(prop, dp_collisions)
-                _dp_expanded = st.session_state.get(f"view_dataprop_{prop_uid}", False) or st.session_state.get(f"edit_dataprop_{prop_uid}", False)
-                with st.expander(f"📝 **{disp_name}** ({prop['domain'] or '?'} → {prop['range']})", expanded=_dp_expanded):
-                    st.write(f"**URI:** `{prop['uri']}`" if prop['uri'].startswith("http://example.org/") else f"**URI:** {prop['uri']}")
+                _dp_expanded = st.session_state.get(
+                    f"view_dataprop_{prop_uid}", False
+                ) or st.session_state.get(f"edit_dataprop_{prop_uid}", False)
+                with st.expander(
+                    f"📝 **{disp_name}** ({prop['domain'] or '?'} → {prop['range']})",
+                    expanded=_dp_expanded,
+                ):
+                    st.write(
+                        f"**URI:** `{prop['uri']}`"
+                        if prop["uri"].startswith("http://example.org/")
+                        else f"**URI:** {prop['uri']}"
+                    )
 
                     btn_view, btn_edit, btn_del, _ = st.columns([1, 1, 1, 4])
                     with btn_view:
-                        st.button("👁️ View", key=f"btn_view_dataprop_{prop_uid}", use_container_width=True,
-                                  on_click=_cb_toggle_view, args=("dataprop", prop_uid))
+                        st.button(
+                            "👁️ View",
+                            key=f"btn_view_dataprop_{prop_uid}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_view,
+                            args=("dataprop", prop_uid),
+                        )
                     with btn_edit:
-                        st.button("✏️ Edit", key=f"btn_edit_dataprop_{prop_uid}", use_container_width=True,
-                                  on_click=_cb_toggle_edit, args=("dataprop", prop_uid))
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_edit_dataprop_{prop_uid}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_edit,
+                            args=("dataprop", prop_uid),
+                        )
                     with btn_del:
-                        st.button("🗑️ Delete", key=f"btn_del_dataprop_{prop_uid}", use_container_width=True,
-                                  on_click=_cb_confirm_delete, args=(f"dataprop_{prop_uid}",))
+                        st.button(
+                            "🗑️ Delete",
+                            key=f"btn_del_dataprop_{prop_uid}",
+                            use_container_width=True,
+                            on_click=_cb_confirm_delete,
+                            args=(f"dataprop_{prop_uid}",),
+                        )
 
                     # View details
                     if st.session_state.get(f"view_dataprop_{prop_uid}", False):
@@ -1208,9 +1521,15 @@ def render_properties():
                         st.write(f"**Comment:** {prop['comment'] or '—'}")
                         st.write(f"**Domain:** {prop['domain'] or '—'}")
                         st.write(f"**Range (Datatype):** {prop['range']}")
-                        st.write(f"**Functional:** {'Yes' if prop['functional'] else 'No'}")
-                        st.button("✏️ Edit", key=f"btn_view_to_edit_dataprop_{prop_uid}",
-                                  on_click=_cb_view_to_edit, args=("dataprop", prop_uid))
+                        st.write(
+                            f"**Functional:** {'Yes' if prop['functional'] else 'No'}"
+                        )
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_view_to_edit_dataprop_{prop_uid}",
+                            on_click=_cb_view_to_edit,
+                            args=("dataprop", prop_uid),
+                        )
 
                     if confirm_delete(prop["uri"], "property", f"dataprop_{prop_uid}"):
                         ont.delete_property(prop["uri"])
@@ -1222,24 +1541,51 @@ def render_properties():
                     if st.session_state.get(f"edit_dataprop_{prop_uid}", False):
                         st.divider()
                         with st.form(f"edit_dataprop_form_{prop_uid}"):
-                            new_name = st.text_input("Name (URI local part)", value=prop["name"], key=f"dp_name_{prop_uid}")
-                            new_label = st.text_input("Label", value=prop["label"], key=f"dp_lbl_{prop_uid}")
-                            new_comment = st.text_area("Comment", value=prop["comment"], key=f"dp_cmt_{prop_uid}")
-                            cls_opts, cls_lookup = build_class_options(classes, include_none=True)
+                            new_name = st.text_input(
+                                "Name (URI local part)",
+                                value=prop["name"],
+                                key=f"dp_name_{prop_uid}",
+                            )
+                            new_label = st.text_input(
+                                "Label", value=prop["label"], key=f"dp_lbl_{prop_uid}"
+                            )
+                            new_comment = st.text_area(
+                                "Comment",
+                                value=prop["comment"],
+                                key=f"dp_cmt_{prop_uid}",
+                            )
+                            cls_opts, cls_lookup = build_class_options(
+                                classes, include_none=True
+                            )
                             cur_dom_uri = prop.get("domain_uri", "")
-                            cur_dom_disp = next((d for d, u in cls_lookup.items() if u == cur_dom_uri), "None")
+                            cur_dom_disp = next(
+                                (d for d, u in cls_lookup.items() if u == cur_dom_uri),
+                                "None",
+                            )
                             col1, col2 = st.columns(2)
                             with col1:
                                 dom_disp = st.selectbox(
-                                    "Domain", options=cls_opts,
-                                    index=cls_opts.index(cur_dom_disp) if cur_dom_disp in cls_opts else 0,
+                                    "Domain",
+                                    options=cls_opts,
+                                    index=cls_opts.index(cur_dom_disp)
+                                    if cur_dom_disp in cls_opts
+                                    else 0,
                                     key=f"dp_dom_{prop_uid}",
                                 )
                             with col2:
-                                current_range = prop["range"] if prop["range"] in datatypes else "string"
-                                new_range = st.selectbox("Range (Datatype)", options=datatypes,
-                                    index=datatypes.index(current_range) if current_range in datatypes else 0,
-                                    key=f"dp_rng_{prop_uid}")
+                                current_range = (
+                                    prop["range"]
+                                    if prop["range"] in datatypes
+                                    else "string"
+                                )
+                                new_range = st.selectbox(
+                                    "Range (Datatype)",
+                                    options=datatypes,
+                                    index=datatypes.index(current_range)
+                                    if current_range in datatypes
+                                    else 0,
+                                    key=f"dp_rng_{prop_uid}",
+                                )
 
                             if st.form_submit_button("Save Changes"):
                                 # Handle rename first — pass URI for cross-namespace safety
@@ -1248,20 +1594,28 @@ def render_properties():
                                     if ont.rename_property(prop["uri"], new_name):
                                         current_ref = new_name
                                         save_checkpoint("Rename property")
-                                        show_message(f"Property renamed to '{new_name}'", "success")
+                                        show_message(
+                                            f"Property renamed to '{new_name}'",
+                                            "success",
+                                        )
                                     else:
-                                        show_message(f"Cannot rename: '{new_name}' already exists!", "error")
+                                        show_message(
+                                            f"Cannot rename: '{new_name}' already exists!",
+                                            "error",
+                                        )
                                         st.rerun()
 
                                 new_dom_uri = cls_lookup.get(dom_disp) or ""
-                                ont.update_property(current_ref,
+                                ont.update_property(
+                                    current_ref,
                                     new_label=new_label,
                                     new_comment=new_comment,
                                     new_domain=new_dom_uri,
-                                    new_range=new_range)
+                                    new_range=new_range,
+                                )
                                 save_checkpoint("Update property")
                                 st.session_state[f"edit_dataprop_{prop_uid}"] = False
-                                show_message(f"Property updated!", "success")
+                                show_message("Property updated!", "success")
                                 st.rerun()
 
     if _prop_tab == "Add Object Property":
@@ -1273,7 +1627,9 @@ def render_properties():
             comment = st.text_area("Comment")
 
             cls_opts, cls_lookup = build_class_options(classes, include_none=True)
-            obj_prop_opts, obj_prop_lookup = build_uri_options(object_props, include_none=True)
+            obj_prop_opts, obj_prop_lookup = build_uri_options(
+                object_props, include_none=True
+            )
             col1, col2 = st.columns(2)
             with col1:
                 domain_disp = st.selectbox("Domain (Class)", options=cls_opts)
@@ -1333,12 +1689,14 @@ def render_properties():
             cls_opts, cls_lookup = build_class_options(classes, include_none=True)
             col1, col2 = st.columns(2)
             with col1:
-                domain_disp = st.selectbox("Domain (Class)", options=cls_opts,
-                                           key="data_prop_domain")
+                domain_disp = st.selectbox(
+                    "Domain (Class)", options=cls_opts, key="data_prop_domain"
+                )
             with col2:
                 datatypes = list(get_ontology_manager_class().XSD_DATATYPES.keys())
-                range_ = st.selectbox("Range (Datatype)", options=datatypes,
-                                     key="data_prop_range")
+                range_ = st.selectbox(
+                    "Range (Datatype)", options=datatypes, key="data_prop_range"
+                )
 
             functional = st.checkbox("Functional", key="data_prop_functional")
 
@@ -1355,7 +1713,7 @@ def render_properties():
                         range_=range_,
                         label=label,
                         comment=comment,
-                        functional=functional
+                        functional=functional,
                     )
                     save_checkpoint("Add data property")
                     show_message(f"Data property '{name}' added!", "success")
@@ -1363,31 +1721,51 @@ def render_properties():
 
     if _prop_tab == "Bulk Operations":
         import pandas as pd
-        bulk_op = st.radio("Operation", ["Add", "Edit", "Delete"], horizontal=True, key="bulk_prop_op")
+
+        bulk_op = st.radio(
+            "Operation", ["Add", "Edit", "Delete"], horizontal=True, key="bulk_prop_op"
+        )
 
         if bulk_op == "Add":
             st.subheader("Bulk Add Properties")
-            prop_type = st.radio("Property Type", ["Object Property", "Data Property"],
-                                 horizontal=True, key="bulk_prop_type")
-            st.caption("Enter one property per line, or CSV: Name, Domain, Range, Label")
-            bulk_text = st.text_area("Property entries", height=200, key="bulk_props_text",
-                                     placeholder="hasFriend\nhasEnemy\n\nor CSV:\nName, Domain, Range, Label\nhasFriend, Person, Person, has friend")
+            prop_type = st.radio(
+                "Property Type",
+                ["Object Property", "Data Property"],
+                horizontal=True,
+                key="bulk_prop_type",
+            )
+            st.caption(
+                "Enter one property per line, or CSV: Name, Domain, Range, Label"
+            )
+            bulk_text = st.text_area(
+                "Property entries",
+                height=200,
+                key="bulk_props_text",
+                placeholder="hasFriend\nhasEnemy\n\nor CSV:\nName, Domain, Range, Label\nhasFriend, Person, Person, has friend",
+            )
             if bulk_text:
                 entries = ont.parse_bulk_text(bulk_text)
                 if entries:
                     st.dataframe(pd.DataFrame(entries), width="stretch")
                     ptype = "object" if prop_type == "Object Property" else "data"
-                    if st.button("Create All Properties", type="primary", key="bulk_create_props"):
+                    if st.button(
+                        "Create All Properties", type="primary", key="bulk_create_props"
+                    ):
                         result = ont.bulk_add_properties(entries, property_type=ptype)
                         save_checkpoint("Bulk add properties")
                         parts = []
                         if result["created"]:
-                            parts.append(f"Created {len(result['created'])} propert(ies)")
+                            parts.append(
+                                f"Created {len(result['created'])} propert(ies)"
+                            )
                         if result["skipped"]:
                             parts.append(f"Skipped {len(result['skipped'])} existing")
                         if result["errors"]:
                             parts.append(f"{len(result['errors'])} error(s)")
-                        show_message(". ".join(parts), "success" if result["created"] else "warning")
+                        show_message(
+                            ". ".join(parts),
+                            "success" if result["created"] else "warning",
+                        )
                         st.rerun()
 
         elif bulk_op == "Edit":
@@ -1397,18 +1775,29 @@ def render_properties():
             if not all_props:
                 st.info("No properties to edit.")
             else:
-                edit_data = [{"Name": p["name"], "Label": p.get("label") or "",
-                              "Type": "Object" if p in object_props else "Data",
-                              "Domain": p.get("domain") or "",
-                              "Range": p.get("range") or ""}
-                             for p in all_props]
+                edit_data = [
+                    {
+                        "Name": p["name"],
+                        "Label": p.get("label") or "",
+                        "Type": "Object" if p in object_props else "Data",
+                        "Domain": p.get("domain") or "",
+                        "Range": p.get("range") or "",
+                    }
+                    for p in all_props
+                ]
                 df = pd.DataFrame(edit_data)
-                edited_df = st.data_editor(df, key="bulk_edit_props_editor", width="stretch",
-                                           disabled=["Name", "Type"])
+                edited_df = st.data_editor(
+                    df,
+                    key="bulk_edit_props_editor",
+                    width="stretch",
+                    disabled=["Name", "Type"],
+                )
                 if st.button("Apply Changes", type="primary", key="bulk_apply_props"):
                     changes = 0
                     for _, row in edited_df.iterrows():
-                        orig = next((p for p in all_props if p["name"] == row["Name"]), None)
+                        orig = next(
+                            (p for p in all_props if p["name"] == row["Name"]), None
+                        )
                         if not orig:
                             continue
                         new_label = row["Label"]
@@ -1429,13 +1818,23 @@ def render_properties():
             if not all_prop_names:
                 st.info("No properties to delete.")
             else:
-                selected = st.multiselect("Select properties to delete", all_prop_names, key="bulk_delete_props_select")
+                selected = st.multiselect(
+                    "Select properties to delete",
+                    all_prop_names,
+                    key="bulk_delete_props_select",
+                )
                 if selected:
-                    st.warning(f"This will delete {len(selected)} propert(ies) and all their references.")
-                    if st.button("Delete Selected", type="primary", key="bulk_delete_props_btn"):
+                    st.warning(
+                        f"This will delete {len(selected)} propert(ies) and all their references."
+                    )
+                    if st.button(
+                        "Delete Selected", type="primary", key="bulk_delete_props_btn"
+                    ):
                         result = ont.bulk_delete_properties(selected)
                         save_checkpoint("Bulk delete properties")
-                        show_message(f"Deleted {len(result['deleted'])} propert(ies)", "success")
+                        show_message(
+                            f"Deleted {len(result['deleted'])} propert(ies)", "success"
+                        )
                         st.rerun()
 
 
@@ -1451,8 +1850,13 @@ def render_individuals():
     object_props = ont.get_object_properties()
     data_props = ont.get_data_properties()
 
-    _ind_tab = st.segmented_control("Section", ["View Individuals", "Add Individual", "Add Property Value", "Bulk Operations"],
-                                    default="View Individuals", key="ind_active_tab", label_visibility="collapsed")
+    _ind_tab = st.segmented_control(
+        "Section",
+        ["View Individuals", "Add Individual", "Add Property Value", "Bulk Operations"],
+        default="View Individuals",
+        key="ind_active_tab",
+        label_visibility="collapsed",
+    )
     if not _ind_tab:
         _ind_tab = "View Individuals"
 
@@ -1464,9 +1868,12 @@ def render_individuals():
             ind_collisions = _build_name_collision_set(individuals)
 
             _active_ind = next(
-                (i for i in individuals
-                 if st.session_state.get(f"view_ind_{_uid(i['uri'])}", False)
-                 or st.session_state.get(f"edit_ind_{_uid(i['uri'])}", False)),
+                (
+                    i
+                    for i in individuals
+                    if st.session_state.get(f"view_ind_{_uid(i['uri'])}", False)
+                    or st.session_state.get(f"edit_ind_{_uid(i['uri'])}", False)
+                ),
                 None,
             )
             if _active_ind:
@@ -1478,23 +1885,48 @@ def render_individuals():
                         st.session_state.pop(f"edit_ind_{i_uid}", None)
 
             for ind in individuals:
-                classes_str = ", ".join(ind["classes"]) if ind["classes"] else "No class"
+                classes_str = (
+                    ", ".join(ind["classes"]) if ind["classes"] else "No class"
+                )
                 _ik = _uid(ind["uri"])
                 disp_ind_name = _disambiguated_name(ind, ind_collisions)
-                _ind_expanded = st.session_state.get(f"view_ind_{_ik}", False) or st.session_state.get(f"edit_ind_{_ik}", False)
-                with st.expander(f"👤 **{disp_ind_name}** ({classes_str})", expanded=_ind_expanded):
-                    st.write(f"**URI:** `{ind['uri']}`" if ind['uri'].startswith("http://example.org/") else f"**URI:** {ind['uri']}")
+                _ind_expanded = st.session_state.get(
+                    f"view_ind_{_ik}", False
+                ) or st.session_state.get(f"edit_ind_{_ik}", False)
+                with st.expander(
+                    f"👤 **{disp_ind_name}** ({classes_str})", expanded=_ind_expanded
+                ):
+                    st.write(
+                        f"**URI:** `{ind['uri']}`"
+                        if ind["uri"].startswith("http://example.org/")
+                        else f"**URI:** {ind['uri']}"
+                    )
 
                     btn_view, btn_edit, btn_del, _ = st.columns([1, 1, 1, 4])
                     with btn_view:
-                        st.button("👁️ View", key=f"btn_view_ind_{_ik}", use_container_width=True,
-                                  on_click=_cb_toggle_view, args=("ind", _ik))
+                        st.button(
+                            "👁️ View",
+                            key=f"btn_view_ind_{_ik}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_view,
+                            args=("ind", _ik),
+                        )
                     with btn_edit:
-                        st.button("✏️ Edit", key=f"btn_edit_ind_{_ik}", use_container_width=True,
-                                  on_click=_cb_toggle_edit, args=("ind", _ik))
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_edit_ind_{_ik}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_edit,
+                            args=("ind", _ik),
+                        )
                     with btn_del:
-                        st.button("🗑️ Delete", key=f"btn_del_ind_{_ik}", use_container_width=True,
-                                  on_click=_cb_confirm_delete, args=(f"ind_{_ik}",))
+                        st.button(
+                            "🗑️ Delete",
+                            key=f"btn_del_ind_{_ik}",
+                            use_container_width=True,
+                            on_click=_cb_confirm_delete,
+                            args=(f"ind_{_ik}",),
+                        )
 
                     # View details
                     if st.session_state.get(f"view_ind_{_ik}", False):
@@ -1502,20 +1934,28 @@ def render_individuals():
                         st.write(f"**Name:** {ind['name']}")
                         st.write(f"**Label:** {ind['label'] or '—'}")
                         st.write(f"**Comment:** {ind['comment'] or '—'}")
-                        st.write(f"**Classes:** {', '.join(ind['classes']) if ind['classes'] else '—'}")
+                        st.write(
+                            f"**Classes:** {', '.join(ind['classes']) if ind['classes'] else '—'}"
+                        )
                         if ind["properties"]:
                             st.write("**Property Values:**")
                             for prop in ind["properties"]:
                                 st.write(f"  - {prop['property']}: {prop['value']}")
                         else:
                             st.write("**Property Values:** —")
-                        st.button("✏️ Edit", key=f"btn_view_to_edit_ind_{_ik}",
-                                  on_click=_cb_view_to_edit, args=("ind", _ik))
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_view_to_edit_ind_{_ik}",
+                            on_click=_cb_view_to_edit,
+                            args=("ind", _ik),
+                        )
 
                     if confirm_delete(ind["uri"], "individual", f"ind_{_ik}"):
                         ont.delete_individual(ind["uri"])
                         save_checkpoint("Delete individual")
-                        set_flash_message(f"Individual '{disp_ind_name}' deleted!", "success")
+                        set_flash_message(
+                            f"Individual '{disp_ind_name}' deleted!", "success"
+                        )
                         st.rerun()
 
                     # Resource usages
@@ -1536,23 +1976,37 @@ def render_individuals():
                     if st.session_state.get(f"edit_ind_{_ik}", False):
                         st.divider()
                         with st.form(f"edit_ind_form_{_ik}"):
-                            new_name = st.text_input("Name (URI local part)", value=ind["name"], key=f"ind_name_{_ik}")
-                            new_label = st.text_input("Label", value=ind["label"], key=f"ind_lbl_{_ik}")
-                            new_comment = st.text_area("Comment", value=ind["comment"], key=f"ind_cmt_{_ik}")
+                            new_name = st.text_input(
+                                "Name (URI local part)",
+                                value=ind["name"],
+                                key=f"ind_name_{_ik}",
+                            )
+                            new_label = st.text_input(
+                                "Label", value=ind["label"], key=f"ind_lbl_{_ik}"
+                            )
+                            new_comment = st.text_area(
+                                "Comment", value=ind["comment"], key=f"ind_cmt_{_ik}"
+                            )
 
                             st.write("**Manage Classes:**")
                             current_classes = ind["classes"]
-                            available_classes = [c for c in class_names if c not in current_classes]
+                            available_classes = [
+                                c for c in class_names if c not in current_classes
+                            ]
 
                             col1, col2 = st.columns(2)
                             with col1:
-                                add_class = st.selectbox("Add to Class",
+                                add_class = st.selectbox(
+                                    "Add to Class",
                                     options=["None"] + available_classes,
-                                    key=f"ind_add_cls_{_ik}")
+                                    key=f"ind_add_cls_{_ik}",
+                                )
                             with col2:
-                                remove_class = st.selectbox("Remove from Class",
+                                remove_class = st.selectbox(
+                                    "Remove from Class",
                                     options=["None"] + current_classes,
-                                    key=f"ind_rem_cls_{_ik}")
+                                    key=f"ind_rem_cls_{_ik}",
+                                )
 
                             if st.form_submit_button("Save Changes"):
                                 # Handle rename first — pass URI for cross-namespace safety
@@ -1561,19 +2015,31 @@ def render_individuals():
                                     if ont.rename_individual(ind["uri"], new_name):
                                         current_ref = new_name
                                         save_checkpoint("Rename individual")
-                                        show_message(f"Individual renamed to '{new_name}'", "success")
+                                        show_message(
+                                            f"Individual renamed to '{new_name}'",
+                                            "success",
+                                        )
                                     else:
-                                        show_message(f"Cannot rename: '{new_name}' already exists!", "error")
+                                        show_message(
+                                            f"Cannot rename: '{new_name}' already exists!",
+                                            "error",
+                                        )
                                         st.rerun()
 
-                                ont.update_individual(current_ref,
+                                ont.update_individual(
+                                    current_ref,
                                     new_label=new_label,
                                     new_comment=new_comment,
-                                    add_class=add_class if add_class != "None" else None,
-                                    remove_class=remove_class if remove_class != "None" else None)
+                                    add_class=add_class
+                                    if add_class != "None"
+                                    else None,
+                                    remove_class=remove_class
+                                    if remove_class != "None"
+                                    else None,
+                                )
                                 save_checkpoint("Update individual")
                                 st.session_state[f"edit_ind_{_ik}"] = False
-                                show_message(f"Individual updated!", "success")
+                                show_message("Individual updated!", "success")
                                 st.rerun()
 
     if _ind_tab == "Add Individual":
@@ -1595,7 +2061,9 @@ def render_individuals():
                     elif name in ind_names:
                         show_message(f"Individual '{name}' already exists!", "error")
                     else:
-                        ont.add_individual(name, class_type, label=label, comment=comment)
+                        ont.add_individual(
+                            name, class_type, label=label, comment=comment
+                        )
                         save_checkpoint("Add individual")
                         show_message(f"Individual '{name}' added!", "success")
                         st.rerun()
@@ -1611,16 +2079,24 @@ def render_individuals():
             with st.form("add_prop_value_form"):
                 individual = st.selectbox("Select Individual", options=ind_names)
 
-                prop_type = st.radio("Property Type", ["Object Property", "Data Property"])
+                prop_type = st.radio(
+                    "Property Type", ["Object Property", "Data Property"]
+                )
 
                 if prop_type == "Object Property":
                     prop_options = [p["name"] for p in object_props]
-                    property_name = st.selectbox("Property", options=prop_options if prop_options else ["No properties"])
+                    property_name = st.selectbox(
+                        "Property",
+                        options=prop_options if prop_options else ["No properties"],
+                    )
                     value = st.selectbox("Value (Individual)", options=ind_names)
                     is_object = True
                 else:
                     prop_options = [p["name"] for p in data_props]
-                    property_name = st.selectbox("Property", options=prop_options if prop_options else ["No properties"])
+                    property_name = st.selectbox(
+                        "Property",
+                        options=prop_options if prop_options else ["No properties"],
+                    )
                     value = st.text_input("Value")
                     is_object = False
 
@@ -1631,36 +2107,60 @@ def render_individuals():
                     elif not value:
                         show_message("Please provide a value!", "error")
                     else:
-                        ont.add_individual_property(individual, property_name, value,
-                                                   is_object_property=is_object)
+                        ont.add_individual_property(
+                            individual,
+                            property_name,
+                            value,
+                            is_object_property=is_object,
+                        )
                         save_checkpoint("Add property assertion")
-                        show_message(f"Property value added to '{individual}'!", "success")
+                        show_message(
+                            f"Property value added to '{individual}'!", "success"
+                        )
                         st.rerun()
 
     if _ind_tab == "Bulk Operations":
         import pandas as pd
-        bulk_op = st.radio("Operation", ["Add", "Edit", "Delete"], horizontal=True, key="bulk_ind_op")
+
+        bulk_op = st.radio(
+            "Operation", ["Add", "Edit", "Delete"], horizontal=True, key="bulk_ind_op"
+        )
 
         if bulk_op == "Add":
             st.subheader("Bulk Add Individuals")
-            st.caption("Enter one individual per line (Name, Class) or CSV: Name, Class, Label")
-            bulk_text = st.text_area("Individual entries", height=200, key="bulk_individuals_text",
-                                     placeholder="Name, Class, Label\nalice, Person, Alice\nbob, Person, Bob")
+            st.caption(
+                "Enter one individual per line (Name, Class) or CSV: Name, Class, Label"
+            )
+            bulk_text = st.text_area(
+                "Individual entries",
+                height=200,
+                key="bulk_individuals_text",
+                placeholder="Name, Class, Label\nalice, Person, Alice\nbob, Person, Bob",
+            )
             if bulk_text:
                 entries = ont.parse_bulk_text(bulk_text)
                 if entries:
                     st.dataframe(pd.DataFrame(entries), width="stretch")
-                    if st.button("Create All Individuals", type="primary", key="bulk_create_individuals"):
+                    if st.button(
+                        "Create All Individuals",
+                        type="primary",
+                        key="bulk_create_individuals",
+                    ):
                         result = ont.bulk_add_individuals(entries)
                         save_checkpoint("Bulk add individuals")
                         parts = []
                         if result["created"]:
-                            parts.append(f"Created {len(result['created'])} individual(s)")
+                            parts.append(
+                                f"Created {len(result['created'])} individual(s)"
+                            )
                         if result["skipped"]:
                             parts.append(f"Skipped {len(result['skipped'])} existing")
                         if result["errors"]:
                             parts.append(f"{len(result['errors'])} error(s)")
-                        show_message(". ".join(parts), "success" if result["created"] else "warning")
+                        show_message(
+                            ". ".join(parts),
+                            "success" if result["created"] else "warning",
+                        )
                         st.rerun()
 
         elif bulk_op == "Edit":
@@ -1669,16 +2169,27 @@ def render_individuals():
             if not individuals:
                 st.info("No individuals to edit.")
             else:
-                edit_data = [{"Name": i["name"], "Label": i.get("label") or "",
-                              "Class": ", ".join(i.get("classes", []))}
-                             for i in individuals]
+                edit_data = [
+                    {
+                        "Name": i["name"],
+                        "Label": i.get("label") or "",
+                        "Class": ", ".join(i.get("classes", [])),
+                    }
+                    for i in individuals
+                ]
                 df = pd.DataFrame(edit_data)
-                edited_df = st.data_editor(df, key="bulk_edit_ind_editor", width="stretch",
-                                           disabled=["Name", "Class"])
+                edited_df = st.data_editor(
+                    df,
+                    key="bulk_edit_ind_editor",
+                    width="stretch",
+                    disabled=["Name", "Class"],
+                )
                 if st.button("Apply Changes", type="primary", key="bulk_apply_ind"):
                     changes = 0
                     for _, row in edited_df.iterrows():
-                        orig = next((i for i in individuals if i["name"] == row["Name"]), None)
+                        orig = next(
+                            (i for i in individuals if i["name"] == row["Name"]), None
+                        )
                         if not orig:
                             continue
                         new_label = row["Label"]
@@ -1698,13 +2209,23 @@ def render_individuals():
             if not individuals:
                 st.info("No individuals to delete.")
             else:
-                selected = st.multiselect("Select individuals to delete", ind_names, key="bulk_delete_ind_select")
+                selected = st.multiselect(
+                    "Select individuals to delete",
+                    ind_names,
+                    key="bulk_delete_ind_select",
+                )
                 if selected:
-                    st.warning(f"This will delete {len(selected)} individual(s) and all their references.")
-                    if st.button("Delete Selected", type="primary", key="bulk_delete_ind_btn"):
+                    st.warning(
+                        f"This will delete {len(selected)} individual(s) and all their references."
+                    )
+                    if st.button(
+                        "Delete Selected", type="primary", key="bulk_delete_ind_btn"
+                    ):
                         result = ont.bulk_delete_individuals(selected)
                         save_checkpoint("Bulk delete individuals")
-                        show_message(f"Deleted {len(result['deleted'])} individual(s)", "success")
+                        show_message(
+                            f"Deleted {len(result['deleted'])} individual(s)", "success"
+                        )
                         st.rerun()
 
 
@@ -1720,8 +2241,13 @@ def render_restrictions():
     all_props = [p["name"] for p in object_props] + [p["name"] for p in data_props]
     restrictions = ont.get_restrictions()
 
-    _rest_tab = st.segmented_control("Section", ["View Restrictions", "Add Restriction"],
-                                     default="View Restrictions", key="rest_active_tab", label_visibility="collapsed")
+    _rest_tab = st.segmented_control(
+        "Section",
+        ["View Restrictions", "Add Restriction"],
+        default="View Restrictions",
+        key="rest_active_tab",
+        label_visibility="collapsed",
+    )
     if not _rest_tab:
         _rest_tab = "View Restrictions"
 
@@ -1738,11 +2264,11 @@ def render_restrictions():
                         st.write(f"**Qualified on Class:** {rest['on_class']}")
                     st.write(f"**Applied to Classes:** {', '.join(rest['applied_to'])}")
 
-                    if rest['applied_to']:
+                    if rest["applied_to"]:
                         if st.button("Delete", key=f"del_rest_{i}"):
-                            ont.delete_restriction(rest['applied_to'][0],
-                                                  rest['property'],
-                                                  rest['type'])
+                            ont.delete_restriction(
+                                rest["applied_to"][0], rest["property"], rest["type"]
+                            )
                             save_checkpoint("Delete restriction")
                             show_message("Restriction deleted!", "success")
                             st.rerun()
@@ -1760,35 +2286,54 @@ def render_restrictions():
                 property_name = st.selectbox("On Property", options=all_props)
 
                 restriction_types = [
-                    "someValuesFrom", "allValuesFrom", "hasValue",
-                    "minCardinality", "maxCardinality", "exactCardinality",
-                    "minQualifiedCardinality", "maxQualifiedCardinality", "qualifiedCardinality"
+                    "someValuesFrom",
+                    "allValuesFrom",
+                    "hasValue",
+                    "minCardinality",
+                    "maxCardinality",
+                    "exactCardinality",
+                    "minQualifiedCardinality",
+                    "maxQualifiedCardinality",
+                    "qualifiedCardinality",
                 ]
-                restriction_type = st.selectbox("Restriction Type", options=restriction_types)
+                restriction_type = st.selectbox(
+                    "Restriction Type", options=restriction_types
+                )
 
                 st.write("**Restriction Value:**")
                 if restriction_type in ["someValuesFrom", "allValuesFrom"]:
-                    value = st.selectbox("Value (Class)", options=class_names, key="rest_class_value")
+                    value = st.selectbox(
+                        "Value (Class)", options=class_names, key="rest_class_value"
+                    )
                 elif restriction_type == "hasValue":
                     value_type = st.radio("Value Type", ["Literal", "Individual"])
                     if value_type == "Literal":
                         value = st.text_input("Literal Value")
                     else:
                         ind_names = [i["name"] for i in ont.get_individuals()]
-                        value = st.selectbox("Individual", options=ind_names if ind_names else ["No individuals"])
+                        value = st.selectbox(
+                            "Individual",
+                            options=ind_names if ind_names else ["No individuals"],
+                        )
                 else:
                     value = st.number_input("Cardinality", min_value=0, value=1)
 
                 on_class = None
                 if "Qualified" in restriction_type:
-                    on_class = st.selectbox("Qualified on Class", options=class_names,
-                                           key="qualified_class")
+                    on_class = st.selectbox(
+                        "Qualified on Class", options=class_names, key="qualified_class"
+                    )
 
                 submitted = st.form_submit_button("Add Restriction")
                 if submitted:
                     try:
-                        ont.add_restriction(target_class, property_name, restriction_type,
-                                          value, on_class=on_class)
+                        ont.add_restriction(
+                            target_class,
+                            property_name,
+                            restriction_type,
+                            value,
+                            on_class=on_class,
+                        )
                         save_checkpoint("Add restriction")
                         show_message("Restriction added!", "success")
                         st.rerun()
@@ -1802,15 +2347,22 @@ def render_relations():
 
     ont = st.session_state.ontology
     classes = ont.get_classes()
-    class_names = [c["name"] for c in classes]
     object_props = ont.get_object_properties()
     data_props = ont.get_data_properties()
-    all_prop_names = [p["name"] for p in object_props] + [p["name"] for p in data_props]
     individuals = ont.get_individuals()
-    ind_names = [i["name"] for i in individuals]
 
-    _rel_tab = st.segmented_control("Section", ["View Relations", "Class Relations", "Property Relations", "Individual Relations"],
-                                    default="View Relations", key="rel_active_tab", label_visibility="collapsed")
+    _rel_tab = st.segmented_control(
+        "Section",
+        [
+            "View Relations",
+            "Class Relations",
+            "Property Relations",
+            "Individual Relations",
+        ],
+        default="View Relations",
+        key="rel_active_tab",
+        label_visibility="collapsed",
+    )
     if not _rel_tab:
         _rel_tab = "View Relations"
 
@@ -1834,7 +2386,7 @@ def render_relations():
                     st.write(f"📦 {rel['object']}")
                 with col4:
                     if st.button("🗑️", key=f"del_crel_{rel_uid}"):
-                        ont.remove_class_relation(subj_uri, rel['relation'], obj_uri)
+                        ont.remove_class_relation(subj_uri, rel["relation"], obj_uri)
                         save_checkpoint("Delete class relation")
                         show_message("Relation deleted!", "success")
                         st.rerun()
@@ -1860,7 +2412,7 @@ def render_relations():
                     obj_uri = rel.get("object_uri", rel["object"])
                     rel_uid = _uid(f"{subj_uri}|{rel['relation']}|{obj_uri}")
                     if st.button("🗑️", key=f"del_prel_{rel_uid}"):
-                        ont.remove_property_relation(subj_uri, rel['relation'], obj_uri)
+                        ont.remove_property_relation(subj_uri, rel["relation"], obj_uri)
                         save_checkpoint("Delete property relation")
                         show_message("Relation deleted!", "success")
                         st.rerun()
@@ -1886,7 +2438,9 @@ def render_relations():
                     obj_uri = rel.get("object_uri", rel["object"])
                     rel_uid = _uid(f"{subj_uri}|{rel['relation']}|{obj_uri}")
                     if st.button("🗑️", key=f"del_irel_{rel_uid}"):
-                        ont.remove_individual_relation(subj_uri, rel['relation'], obj_uri)
+                        ont.remove_individual_relation(
+                            subj_uri, rel["relation"], obj_uri
+                        )
                         save_checkpoint("Delete individual relation")
                         show_message("Relation deleted!", "success")
                         st.rerun()
@@ -1904,15 +2458,19 @@ def render_relations():
                 col1, col2, col3 = st.columns(3)
 
                 with col1:
-                    class1_disp = st.selectbox("Class 1", options=cls_opts, key="crel_class1")
+                    class1_disp = st.selectbox(
+                        "Class 1", options=cls_opts, key="crel_class1"
+                    )
                 with col2:
-                    relation_type = st.selectbox("Relation Type", options=[
-                        "subClassOf",
-                        "equivalentClass",
-                        "disjointWith"
-                    ], key="crel_type")
+                    relation_type = st.selectbox(
+                        "Relation Type",
+                        options=["subClassOf", "equivalentClass", "disjointWith"],
+                        key="crel_type",
+                    )
                 with col3:
-                    class2_disp = st.selectbox("Class 2", options=cls_opts, key="crel_class2")
+                    class2_disp = st.selectbox(
+                        "Class 2", options=cls_opts, key="crel_class2"
+                    )
 
                 st.caption("""
                 - **subClassOf**: Class 1 is a subclass of Class 2
@@ -1929,7 +2487,10 @@ def render_relations():
                     else:
                         ont.add_class_relation(class1_uri, relation_type, class2_uri)
                         save_checkpoint("Add class relation")
-                        show_message(f"Relation added: {class1_disp} {relation_type} {class2_disp}", "success")
+                        show_message(
+                            f"Relation added: {class1_disp} {relation_type} {class2_disp}",
+                            "success",
+                        )
                         st.rerun()
 
     if _rel_tab == "Property Relations":
@@ -1944,15 +2505,19 @@ def render_relations():
                 col1, col2, col3 = st.columns(3)
 
                 with col1:
-                    prop1_disp = st.selectbox("Property 1", options=prop_opts, key="prel_prop1")
+                    prop1_disp = st.selectbox(
+                        "Property 1", options=prop_opts, key="prel_prop1"
+                    )
                 with col2:
-                    relation_type = st.selectbox("Relation Type", options=[
-                        "subPropertyOf",
-                        "equivalentProperty",
-                        "inverseOf"
-                    ], key="prel_type")
+                    relation_type = st.selectbox(
+                        "Relation Type",
+                        options=["subPropertyOf", "equivalentProperty", "inverseOf"],
+                        key="prel_type",
+                    )
                 with col3:
-                    prop2_disp = st.selectbox("Property 2", options=prop_opts, key="prel_prop2")
+                    prop2_disp = st.selectbox(
+                        "Property 2", options=prop_opts, key="prel_prop2"
+                    )
 
                 st.caption("""
                 - **subPropertyOf**: Property 1 is a sub-property of Property 2
@@ -1969,7 +2534,10 @@ def render_relations():
                     else:
                         ont.add_property_relation(prop1_uri, relation_type, prop2_uri)
                         save_checkpoint("Add property relation")
-                        show_message(f"Relation added: {prop1_disp} {relation_type} {prop2_disp}", "success")
+                        show_message(
+                            f"Relation added: {prop1_disp} {relation_type} {prop2_disp}",
+                            "success",
+                        )
                         st.rerun()
 
     if _rel_tab == "Individual Relations":
@@ -1983,14 +2551,19 @@ def render_relations():
                 col1, col2, col3 = st.columns(3)
 
                 with col1:
-                    ind1_disp = st.selectbox("Individual 1", options=ind_opts, key="irel_ind1")
+                    ind1_disp = st.selectbox(
+                        "Individual 1", options=ind_opts, key="irel_ind1"
+                    )
                 with col2:
-                    relation_type = st.selectbox("Relation Type", options=[
-                        "sameAs",
-                        "differentFrom"
-                    ], key="irel_type")
+                    relation_type = st.selectbox(
+                        "Relation Type",
+                        options=["sameAs", "differentFrom"],
+                        key="irel_type",
+                    )
                 with col3:
-                    ind2_disp = st.selectbox("Individual 2", options=ind_opts, key="irel_ind2")
+                    ind2_disp = st.selectbox(
+                        "Individual 2", options=ind_opts, key="irel_ind2"
+                    )
 
                 st.caption("""
                 - **sameAs**: Individual 1 and Individual 2 refer to the same entity
@@ -2002,11 +2575,16 @@ def render_relations():
                     ind1_uri = ind_lookup.get(ind1_disp)
                     ind2_uri = ind_lookup.get(ind2_disp)
                     if ind1_uri == ind2_uri:
-                        show_message("Please select two different individuals!", "error")
+                        show_message(
+                            "Please select two different individuals!", "error"
+                        )
                     else:
                         ont.add_individual_relation(ind1_uri, relation_type, ind2_uri)
                         save_checkpoint("Add individual relation")
-                        show_message(f"Relation added: {ind1_disp} {relation_type} {ind2_disp}", "success")
+                        show_message(
+                            f"Relation added: {ind1_disp} {relation_type} {ind2_disp}",
+                            "success",
+                        )
                         st.rerun()
 
 
@@ -2030,47 +2608,86 @@ def render_annotations():
     all_resources = []
     for c in classes:
         display = format_resource(c["name"], c.get("label"), "Class")
-        all_resources.append({"name": c["name"], "label": c.get("label"), "type": "Class", "display": display})
+        all_resources.append(
+            {
+                "name": c["name"],
+                "label": c.get("label"),
+                "type": "Class",
+                "display": display,
+            }
+        )
     for p in object_props:
         display = format_resource(p["name"], p.get("label"), "Object Property")
-        all_resources.append({"name": p["name"], "label": p.get("label"), "type": "Object Property", "display": display})
+        all_resources.append(
+            {
+                "name": p["name"],
+                "label": p.get("label"),
+                "type": "Object Property",
+                "display": display,
+            }
+        )
     for p in data_props:
         display = format_resource(p["name"], p.get("label"), "Data Property")
-        all_resources.append({"name": p["name"], "label": p.get("label"), "type": "Data Property", "display": display})
+        all_resources.append(
+            {
+                "name": p["name"],
+                "label": p.get("label"),
+                "type": "Data Property",
+                "display": display,
+            }
+        )
     for i in individuals:
         display = format_resource(i["name"], i.get("label"), "Individual")
-        all_resources.append({"name": i["name"], "label": i.get("label"), "type": "Individual", "display": display})
+        all_resources.append(
+            {
+                "name": i["name"],
+                "label": i.get("label"),
+                "type": "Individual",
+                "display": display,
+            }
+        )
 
     # Sort all resources by display text
     all_resources.sort(key=lambda r: r["display"].lower())
 
-    _ann_tab = st.segmented_control("Section", ["View Annotations", "Add Annotation", "Bulk Edit"],
-                                    default="View Annotations", key="ann_active_tab", label_visibility="collapsed")
+    _ann_tab = st.segmented_control(
+        "Section",
+        ["View Annotations", "Add Annotation", "Bulk Edit"],
+        default="View Annotations",
+        key="ann_active_tab",
+        label_visibility="collapsed",
+    )
     if not _ann_tab:
         _ann_tab = "View Annotations"
 
     if _ann_tab == "View Annotations":
         if not all_resources:
-            st.info("No resources to annotate. Create classes, properties, or individuals first.")
+            st.info(
+                "No resources to annotate. Create classes, properties, or individuals first."
+            )
         else:
             # Filter by resource type
             col1, col2 = st.columns([1, 3])
             with col1:
                 filter_types = ["All"] + list(set(r["type"] for r in all_resources))
-                selected_type = st.selectbox("Filter by Type", options=filter_types, key="filter_type")
+                selected_type = st.selectbox(
+                    "Filter by Type", options=filter_types, key="filter_type"
+                )
 
             # Filter resources based on selection
             if selected_type == "All":
                 filtered_resources = all_resources
             else:
-                filtered_resources = [r for r in all_resources if r["type"] == selected_type]
+                filtered_resources = [
+                    r for r in all_resources if r["type"] == selected_type
+                ]
 
             with col2:
                 if filtered_resources:
                     selected = st.selectbox(
                         "Select Resource",
                         options=[r["display"] for r in filtered_resources],
-                        key="view_annotations_select"
+                        key="view_annotations_select",
                     )
                 else:
                     selected = None
@@ -2078,7 +2695,9 @@ def render_annotations():
 
             if selected:
                 # Find the actual resource name from display string
-                resource = next((r for r in filtered_resources if r["display"] == selected), None)
+                resource = next(
+                    (r for r in filtered_resources if r["display"] == selected), None
+                )
                 if resource:
                     resource_name = resource["name"]
                     annotations = ont.get_annotations(resource_name)
@@ -2091,17 +2710,33 @@ def render_annotations():
                             col1, col2, col3 = st.columns([2, 4, 1])
                             with col1:
                                 # Show prefixed predicate (e.g., rdfs:label, skos:prefLabel)
-                                predicate_display = ann.get('predicate_prefixed', ann['predicate'])
+                                predicate_display = ann.get(
+                                    "predicate_prefixed", ann["predicate"]
+                                )
                                 st.write(f"**{predicate_display}**")
                             with col2:
-                                lang_str = f" @{ann['language']}" if ann.get('language') else ""
-                                dtype_str = f" ({ann['datatype']})" if ann.get('datatype') else ""
+                                lang_str = (
+                                    f" @{ann['language']}"
+                                    if ann.get("language")
+                                    else ""
+                                )
+                                dtype_str = (
+                                    f" ({ann['datatype']})"
+                                    if ann.get("datatype")
+                                    else ""
+                                )
                                 st.write(f"{ann['value']}{lang_str}{dtype_str}")
                             with col3:
-                                if st.button("🗑️", key=f"del_ann_{resource_name}_{ann['predicate']}_{hash(ann['value'])}"):
+                                if st.button(
+                                    "🗑️",
+                                    key=f"del_ann_{resource_name}_{ann['predicate']}_{hash(ann['value'])}",
+                                ):
                                     ont.delete_annotation(
-                                        resource_name, ann['predicate'], ann['value'],
-                                        lang=ann.get('language'), datatype=ann.get('datatype')
+                                        resource_name,
+                                        ann["predicate"],
+                                        ann["value"],
+                                        lang=ann.get("language"),
+                                        datatype=ann.get("datatype"),
                                     )
                                     save_checkpoint("Delete annotation")
                                     show_message("Annotation deleted!", "success")
@@ -2128,9 +2763,17 @@ def render_annotations():
                 {"local_name": "example", "uri": "example", "prefix": "skos"},
                 {"local_name": "note", "uri": "note", "prefix": "skos"},
                 {"local_name": "title", "uri": "title", "prefix": "dcterms"},
-                {"local_name": "description", "uri": "description", "prefix": "dcterms"},
+                {
+                    "local_name": "description",
+                    "uri": "description",
+                    "prefix": "dcterms",
+                },
                 {"local_name": "creator", "uri": "creator", "prefix": "dcterms"},
-                {"local_name": "contributor", "uri": "contributor", "prefix": "dcterms"},
+                {
+                    "local_name": "contributor",
+                    "uri": "contributor",
+                    "prefix": "dcterms",
+                },
                 {"local_name": "date", "uri": "date", "prefix": "dcterms"},
                 {"local_name": "deprecated", "uri": "deprecated", "prefix": "owl"},
             ]
@@ -2142,33 +2785,45 @@ def render_annotations():
             # Add used predicates first (from ontology)
             seen_names = set()
             for p in used_predicates:
-                display = f"{p['prefix']}:{p['local_name']}" if p['prefix'] else p['local_name']
+                display = (
+                    f"{p['prefix']}:{p['local_name']}"
+                    if p["prefix"]
+                    else p["local_name"]
+                )
                 if display not in seen_names:
                     predicate_options.append(display)
-                    predicate_lookup[display] = p['uri']
+                    predicate_lookup[display] = p["uri"]
                     seen_names.add(display)
-                    seen_names.add(p['local_name'])  # Also mark local name as seen
+                    seen_names.add(p["local_name"])  # Also mark local name as seen
 
             # Add standard predicates that aren't already included
             for p in standard_predicates:
                 display = f"{p['prefix']}:{p['local_name']}"
-                if p['local_name'] not in seen_names and display not in seen_names:
+                if p["local_name"] not in seen_names and display not in seen_names:
                     predicate_options.append(display)
-                    predicate_lookup[display] = p['uri']  # Use short name for standard ones
+                    predicate_lookup[display] = p[
+                        "uri"
+                    ]  # Use short name for standard ones
 
             # Sort options
             predicate_options.sort(key=lambda x: x.lower())
 
             with st.form("add_annotation_form"):
                 # Use display format with label
-                resource_options = [f"{r['display']} [{r['type']}]" for r in all_resources]
+                resource_options = [
+                    f"{r['display']} [{r['type']}]" for r in all_resources
+                ]
                 selected = st.selectbox("Select Resource", options=resource_options)
 
-                predicate_display = st.selectbox("Annotation Type", options=predicate_options)
+                predicate_display = st.selectbox(
+                    "Annotation Type", options=predicate_options
+                )
 
                 value = st.text_area("Value")
 
-                language = st.text_input("Language Tag (optional)", placeholder="en, de, fr...")
+                language = st.text_input(
+                    "Language Tag (optional)", placeholder="en, de, fr..."
+                )
 
                 submitted = st.form_submit_button("Add Annotation")
                 if submitted:
@@ -2178,42 +2833,57 @@ def render_annotations():
                         # Find the resource by matching the option string
                         idx = resource_options.index(selected)
                         resource_name = all_resources[idx]["name"]
-                        predicate_uri = predicate_lookup.get(predicate_display, predicate_display)
-                        ont.add_annotation(resource_name, predicate_uri, value,
-                                         lang=language if language else None)
+                        predicate_uri = predicate_lookup.get(
+                            predicate_display, predicate_display
+                        )
+                        ont.add_annotation(
+                            resource_name,
+                            predicate_uri,
+                            value,
+                            lang=language if language else None,
+                        )
                         save_checkpoint("Add annotation")
                         show_message("Annotation added!", "success")
                         st.rerun()
 
     if _ann_tab == "Bulk Edit":
         st.subheader("Bulk Edit Annotations")
-        st.caption("Edit annotations in a spreadsheet. Add rows to create, mark action as 'delete' to remove.")
+        st.caption(
+            "Edit annotations in a spreadsheet. Add rows to create, mark action as 'delete' to remove."
+        )
 
         # Build initial data from existing annotations
         annotation_data = []
         for res in all_resources:
             annots = ont.get_annotations(res["name"])
             for a in annots:
-                annotation_data.append({
-                    "Resource": res["name"],
-                    "Predicate": a.get("predicate_label", ""),
-                    "Value": a.get("value", ""),
-                    "Language": a.get("language", ""),
-                    "Action": "keep",
-                })
+                annotation_data.append(
+                    {
+                        "Resource": res["name"],
+                        "Predicate": a.get("predicate_label", ""),
+                        "Value": a.get("value", ""),
+                        "Language": a.get("language", ""),
+                        "Action": "keep",
+                    }
+                )
 
         import pandas as pd
+
         if annotation_data:
             df = pd.DataFrame(annotation_data)
         else:
-            df = pd.DataFrame(columns=["Resource", "Predicate", "Value", "Language", "Action"])
+            df = pd.DataFrame(
+                columns=["Resource", "Predicate", "Value", "Language", "Action"]
+            )
 
         edited_df = st.data_editor(
             df,
             num_rows="dynamic",
             column_config={
                 "Action": st.column_config.SelectboxColumn(
-                    "Action", options=["keep", "add", "delete"], default="add",
+                    "Action",
+                    options=["keep", "add", "delete"],
+                    default="add",
                 ),
             },
             key="bulk_annotations_editor",
@@ -2225,13 +2895,15 @@ def render_annotations():
             for _, row in edited_df.iterrows():
                 action = row.get("Action", "keep")
                 if action in ("add", "delete"):
-                    updates.append({
-                        "resource": row["Resource"],
-                        "predicate": row["Predicate"],
-                        "value": row["Value"],
-                        "lang": row.get("Language", ""),
-                        "action": action,
-                    })
+                    updates.append(
+                        {
+                            "resource": row["Resource"],
+                            "predicate": row["Predicate"],
+                            "value": row["Value"],
+                            "lang": row.get("Language", ""),
+                            "action": action,
+                        }
+                    )
             if updates:
                 result = ont.bulk_update_annotations(updates)
                 save_checkpoint("Bulk edit annotations")
@@ -2241,7 +2913,9 @@ def render_annotations():
                 show_message(msg, "success" if not result["errors"] else "warning")
                 st.rerun()
             else:
-                show_message("No changes to apply. Set Action to 'add' or 'delete'.", "info")
+                show_message(
+                    "No changes to apply. Set Action to 'add' or 'delete'.", "info"
+                )
 
 
 def render_skos_vocabulary():
@@ -2257,8 +2931,13 @@ def render_skos_vocabulary():
     # Clean up unused navigation flag
     st.session_state.pop("_skos_navigate_to_concept", None)
 
-    _skos_tab = st.segmented_control("Section", ["Concepts", "Concept Schemes", "Concept Hierarchy", "SKOS Validation"],
-                                     default="Concepts", key="skos_active_tab", label_visibility="collapsed")
+    _skos_tab = st.segmented_control(
+        "Section",
+        ["Concepts", "Concept Schemes", "Concept Hierarchy", "SKOS Validation"],
+        default="Concepts",
+        key="skos_active_tab",
+        label_visibility="collapsed",
+    )
     if not _skos_tab:
         _skos_tab = "Concepts"
 
@@ -2268,21 +2947,45 @@ def render_skos_vocabulary():
             st.info("No concept schemes defined yet.")
         else:
             for scheme in schemes:
-                display_name = format_label_name(scheme['name'], scheme.get('label'))
-                _scheme_expanded = st.session_state.get(f"view_scheme_{scheme['name']}", False) or st.session_state.get(f"edit_scheme_{scheme['name']}", False)
-                with st.expander(f"📚 **{display_name}** ({scheme['concept_count']} concepts)", expanded=_scheme_expanded):
-                    st.write(f"**URI:** `{scheme['uri']}`" if scheme['uri'].startswith("http://example.org/") else f"**URI:** {scheme['uri']}")
+                display_name = format_label_name(scheme["name"], scheme.get("label"))
+                _scheme_expanded = st.session_state.get(
+                    f"view_scheme_{scheme['name']}", False
+                ) or st.session_state.get(f"edit_scheme_{scheme['name']}", False)
+                with st.expander(
+                    f"📚 **{display_name}** ({scheme['concept_count']} concepts)",
+                    expanded=_scheme_expanded,
+                ):
+                    st.write(
+                        f"**URI:** `{scheme['uri']}`"
+                        if scheme["uri"].startswith("http://example.org/")
+                        else f"**URI:** {scheme['uri']}"
+                    )
 
                     btn_view, btn_edit, btn_del, _ = st.columns([1, 1, 1, 4])
                     with btn_view:
-                        st.button("👁️ View", key=f"btn_view_scheme_{scheme['name']}", use_container_width=True,
-                                  on_click=_cb_toggle_view, args=("scheme", scheme['name']))
+                        st.button(
+                            "👁️ View",
+                            key=f"btn_view_scheme_{scheme['name']}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_view,
+                            args=("scheme", scheme["name"]),
+                        )
                     with btn_edit:
-                        st.button("✏️ Edit", key=f"btn_edit_scheme_{scheme['name']}", use_container_width=True,
-                                  on_click=_cb_toggle_edit, args=("scheme", scheme['name']))
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_edit_scheme_{scheme['name']}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_edit,
+                            args=("scheme", scheme["name"]),
+                        )
                     with btn_del:
-                        st.button("🗑️ Delete", key=f"btn_del_scheme_{scheme['name']}", use_container_width=True,
-                                  on_click=_cb_confirm_delete, args=(f"scheme_{scheme['name']}",))
+                        st.button(
+                            "🗑️ Delete",
+                            key=f"btn_del_scheme_{scheme['name']}",
+                            use_container_width=True,
+                            on_click=_cb_confirm_delete,
+                            args=(f"scheme_{scheme['name']}",),
+                        )
 
                     if st.session_state.get(f"view_scheme_{scheme['name']}", False):
                         st.divider()
@@ -2291,23 +2994,43 @@ def render_skos_vocabulary():
                         st.write(f"**Comment:** {scheme['comment'] or '—'}")
                         st.write(f"**Concepts:** {scheme['concept_count']}")
 
-                    if confirm_delete(scheme["name"], "concept", f"scheme_{scheme['name']}"):
-                        ont.delete_concept_scheme(scheme['name'])
+                    if confirm_delete(
+                        scheme["name"], "concept", f"scheme_{scheme['name']}"
+                    ):
+                        ont.delete_concept_scheme(scheme["name"])
                         save_checkpoint("Delete concept scheme")
-                        set_flash_message(f"Scheme '{scheme['name']}' deleted!", "success")
+                        set_flash_message(
+                            f"Scheme '{scheme['name']}' deleted!", "success"
+                        )
                         st.rerun()
 
                     if st.session_state.get(f"edit_scheme_{scheme['name']}", False):
                         st.divider()
                         with st.form(f"edit_scheme_form_{scheme['name']}"):
-                            new_label = st.text_input("Label", value=scheme["label"] or "", key=f"scheme_lbl_{scheme['name']}")
-                            new_comment = st.text_area("Comment", value=scheme["comment"] or "", key=f"scheme_cmt_{scheme['name']}")
+                            new_label = st.text_input(
+                                "Label",
+                                value=scheme["label"] or "",
+                                key=f"scheme_lbl_{scheme['name']}",
+                            )
+                            new_comment = st.text_area(
+                                "Comment",
+                                value=scheme["comment"] or "",
+                                key=f"scheme_cmt_{scheme['name']}",
+                            )
                             if st.form_submit_button("Save Changes"):
-                                ont.update_concept_scheme(scheme['name'], new_label=new_label, new_comment=new_comment)
+                                ont.update_concept_scheme(
+                                    scheme["name"],
+                                    new_label=new_label,
+                                    new_comment=new_comment,
+                                )
                                 save_checkpoint("Update concept scheme")
-                                st.session_state[f"edit_scheme_{scheme['name']}"] = False
+                                st.session_state[f"edit_scheme_{scheme['name']}"] = (
+                                    False
+                                )
                                 st.session_state[f"view_scheme_{scheme['name']}"] = True
-                                show_message(f"Scheme '{scheme['name']}' updated!", "success")
+                                show_message(
+                                    f"Scheme '{scheme['name']}' updated!", "success"
+                                )
                                 st.rerun()
 
         st.divider()
@@ -2322,7 +3045,9 @@ def render_skos_vocabulary():
                 elif s_name in scheme_names:
                     show_message(f"Scheme '{s_name}' already exists!", "error")
                 else:
-                    ont.add_concept_scheme(s_name, label=s_label or None, comment=s_comment or None)
+                    ont.add_concept_scheme(
+                        s_name, label=s_label or None, comment=s_comment or None
+                    )
                     save_checkpoint("Add concept scheme")
                     show_message(f"Scheme '{s_name}' added!", "success")
                     st.rerun()
@@ -2333,14 +3058,28 @@ def render_skos_vocabulary():
             st.info("No concepts defined yet.")
         else:
             # Filter by scheme
-            filter_scheme = st.selectbox("Filter by Scheme", ["All"] + scheme_names,
-                                         key="concept_filter_scheme")
-            filtered = concepts if filter_scheme == "All" else ont.get_concepts(scheme=filter_scheme)
+            filter_scheme = st.selectbox(
+                "Filter by Scheme", ["All"] + scheme_names, key="concept_filter_scheme"
+            )
+            filtered = (
+                concepts
+                if filter_scheme == "All"
+                else ont.get_concepts(scheme=filter_scheme)
+            )
 
             # Collapse other concepts when one is active
             def _concept_key(c):
-                return str(abs(hash(c['uri'])))[:8]
-            _active_concept = next((c for c in filtered if st.session_state.get(f"view_skos_{_concept_key(c)}", False) or st.session_state.get(f"edit_skos_{_concept_key(c)}", False)), None)
+                return str(abs(hash(c["uri"])))[:8]
+
+            _active_concept = next(
+                (
+                    c
+                    for c in filtered
+                    if st.session_state.get(f"view_skos_{_concept_key(c)}", False)
+                    or st.session_state.get(f"edit_skos_{_concept_key(c)}", False)
+                ),
+                None,
+            )
             if _active_concept:
                 _active_ck = _concept_key(_active_concept)
                 for c in filtered:
@@ -2350,34 +3089,59 @@ def render_skos_vocabulary():
                         st.session_state.pop(f"edit_skos_{ck}", None)
 
             for concept in filtered:
-                pref = concept['prefLabel'] or concept['name']
-                display_name = format_label_name(concept['name'], pref if pref != concept['name'] else '')
+                pref = concept["prefLabel"] or concept["name"]
+                display_name = format_label_name(
+                    concept["name"], pref if pref != concept["name"] else ""
+                )
                 badges = []
-                if concept['broader']:
+                if concept["broader"]:
                     badges.append(f"broader: {', '.join(concept['broader'])}")
-                if concept['schemes']:
+                if concept["schemes"]:
                     badges.append(f"scheme: {', '.join(concept['schemes'])}")
                 badge_str = f" — {'; '.join(badges)}" if badges else ""
 
                 # Use URI hash for unique widget keys (local name may not be unique)
-                _ck = str(abs(hash(concept['uri'])))[:8]
+                _ck = str(abs(hash(concept["uri"])))[:8]
                 _sk = f"view_skos_{_ck}"
                 _ek = f"edit_skos_{_ck}"
 
-                _skos_expanded = st.session_state.get(_sk, False) or st.session_state.get(_ek, False)
-                with st.expander(f"🏷️ **{display_name}**{badge_str}", expanded=_skos_expanded):
-                    st.write(f"**URI:** `{concept['uri']}`" if concept['uri'].startswith("http://example.org/") else f"**URI:** {concept['uri']}")
+                _skos_expanded = st.session_state.get(
+                    _sk, False
+                ) or st.session_state.get(_ek, False)
+                with st.expander(
+                    f"🏷️ **{display_name}**{badge_str}", expanded=_skos_expanded
+                ):
+                    st.write(
+                        f"**URI:** `{concept['uri']}`"
+                        if concept["uri"].startswith("http://example.org/")
+                        else f"**URI:** {concept['uri']}"
+                    )
 
                     btn_view, btn_edit, btn_del, _ = st.columns([1, 1, 1, 4])
                     with btn_view:
-                        st.button("👁️ View", key=f"btn_view_{_ck}", use_container_width=True,
-                                  on_click=_cb_toggle_view, args=("skos", _ck))
+                        st.button(
+                            "👁️ View",
+                            key=f"btn_view_{_ck}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_view,
+                            args=("skos", _ck),
+                        )
                     with btn_edit:
-                        st.button("✏️ Edit", key=f"btn_edit_{_ck}", use_container_width=True,
-                                  on_click=_cb_toggle_edit, args=("skos", _ck))
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_edit_{_ck}",
+                            use_container_width=True,
+                            on_click=_cb_toggle_edit,
+                            args=("skos", _ck),
+                        )
                     with btn_del:
-                        st.button("🗑️ Delete", key=f"btn_del_{_ck}", use_container_width=True,
-                                  on_click=_cb_confirm_delete, args=(f"c_{_ck}",))
+                        st.button(
+                            "🗑️ Delete",
+                            key=f"btn_del_{_ck}",
+                            use_container_width=True,
+                            on_click=_cb_confirm_delete,
+                            args=(f"c_{_ck}",),
+                        )
 
                     # View details
                     if st.session_state.get(_sk, False):
@@ -2385,83 +3149,156 @@ def render_skos_vocabulary():
                         st.write(f"**Name:** {concept['name']}")
                         st.write(f"**prefLabel:** {concept['prefLabel'] or '—'}")
                         st.write(f"**definition:** {concept['definition'] or '—'}")
-                        if concept['altLabels']:
-                            st.write(f"**altLabels:** {', '.join(concept['altLabels'])}")
-                        if concept['broader']:
+                        if concept["altLabels"]:
+                            st.write(
+                                f"**altLabels:** {', '.join(concept['altLabels'])}"
+                            )
+                        if concept["broader"]:
                             st.write(f"**broader:** {', '.join(concept['broader'])}")
-                        if concept['narrower']:
+                        if concept["narrower"]:
                             st.write(f"**narrower:** {', '.join(concept['narrower'])}")
-                        if concept['related']:
+                        if concept["related"]:
                             st.write(f"**related:** {', '.join(concept['related'])}")
-                        if concept['schemes']:
+                        if concept["schemes"]:
                             st.write(f"**schemes:** {', '.join(concept['schemes'])}")
 
                         # Add relation inline
                         with st.popover("Add Relation"):
-                            rel_type = st.selectbox("Relation", list(ont.SKOS_RELATIONS.keys()),
-                                                    key=f"rel_type_{_ck}")
-                            other_concepts = [c for c in concept_names if c != concept['name']]
-                            rel_target = st.selectbox("Target Concept", other_concepts,
-                                                      key=f"rel_target_{_ck}")
+                            rel_type = st.selectbox(
+                                "Relation",
+                                list(ont.SKOS_RELATIONS.keys()),
+                                key=f"rel_type_{_ck}",
+                            )
+                            other_concepts = [
+                                c for c in concept_names if c != concept["name"]
+                            ]
+                            rel_target = st.selectbox(
+                                "Target Concept",
+                                other_concepts,
+                                key=f"rel_target_{_ck}",
+                            )
                             if st.button("Add", key=f"add_rel_{_ck}"):
-                                ont.add_concept_relation(concept['name'], rel_type, rel_target)
+                                ont.add_concept_relation(
+                                    concept["name"], rel_type, rel_target
+                                )
                                 save_checkpoint("Add concept relation")
                                 show_message(f"Added {rel_type} relation!", "success")
                                 st.rerun()
 
-                        st.button("✏️ Edit", key=f"btn_v2e_{_ck}",
-                                  on_click=_cb_view_to_edit, args=("skos", _ck))
+                        st.button(
+                            "✏️ Edit",
+                            key=f"btn_v2e_{_ck}",
+                            on_click=_cb_view_to_edit,
+                            args=("skos", _ck),
+                        )
 
                     if confirm_delete(concept["name"], "concept", f"c_{_ck}"):
-                        ont.delete_concept(concept['name'])
+                        ont.delete_concept(concept["name"])
                         save_checkpoint("Delete concept")
-                        set_flash_message(f"Concept '{concept['name']}' deleted!", "success")
+                        set_flash_message(
+                            f"Concept '{concept['name']}' deleted!", "success"
+                        )
                         st.rerun()
 
                     # Inline edit form
                     if st.session_state.get(_ek, False):
                         st.divider()
                         with st.form(f"edit_concept_form_{_ck}"):
-                            new_pref = st.text_input("Preferred Label", value=concept["prefLabel"] or "", key=f"pref_{_ck}")
-                            new_def = st.text_area("Definition", value=concept["definition"] or "", key=f"def_{_ck}")
+                            new_pref = st.text_input(
+                                "Preferred Label",
+                                value=concept["prefLabel"] or "",
+                                key=f"pref_{_ck}",
+                            )
+                            new_def = st.text_area(
+                                "Definition",
+                                value=concept["definition"] or "",
+                                key=f"def_{_ck}",
+                            )
 
                             # Broader concept
-                            other_concepts = [c for c in concept_names if c != concept['name']]
-                            current_broader = concept["broader"][0] if concept["broader"] else "None"
+                            other_concepts = [
+                                c for c in concept_names if c != concept["name"]
+                            ]
+                            current_broader = (
+                                concept["broader"][0] if concept["broader"] else "None"
+                            )
                             broader_options = ["None"] + other_concepts
-                            broader_idx = broader_options.index(current_broader) if current_broader in broader_options else 0
-                            new_broader = st.selectbox("Broader Concept", broader_options, index=broader_idx, key=f"broader_{_ck}")
+                            broader_idx = (
+                                broader_options.index(current_broader)
+                                if current_broader in broader_options
+                                else 0
+                            )
+                            new_broader = st.selectbox(
+                                "Broader Concept",
+                                broader_options,
+                                index=broader_idx,
+                                key=f"broader_{_ck}",
+                            )
 
                             # Scheme
-                            current_scheme = concept["schemes"][0] if concept.get("schemes") else "None"
+                            current_scheme = (
+                                concept["schemes"][0]
+                                if concept.get("schemes")
+                                else "None"
+                            )
                             scheme_options = ["None"] + scheme_names
-                            scheme_idx = scheme_options.index(current_scheme) if current_scheme in scheme_options else 0
-                            new_scheme = st.selectbox("Scheme", scheme_options, index=scheme_idx, key=f"scheme_{_ck}")
+                            scheme_idx = (
+                                scheme_options.index(current_scheme)
+                                if current_scheme in scheme_options
+                                else 0
+                            )
+                            new_scheme = st.selectbox(
+                                "Scheme",
+                                scheme_options,
+                                index=scheme_idx,
+                                key=f"scheme_{_ck}",
+                            )
 
                             if st.form_submit_button("Save Changes"):
                                 # Handle broader change
-                                broader_val = new_broader if new_broader != "None" else ""
-                                old_broader = concept["broader"][0] if concept["broader"] else ""
+                                broader_val = (
+                                    new_broader if new_broader != "None" else ""
+                                )
+                                old_broader = (
+                                    concept["broader"][0] if concept["broader"] else ""
+                                )
                                 broader_changed = broader_val != old_broader
 
                                 # Handle scheme change
-                                old_scheme = concept["schemes"][0] if concept.get("schemes") else ""
-                                new_scheme_val = new_scheme if new_scheme != "None" else ""
-                                add_s = new_scheme_val if new_scheme_val and new_scheme_val != old_scheme else None
-                                remove_s = old_scheme if old_scheme and old_scheme != new_scheme_val else None
+                                old_scheme = (
+                                    concept["schemes"][0]
+                                    if concept.get("schemes")
+                                    else ""
+                                )
+                                new_scheme_val = (
+                                    new_scheme if new_scheme != "None" else ""
+                                )
+                                add_s = (
+                                    new_scheme_val
+                                    if new_scheme_val and new_scheme_val != old_scheme
+                                    else None
+                                )
+                                remove_s = (
+                                    old_scheme
+                                    if old_scheme and old_scheme != new_scheme_val
+                                    else None
+                                )
 
                                 _update_kwargs = dict(
                                     new_pref_label=new_pref,
                                     new_definition=new_def,
                                     add_scheme=add_s,
-                                    remove_scheme=remove_s)
+                                    remove_scheme=remove_s,
+                                )
                                 if broader_changed:
                                     _update_kwargs["new_broader"] = broader_val
-                                ont.update_concept(concept['name'], **_update_kwargs)
+                                ont.update_concept(concept["name"], **_update_kwargs)
                                 save_checkpoint("Update concept")
                                 st.session_state[_ek] = False
                                 st.session_state[_sk] = True
-                                show_message(f"Concept '{concept['name']}' updated!", "success")
+                                show_message(
+                                    f"Concept '{concept['name']}' updated!", "success"
+                                )
                                 st.rerun()
 
         st.divider()
@@ -2470,8 +3307,14 @@ def render_skos_vocabulary():
             c_name = st.text_input("Concept Name *")
             c_pref = st.text_input("Preferred Label")
             c_def = st.text_area("Definition")
-            c_scheme = st.selectbox("Scheme", ["None"] + scheme_names, key="concept_scheme_select")
-            c_broader = st.selectbox("Broader Concept", ["None"] + concept_names, key="concept_broader_select")
+            c_scheme = st.selectbox(
+                "Scheme", ["None"] + scheme_names, key="concept_scheme_select"
+            )
+            c_broader = st.selectbox(
+                "Broader Concept",
+                ["None"] + concept_names,
+                key="concept_broader_select",
+            )
             c_lang = st.text_input("Language Tag (e.g., en, de)", key="concept_lang")
             if st.form_submit_button("Add Concept"):
                 if not c_name:
@@ -2496,8 +3339,9 @@ def render_skos_vocabulary():
         if not concepts:
             st.info("No concepts to display.")
         else:
-            h_scheme = st.selectbox("Scheme", ["All"] + scheme_names,
-                                    key="hierarchy_scheme_select")
+            h_scheme = st.selectbox(
+                "Scheme", ["All"] + scheme_names, key="hierarchy_scheme_select"
+            )
             hierarchy = ont.get_concept_hierarchy(
                 scheme=h_scheme if h_scheme != "All" else None
             )
@@ -2510,8 +3354,14 @@ def render_skos_vocabulary():
 
             def render_tree(name, indent=0):
                 concept_data = next((c for c in concepts if c["name"] == name), None)
-                pref = concept_data["prefLabel"] if concept_data and concept_data["prefLabel"] else name
-                st.markdown(f"{'&nbsp;&nbsp;&nbsp;&nbsp;' * indent}{'└─ ' if indent > 0 else ''}**{pref}** ({name})")
+                pref = (
+                    concept_data["prefLabel"]
+                    if concept_data and concept_data["prefLabel"]
+                    else name
+                )
+                st.markdown(
+                    f"{'&nbsp;&nbsp;&nbsp;&nbsp;' * indent}{'└─ ' if indent > 0 else ''}**{pref}** ({name})"
+                )
                 for child in sorted(hierarchy.get(name, [])):
                     render_tree(child, indent + 1)
 
@@ -2530,8 +3380,12 @@ def render_skos_vocabulary():
             else:
                 for issue in issues:
                     severity = issue["severity"]
-                    icon = {"error": "🔴", "warning": "🟡", "info": "🔵"}.get(severity, "⚪")
-                    st.markdown(f"{icon} **{issue['type']}** — {issue['subject']}: {issue['message']}")
+                    icon = {"error": "🔴", "warning": "🟡", "info": "🔵"}.get(
+                        severity, "⚪"
+                    )
+                    st.markdown(
+                        f"{icon} **{issue['type']}** — {issue['subject']}: {issue['message']}"
+                    )
 
 
 def render_import_export():
@@ -2543,9 +3397,21 @@ def render_import_export():
 
     ont = st.session_state.ontology
 
-    _ie_tabs = ["Import", "Export", "New Ontology", "Templates", "Upper Ontologies", "Reference Ontologies"]
-    _ie_tab = st.segmented_control("Section", _ie_tabs, default="Import",
-                                   key="ie_active_tab", label_visibility="collapsed")
+    _ie_tabs = [
+        "Import",
+        "Export",
+        "New Ontology",
+        "Templates",
+        "Upper Ontologies",
+        "Reference Ontologies",
+    ]
+    _ie_tab = st.segmented_control(
+        "Section",
+        _ie_tabs,
+        default="Import",
+        key="ie_active_tab",
+        label_visibility="collapsed",
+    )
     if not _ie_tab:
         _ie_tab = "Import"
 
@@ -2562,19 +3428,28 @@ def render_import_export():
 
         # Check if ontology is empty (only default scaffolding, no user content)
         _stats = ont.get_statistics()
-        _ont_is_empty = (_stats["classes"] == 0 and _stats["object_properties"] == 0
-                         and _stats["data_properties"] == 0 and _stats["individuals"] == 0
-                         and _stats.get("concepts", 0) == 0)
+        _ont_is_empty = (
+            _stats["classes"] == 0
+            and _stats["object_properties"] == 0
+            and _stats["data_properties"] == 0
+            and _stats["individuals"] == 0
+            and _stats.get("concepts", 0) == 0
+        )
 
         if st.session_state.get("_ontology_cleared"):
             st.success(st.session_state.pop("_ontology_cleared"))
 
         with st.popover("Clear Ontology", disabled=_ont_is_empty):
-            st.warning("This will delete all classes, properties, individuals, and triples.")
+            st.warning(
+                "This will delete all classes, properties, individuals, and triples."
+            )
             if st.button("Confirm Clear", type="primary", key="clear_ontology_btn"):
                 base_uri = str(ont.namespace)
-                st.session_state.ontology = get_ontology_manager_class()(base_uri=base_uri)
+                st.session_state.ontology = get_ontology_manager_class()(
+                    base_uri=base_uri
+                )
                 from .ontology_manager import UndoManager
+
                 st.session_state.undo_manager = UndoManager(st.session_state.ontology)
                 st.session_state["_ontology_cleared"] = "Ontology cleared!"
                 st.rerun()
@@ -2586,10 +3461,13 @@ def render_import_export():
                 st.session_state.ontology = ont
                 save_checkpoint("Import ontology")
                 set_flash_message(
-                    f"Ontology imported successfully! ({len(ont.graph)} triples)", "success"
+                    f"Ontology imported successfully! ({len(ont.graph)} triples)",
+                    "success",
                 )
                 # Clear file uploader by incrementing its key
-                st.session_state["import_uploader_key"] = st.session_state.get("import_uploader_key", 0) + 1
+                st.session_state["import_uploader_key"] = (
+                    st.session_state.get("import_uploader_key", 0) + 1
+                )
                 st.rerun()
             except Exception as e:
                 show_message(f"Error importing ontology: {str(e)}", "error")
@@ -2637,7 +3515,9 @@ def render_import_export():
 
             else:
                 content = st.text_area("Paste Ontology Content", height=300)
-                format_ = st.selectbox("Format", ["turtle", "xml", "n3", "nt", "json-ld"])
+                format_ = st.selectbox(
+                    "Format", ["turtle", "xml", "n3", "nt", "json-ld"]
+                )
 
                 btn_label = "Import" if _ont_is_empty else "Preview Import"
                 if st.button(btn_label):
@@ -2662,10 +3542,17 @@ def render_import_export():
             diff = preview["diff"]
             diff_stats = diff["stats"]
 
-            st.info("Review the import changes below, then choose an import mode and apply.")
+            st.info(
+                "Review the import changes below, then choose an import mode and apply."
+            )
 
             # Import mode selector
-            from .ontology_manager import IMPORT_REPLACE, IMPORT_MERGE, IMPORT_MERGE_OVERWRITE
+            from .ontology_manager import (
+                IMPORT_REPLACE,
+                IMPORT_MERGE,
+                IMPORT_MERGE_OVERWRITE,
+            )
+
             strategy = st.radio(
                 "Import Mode",
                 ["Replace", "Merge", "Merge (Overwrite)"],
@@ -2774,7 +3661,9 @@ def render_import_export():
                     conflict_data = {
                         "Subject": [c["subject"] for c in conflicts],
                         "Predicate": [c["predicate"] for c in conflicts],
-                        "Current Value": [", ".join(c["current_values"]) for c in conflicts],
+                        "Current Value": [
+                            ", ".join(c["current_values"]) for c in conflicts
+                        ],
                         "Incoming Value": [c["incoming_value"] for c in conflicts],
                     }
                     st.dataframe(conflict_data, width="stretch", hide_index=True)
@@ -2785,8 +3674,12 @@ def render_import_export():
                 with st.expander(f"Prefix Changes ({len(prefix_conflicts)} conflicts)"):
                     pfx_data = {
                         "Prefix": [c["prefix"] for c in prefix_conflicts],
-                        "Current Namespace": [c["current_namespace"] for c in prefix_conflicts],
-                        "Incoming Namespace": [c["incoming_namespace"] for c in prefix_conflicts],
+                        "Current Namespace": [
+                            c["current_namespace"] for c in prefix_conflicts
+                        ],
+                        "Incoming Namespace": [
+                            c["incoming_namespace"] for c in prefix_conflicts
+                        ],
                     }
                     st.dataframe(pfx_data, width="stretch", hide_index=True)
 
@@ -2807,10 +3700,12 @@ def render_import_export():
             "RDF/XML (.owl)": "xml",
             "N-Triples (.nt)": "nt",
             "N3 (.n3)": "n3",
-            "JSON-LD (.jsonld)": "json-ld"
+            "JSON-LD (.jsonld)": "json-ld",
         }
 
-        selected_format = st.selectbox("Export Format", options=list(format_options.keys()))
+        selected_format = st.selectbox(
+            "Export Format", options=list(format_options.keys())
+        )
         format_ = format_options[selected_format]
 
         file_extensions = {
@@ -2818,7 +3713,7 @@ def render_import_export():
             "xml": "owl",
             "nt": "nt",
             "n3": "n3",
-            "json-ld": "jsonld"
+            "json-ld": "jsonld",
         }
 
         if st.button("Generate Export"):
@@ -2831,7 +3726,7 @@ def render_import_export():
                     label=f"Download .{ext} file",
                     data=content,
                     file_name=f"ontology.{ext}",
-                    mime="text/plain"
+                    mime="text/plain",
                 )
             except Exception as e:
                 show_message(f"Error exporting ontology: {str(e)}", "error")
@@ -2839,12 +3734,16 @@ def render_import_export():
     if _ie_tab == "New Ontology":
         st.subheader("Create New Ontology")
 
-        st.warning("This will clear the current ontology. Make sure to export first if needed.")
+        st.warning(
+            "This will clear the current ontology. Make sure to export first if needed."
+        )
 
         with st.form("new_ontology_form"):
-            base_uri = st.text_input("Base URI *",
-                                    value="http://example.org/ontology#",
-                                    help="The base namespace URI for your ontology")
+            base_uri = st.text_input(
+                "Base URI *",
+                value="http://example.org/ontology#",
+                help="The base namespace URI for your ontology",
+            )
             label = st.text_input("Label (rdfs:label)")
             comment = st.text_area("Comment (rdfs:comment)")
             creator = st.text_input("Creator")
@@ -2854,18 +3753,22 @@ def render_import_export():
                 if not base_uri:
                     show_message("Base URI is required!", "error")
                 else:
-                    st.session_state.ontology = get_ontology_manager_class()(base_uri=base_uri)
+                    st.session_state.ontology = get_ontology_manager_class()(
+                        base_uri=base_uri
+                    )
                     st.session_state.ontology.set_ontology_metadata(
-                        label=label, comment=comment,
-                        creator=creator
+                        label=label, comment=comment, creator=creator
                     )
                     from .ontology_manager import UndoManager
-                    st.session_state.undo_manager = UndoManager(st.session_state.ontology)
+
+                    st.session_state.undo_manager = UndoManager(
+                        st.session_state.ontology
+                    )
                     show_message("New ontology created!", "success")
                     st.rerun()
 
     if _ie_tab == "Templates":
-        from .templates import (get_template_names, get_template, render_template)
+        from .templates import get_template_names, get_template, render_template
 
         def _on_apply_template():
             selected = st.session_state.template_select
@@ -2892,7 +3795,9 @@ def render_import_export():
             st.success(st.session_state.pop("_template_msg"))
 
         template_names = get_template_names()
-        selected_template = st.selectbox("Select Template", template_names, key="template_select")
+        selected_template = st.selectbox(
+            "Select Template", template_names, key="template_select"
+        )
 
         if selected_template:
             tmpl = get_template(selected_template)
@@ -2903,16 +3808,26 @@ def render_import_export():
                 rendered = render_template(tmpl, base_uri)
                 st.code(rendered, language="turtle")
 
-            st.radio("Apply Mode",
-                     ["Merge into current", "Replace current"],
-                     horizontal=True, key="template_apply_mode")
+            st.radio(
+                "Apply Mode",
+                ["Merge into current", "Replace current"],
+                horizontal=True,
+                key="template_apply_mode",
+            )
 
-            st.button("Apply Template", type="primary", key="apply_template_btn",
-                      on_click=_on_apply_template)
+            st.button(
+                "Apply Template",
+                type="primary",
+                key="apply_template_btn",
+                on_click=_on_apply_template,
+            )
 
     if _ie_tab == "Upper Ontologies":
-        from .templates import (get_upper_ontology_names, get_upper_ontology,
-                               load_upper_ontology_module)
+        from .templates import (
+            get_upper_ontology_names,
+            get_upper_ontology,
+            load_upper_ontology_module,
+        )
 
         def _on_load_upper_ontology(upper):
             selected_modules = []
@@ -2935,9 +3850,7 @@ def render_import_export():
                     else:
                         ont.merge_from_string(content, "turtle")
                 mod_names = ", ".join(m["name"] for m in selected_modules)
-                save_checkpoint(
-                    f"Load upper ontology: {upper['name']} ({mod_names})"
-                )
+                save_checkpoint(f"Load upper ontology: {upper['name']} ({mod_names})")
                 s = ont.get_statistics()
                 st.session_state["_upper_onto_msg"] = (
                     f"Loaded {upper['name']} ({mod_names})! "
@@ -2961,14 +3874,17 @@ def render_import_export():
             st.error(st.session_state.pop("_upper_onto_err"))
 
         upper_names = get_upper_ontology_names()
-        selected_upper = st.selectbox("Select Upper Ontology", upper_names,
-                                      key="upper_ontology_select")
+        selected_upper = st.selectbox(
+            "Select Upper Ontology", upper_names, key="upper_ontology_select"
+        )
 
         if selected_upper:
             upper = get_upper_ontology(selected_upper)
             st.write(f"**{upper['name']}** v{upper['version']}")
             st.write(upper["description"])
-            st.caption(f"License: {upper['license']} — Attribution: {upper['attribution']}")
+            st.caption(
+                f"License: {upper['license']} — Attribution: {upper['attribution']}"
+            )
             if upper.get("url"):
                 st.caption(f"More info: {upper['url']}")
 
@@ -2989,14 +3905,20 @@ def render_import_export():
                 key="upper_apply_mode",
             )
 
-            st.button("Load Upper Ontology", type="primary",
-                      key="apply_upper_ontology_btn",
-                      on_click=_on_load_upper_ontology, args=(upper,))
+            st.button(
+                "Load Upper Ontology",
+                type="primary",
+                key="apply_upper_ontology_btn",
+                on_click=_on_load_upper_ontology,
+                args=(upper,),
+            )
 
     if _ie_tab == "Reference Ontologies":
-        from .templates import (get_reference_ontology_names,
-                               get_reference_ontology,
-                               load_reference_ontology_module)
+        from .templates import (
+            get_reference_ontology_names,
+            get_reference_ontology,
+            load_reference_ontology_module,
+        )
 
         def _on_load_reference_ontology(ref):
             selected_modules = []
@@ -3021,9 +3943,7 @@ def render_import_export():
                         else:
                             ont.merge_from_string(content, fmt)
                 mod_names = ", ".join(m["name"] for m in selected_modules)
-                save_checkpoint(
-                    f"Load reference ontology: {ref['name']} ({mod_names})"
-                )
+                save_checkpoint(f"Load reference ontology: {ref['name']} ({mod_names})")
                 s = ont.get_statistics()
                 st.session_state["_ref_onto_msg"] = (
                     f"Loaded {ref['name']} ({mod_names})! "
@@ -3048,8 +3968,9 @@ def render_import_export():
             st.error(st.session_state.pop("_ref_onto_err"))
 
         ref_names = get_reference_ontology_names()
-        selected_ref = st.selectbox("Select Reference Ontology", ref_names,
-                                    key="reference_ontology_select")
+        selected_ref = st.selectbox(
+            "Select Reference Ontology", ref_names, key="reference_ontology_select"
+        )
 
         if selected_ref:
             ref = get_reference_ontology(selected_ref)
@@ -3107,8 +4028,19 @@ def render_advanced():
     individuals = ont.get_individuals()
     ind_names = [i["name"] for i in individuals]
 
-    _adv_tab = st.segmented_control("Section", ["Class Expressions", "Property Chains", "Disjoint Union", "All Different", "Has Key"],
-                                    default="Class Expressions", key="adv_active_tab", label_visibility="collapsed")
+    _adv_tab = st.segmented_control(
+        "Section",
+        [
+            "Class Expressions",
+            "Property Chains",
+            "Disjoint Union",
+            "All Different",
+            "Has Key",
+        ],
+        default="Class Expressions",
+        key="adv_active_tab",
+        label_visibility="collapsed",
+    )
     if not _adv_tab:
         _adv_tab = "Class Expressions"
 
@@ -3121,7 +4053,9 @@ def render_advanced():
         if expressions:
             st.write("**Existing Expressions:**")
             for expr in expressions:
-                st.write(f"- **{expr['class']}** {expr['type']}: {', '.join(expr['members'])}")
+                st.write(
+                    f"- **{expr['class']}** {expr['type']}: {', '.join(expr['members'])}"
+                )
         else:
             st.info("No class expressions defined yet.")
 
@@ -3131,21 +4065,28 @@ def render_advanced():
             st.warning("Need at least 2 classes to create expressions.")
         else:
             with st.form("add_class_expression_form"):
-                target_class = st.selectbox("Target Class", options=class_names,
-                    help="The class to define with this expression")
+                target_class = st.selectbox(
+                    "Target Class",
+                    options=class_names,
+                    help="The class to define with this expression",
+                )
 
-                expr_type = st.selectbox("Expression Type", options=[
-                    "unionOf", "intersectionOf", "complementOf", "oneOf"
-                ])
+                expr_type = st.selectbox(
+                    "Expression Type",
+                    options=["unionOf", "intersectionOf", "complementOf", "oneOf"],
+                )
 
                 st.write("**Select members:**")
                 if expr_type == "complementOf":
-                    complement_class = st.selectbox("Complement of Class", options=class_names)
+                    complement_class = st.selectbox(
+                        "Complement of Class", options=class_names
+                    )
                     selected_classes = [complement_class] if complement_class else []
                     selected_individuals = []
                 elif expr_type == "oneOf":
-                    selected_individuals = st.multiselect("Individuals (enumeration)",
-                        options=ind_names)
+                    selected_individuals = st.multiselect(
+                        "Individuals (enumeration)", options=ind_names
+                    )
                     selected_classes = []
                 else:
                     selected_classes = st.multiselect("Classes", options=class_names)
@@ -3154,14 +4095,16 @@ def render_advanced():
                 submitted = st.form_submit_button("Add Expression")
                 if submitted:
                     if expr_type == "oneOf" and selected_individuals:
-                        ont.add_class_expression(target_class, expr_type,
-                            individuals=selected_individuals)
+                        ont.add_class_expression(
+                            target_class, expr_type, individuals=selected_individuals
+                        )
                         save_checkpoint("Add class expression")
                         show_message(f"Expression added to {target_class}", "success")
                         st.rerun()
                     elif selected_classes:
-                        ont.add_class_expression(target_class, expr_type,
-                            classes=selected_classes)
+                        ont.add_class_expression(
+                            target_class, expr_type, classes=selected_classes
+                        )
                         save_checkpoint("Add class expression")
                         show_message(f"Expression added to {target_class}", "success")
                         st.rerun()
@@ -3170,7 +4113,9 @@ def render_advanced():
 
     if _adv_tab == "Property Chains":
         st.subheader("Property Chains")
-        st.caption("Define property chain axioms (e.g., hasParent o hasBrother = hasUncle)")
+        st.caption(
+            "Define property chain axioms (e.g., hasParent o hasBrother = hasUncle)"
+        )
 
         # View existing chains
         chains = ont.get_property_chains()
@@ -3188,13 +4133,17 @@ def render_advanced():
             st.warning("Need at least 2 object properties to create chains.")
         else:
             with st.form("add_property_chain_form"):
-                result_prop = st.selectbox("Result Property",
+                result_prop = st.selectbox(
+                    "Result Property",
                     options=obj_prop_names,
-                    help="The property that results from following the chain")
+                    help="The property that results from following the chain",
+                )
 
-                chain_props = st.multiselect("Chain Properties (in order)",
+                chain_props = st.multiselect(
+                    "Chain Properties (in order)",
                     options=obj_prop_names,
-                    help="Select properties in the order they should be followed")
+                    help="Select properties in the order they should be followed",
+                )
 
                 submitted = st.form_submit_button("Add Property Chain")
                 if submitted:
@@ -3202,7 +4151,9 @@ def render_advanced():
                         show_message("Chain must have at least 2 properties!", "error")
                     else:
                         ont.add_property_chain(result_prop, chain_props)
-                        show_message(f"Property chain added for {result_prop}", "success")
+                        show_message(
+                            f"Property chain added for {result_prop}", "success"
+                        )
                         st.rerun()
 
     if _adv_tab == "Disjoint Union":
@@ -3214,23 +4165,31 @@ def render_advanced():
         if unions:
             st.write("**Existing Disjoint Unions:**")
             for union in unions:
-                st.write(f"- **{union['class']}** = disjointUnionOf({', '.join(union['members'])})")
+                st.write(
+                    f"- **{union['class']}** = disjointUnionOf({', '.join(union['members'])})"
+                )
         else:
             st.info("No disjoint unions defined yet.")
 
         st.divider()
 
         if len(class_names) < 3:
-            st.warning("Need at least 3 classes (1 parent + 2 children) for disjoint union.")
+            st.warning(
+                "Need at least 3 classes (1 parent + 2 children) for disjoint union."
+            )
         else:
             with st.form("add_disjoint_union_form"):
-                parent_class = st.selectbox("Parent Class",
+                parent_class = st.selectbox(
+                    "Parent Class",
                     options=class_names,
-                    help="The class that is the disjoint union")
+                    help="The class that is the disjoint union",
+                )
 
-                member_classes = st.multiselect("Member Classes",
+                member_classes = st.multiselect(
+                    "Member Classes",
                     options=class_names,
-                    help="Classes that make up the disjoint union")
+                    help="Classes that make up the disjoint union",
+                )
 
                 submitted = st.form_submit_button("Add Disjoint Union")
                 if submitted:
@@ -3240,7 +4199,9 @@ def render_advanced():
                         show_message("Parent class cannot be a member!", "error")
                     else:
                         ont.add_disjoint_union(parent_class, member_classes)
-                        show_message(f"Disjoint union added for {parent_class}", "success")
+                        show_message(
+                            f"Disjoint union added for {parent_class}", "success"
+                        )
                         st.rerun()
 
     if _adv_tab == "All Different":
@@ -3262,9 +4223,11 @@ def render_advanced():
             st.warning("Need at least 2 individuals for AllDifferent.")
         else:
             with st.form("add_all_different_form"):
-                selected_inds = st.multiselect("Select Individuals",
+                selected_inds = st.multiselect(
+                    "Select Individuals",
                     options=ind_names,
-                    help="All selected individuals will be declared mutually different")
+                    help="All selected individuals will be declared mutually different",
+                )
 
                 submitted = st.form_submit_button("Add AllDifferent")
                 if submitted:
@@ -3298,9 +4261,11 @@ def render_advanced():
             with st.form("add_has_key_form"):
                 target_class = st.selectbox("Class", options=class_names)
 
-                key_props = st.multiselect("Key Properties",
+                key_props = st.multiselect(
+                    "Key Properties",
                     options=all_prop_names,
-                    help="Properties that together uniquely identify instances")
+                    help="Properties that together uniquely identify instances",
+                )
 
                 submitted = st.form_submit_button("Add hasKey")
                 if submitted:
@@ -3318,8 +4283,13 @@ def render_validation():
 
     ont = st.session_state.ontology
 
-    _val_tab = st.segmented_control("Section", ["Validation", "Reasoning"],
-                                    default="Validation", key="val_active_tab", label_visibility="collapsed")
+    _val_tab = st.segmented_control(
+        "Section",
+        ["Validation", "Reasoning"],
+        default="Validation",
+        key="val_active_tab",
+        label_visibility="collapsed",
+    )
     if not _val_tab:
         _val_tab = "Validation"
 
@@ -3329,7 +4299,7 @@ def render_validation():
         check_domain_range = st.checkbox(
             "Check for missing domain/range",
             value=False,
-            help="Report properties without rdfs:domain/rdfs:range (or schema:domainIncludes/gist:domainIncludes). Off by default since many ontologies intentionally omit these."
+            help="Report properties without rdfs:domain/rdfs:range (or schema:domainIncludes/gist:domainIncludes). Off by default since many ontologies intentionally omit these.",
         )
 
         if st.button("Run Validation"):
@@ -3368,11 +4338,11 @@ def render_validation():
         This uses OWL-RL (Rule Language) reasoning.
         """)
 
-        profile = st.selectbox("Reasoning Profile", [
-            ("RDFS", "rdfs"),
-            ("OWL-RL", "owl-rl"),
-            ("OWL-RL Extended", "owl-rl-ext")
-        ], format_func=lambda x: x[0])
+        profile = st.selectbox(
+            "Reasoning Profile",
+            [("RDFS", "rdfs"), ("OWL-RL", "owl-rl"), ("OWL-RL Extended", "owl-rl-ext")],
+            format_func=lambda x: x[0],
+        )
 
         current_triples = len(ont.graph)
         st.write(f"Current triple count: {current_triples}")
@@ -3381,7 +4351,10 @@ def render_validation():
             try:
                 new_triples = ont.apply_reasoning(profile=profile[1])
                 save_checkpoint("Apply reasoning")
-                show_message(f"Reasoning complete! {new_triples} new triples inferred.", "success")
+                show_message(
+                    f"Reasoning complete! {new_triples} new triples inferred.",
+                    "success",
+                )
                 st.write(f"New triple count: {len(ont.graph)}")
             except Exception as e:
                 show_message(f"Error during reasoning: {str(e)}", "error")
@@ -3400,18 +4373,29 @@ def render_visualization():
     stats = ont.get_statistics()
 
     if stats["content_triples"] == 0:
-        st.info("No content to visualize. Add classes, properties, individuals, or SKOS concepts first.")
+        st.info(
+            "No content to visualize. Add classes, properties, individuals, or SKOS concepts first."
+        )
         return
 
-    _viz_tab = st.segmented_control("Section", ["Interactive Graph", "Class Hierarchy", "Statistics"],
-                                    default="Interactive Graph", key="viz_active_tab", label_visibility="collapsed")
+    _viz_tab = st.segmented_control(
+        "Section",
+        ["Interactive Graph", "Class Hierarchy", "Statistics"],
+        default="Interactive Graph",
+        key="viz_active_tab",
+        label_visibility="collapsed",
+    )
     if not _viz_tab:
         _viz_tab = "Interactive Graph"
 
     if _viz_tab == "Interactive Graph":
         # Row 1: entity type checkboxes + ind. edges + triples
         _has_skos = stats.get("concepts", 0) > 0
-        _has_owl = stats["classes"] > 0 or stats["object_properties"] > 0 or stats["data_properties"] > 0
+        _has_owl = (
+            stats["classes"] > 0
+            or stats["object_properties"] > 0
+            or stats["data_properties"] > 0
+        )
 
         # Persist viz settings across page switches.
         # Widget keys are removed from session_state when the page is not rendered,
@@ -3442,48 +4426,128 @@ def render_visualization():
             """Callback to persist widget value when changed."""
             st.session_state[cfg_key] = st.session_state[wid_key]
 
-        _cols = st.columns([1, 1, 1, 1, 1, 1, 1, 1]) if _has_skos else st.columns([1, 1, 1, 1, 1, 1, 1])
+        _cols = (
+            st.columns([1, 1, 1, 1, 1, 1, 1, 1])
+            if _has_skos
+            else st.columns([1, 1, 1, 1, 1, 1, 1])
+        )
         with _cols[0]:
-            show_classes = st.checkbox("Classes", key="viz_show_classes", on_change=_viz_sync, args=("_viz_cfg_show_classes", "viz_show_classes"))
+            show_classes = st.checkbox(
+                "Classes",
+                key="viz_show_classes",
+                on_change=_viz_sync,
+                args=("_viz_cfg_show_classes", "viz_show_classes"),
+            )
         with _cols[1]:
-            show_properties = st.checkbox("Obj Props", key="viz_show_obj_props", on_change=_viz_sync, args=("_viz_cfg_show_obj_props", "viz_show_obj_props"))
+            show_properties = st.checkbox(
+                "Obj Props",
+                key="viz_show_obj_props",
+                on_change=_viz_sync,
+                args=("_viz_cfg_show_obj_props", "viz_show_obj_props"),
+            )
         with _cols[2]:
-            show_data_props = st.checkbox("Data Props", key="viz_show_data_props", on_change=_viz_sync, args=("_viz_cfg_show_data_props", "viz_show_data_props"))
+            show_data_props = st.checkbox(
+                "Data Props",
+                key="viz_show_data_props",
+                on_change=_viz_sync,
+                args=("_viz_cfg_show_data_props", "viz_show_data_props"),
+            )
         with _cols[3]:
-            show_annotations = st.checkbox("Annotations", key="viz_show_annotations", on_change=_viz_sync, args=("_viz_cfg_show_annotations", "viz_show_annotations"))
+            show_annotations = st.checkbox(
+                "Annotations",
+                key="viz_show_annotations",
+                on_change=_viz_sync,
+                args=("_viz_cfg_show_annotations", "viz_show_annotations"),
+            )
         with _cols[4]:
-            show_individuals = st.checkbox("Individuals", key="viz_show_individuals", on_change=_viz_sync, args=("_viz_cfg_show_individuals", "viz_show_individuals"))
+            show_individuals = st.checkbox(
+                "Individuals",
+                key="viz_show_individuals",
+                on_change=_viz_sync,
+                args=("_viz_cfg_show_individuals", "viz_show_individuals"),
+            )
         if _has_skos:
             with _cols[5]:
-                show_skos = st.checkbox("SKOS", key="viz_show_skos", on_change=_viz_sync, args=("_viz_cfg_show_skos", "viz_show_skos"))
+                show_skos = st.checkbox(
+                    "SKOS",
+                    key="viz_show_skos",
+                    on_change=_viz_sync,
+                    args=("_viz_cfg_show_skos", "viz_show_skos"),
+                )
             with _cols[6]:
-                show_ind_edges = st.checkbox("Ind. Edges", key="viz_show_ind_edges", on_change=_viz_sync, args=("_viz_cfg_show_ind_edges", "viz_show_ind_edges"), help="Show property edges between individuals")
+                show_ind_edges = st.checkbox(
+                    "Ind. Edges",
+                    key="viz_show_ind_edges",
+                    on_change=_viz_sync,
+                    args=("_viz_cfg_show_ind_edges", "viz_show_ind_edges"),
+                    help="Show property edges between individuals",
+                )
             with _cols[7]:
-                show_triples = st.checkbox("Triples", key="viz_show_triples", on_change=_viz_sync, args=("_viz_cfg_show_triples", "viz_show_triples"), help="Show all RDF triples for visible nodes")
+                show_triples = st.checkbox(
+                    "Triples",
+                    key="viz_show_triples",
+                    on_change=_viz_sync,
+                    args=("_viz_cfg_show_triples", "viz_show_triples"),
+                    help="Show all RDF triples for visible nodes",
+                )
         else:
             show_skos = False
             with _cols[5]:
-                show_ind_edges = st.checkbox("Ind. Edges", key="viz_show_ind_edges", on_change=_viz_sync, args=("_viz_cfg_show_ind_edges", "viz_show_ind_edges"), help="Show property edges between individuals")
+                show_ind_edges = st.checkbox(
+                    "Ind. Edges",
+                    key="viz_show_ind_edges",
+                    on_change=_viz_sync,
+                    args=("_viz_cfg_show_ind_edges", "viz_show_ind_edges"),
+                    help="Show property edges between individuals",
+                )
             with _cols[6]:
-                show_triples = st.checkbox("Triples", key="viz_show_triples", on_change=_viz_sync, args=("_viz_cfg_show_triples", "viz_show_triples"), help="Show all RDF triples for visible nodes")
+                show_triples = st.checkbox(
+                    "Triples",
+                    key="viz_show_triples",
+                    on_change=_viz_sync,
+                    args=("_viz_cfg_show_triples", "viz_show_triples"),
+                    help="Show all RDF triples for visible nodes",
+                )
 
         # Row 2: sliders + maximize + highlight issues + render button
         col1, col2, col3, col4, col5 = st.columns([2, 2, 1, 1, 1])
         with col1:
-            height = st.slider("Graph Height", 300, 1200, step=10, key="viz_graph_height", on_change=_viz_sync, args=("_viz_cfg_graph_height", "viz_graph_height"))
+            height = st.slider(
+                "Graph Height",
+                300,
+                1200,
+                step=10,
+                key="viz_graph_height",
+                on_change=_viz_sync,
+                args=("_viz_cfg_graph_height", "viz_graph_height"),
+            )
         with col2:
             node_spacing = st.slider(
                 "Node Spacing",
-                50, 300,
+                50,
+                300,
                 help="Distance between nodes. Increase for less overlap.",
-                key="viz_node_spacing", on_change=_viz_sync, args=("_viz_cfg_node_spacing", "viz_node_spacing")
+                key="viz_node_spacing",
+                on_change=_viz_sync,
+                args=("_viz_cfg_node_spacing", "viz_node_spacing"),
             )
         with col3:
-            maximize = st.checkbox("Maximize", help="Expand graph to full height", key="viz_maximize", on_change=_viz_sync, args=("_viz_cfg_maximize", "viz_maximize"))
+            maximize = st.checkbox(
+                "Maximize",
+                help="Expand graph to full height",
+                key="viz_maximize",
+                on_change=_viz_sync,
+                args=("_viz_cfg_maximize", "viz_maximize"),
+            )
             if maximize:
                 height = 1200
         with col4:
-            highlight_issues = st.checkbox("Highlight Issues", key="viz_highlight_issues", on_change=_viz_sync, args=("_viz_cfg_highlight_issues", "viz_highlight_issues"))
+            highlight_issues = st.checkbox(
+                "Highlight Issues",
+                key="viz_highlight_issues",
+                on_change=_viz_sync,
+                args=("_viz_cfg_highlight_issues", "viz_highlight_issues"),
+            )
         with col5:
             render_graph = st.button("Render", type="primary", use_container_width=True)
 
@@ -3506,22 +4570,31 @@ def render_visualization():
             st.session_state["_viz_cfg_selected_classes"] = all_class_names
             st.session_state["_viz_cfg_classes_at_mutation"] = current_mutation
         else:
-            valid = [c for c in st.session_state["_viz_cfg_selected_classes"] if c in all_class_set]
+            valid = [
+                c
+                for c in st.session_state["_viz_cfg_selected_classes"]
+                if c in all_class_set
+            ]
             if not valid and all_class_names:
                 valid = all_class_names
             st.session_state["_viz_cfg_selected_classes"] = valid
-        st.session_state["viz_selected_classes"] = st.session_state["_viz_cfg_selected_classes"]
+        st.session_state["viz_selected_classes"] = st.session_state[
+            "_viz_cfg_selected_classes"
+        ]
         with st.expander("Filter Classes", expanded=False):
             selected_classes = st.multiselect(
                 "Select classes to display",
                 options=all_class_names,
                 help="Choose which classes to show in the graph",
                 key="viz_selected_classes",
-                on_change=_viz_sync, args=("_viz_cfg_selected_classes", "viz_selected_classes")
+                on_change=_viz_sync,
+                args=("_viz_cfg_selected_classes", "viz_selected_classes"),
             )
 
         # Store graph settings in session state for caching
-        selected_classes_key = "_".join(sorted(selected_classes)) if selected_classes else "none"
+        selected_classes_key = (
+            "_".join(sorted(selected_classes)) if selected_classes else "none"
+        )
         _graph_ver = 15  # Bump to invalidate cached graph data after code changes
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
@@ -3539,7 +4612,10 @@ def render_visualization():
             st.session_state.viz_render_seq += 1
 
         # Rebuild graph data when settings change or on first visit
-        needs_rebuild = st.session_state.last_graph_key != graph_key or st.session_state.last_graph_data is None
+        needs_rebuild = (
+            st.session_state.last_graph_key != graph_key
+            or st.session_state.last_graph_data is None
+        )
 
         if needs_rebuild:
             # Build the graph using lightweight dicts (no pyvis overhead)
@@ -3548,18 +4624,22 @@ def render_visualization():
 
             class _GraphBuilder:
                 """Minimal replacement for pyvis.Network — just collects nodes/edges."""
+
                 __slots__ = ("nodes", "edges", "_node_ids", "options")
+
                 def __init__(self):
                     self.nodes = []
                     self.edges = []
                     self._node_ids = set()
                     self.options = {}
+
                 def add_node(self, node_id, **kwargs):
                     if node_id in self._node_ids:
                         return
                     self._node_ids.add(node_id)
                     kwargs["id"] = node_id
                     self.nodes.append(kwargs)
+
                 def add_edge(self, source, target, **kwargs):
                     kwargs["from"] = source
                     kwargs["to"] = target
@@ -3574,15 +4654,20 @@ def render_visualization():
                         "centralGravity": 0.3,
                         "springLength": node_spacing,
                         "springConstant": 0.04,
-                        "avoidOverlap": 0.3
+                        "avoidOverlap": 0.3,
                     },
-                    "stabilization": {"enabled": True, "iterations": 80}
+                    "stabilization": {"enabled": True, "iterations": 80},
                 },
                 "nodes": {"font": {"color": "#f0f0f0", "size": 12}},
                 "edges": {
-                    "font": {"color": "#cccccc", "size": 10, "strokeWidth": 2, "strokeColor": "#ffffff"},
-                    "smooth": {"enabled": True, "type": "curvedCW", "roundness": 0.2}
-                }
+                    "font": {
+                        "color": "#cccccc",
+                        "size": 10,
+                        "strokeWidth": 2,
+                        "strokeColor": "#ffffff",
+                    },
+                    "smooth": {"enabled": True, "type": "curvedCW", "roundness": 0.2},
+                },
             }
 
             # Limit total nodes to prevent browser hanging
@@ -3611,16 +4696,29 @@ def render_visualization():
                         title += f"\nComment: {cls['comment'][:100]}"
 
                     has_issue = cls["name"] in validation_subjects
-                    node_color = ({"background": "#4CAF50", "border": "#F44336", "highlight": {"border": "#F44336"}}
-                                  if has_issue
-                                  else {"background": "#4CAF50", "border": "#388E3C"})
+                    node_color = (
+                        {
+                            "background": "#4CAF50",
+                            "border": "#F44336",
+                            "highlight": {"border": "#F44336"},
+                        }
+                        if has_issue
+                        else {"background": "#4CAF50", "border": "#388E3C"}
+                    )
                     border_width = 3 if has_issue else 1
                     if has_issue:
                         title += "\n⚠ Has validation issues"
-                    net.add_node(cls_node_id, label=label, title=title,
-                               color=node_color, borderWidth=border_width,
-                               shape="box", size=25,
-                               ntype="Class", ename=cls_node_id)
+                    net.add_node(
+                        cls_node_id,
+                        label=label,
+                        title=title,
+                        color=node_color,
+                        borderWidth=border_width,
+                        shape="box",
+                        size=25,
+                        ntype="Class",
+                        ename=cls_node_id,
+                    )
                     displayed_class_uris.add(cls["uri"])
                     node_count += 1
 
@@ -3632,9 +4730,14 @@ def render_visualization():
                     for parent_uri in cls.get("parent_uris", []):
                         if parent_uri in displayed_class_uris:
                             parent_node_id = _uid(parent_uri)
-                            net.add_edge(cls_node_id, parent_node_id, label="subClassOf",
-                                       title=f"Subclass relation:\n{cls['name']} is a subclass of {parent_uri.rsplit('#', 1)[-1].rsplit('/', 1)[-1]}",
-                                       color="#81C784", arrows="to")
+                            net.add_edge(
+                                cls_node_id,
+                                parent_node_id,
+                                label="subClassOf",
+                                title=f"Subclass relation:\n{cls['name']} is a subclass of {parent_uri.rsplit('#', 1)[-1].rsplit('/', 1)[-1]}",
+                                color="#81C784",
+                                arrows="to",
+                            )
 
             # Add object properties as labeled edges between domain and range
             if show_properties and object_props and show_classes:
@@ -3642,19 +4745,27 @@ def render_visualization():
                     # Only show if both domain and range exist as class nodes (URI-keyed)
                     dom_uri = prop.get("domain_uri", "")
                     rng_uri = prop.get("range_uri", "")
-                    if (dom_uri and rng_uri
-                            and dom_uri in displayed_class_uris
-                            and rng_uri in displayed_class_uris):
+                    if (
+                        dom_uri
+                        and rng_uri
+                        and dom_uri in displayed_class_uris
+                        and rng_uri in displayed_class_uris
+                    ):
                         prop_node_id = _uid(prop["uri"])
                         label = prop["label"] if prop["label"] else prop["name"]
                         title = f"Object Property: {prop['name']}"
                         if prop["label"]:
                             title += f"\nLabel: {prop['label']}"
-                        net.add_edge(_uid(dom_uri), _uid(rng_uri),
-                                   label=label,
-                                   title=title,
-                                   color="#2196F3", arrows="to",
-                                   ntype="Object Property", ename=prop_node_id)
+                        net.add_edge(
+                            _uid(dom_uri),
+                            _uid(rng_uri),
+                            label=label,
+                            title=title,
+                            color="#2196F3",
+                            arrows="to",
+                            ntype="Object Property",
+                            ename=prop_node_id,
+                        )
 
             # Add data properties (connected to displayed classes, or standalone if no domain)
             if show_data_props and data_props and node_count < max_nodes:
@@ -3676,17 +4787,29 @@ def render_visualization():
                     if prop["functional"]:
                         title += "\nFunctional: Yes"
 
-                    net.add_node(prop_node_id, label=label, title=title,
-                               color={"background": "#9C27B0", "border": "#7B1FA2"},
-                               shape="box", size=12, font={"color": "#f0f0f0"},
-                               ntype="Data Property", ename=_uid(prop["uri"]))
+                    net.add_node(
+                        prop_node_id,
+                        label=label,
+                        title=title,
+                        color={"background": "#9C27B0", "border": "#7B1FA2"},
+                        shape="box",
+                        size=12,
+                        font={"color": "#f0f0f0"},
+                        ntype="Data Property",
+                        ename=_uid(prop["uri"]),
+                    )
                     node_count += 1
 
                     # Connect to domain class
                     if dom_uri and dom_uri in displayed_class_uris:
-                        net.add_edge(_uid(dom_uri), prop_node_id,
-                                   title=f"Domain:\n{prop['name']} has domain {prop['domain']}",
-                                   color="#CE93D8", arrows="to", dashes=True)
+                        net.add_edge(
+                            _uid(dom_uri),
+                            prop_node_id,
+                            title=f"Domain:\n{prop['name']} has domain {prop['domain']}",
+                            color="#CE93D8",
+                            arrows="to",
+                            dashes=True,
+                        )
 
             # Add individuals
             if show_individuals and individuals and node_count < max_nodes:
@@ -3700,16 +4823,29 @@ def render_visualization():
                         title += f"\nType: {', '.join(ind['classes'])}"
 
                     has_issue = ind["name"] in validation_subjects
-                    ind_color = ({"background": "#FF9800", "border": "#F44336", "highlight": {"border": "#F44336"}}
-                                 if has_issue
-                                 else {"background": "#FF9800", "border": "#F57C00"})
+                    ind_color = (
+                        {
+                            "background": "#FF9800",
+                            "border": "#F44336",
+                            "highlight": {"border": "#F44336"},
+                        }
+                        if has_issue
+                        else {"background": "#FF9800", "border": "#F57C00"}
+                    )
                     border_width = 3 if has_issue else 1
                     if has_issue:
                         title += "\n⚠ Has validation issues"
-                    net.add_node(ind_node_id, label=label, title=title,
-                               color=ind_color, borderWidth=border_width,
-                               shape="box", size=20,
-                               ntype="Individual", ename=_uid(ind["uri"]))
+                    net.add_node(
+                        ind_node_id,
+                        label=label,
+                        title=title,
+                        color=ind_color,
+                        borderWidth=border_width,
+                        shape="box",
+                        size=20,
+                        ntype="Individual",
+                        ename=_uid(ind["uri"]),
+                    )
                     node_count += 1
 
                     # Connect to classes via URI so the edge points to the
@@ -3720,23 +4856,35 @@ def render_visualization():
                         cls_names = ind.get("classes") or []
                         for idx, cls_uri in enumerate(class_uris):
                             if cls_uri in displayed_class_uris:
-                                cls_name = cls_names[idx] if idx < len(cls_names) else cls_uri
-                                net.add_edge(ind_node_id, _uid(cls_uri),
-                                           label="type",
-                                           title=f"Instance of:\n{ind['name']} is an instance of {cls_name}",
-                                           color="#FFB74D", arrows="to")
+                                cls_name = (
+                                    cls_names[idx] if idx < len(cls_names) else cls_uri
+                                )
+                                net.add_edge(
+                                    ind_node_id,
+                                    _uid(cls_uri),
+                                    label="type",
+                                    title=f"Instance of:\n{ind['name']} is an instance of {cls_name}",
+                                    color="#FFB74D",
+                                    arrows="to",
+                                )
 
                 # Add edges between individuals (object property assertions)
                 if show_ind_edges:
-                    ind_uri_by_name: dict[str, str] = {ind["name"]: ind["uri"] for ind in individuals}
+                    ind_uri_by_name: dict[str, str] = {
+                        ind["name"]: ind["uri"] for ind in individuals
+                    }
                     for ind in individuals:
                         for prop in ind.get("properties", []):
                             target_uri = ind_uri_by_name.get(prop["value"])
                             if target_uri:
-                                net.add_edge(f"ind_{_uid(ind['uri'])}", f"ind_{_uid(target_uri)}",
-                                           label=prop["property"],
-                                           title=f"{prop['property']}:\n{ind['name']} → {prop['value']}",
-                                           color="#FF9800", arrows="to")
+                                net.add_edge(
+                                    f"ind_{_uid(ind['uri'])}",
+                                    f"ind_{_uid(target_uri)}",
+                                    label=prop["property"],
+                                    title=f"{prop['property']}:\n{ind['name']} → {prop['value']}",
+                                    color="#FF9800",
+                                    arrows="to",
+                                )
 
             # Add class relations (only if both nodes exist) — URI-keyed
             class_relations = ont.get_class_relations()
@@ -3744,19 +4892,30 @@ def render_visualization():
                 for rel in class_relations:
                     subj_uri = rel.get("subject_uri", "")
                     obj_uri = rel.get("object_uri", "")
-                    if subj_uri in displayed_class_uris and obj_uri in displayed_class_uris:
+                    if (
+                        subj_uri in displayed_class_uris
+                        and obj_uri in displayed_class_uris
+                    ):
                         subj_node = _uid(subj_uri)
                         obj_node = _uid(obj_uri)
                         if rel["relation"] == "equivalentClass":
-                            net.add_edge(subj_node, obj_node,
-                                       label="equivalentClass",
-                                       title=f"Equivalent classes:\n{rel['subject']} and {rel['object']} represent the same concept",
-                                       color="#9C27B0", arrows="to")
+                            net.add_edge(
+                                subj_node,
+                                obj_node,
+                                label="equivalentClass",
+                                title=f"Equivalent classes:\n{rel['subject']} and {rel['object']} represent the same concept",
+                                color="#9C27B0",
+                                arrows="to",
+                            )
                         elif rel["relation"] == "disjointWith":
-                            net.add_edge(subj_node, obj_node,
-                                       label="disjointWith",
-                                       title=f"Disjoint classes:\n{rel['subject']} and {rel['object']} cannot share instances",
-                                       color="#F44336", arrows="to")
+                            net.add_edge(
+                                subj_node,
+                                obj_node,
+                                label="disjointWith",
+                                title=f"Disjoint classes:\n{rel['subject']} and {rel['object']} cannot share instances",
+                                color="#F44336",
+                                arrows="to",
+                            )
 
             # Add annotations for classes and individuals
             if show_annotations and node_count < max_nodes:
@@ -3777,17 +4936,36 @@ def render_visualization():
                                 annotation_counter += 1
                                 ann_id = f"ann_{annotation_counter}"
                                 # Use prefixed predicate name
-                                pred_display = ann.get("predicate_prefixed", ann["predicate"])
+                                pred_display = ann.get(
+                                    "predicate_prefixed", ann["predicate"]
+                                )
                                 # Truncate long values
-                                value_display = ann["value"][:30] + "..." if len(ann["value"]) > 30 else ann["value"]
-                                net.add_node(ann_id, label=value_display,
-                                           title=f"{pred_display}: {ann['value']}",
-                                           color={"background": "#795548", "border": "#5D4037"},
-                                           shape="box", size=8, font={"size": 10, "color": "#f0f0f0"})
+                                value_display = (
+                                    ann["value"][:30] + "..."
+                                    if len(ann["value"]) > 30
+                                    else ann["value"]
+                                )
+                                net.add_node(
+                                    ann_id,
+                                    label=value_display,
+                                    title=f"{pred_display}: {ann['value']}",
+                                    color={
+                                        "background": "#795548",
+                                        "border": "#5D4037",
+                                    },
+                                    shape="box",
+                                    size=8,
+                                    font={"size": 10, "color": "#f0f0f0"},
+                                )
                                 node_count += 1
-                                net.add_edge(cls["name"], ann_id,
-                                           title=f"Annotation: {pred_display}",
-                                           color="#A1887F", arrows="to", dashes=True)
+                                net.add_edge(
+                                    cls["name"],
+                                    ann_id,
+                                    title=f"Annotation: {pred_display}",
+                                    color="#A1887F",
+                                    arrows="to",
+                                    dashes=True,
+                                )
                         except Exception:
                             pass  # Skip problematic annotations
 
@@ -3805,16 +4983,35 @@ def render_visualization():
                                     continue
                                 annotation_counter += 1
                                 ann_id = f"ann_{annotation_counter}"
-                                pred_display = ann.get("predicate_prefixed", ann["predicate"])
-                                value_display = ann["value"][:30] + "..." if len(ann["value"]) > 30 else ann["value"]
-                                net.add_node(ann_id, label=value_display,
-                                           title=f"{pred_display}: {ann['value']}",
-                                           color={"background": "#795548", "border": "#5D4037"},
-                                           shape="box", size=8, font={"size": 10, "color": "#f0f0f0"})
+                                pred_display = ann.get(
+                                    "predicate_prefixed", ann["predicate"]
+                                )
+                                value_display = (
+                                    ann["value"][:30] + "..."
+                                    if len(ann["value"]) > 30
+                                    else ann["value"]
+                                )
+                                net.add_node(
+                                    ann_id,
+                                    label=value_display,
+                                    title=f"{pred_display}: {ann['value']}",
+                                    color={
+                                        "background": "#795548",
+                                        "border": "#5D4037",
+                                    },
+                                    shape="box",
+                                    size=8,
+                                    font={"size": 10, "color": "#f0f0f0"},
+                                )
                                 node_count += 1
-                                net.add_edge(f"ind_{ind['name']}", ann_id,
-                                           title=f"Annotation: {pred_display}",
-                                           color="#A1887F", arrows="to", dashes=True)
+                                net.add_edge(
+                                    f"ind_{ind['name']}",
+                                    ann_id,
+                                    title=f"Annotation: {pred_display}",
+                                    color="#A1887F",
+                                    arrows="to",
+                                    dashes=True,
+                                )
                         except Exception:
                             pass  # Skip problematic annotations
 
@@ -3834,10 +5031,16 @@ def render_visualization():
                         title += f"\nDefinition: {concept['definition'][:100]}"
                     if concept.get("scheme"):
                         title += f"\nScheme: {concept['scheme']}"
-                    net.add_node(c_id, label=label, title=title,
-                               color={"background": "#00897B", "border": "#00695C"},
-                               shape="box", size=20,
-                               ntype="SKOS Concept", ename=concept.get("uri", concept["name"]))
+                    net.add_node(
+                        c_id,
+                        label=label,
+                        title=title,
+                        color={"background": "#00897B", "border": "#00695C"},
+                        shape="box",
+                        size=20,
+                        ntype="SKOS Concept",
+                        ename=concept.get("uri", concept["name"]),
+                    )
                     skos_node_ids.add(c_id)
                     node_count += 1
 
@@ -3849,15 +5052,26 @@ def render_visualization():
                     for broader in concept.get("broader", []):
                         b_id = f"skos_{broader}"
                         if b_id in skos_node_ids:
-                            net.add_edge(c_id, b_id, label="broader",
-                                       title=f"Broader: {concept['name']} → {broader}",
-                                       color="#26A69A", arrows="to")
+                            net.add_edge(
+                                c_id,
+                                b_id,
+                                label="broader",
+                                title=f"Broader: {concept['name']} → {broader}",
+                                color="#26A69A",
+                                arrows="to",
+                            )
                     for related in concept.get("related", []):
                         r_id = f"skos_{related}"
                         if r_id in skos_node_ids:
-                            net.add_edge(c_id, r_id, label="related",
-                                       title=f"Related: {concept['name']} ↔ {related}",
-                                       color="#80CBC4", arrows="", dashes=True)
+                            net.add_edge(
+                                c_id,
+                                r_id,
+                                label="related",
+                                title=f"Related: {concept['name']} ↔ {related}",
+                                color="#80CBC4",
+                                arrows="",
+                                dashes=True,
+                            )
 
             # Add raw RDF triples for visible nodes
             if show_triples and node_count < max_nodes:
@@ -3897,38 +5111,65 @@ def render_visualization():
                                 if _triple_new >= _max_triple_new:
                                     continue
                                 o_node = f"triple_{abs(hash(o_str)) % 10**8}"
-                                net.add_node(o_node, label=_local(o),
-                                           title=f"URI: {o_str}",
-                                           color=_triple_node_color,
-                                           shape="box", size=10, font={"size": 10, "color": "#f0f0f0"})
+                                net.add_node(
+                                    o_node,
+                                    label=_local(o),
+                                    title=f"URI: {o_str}",
+                                    color=_triple_node_color,
+                                    shape="box",
+                                    size=10,
+                                    font={"size": 10, "color": "#f0f0f0"},
+                                )
                                 _uri_to_node[o_str] = o_node
                                 _triple_new += 1
                                 node_count += 1
 
-                            net.add_edge(s_node, o_node, label=p_label,
-                                       title=f"{s_local} → {p_label} → {_local(o)}",
-                                       color="#90A4AE", arrows="to")
+                            net.add_edge(
+                                s_node,
+                                o_node,
+                                label=p_label,
+                                title=f"{s_local} → {p_label} → {_local(o)}",
+                                color="#90A4AE",
+                                arrows="to",
+                            )
 
                         elif isinstance(o, _Literal):
                             if _triple_new >= _max_triple_new:
                                 continue
                             o_str = str(o)
                             o_display = o_str[:30] + "..." if len(o_str) > 30 else o_str
-                            o_node = f"lit_{abs(hash(s_uri_str + str(p) + o_str)) % 10**8}"
-                            dt = str(o.datatype).split("#")[-1] if o.datatype else "string"
-                            net.add_node(o_node, label=o_display,
-                                       title=f"Literal: {o_str}\nDatatype: {dt}",
-                                       color=_literal_node_color,
-                                       shape="box", size=8, font={"size": 9, "color": "#333333"})
+                            o_node = (
+                                f"lit_{abs(hash(s_uri_str + str(p) + o_str)) % 10**8}"
+                            )
+                            dt = (
+                                str(o.datatype).split("#")[-1]
+                                if o.datatype
+                                else "string"
+                            )
+                            net.add_node(
+                                o_node,
+                                label=o_display,
+                                title=f"Literal: {o_str}\nDatatype: {dt}",
+                                color=_literal_node_color,
+                                shape="box",
+                                size=8,
+                                font={"size": 9, "color": "#333333"},
+                            )
                             _triple_new += 1
                             node_count += 1
 
-                            net.add_edge(s_node, o_node, label=p_label,
-                                       title=f"{s_local} → {p_label} → {o_display}",
-                                       color="#B0BEC5", arrows="to")
+                            net.add_edge(
+                                s_node,
+                                o_node,
+                                label=p_label,
+                                title=f"{s_local} → {p_label} → {o_display}",
+                                color="#B0BEC5",
+                                arrows="to",
+                            )
 
             # Spread parallel edges so they don't overlap
             from collections import defaultdict as _defaultdict
+
             _edge_groups = _defaultdict(list)
             for edge in net.edges:
                 key = tuple(sorted((edge["from"], edge["to"])))
@@ -3938,11 +5179,23 @@ def render_visualization():
                     continue
                 for i, edge in enumerate(group):
                     if i == 0:
-                        edge["smooth"] = {"enabled": True, "type": "curvedCW", "roundness": 0.2}
+                        edge["smooth"] = {
+                            "enabled": True,
+                            "type": "curvedCW",
+                            "roundness": 0.2,
+                        }
                     elif i % 2 == 1:
-                        edge["smooth"] = {"enabled": True, "type": "curvedCCW", "roundness": 0.2 * ((i + 1) // 2)}
+                        edge["smooth"] = {
+                            "enabled": True,
+                            "type": "curvedCCW",
+                            "roundness": 0.2 * ((i + 1) // 2),
+                        }
                     else:
-                        edge["smooth"] = {"enabled": True, "type": "curvedCW", "roundness": 0.2 * ((i + 1) // 2)}
+                        edge["smooth"] = {
+                            "enabled": True,
+                            "type": "curvedCW",
+                            "roundness": 0.2 * ((i + 1) // 2),
+                        }
 
             # Generate and display the graph using custom component
             try:
@@ -3971,19 +5224,32 @@ def render_visualization():
         gdata = st.session_state.get("last_graph_data")
         if gdata:
             import os as _os
-            _component_path = _os.path.join(_os.path.dirname(_os.path.abspath(__file__)), "lib", "graph_viewer")
-            _graph_component = st.components.v1.declare_component("graph_viewer", path=_component_path)
+
+            _component_path = _os.path.join(
+                _os.path.dirname(_os.path.abspath(__file__)), "lib", "graph_viewer"
+            )
+            _graph_component = st.components.v1.declare_component(
+                "graph_viewer", path=_component_path
+            )
 
             selection = _graph_component(
-                nodes=gdata["nodes"], edges=gdata["edges"], options=gdata["options"],
-                height=height, seq=st.session_state.viz_render_seq,
-                key="graph_viewer", default=None
+                nodes=gdata["nodes"],
+                edges=gdata["edges"],
+                options=gdata["options"],
+                height=height,
+                seq=st.session_state.viz_render_seq,
+                key="graph_viewer",
+                default=None,
             )
 
             # Status bar outside iframe — dark styled
-            _type_to_page = {"Class": "Classes", "Object Property": "Properties",
-                             "Data Property": "Properties", "Individual": "Individuals",
-                             "SKOS Concept": "SKOS Vocabulary"}
+            _type_to_page = {
+                "Class": "Classes",
+                "Object Property": "Properties",
+                "Data Property": "Properties",
+                "Individual": "Individuals",
+                "SKOS Concept": "SKOS Vocabulary",
+            }
             _view_key_map = {
                 "Class": lambda n: f"view_class_{n}",
                 "Object Property": lambda n: f"view_objprop_{n}",
@@ -3993,7 +5259,9 @@ def render_visualization():
             }
 
             # Status bar with View button
-            has_selection = selection and isinstance(selection, dict) and selection.get("selected")
+            has_selection = (
+                selection and isinstance(selection, dict) and selection.get("selected")
+            )
             ntype = selection.get("ntype") if has_selection else None
             ename = selection.get("ename") if has_selection else None
             show_view = has_selection and ntype and ename and ntype in _type_to_page
@@ -4006,7 +5274,8 @@ def render_visualization():
                 sel_html = "Click a node or edge to see details"
 
             # Inject CSS to remove gap between status bar columns
-            st.markdown("""<style>
+            st.markdown(
+                """<style>
             div[data-testid="stHorizontalBlock"]:has(#graph-status-bar) { gap: 0 !important; }
             div[data-testid="stHorizontalBlock"]:has(#graph-status-bar) [data-testid="stBaseButton-secondary"] button,
             div[data-testid="stHorizontalBlock"]:has(#graph-status-bar) button[kind] ,
@@ -4023,21 +5292,25 @@ def render_visualization():
             div[data-testid="stHorizontalBlock"]:has(#graph-status-bar) button:hover {
                 background: #388E3C !important;
             }
-            </style>""", unsafe_allow_html=True)
+            </style>""",
+                unsafe_allow_html=True,
+            )
 
             if show_view:
                 col_info, col_btn = st.columns([20, 1])
                 with col_info:
                     st.markdown(
                         f'<div id="graph-status-bar" style="background:#1e1e1e;color:#fff;padding:6px 12px;'
-                        f'border-radius:4px 0 0 4px;font-size:14px;display:flex;align-items:center;gap:8px;'
+                        f"border-radius:4px 0 0 4px;font-size:14px;display:flex;align-items:center;gap:8px;"
                         f'height:36px;">'
                         f'<span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{sel_html}</span>'
-                        f'</div>',
-                        unsafe_allow_html=True
+                        f"</div>",
+                        unsafe_allow_html=True,
                     )
                 with col_btn:
-                    if st.button("View", key="graph_view_btn", use_container_width=True):
+                    if st.button(
+                        "View", key="graph_view_btn", use_container_width=True
+                    ):
                         page = _type_to_page[ntype]
                         vk = _view_key_map[ntype](ename)
                         st.session_state.search_navigate_to = page
@@ -4048,11 +5321,11 @@ def render_visualization():
             else:
                 st.markdown(
                     f'<div id="graph-status-bar" style="background:#1e1e1e;color:#fff;padding:6px 12px;'
-                    f'border-radius:4px;font-size:14px;display:flex;align-items:center;gap:8px;'
+                    f"border-radius:4px;font-size:14px;display:flex;align-items:center;gap:8px;"
                     f'height:36px;">'
                     f'<span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{sel_html}</span>'
-                    f'</div>',
-                    unsafe_allow_html=True
+                    f"</div>",
+                    unsafe_allow_html=True,
                 )
 
     if _viz_tab == "Class Hierarchy":
@@ -4095,8 +5368,12 @@ def render_visualization():
             st.write("**Element Distribution:**")
             chart_data = {
                 "Element": ["Classes", "Object Props", "Data Props", "Individuals"],
-                "Count": [stats["classes"], stats["object_properties"],
-                         stats["data_properties"], stats["individuals"]]
+                "Count": [
+                    stats["classes"],
+                    stats["object_properties"],
+                    stats["data_properties"],
+                    stats["individuals"],
+                ],
             }
             st.bar_chart(chart_data, x="Element", y="Count")
 
@@ -4135,7 +5412,7 @@ def main():
     st.sidebar.markdown("\u00a9 2025 [RALFORION d.o.o.](https://ralforion.com)")
     _gh_repo = GITHUB_ISSUES_URL.rsplit("/", 1)[0]
     st.sidebar.markdown(
-        f'<small>v{APP_VERSION} · '
+        f"<small>v{APP_VERSION} · "
         f'<a href="{_gh_repo}" title="GitHub"><svg height="13" width="13" viewBox="0 0 16 16" style="vertical-align:middle;fill:currentColor;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a> · '
         f'<a href="{GITHUB_ISSUES_URL}/new">Report Issue</a></small>',
         unsafe_allow_html=True,
@@ -4154,7 +5431,7 @@ def main():
         "Import / Export": render_import_export,
         "Source": render_source,
         "Validation": render_validation,
-        "Visualization": render_visualization
+        "Visualization": render_visualization,
     }
 
     # Handle graph view navigation (from visualization click)
@@ -4162,7 +5439,13 @@ def main():
     if "graph_view_type" in _qp and "graph_view_name" in _qp:
         _gv_type = _qp["graph_view_type"]
         _gv_name = _qp["graph_view_name"]
-        _type_to_page = {"Class": "Classes", "Object Property": "Properties", "Data Property": "Properties", "Individual": "Individuals", "SKOS Concept": "SKOS Vocabulary"}
+        _type_to_page = {
+            "Class": "Classes",
+            "Object Property": "Properties",
+            "Data Property": "Properties",
+            "Individual": "Individuals",
+            "SKOS Concept": "SKOS Vocabulary",
+        }
         _view_key_map = {
             "Class": f"view_class_{_gv_name}",
             "Object Property": f"view_objprop_{_gv_name}",
@@ -4195,15 +5478,29 @@ def main():
     if um:
         undo_col, redo_col = st.sidebar.columns(2)
         with undo_col:
-            if st.button("Undo", disabled=not um.can_undo(), use_container_width=True, key="btn_undo"):
+            if st.button(
+                "Undo",
+                disabled=not um.can_undo(),
+                use_container_width=True,
+                key="btn_undo",
+            ):
                 label = um.undo()
-                st.session_state["_ont_mutation_count"] = st.session_state.get("_ont_mutation_count", 0) + 1
+                st.session_state["_ont_mutation_count"] = (
+                    st.session_state.get("_ont_mutation_count", 0) + 1
+                )
                 set_flash_message(f"Undid: {label}", "info")
                 st.rerun()
         with redo_col:
-            if st.button("Redo", disabled=not um.can_redo(), use_container_width=True, key="btn_redo"):
+            if st.button(
+                "Redo",
+                disabled=not um.can_redo(),
+                use_container_width=True,
+                key="btn_redo",
+            ):
                 label = um.redo()
-                st.session_state["_ont_mutation_count"] = st.session_state.get("_ont_mutation_count", 0) + 1
+                st.session_state["_ont_mutation_count"] = (
+                    st.session_state.get("_ont_mutation_count", 0) + 1
+                )
                 set_flash_message(f"Redid: {label}", "info")
                 st.rerun()
 
@@ -4219,7 +5516,9 @@ def main():
         "Individual": "Individuals",
         "SKOS Concept": "SKOS Vocabulary",
     }
-    search_query = st.sidebar.text_input("Search", placeholder="Search resources...", key="global_search")
+    search_query = st.sidebar.text_input(
+        "Search", placeholder="Search resources...", key="global_search"
+    )
     if search_query:
         results = st.session_state.ontology.search(search_query)
         if results:
@@ -4231,14 +5530,20 @@ def main():
                 st.sidebar.caption(type_label)
                 page = type_to_page.get(type_label, "Dashboard")
                 for r in items:
-                    label_str = f" ({r['label']})" if r["label"] and r["label"] != r["name"] else ""
+                    label_str = (
+                        f" ({r['label']})"
+                        if r["label"] and r["label"] != r["name"]
+                        else ""
+                    )
                     # Key the search button by URI hash so duplicate local
                     # names in different namespaces produce distinct buttons.
                     r_uri = r.get("uri", r["name"])
                     r_uid = _uid(r_uri)
-                    if st.sidebar.button(f"{r['name']}{label_str}",
-                                         key=f"search_{type_label}_{r_uid}",
-                                         use_container_width=True):
+                    if st.sidebar.button(
+                        f"{r['name']}{label_str}",
+                        key=f"search_{type_label}_{r_uid}",
+                        use_container_width=True,
+                    ):
                         st.session_state.search_navigate_to = page
                         # Open the view pane keyed by URI hash so we navigate
                         # to the *exact* resource, not whichever shares the
@@ -4266,7 +5571,7 @@ def main():
     st.sidebar.write(f"🔗 Object Props: {stats['object_properties']}")
     st.sidebar.write(f"📝 Data Props: {stats['data_properties']}")
     st.sidebar.write(f"👤 Individuals: {stats['individuals']}")
-    if stats.get('concepts', 0) > 0:
+    if stats.get("concepts", 0) > 0:
         st.sidebar.write(f"🏷️ SKOS Concepts: {stats['concepts']}")
     st.sidebar.write(f"📊 Triples: {stats['content_triples']}")
 
@@ -4277,20 +5582,21 @@ def main():
     ont_uri = str(ont.namespace)
     if not ont_label:
         import re
+
         parts = [p for p in ont_uri.rstrip("#/").split("/") if p and ":" not in p]
-        name_parts = [p for p in parts if not re.match(r'^v?\d+[\d.]*$', p)]
+        name_parts = [p for p in parts if not re.match(r"^v?\d+[\d.]*$", p)]
         ont_label = name_parts[-1] if name_parts else (parts[-1] if parts else ont_uri)
     if ont_uri.startswith("http://example.org/"):
         st.markdown(
             f'<p style="color:gray;font-size:0.9rem;margin:0"><b>{ont_label}</b> — '
-            f'{ont_uri.replace("http://", "http&#58;//")}</p>',
-            unsafe_allow_html=True
+            f"{ont_uri.replace('http://', 'http&#58;//')}</p>",
+            unsafe_allow_html=True,
         )
     else:
         st.markdown(
             f'<p style="color:gray;font-size:0.9rem;margin:0"><b>{ont_label}</b> — '
             f'<a href="{ont_uri}" target="_blank" style="color:gray">{ont_uri}</a></p>',
-            unsafe_allow_html=True
+            unsafe_allow_html=True,
         )
 
     # Render selected page
@@ -4308,9 +5614,9 @@ def main():
         with st.sidebar.expander(f"Errors ({len(error_log)})", expanded=False):
             for i, entry in enumerate(reversed(error_log)):
                 st.markdown(f"**{entry['time']}** — {entry['context']}")
-                st.code(entry['error'], language=None)
+                st.code(entry["error"], language=None)
                 with st.expander("Traceback", expanded=False):
-                    st.code(entry['traceback'], language="python")
+                    st.code(entry["traceback"], language="python")
             if st.button("Clear errors", key="btn_clear_errors"):
                 st.session_state.error_log = []
                 st.rerun()

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -4,11 +4,16 @@ OntologyManager - Core class for managing OWL ontologies using rdflib.
 
 from rdflib import Graph, Namespace, URIRef, Literal, BNode
 from rdflib.namespace import RDF, RDFS, OWL, XSD, SKOS, DC, DCTERMS
+from rdflib.term import Node
 from rdflib.collection import Collection
-from typing import Optional, List, Dict, Tuple, Any, Set
+from typing import Optional, List, Dict, Tuple, Any, Set, cast
 import owlrl
 
-_UNSET = object()  # sentinel: "parameter not provided"
+_UNSET: Any = object()  # sentinel: "parameter not provided"
+
+# A triple and a list of (old_triple, new_triple) rename operations.
+_Triple = Tuple[Node, Node, Node]
+_TripleUpdates = List[Tuple[_Triple, _Triple]]
 
 # domainIncludes/rangeIncludes from Schema.org and gist
 _SCHEMA = Namespace("https://schema.org/")
@@ -74,8 +79,9 @@ class OntologyManager:
         self.ontology_uri = URIRef(base_uri.rstrip("#").rstrip("/"))
         self.graph.add((self.ontology_uri, RDF.type, OWL.Ontology))
 
-    def set_ontology_metadata(self, label=_UNSET, comment=_UNSET,
-                              creator=_UNSET, version_iri=_UNSET):
+    def set_ontology_metadata(
+        self, label=_UNSET, comment=_UNSET, creator=_UNSET, version_iri=_UNSET
+    ):
         """Set ontology-level metadata.
 
         Pass a non-empty string to set a value.
@@ -127,7 +133,7 @@ class OntologyManager:
                 seen.add(display)
                 prefixes.append({"prefix": display, "namespace": str(ns)})
         # Include loaded prefixes not yet in graph
-        if hasattr(self, '_loaded_prefixes') and self._loaded_prefixes:
+        if hasattr(self, "_loaded_prefixes") and self._loaded_prefixes:
             for p in self._loaded_prefixes:
                 if p["prefix"] not in seen:
                     seen.add(p["prefix"])
@@ -149,11 +155,13 @@ class OntologyManager:
                 source = "default"
             else:
                 source = "custom"
-            prefixes.append({
-                "prefix": display,
-                "namespace": str(ns),
-                "source": source,
-            })
+            prefixes.append(
+                {
+                    "prefix": display,
+                    "namespace": str(ns),
+                    "source": source,
+                }
+            )
         prefixes.sort(key=lambda x: ("" if x["prefix"] == "(default)" else x["prefix"]))
         return prefixes
 
@@ -178,16 +186,16 @@ class OntologyManager:
     def _extract_prefixes_from_ttl(self, data: str) -> List[Dict[str, str]]:
         """Extract @prefix declarations from TTL content."""
         import re
+
         prefixes = []
         # Match @prefix declarations: @prefix name: <uri> .
-        pattern = r'@prefix\s+([a-zA-Z0-9_-]*)\s*:\s*<([^>]+)>\s*\.'
+        pattern = r"@prefix\s+([a-zA-Z0-9_-]*)\s*:\s*<([^>]+)>\s*\."
         for match in re.finditer(pattern, data):
             prefix = match.group(1)
             namespace = match.group(2)
-            prefixes.append({
-                "prefix": prefix if prefix else "(default)",
-                "namespace": namespace
-            })
+            prefixes.append(
+                {"prefix": prefix if prefix else "(default)", "namespace": namespace}
+            )
         # Sort by prefix name, with default first
         prefixes.sort(key=lambda x: ("" if x["prefix"] == "(default)" else x["prefix"]))
         return prefixes
@@ -195,7 +203,8 @@ class OntologyManager:
     def _extract_prefixes_from_jsonld(self, data: str) -> List[Dict[str, str]]:
         """Extract prefix declarations from JSON-LD @context."""
         import json
-        prefixes = []
+
+        prefixes: List[Dict[str, str]] = []
         try:
             doc = json.loads(data)
         except (json.JSONDecodeError, TypeError):
@@ -215,20 +224,27 @@ class OntologyManager:
             for key, value in context.items():
                 if key.startswith("@"):
                     continue
-                if isinstance(value, str) and (value.startswith("http://") or
-                                                value.startswith("https://")):
-                    prefixes.append({
-                        "prefix": key if key else "(default)",
-                        "namespace": value,
-                    })
+                if isinstance(value, str) and (
+                    value.startswith("http://") or value.startswith("https://")
+                ):
+                    prefixes.append(
+                        {
+                            "prefix": key if key else "(default)",
+                            "namespace": value,
+                        }
+                    )
         prefixes.sort(key=lambda x: ("" if x["prefix"] == "(default)" else x["prefix"]))
         return prefixes
 
     def get_ontology_metadata(self) -> Dict[str, str]:
         """Get ontology-level metadata."""
         metadata = {}
-        for pred, key in [(RDFS.label, "label"), (RDFS.comment, "comment"),
-                          (DCTERMS.creator, "creator"), (OWL.versionIRI, "version_iri")]:
+        for pred, key in [
+            (RDFS.label, "label"),
+            (RDFS.comment, "comment"),
+            (DCTERMS.creator, "creator"),
+            (OWL.versionIRI, "version_iri"),
+        ]:
             value = self.graph.value(self.ontology_uri, pred)
             if value:
                 metadata[key] = str(value)
@@ -270,10 +286,10 @@ class OntologyManager:
             for s, p, o in self.graph:
                 new_s, new_o = s, o
                 if isinstance(s, URIRef) and str(s).startswith(old_base_uri):
-                    local_name = str(s)[len(old_base_uri):]
+                    local_name = str(s)[len(old_base_uri) :]
                     new_s = URIRef(new_base_uri + local_name)
                 if isinstance(o, URIRef) and str(o).startswith(old_base_uri):
-                    local_name = str(o)[len(old_base_uri):]
+                    local_name = str(o)[len(old_base_uri) :]
                     new_o = URIRef(new_base_uri + local_name)
                 if new_s != s or new_o != o:
                     updates.append(((s, p, o), (new_s, p, new_o)))
@@ -291,7 +307,7 @@ class OntologyManager:
             return URIRef(local_name)
         return self.namespace[local_name]
 
-    def _local_name(self, uri: URIRef) -> str:
+    def _local_name(self, uri: Node) -> str:
         """Extract local name from a URI."""
         uri_str = str(uri)
         if "#" in uri_str:
@@ -300,8 +316,13 @@ class OntologyManager:
 
     # ==================== CLASS OPERATIONS ====================
 
-    def add_class(self, name: str, parent: str = None, label: str = None,
-                  comment: str = None) -> URIRef:
+    def add_class(
+        self,
+        name: str,
+        parent: Optional[str] = None,
+        label: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> URIRef:
         """Add a new OWL class."""
         class_uri = self._uri(name)
         self.graph.add((class_uri, RDF.type, OWL.Class))
@@ -317,8 +338,14 @@ class OntologyManager:
 
         return class_uri
 
-    def update_class(self, name: str, new_label: str = None, new_comment: str = None,
-                     new_parent: str = None, remove_parent: str = None):
+    def update_class(
+        self,
+        name: str,
+        new_label: Optional[str] = None,
+        new_comment: Optional[str] = None,
+        new_parent: Optional[str] = None,
+        remove_parent: Optional[str] = None,
+    ):
         """Update an existing class."""
         class_uri = self._uri(name)
 
@@ -351,7 +378,7 @@ class OntologyManager:
             return False
 
         # Collect all triples to update
-        updates = []
+        updates: _TripleUpdates = []
 
         # Triples where old_uri is subject
         for p, o in self.graph.predicate_objects(old_uri):
@@ -368,7 +395,9 @@ class OntologyManager:
 
         return True
 
-    def get_delete_impact(self, name: str, resource_type: str = "class") -> Dict[str, Any]:
+    def get_delete_impact(
+        self, name: str, resource_type: str = "class"
+    ) -> Dict[str, Any]:
         """Analyse the impact of deleting a resource before executing it.
 
         Args:
@@ -399,7 +428,10 @@ class OntologyManager:
 
             # Instances typed with this class
             for ind in self.graph.subjects(RDF.type, uri):
-                if isinstance(ind, URIRef) and (ind, RDF.type, OWL.NamedIndividual) in self.graph:
+                if (
+                    isinstance(ind, URIRef)
+                    and (ind, RDF.type, OWL.NamedIndividual) in self.graph
+                ):
                     impact["instances"].append(self._local_name(ind))
 
             # Properties that use this class as domain
@@ -440,16 +472,27 @@ class OntologyManager:
         impact["direct_triples"] = len(list(self.graph.predicate_objects(uri)))
 
         # Count annotations (literal-valued predicates on this resource)
-        structural = {RDF.type, RDFS.subClassOf, RDFS.subPropertyOf,
-                      RDFS.domain, RDFS.range, OWL.equivalentClass,
-                      OWL.disjointWith, OWL.inverseOf}
+        structural = {
+            RDF.type,
+            RDFS.subClassOf,
+            RDFS.subPropertyOf,
+            RDFS.domain,
+            RDFS.range,
+            OWL.equivalentClass,
+            OWL.disjointWith,
+            OWL.inverseOf,
+        }
         for p, o in self.graph.predicate_objects(uri):
             if p not in structural and isinstance(o, Literal):
                 impact["annotations"] += 1
 
         # Total affected triples (as subject + as object + as predicate for properties)
         ref_count = len(list(self.graph.subject_predicates(uri)))
-        pred_count = len(list(self.graph.subject_objects(uri))) if resource_type == "property" else 0
+        pred_count = (
+            len(list(self.graph.subject_objects(uri)))
+            if resource_type == "property"
+            else 0
+        )
         impact["total_triples"] = impact["direct_triples"] + ref_count + pred_count
 
         return impact
@@ -458,20 +501,32 @@ class OntologyManager:
         """Format an impact dict into a human-readable summary string."""
         parts = []
         rt = impact["resource_type"]
-        parts.append(f"Deleting {rt} **{impact['resource']}** will remove {impact['total_triples']} triple(s).")
+        parts.append(
+            f"Deleting {rt} **{impact['resource']}** will remove {impact['total_triples']} triple(s)."
+        )
 
         if impact["subclasses"]:
-            parts.append(f"- {len(impact['subclasses'])} subclass link(s) lost: {', '.join(impact['subclasses'])}")
+            parts.append(
+                f"- {len(impact['subclasses'])} subclass link(s) lost: {', '.join(impact['subclasses'])}"
+            )
         if impact["instances"]:
-            parts.append(f"- {len(impact['instances'])} instance(s) lose their class type: {', '.join(impact['instances'])}")
+            parts.append(
+                f"- {len(impact['instances'])} instance(s) lose their class type: {', '.join(impact['instances'])}"
+            )
         if impact["domain_of"]:
-            parts.append(f"- {len(impact['domain_of'])} property domain reference(s) lost: {', '.join(impact['domain_of'])}")
+            parts.append(
+                f"- {len(impact['domain_of'])} property domain reference(s) lost: {', '.join(impact['domain_of'])}"
+            )
         if impact["range_of"]:
-            parts.append(f"- {len(impact['range_of'])} property range reference(s) lost: {', '.join(impact['range_of'])}")
+            parts.append(
+                f"- {len(impact['range_of'])} property range reference(s) lost: {', '.join(impact['range_of'])}"
+            )
         if impact["annotations"]:
             parts.append(f"- {impact['annotations']} annotation(s) removed")
         if impact["property_assertions"]:
-            parts.append(f"- {len(impact['property_assertions'])} property assertion(s) removed")
+            parts.append(
+                f"- {len(impact['property_assertions'])} property assertion(s) removed"
+            )
         if impact["relations"]:
             parts.append(f"- {len(impact['relations'])} inbound relation(s) removed")
 
@@ -497,7 +552,7 @@ class OntologyManager:
             if isinstance(class_uri, BNode):
                 continue  # Skip anonymous classes (restrictions)
 
-            class_info = {
+            class_info: Dict[str, Any] = {
                 "uri": str(class_uri),
                 "name": self._local_name(class_uri),
                 "label": str(self.graph.value(class_uri, RDFS.label) or ""),
@@ -526,7 +581,7 @@ class OntologyManager:
 
     def get_class_hierarchy(self) -> Dict[str, List[str]]:
         """Get class hierarchy as adjacency list."""
-        hierarchy = {}
+        hierarchy: Dict[str, List[str]] = {}
         for class_uri in self.graph.subjects(RDF.type, OWL.Class):
             if isinstance(class_uri, BNode):
                 continue
@@ -540,7 +595,9 @@ class OntologyManager:
     # ==================== BULK OPERATIONS ====================
 
     @staticmethod
-    def parse_bulk_text(text: str, columns: List[str] = None) -> List[Dict[str, str]]:
+    def parse_bulk_text(
+        text: str, columns: Optional[List[str]] = None
+    ) -> List[Dict[str, str]]:
         """Parse multi-line text into list of dicts.
 
         Supports:
@@ -606,8 +663,9 @@ class OntologyManager:
 
         return result
 
-    def bulk_add_properties(self, entries: List[Dict[str, str]],
-                            property_type: str = "object") -> Dict[str, Any]:
+    def bulk_add_properties(
+        self, entries: List[Dict[str, str]], property_type: str = "object"
+    ) -> Dict[str, Any]:
         """Batch create properties.
 
         Each entry dict can have: name, domain, range, label.
@@ -633,9 +691,13 @@ class OntologyManager:
                 range_ = entry.get("range", "").strip() or None
                 label = entry.get("label", "").strip() or None
                 if property_type == "object":
-                    self.add_object_property(name, domain=domain, range_=range_, label=label)
+                    self.add_object_property(
+                        name, domain=domain, range_=range_, label=label
+                    )
                 else:
-                    self.add_data_property(name, domain=domain, range_=range_ or "string", label=label)
+                    self.add_data_property(
+                        name, domain=domain, range_=range_ or "string", label=label
+                    )
                 result["created"].append(name)
                 existing.add(name)
             except Exception as e:
@@ -727,40 +789,58 @@ class OntologyManager:
             action = update.get("action", "add").strip().lower()
 
             if not resource or not predicate:
-                result["errors"].append({
-                    "resource": resource,
-                    "error": "Missing resource or predicate",
-                })
+                result["errors"].append(
+                    {
+                        "resource": resource,
+                        "error": "Missing resource or predicate",
+                    }
+                )
                 continue
 
             try:
                 if action == "delete":
-                    self.delete_annotation(resource, predicate, value=value or None, lang=lang)
+                    self.delete_annotation(
+                        resource, predicate, value=value or None, lang=lang
+                    )
                 else:
                     if not value:
-                        result["errors"].append({
-                            "resource": resource,
-                            "error": "Missing value for add",
-                        })
+                        result["errors"].append(
+                            {
+                                "resource": resource,
+                                "error": "Missing value for add",
+                            }
+                        )
                         continue
                     self.add_annotation(resource, predicate, value, lang=lang)
                 result["applied"] += 1
             except Exception as e:
-                result["errors"].append({
-                    "resource": resource,
-                    "error": str(e),
-                })
+                result["errors"].append(
+                    {
+                        "resource": resource,
+                        "error": str(e),
+                    }
+                )
 
         return result
 
     # ==================== PROPERTY OPERATIONS ====================
 
-    def add_object_property(self, name: str, domain: str = None, range_: str = None,
-                            label: str = None, comment: str = None,
-                            functional: bool = False, inverse_functional: bool = False,
-                            transitive: bool = False, symmetric: bool = False,
-                            asymmetric: bool = False, reflexive: bool = False,
-                            irreflexive: bool = False, inverse_of: str = None) -> URIRef:
+    def add_object_property(
+        self,
+        name: str,
+        domain: Optional[str] = None,
+        range_: Optional[str] = None,
+        label: Optional[str] = None,
+        comment: Optional[str] = None,
+        functional: bool = False,
+        inverse_functional: bool = False,
+        transitive: bool = False,
+        symmetric: bool = False,
+        asymmetric: bool = False,
+        reflexive: bool = False,
+        irreflexive: bool = False,
+        inverse_of: Optional[str] = None,
+    ) -> URIRef:
         """Add a new object property."""
         prop_uri = self._uri(name)
         self.graph.add((prop_uri, RDF.type, OWL.ObjectProperty))
@@ -794,9 +874,15 @@ class OntologyManager:
 
         return prop_uri
 
-    def add_data_property(self, name: str, domain: str = None, range_: str = "string",
-                          label: str = None, comment: str = None,
-                          functional: bool = False) -> URIRef:
+    def add_data_property(
+        self,
+        name: str,
+        domain: Optional[str] = None,
+        range_: str = "string",
+        label: Optional[str] = None,
+        comment: Optional[str] = None,
+        functional: bool = False,
+    ) -> URIRef:
         """Add a new data property."""
         prop_uri = self._uri(name)
         self.graph.add((prop_uri, RDF.type, OWL.DatatypeProperty))
@@ -815,8 +901,14 @@ class OntologyManager:
 
         return prop_uri
 
-    def update_property(self, name: str, new_label: str = None, new_comment: str = None,
-                        new_domain: str = None, new_range: str = None):
+    def update_property(
+        self,
+        name: str,
+        new_label: Optional[str] = None,
+        new_comment: Optional[str] = None,
+        new_domain: Optional[str] = None,
+        new_range: Optional[str] = None,
+    ):
         """Update an existing property."""
         prop_uri = self._uri(name)
 
@@ -840,7 +932,9 @@ class OntologyManager:
             if new_range:
                 # Check if it's a datatype or class
                 if new_range in self.XSD_DATATYPES:
-                    self.graph.add((prop_uri, RDFS.range, self.XSD_DATATYPES[new_range]))
+                    self.graph.add(
+                        (prop_uri, RDFS.range, self.XSD_DATATYPES[new_range])
+                    )
                 else:
                     self.graph.add((prop_uri, RDFS.range, self._uri(new_range)))
 
@@ -853,12 +947,15 @@ class OntologyManager:
         new_uri = self._uri(new_name)
 
         # Check if new name already exists
-        if (new_uri, RDF.type, OWL.ObjectProperty) in self.graph or \
-           (new_uri, RDF.type, OWL.DatatypeProperty) in self.graph:
+        if (new_uri, RDF.type, OWL.ObjectProperty) in self.graph or (
+            new_uri,
+            RDF.type,
+            OWL.DatatypeProperty,
+        ) in self.graph:
             return False
 
         # Collect all triples to update
-        updates = []
+        updates: _TripleUpdates = []
 
         # Triples where old_uri is subject
         for p, o in self.graph.predicate_objects(old_uri):
@@ -893,7 +990,7 @@ class OntologyManager:
             if isinstance(prop_uri, BNode):
                 continue
 
-            prop_info = {
+            prop_info: Dict[str, Any] = {
                 "uri": str(prop_uri),
                 "name": self._local_name(prop_uri),
                 "label": str(self.graph.value(prop_uri, RDFS.label) or ""),
@@ -902,7 +999,7 @@ class OntologyManager:
                 "domain_uri": "",
                 "range": "",
                 "range_uri": "",
-                "characteristics": []
+                "characteristics": [],
             }
 
             domain = self.graph.value(prop_uri, RDFS.domain)
@@ -964,7 +1061,7 @@ class OntologyManager:
                 "domain": "",
                 "domain_uri": "",
                 "range": "",
-                "functional": False
+                "functional": False,
             }
 
             domain = self.graph.value(prop_uri, RDFS.domain)
@@ -981,7 +1078,11 @@ class OntologyManager:
             if range_:
                 prop_info["range"] = self._local_name(range_)
 
-            prop_info["functional"] = (prop_uri, RDF.type, OWL.FunctionalProperty) in self.graph
+            prop_info["functional"] = (
+                prop_uri,
+                RDF.type,
+                OWL.FunctionalProperty,
+            ) in self.graph
 
             properties.append(prop_info)
 
@@ -989,8 +1090,13 @@ class OntologyManager:
 
     # ==================== INDIVIDUAL OPERATIONS ====================
 
-    def add_individual(self, name: str, class_name: str, label: str = None,
-                       comment: str = None) -> URIRef:
+    def add_individual(
+        self,
+        name: str,
+        class_name: str,
+        label: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> URIRef:
         """Add a new individual (instance)."""
         ind_uri = self._uri(name)
         class_uri = self._uri(class_name)
@@ -1005,8 +1111,13 @@ class OntologyManager:
 
         return ind_uri
 
-    def add_individual_property(self, individual: str, property_name: str, value: Any,
-                                is_object_property: bool = True):
+    def add_individual_property(
+        self,
+        individual: str,
+        property_name: str,
+        value: Any,
+        is_object_property: bool = True,
+    ):
         """Add a property assertion to an individual."""
         ind_uri = self._uri(individual)
         prop_uri = self._uri(property_name)
@@ -1017,8 +1128,14 @@ class OntologyManager:
         else:
             self.graph.add((ind_uri, prop_uri, Literal(value)))
 
-    def update_individual(self, name: str, new_label: str = None, new_comment: str = None,
-                          add_class: str = None, remove_class: str = None):
+    def update_individual(
+        self,
+        name: str,
+        new_label: Optional[str] = None,
+        new_comment: Optional[str] = None,
+        add_class: Optional[str] = None,
+        remove_class: Optional[str] = None,
+    ):
         """Update an existing individual."""
         ind_uri = self._uri(name)
 
@@ -1051,7 +1168,7 @@ class OntologyManager:
             return False
 
         # Collect all triples to update
-        updates = []
+        updates: _TripleUpdates = []
 
         # Triples where old_uri is subject
         for p, o in self.graph.predicate_objects(old_uri):
@@ -1084,14 +1201,14 @@ class OntologyManager:
                 continue
             seen.add(str(ind_uri))
 
-            ind_info = {
+            ind_info: Dict[str, Any] = {
                 "uri": str(ind_uri),
                 "name": self._local_name(ind_uri),
                 "label": str(self.graph.value(ind_uri, RDFS.label) or ""),
                 "comment": str(self.graph.value(ind_uri, RDFS.comment) or ""),
                 "classes": [],
                 "class_uris": [],
-                "properties": []
+                "properties": [],
             }
 
             # Get classes — expose both the local name (for display) and the
@@ -1110,7 +1227,9 @@ class OntologyManager:
                         value = self._local_name(obj)
                     else:
                         value = str(obj)
-                    ind_info["properties"].append({"property": prop_name, "value": value})
+                    ind_info["properties"].append(
+                        {"property": prop_name, "value": value}
+                    )
 
             individuals.append(ind_info)
 
@@ -1118,8 +1237,14 @@ class OntologyManager:
 
     # ==================== RESTRICTION OPERATIONS ====================
 
-    def add_restriction(self, class_name: str, property_name: str, restriction_type: str,
-                        value: Any, on_class: str = None) -> BNode:
+    def add_restriction(
+        self,
+        class_name: str,
+        property_name: str,
+        restriction_type: str,
+        value: Any,
+        on_class: Optional[str] = None,
+    ) -> BNode:
         """Add a restriction to a class."""
         class_uri = self._uri(class_name)
         prop_uri = self._uri(property_name)
@@ -1140,13 +1265,30 @@ class OntologyManager:
                 self.graph.add((restriction, restriction_pred, Literal(value)))
             else:
                 self.graph.add((restriction, restriction_pred, self._uri(value)))
-        elif restriction_type in ["minCardinality", "maxCardinality", "exactCardinality"]:
-            self.graph.add((restriction, restriction_pred,
-                          Literal(int(value), datatype=XSD.nonNegativeInteger)))
-        elif restriction_type in ["minQualifiedCardinality", "maxQualifiedCardinality",
-                                  "qualifiedCardinality"]:
-            self.graph.add((restriction, restriction_pred,
-                          Literal(int(value), datatype=XSD.nonNegativeInteger)))
+        elif restriction_type in [
+            "minCardinality",
+            "maxCardinality",
+            "exactCardinality",
+        ]:
+            self.graph.add(
+                (
+                    restriction,
+                    restriction_pred,
+                    Literal(int(value), datatype=XSD.nonNegativeInteger),
+                )
+            )
+        elif restriction_type in [
+            "minQualifiedCardinality",
+            "maxQualifiedCardinality",
+            "qualifiedCardinality",
+        ]:
+            self.graph.add(
+                (
+                    restriction,
+                    restriction_pred,
+                    Literal(int(value), datatype=XSD.nonNegativeInteger),
+                )
+            )
             if on_class:
                 self.graph.add((restriction, OWL.onClass, self._uri(on_class)))
 
@@ -1155,7 +1297,9 @@ class OntologyManager:
 
         return restriction
 
-    def get_restrictions(self, class_name: str = None) -> List[Dict[str, Any]]:
+    def get_restrictions(
+        self, class_name: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
         """Get restrictions, optionally filtered by class."""
         restrictions = []
 
@@ -1164,12 +1308,12 @@ class OntologyManager:
             if not prop:
                 continue
 
-            rest_info = {
+            rest_info: Dict[str, Any] = {
                 "property": self._local_name(prop),
                 "type": None,
                 "value": None,
                 "on_class": None,
-                "applied_to": []
+                "applied_to": [],
             }
 
             # Determine restriction type
@@ -1197,7 +1341,9 @@ class OntologyManager:
 
         return restrictions
 
-    def delete_restriction(self, class_name: str, property_name: str, restriction_type: str):
+    def delete_restriction(
+        self, class_name: str, property_name: str, restriction_type: str
+    ):
         """Delete a restriction from a class."""
         class_uri = self._uri(class_name)
         prop_uri = self._uri(property_name)
@@ -1216,7 +1362,9 @@ class OntologyManager:
 
     # ==================== ANNOTATION OPERATIONS ====================
 
-    def add_annotation(self, subject: str, predicate: str, value: str, lang: str = None):
+    def add_annotation(
+        self, subject: str, predicate: str, value: str, lang: Optional[str] = None
+    ):
         """Add an annotation to any resource.
 
         Args:
@@ -1267,14 +1415,28 @@ class OntologyManager:
         # Get all predicates for this subject, excluding rdf:type, rdfs:subClassOf,
         # rdfs:domain, rdfs:range, and other structural predicates
         structural_predicates = {
-            RDF.type, RDFS.subClassOf, RDFS.subPropertyOf,
-            RDFS.domain, RDFS.range,
-            OWL.equivalentClass, OWL.equivalentProperty, OWL.disjointWith,
-            OWL.inverseOf, OWL.propertyChainAxiom,
-            OWL.onProperty, OWL.someValuesFrom, OWL.allValuesFrom,
-            OWL.hasValue, OWL.minCardinality, OWL.maxCardinality, OWL.cardinality,
-            OWL.unionOf, OWL.intersectionOf, OWL.complementOf, OWL.oneOf,
-            OWL.imports
+            RDF.type,
+            RDFS.subClassOf,
+            RDFS.subPropertyOf,
+            RDFS.domain,
+            RDFS.range,
+            OWL.equivalentClass,
+            OWL.equivalentProperty,
+            OWL.disjointWith,
+            OWL.inverseOf,
+            OWL.propertyChainAxiom,
+            OWL.onProperty,
+            OWL.someValuesFrom,
+            OWL.allValuesFrom,
+            OWL.hasValue,
+            OWL.minCardinality,
+            OWL.maxCardinality,
+            OWL.cardinality,
+            OWL.unionOf,
+            OWL.intersectionOf,
+            OWL.complementOf,
+            OWL.oneOf,
+            OWL.imports,
         }
 
         for pred, obj in self.graph.predicate_objects(subj_uri):
@@ -1291,12 +1453,14 @@ class OntologyManager:
             ann = {
                 "predicate": local_name,
                 "predicate_uri": pred_uri,
-                "predicate_prefixed": f"{prefix}:{local_name}" if prefix else local_name,
-                "value": str(obj)
+                "predicate_prefixed": f"{prefix}:{local_name}"
+                if prefix
+                else local_name,
+                "value": str(obj),
             }
-            if hasattr(obj, 'language') and obj.language:
+            if hasattr(obj, "language") and obj.language:
                 ann["language"] = obj.language
-            if hasattr(obj, 'datatype') and obj.datatype:
+            if hasattr(obj, "datatype") and obj.datatype:
                 ann["datatype"] = self._local_name(obj.datatype)
             annotations.append(ann)
 
@@ -1307,14 +1471,28 @@ class OntologyManager:
     def get_used_annotation_predicates(self) -> List[Dict[str, str]]:
         """Get all unique annotation predicates used in the ontology."""
         structural_predicates = {
-            RDF.type, RDFS.subClassOf, RDFS.subPropertyOf,
-            RDFS.domain, RDFS.range,
-            OWL.equivalentClass, OWL.equivalentProperty, OWL.disjointWith,
-            OWL.inverseOf, OWL.propertyChainAxiom,
-            OWL.onProperty, OWL.someValuesFrom, OWL.allValuesFrom,
-            OWL.hasValue, OWL.minCardinality, OWL.maxCardinality, OWL.cardinality,
-            OWL.unionOf, OWL.intersectionOf, OWL.complementOf, OWL.oneOf,
-            OWL.imports
+            RDF.type,
+            RDFS.subClassOf,
+            RDFS.subPropertyOf,
+            RDFS.domain,
+            RDFS.range,
+            OWL.equivalentClass,
+            OWL.equivalentProperty,
+            OWL.disjointWith,
+            OWL.inverseOf,
+            OWL.propertyChainAxiom,
+            OWL.onProperty,
+            OWL.someValuesFrom,
+            OWL.allValuesFrom,
+            OWL.hasValue,
+            OWL.minCardinality,
+            OWL.maxCardinality,
+            OWL.cardinality,
+            OWL.unionOf,
+            OWL.intersectionOf,
+            OWL.complementOf,
+            OWL.oneOf,
+            OWL.imports,
         }
 
         predicates = {}
@@ -1332,7 +1510,7 @@ class OntologyManager:
                     predicates[pred_uri] = {
                         "uri": pred_uri,
                         "local_name": self._local_name(pred),
-                        "prefix": self._get_prefix_for_uri(pred_uri)
+                        "prefix": self._get_prefix_for_uri(pred_uri),
                     }
 
         # Sort by local name
@@ -1347,8 +1525,14 @@ class OntologyManager:
                 return prefix if prefix else "(default)"
         return ""
 
-    def delete_annotation(self, subject: str, predicate: str, value: str = None,
-                          lang: str = None, datatype: str = None):
+    def delete_annotation(
+        self,
+        subject: str,
+        predicate: str,
+        value: Optional[str] = None,
+        lang: Optional[str] = None,
+        datatype: Optional[str] = None,
+    ):
         """Delete an annotation from a resource.
 
         Matches language-tagged and datatype-qualified literals when lang/datatype
@@ -1358,9 +1542,12 @@ class OntologyManager:
         subj_uri = self._uri(subject)
 
         annotation_predicates = {
-            "label": RDFS.label, "comment": RDFS.comment,
-            "prefLabel": SKOS.prefLabel, "altLabel": SKOS.altLabel,
-            "definition": SKOS.definition, "note": SKOS.note,
+            "label": RDFS.label,
+            "comment": RDFS.comment,
+            "prefLabel": SKOS.prefLabel,
+            "altLabel": SKOS.altLabel,
+            "definition": SKOS.definition,
+            "note": SKOS.note,
         }
 
         pred_uri = annotation_predicates.get(predicate, self._uri(predicate))
@@ -1389,10 +1576,14 @@ class OntologyManager:
     # ==================== SKOS VOCABULARY OPERATIONS ====================
 
     SKOS_RELATIONS = {
-        "broader": SKOS.broader, "narrower": SKOS.narrower,
-        "related": SKOS.related, "broadMatch": SKOS.broadMatch,
-        "narrowMatch": SKOS.narrowMatch, "exactMatch": SKOS.exactMatch,
-        "closeMatch": SKOS.closeMatch, "relatedMatch": SKOS.relatedMatch,
+        "broader": SKOS.broader,
+        "narrower": SKOS.narrower,
+        "related": SKOS.related,
+        "broadMatch": SKOS.broadMatch,
+        "narrowMatch": SKOS.narrowMatch,
+        "exactMatch": SKOS.exactMatch,
+        "closeMatch": SKOS.closeMatch,
+        "relatedMatch": SKOS.relatedMatch,
     }
 
     SKOS_INVERSES = {
@@ -1402,8 +1593,9 @@ class OntologyManager:
 
     SKOS_SYMMETRIC = {SKOS.related, SKOS.closeMatch, SKOS.exactMatch, SKOS.relatedMatch}
 
-    def add_concept_scheme(self, name: str, label: str = None,
-                           comment: str = None) -> URIRef:
+    def add_concept_scheme(
+        self, name: str, label: Optional[str] = None, comment: Optional[str] = None
+    ) -> URIRef:
         """Add a new SKOS ConceptScheme."""
         scheme_uri = self._uri(name)
         self.graph.add((scheme_uri, RDF.type, SKOS.ConceptScheme))
@@ -1423,26 +1615,27 @@ class OntologyManager:
             label = str(self.graph.value(uri, RDFS.label) or "")
             comment = str(self.graph.value(uri, RDFS.comment) or "")
             # Count concepts in this scheme
-            concept_count = sum(
-                1 for _ in self.graph.subjects(SKOS.inScheme, uri)
+            concept_count = sum(1 for _ in self.graph.subjects(SKOS.inScheme, uri))
+            schemes.append(
+                {
+                    "name": name,
+                    "uri": str(uri),
+                    "label": label,
+                    "comment": comment,
+                    "concept_count": concept_count,
+                }
             )
-            schemes.append({
-                "name": name,
-                "uri": str(uri),
-                "label": label,
-                "comment": comment,
-                "concept_count": concept_count,
-            })
         return sorted(schemes, key=lambda s: s["name"])
 
-    def update_concept_scheme(self, name: str, new_label: str = _UNSET,
-                              new_comment: str = _UNSET):
+    def update_concept_scheme(
+        self, name: str, new_label: str = _UNSET, new_comment: str = _UNSET
+    ):
         """Update a SKOS ConceptScheme's properties."""
         uri = self._uri(name)
         # Resolve actual URI from graph if _uri doesn't match
         for s_uri in self.graph.subjects(RDF.type, SKOS.ConceptScheme):
             if self._local_name(s_uri) == name:
-                uri = s_uri
+                uri = cast(URIRef, s_uri)
                 break
 
         if new_label is not _UNSET:
@@ -1461,15 +1654,21 @@ class OntologyManager:
         # Resolve actual URI from graph if _uri doesn't match
         for s_uri in self.graph.subjects(RDF.type, SKOS.ConceptScheme):
             if self._local_name(s_uri) == name:
-                uri = s_uri
+                uri = cast(URIRef, s_uri)
                 break
         self.graph.remove((uri, None, None))
         self.graph.remove((None, SKOS.inScheme, uri))
         self.graph.remove((None, None, uri))
 
-    def add_concept(self, name: str, scheme: str = None,
-                    pref_label: str = None, definition: str = None,
-                    broader: str = None, lang: str = None) -> URIRef:
+    def add_concept(
+        self,
+        name: str,
+        scheme: Optional[str] = None,
+        pref_label: Optional[str] = None,
+        definition: Optional[str] = None,
+        broader: Optional[str] = None,
+        lang: Optional[str] = None,
+    ) -> URIRef:
         """Add a SKOS Concept with optional scheme/broader links."""
         concept_uri = self._uri(name)
         self.graph.add((concept_uri, RDF.type, SKOS.Concept))
@@ -1480,13 +1679,17 @@ class OntologyManager:
 
         if pref_label:
             if lang:
-                self.graph.add((concept_uri, SKOS.prefLabel, Literal(pref_label, lang=lang)))
+                self.graph.add(
+                    (concept_uri, SKOS.prefLabel, Literal(pref_label, lang=lang))
+                )
             else:
                 self.graph.add((concept_uri, SKOS.prefLabel, Literal(pref_label)))
 
         if definition:
             if lang:
-                self.graph.add((concept_uri, SKOS.definition, Literal(definition, lang=lang)))
+                self.graph.add(
+                    (concept_uri, SKOS.definition, Literal(definition, lang=lang))
+                )
             else:
                 self.graph.add((concept_uri, SKOS.definition, Literal(definition)))
 
@@ -1497,7 +1700,7 @@ class OntologyManager:
 
         return concept_uri
 
-    def get_concepts(self, scheme: str = None) -> List[Dict[str, Any]]:
+    def get_concepts(self, scheme: Optional[str] = None) -> List[Dict[str, Any]]:
         """Get SKOS Concepts, optionally filtered by scheme."""
         # Resolve scheme name to URI by looking it up in the graph
         scheme_uri = None
@@ -1527,41 +1730,52 @@ class OntologyManager:
             alt_labels = [str(o) for o in self.graph.objects(uri, SKOS.altLabel)]
 
             broader_list = [
-                self._local_name(o) for o in self.graph.objects(uri, SKOS.broader)
+                self._local_name(o)
+                for o in self.graph.objects(uri, SKOS.broader)
                 if isinstance(o, URIRef)
             ]
             narrower_list = [
-                self._local_name(o) for o in self.graph.objects(uri, SKOS.narrower)
+                self._local_name(o)
+                for o in self.graph.objects(uri, SKOS.narrower)
                 if isinstance(o, URIRef)
             ]
             related_list = [
-                self._local_name(o) for o in self.graph.objects(uri, SKOS.related)
+                self._local_name(o)
+                for o in self.graph.objects(uri, SKOS.related)
                 if isinstance(o, URIRef)
             ]
 
             schemes = [
-                self._local_name(o) for o in self.graph.objects(uri, SKOS.inScheme)
+                self._local_name(o)
+                for o in self.graph.objects(uri, SKOS.inScheme)
                 if isinstance(o, URIRef)
             ]
 
-            concepts.append({
-                "name": name,
-                "uri": str(uri),
-                "prefLabel": pref_label,
-                "definition": definition,
-                "altLabels": alt_labels,
-                "broader": broader_list,
-                "narrower": narrower_list,
-                "related": related_list,
-                "schemes": schemes,
-            })
+            concepts.append(
+                {
+                    "name": name,
+                    "uri": str(uri),
+                    "prefLabel": pref_label,
+                    "definition": definition,
+                    "altLabels": alt_labels,
+                    "broader": broader_list,
+                    "narrower": narrower_list,
+                    "related": related_list,
+                    "schemes": schemes,
+                }
+            )
 
         return sorted(concepts, key=lambda c: c["name"])
 
-    def update_concept(self, name: str, new_pref_label: str = _UNSET,
-                       new_definition: str = _UNSET,
-                       new_broader: str = _UNSET,
-                       add_scheme: str = None, remove_scheme: str = None):
+    def update_concept(
+        self,
+        name: str,
+        new_pref_label: str = _UNSET,
+        new_definition: str = _UNSET,
+        new_broader: str = _UNSET,
+        add_scheme: Optional[str] = None,
+        remove_scheme: Optional[str] = None,
+    ):
         """Update a SKOS Concept's properties."""
         uri = self._uri(name)
 
@@ -1635,7 +1849,9 @@ class OntologyManager:
         self.graph.remove((uri, None, None))
         self.graph.remove((None, None, uri))
 
-    def get_concept_hierarchy(self, scheme: str = None) -> Dict[str, List[str]]:
+    def get_concept_hierarchy(
+        self, scheme: Optional[str] = None
+    ) -> Dict[str, List[str]]:
         """Return concept hierarchy as {parent: [children]} dict."""
         hierarchy: Dict[str, List[str]] = {}
         concepts = self.get_concepts(scheme=scheme)
@@ -1669,21 +1885,25 @@ class OntologyManager:
         for concept in concepts:
             # Missing prefLabel
             if not concept["prefLabel"]:
-                issues.append({
-                    "severity": "warning",
-                    "type": "missing_prefLabel",
-                    "subject": concept["name"],
-                    "message": f"Concept '{concept['name']}' has no prefLabel",
-                })
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "type": "missing_prefLabel",
+                        "subject": concept["name"],
+                        "message": f"Concept '{concept['name']}' has no prefLabel",
+                    }
+                )
 
             # Not in any scheme
             if not concept["schemes"] and schemes:
-                issues.append({
-                    "severity": "info",
-                    "type": "no_scheme",
-                    "subject": concept["name"],
-                    "message": f"Concept '{concept['name']}' is not in any ConceptScheme",
-                })
+                issues.append(
+                    {
+                        "severity": "info",
+                        "type": "no_scheme",
+                        "subject": concept["name"],
+                        "message": f"Concept '{concept['name']}' is not in any ConceptScheme",
+                    }
+                )
 
         # Duplicate prefLabels within schemes
         for scheme in schemes:
@@ -1692,12 +1912,14 @@ class OntologyManager:
             for concept in scheme_concepts:
                 lbl = concept["prefLabel"]
                 if lbl and lbl in labels_seen:
-                    issues.append({
-                        "severity": "warning",
-                        "type": "duplicate_prefLabel",
-                        "subject": concept["name"],
-                        "message": f"Duplicate prefLabel '{lbl}' in scheme '{scheme['name']}' (also on '{labels_seen[lbl]}')",
-                    })
+                    issues.append(
+                        {
+                            "severity": "warning",
+                            "type": "duplicate_prefLabel",
+                            "subject": concept["name"],
+                            "message": f"Duplicate prefLabel '{lbl}' in scheme '{scheme['name']}' (also on '{labels_seen[lbl]}')",
+                        }
+                    )
                 elif lbl:
                     labels_seen[lbl] = concept["name"]
 
@@ -1727,12 +1949,14 @@ class OntologyManager:
                 chain.append(current)
 
             if has_cycle:
-                issues.append({
-                    "severity": "error",
-                    "type": "broader_cycle",
-                    "subject": concept["name"],
-                    "message": f"Broader/narrower cycle detected: {' -> '.join(chain)}",
-                })
+                issues.append(
+                    {
+                        "severity": "error",
+                        "type": "broader_cycle",
+                        "subject": concept["name"],
+                        "message": f"Broader/narrower cycle detected: {' -> '.join(chain)}",
+                    }
+                )
 
         return issues
 
@@ -1775,7 +1999,9 @@ class OntologyManager:
         if relation:
             self.graph.remove((class1_uri, relation, class2_uri))
 
-    def get_class_relations(self, class_name: str = None) -> List[Dict[str, str]]:
+    def get_class_relations(
+        self, class_name: Optional[str] = None
+    ) -> List[Dict[str, str]]:
         """Get all class relations, optionally filtered by class.
 
         Each result dict includes both local names (subject/object) and full
@@ -1789,13 +2015,15 @@ class OntologyManager:
                     subj_name = self._local_name(subj)
                     obj_name = self._local_name(obj)
                     if class_name is None or class_name in [subj_name, obj_name]:
-                        relations.append({
-                            "subject": subj_name,
-                            "subject_uri": str(subj),
-                            "relation": rel_name,
-                            "object": obj_name,
-                            "object_uri": str(obj),
-                        })
+                        relations.append(
+                            {
+                                "subject": subj_name,
+                                "subject_uri": str(subj),
+                                "relation": rel_name,
+                                "object": obj_name,
+                                "object_uri": str(obj),
+                            }
+                        )
         return relations
 
     def add_property_relation(self, prop1: str, relation_type: str, prop2: str):
@@ -1814,7 +2042,9 @@ class OntologyManager:
         if relation:
             self.graph.remove((prop1_uri, relation, prop2_uri))
 
-    def get_property_relations(self, prop_name: str = None) -> List[Dict[str, str]]:
+    def get_property_relations(
+        self, prop_name: Optional[str] = None
+    ) -> List[Dict[str, str]]:
         """Get all property relations, optionally filtered by property.
 
         Each result dict includes both local names and full URIs.
@@ -1826,13 +2056,15 @@ class OntologyManager:
                     subj_name = self._local_name(subj)
                     obj_name = self._local_name(obj)
                     if prop_name is None or prop_name in [subj_name, obj_name]:
-                        relations.append({
-                            "subject": subj_name,
-                            "subject_uri": str(subj),
-                            "relation": rel_name,
-                            "object": obj_name,
-                            "object_uri": str(obj),
-                        })
+                        relations.append(
+                            {
+                                "subject": subj_name,
+                                "subject_uri": str(subj),
+                                "relation": rel_name,
+                                "object": obj_name,
+                                "object_uri": str(obj),
+                            }
+                        )
         return relations
 
     def add_individual_relation(self, ind1: str, relation_type: str, ind2: str):
@@ -1851,7 +2083,9 @@ class OntologyManager:
         if relation:
             self.graph.remove((ind1_uri, relation, ind2_uri))
 
-    def get_individual_relations(self, ind_name: str = None) -> List[Dict[str, str]]:
+    def get_individual_relations(
+        self, ind_name: Optional[str] = None
+    ) -> List[Dict[str, str]]:
         """Get all individual relations (sameAs, differentFrom).
 
         Each result dict includes both local names and full URIs.
@@ -1863,13 +2097,15 @@ class OntologyManager:
                     subj_name = self._local_name(subj)
                     obj_name = self._local_name(obj)
                     if ind_name is None or ind_name in [subj_name, obj_name]:
-                        relations.append({
-                            "subject": subj_name,
-                            "subject_uri": str(subj),
-                            "relation": rel_name,
-                            "object": obj_name,
-                            "object_uri": str(obj),
-                        })
+                        relations.append(
+                            {
+                                "subject": subj_name,
+                                "subject_uri": str(subj),
+                                "relation": rel_name,
+                                "object": obj_name,
+                                "object_uri": str(obj),
+                            }
+                        )
         return relations
 
     # ==================== ADVANCED OWL FEATURES ====================
@@ -1877,7 +2113,7 @@ class OntologyManager:
     def add_property_chain(self, property_name: str, chain_properties: List[str]):
         """Add a property chain axiom (owl:propertyChainAxiom)."""
         prop_uri = self._uri(property_name)
-        chain_uris = [self._uri(p) for p in chain_properties]
+        chain_uris: List[Node] = [self._uri(p) for p in chain_properties]
 
         # Create RDF list for the chain
         chain_list = BNode()
@@ -1890,14 +2126,23 @@ class OntologyManager:
         for prop, chain_list in self.graph.subject_objects(OWL.propertyChainAxiom):
             if isinstance(prop, URIRef):
                 chain = list(Collection(self.graph, chain_list))
-                chains.append({
-                    "property": self._local_name(prop),
-                    "chain": [self._local_name(p) for p in chain if isinstance(p, URIRef)]
-                })
+                chains.append(
+                    {
+                        "property": self._local_name(prop),
+                        "chain": [
+                            self._local_name(p) for p in chain if isinstance(p, URIRef)
+                        ],
+                    }
+                )
         return chains
 
-    def add_class_expression(self, class_name: str, expression_type: str,
-                            classes: List[str] = None, individuals: List[str] = None):
+    def add_class_expression(
+        self,
+        class_name: str,
+        expression_type: str,
+        classes: Optional[List[str]] = None,
+        individuals: Optional[List[str]] = None,
+    ):
         """Add a class expression (unionOf, intersectionOf, complementOf, oneOf)."""
         class_uri = self._uri(class_name)
 
@@ -1907,14 +2152,14 @@ class OntologyManager:
 
         elif expression_type == "oneOf" and individuals:
             # oneOf takes a list of individuals
-            ind_uris = [self._uri(i) for i in individuals]
+            ind_uris: List[Node] = [self._uri(i) for i in individuals]
             list_node = BNode()
             Collection(self.graph, list_node, ind_uris)
             self.graph.add((class_uri, OWL.oneOf, list_node))
 
         elif expression_type in ["unionOf", "intersectionOf"] and classes:
             # unionOf and intersectionOf take a list of classes
-            class_uris = [self._uri(c) for c in classes]
+            class_uris: List[Node] = [self._uri(c) for c in classes]
             list_node = BNode()
             Collection(self.graph, list_node, class_uris)
             if expression_type == "unionOf":
@@ -1922,7 +2167,9 @@ class OntologyManager:
             else:
                 self.graph.add((class_uri, OWL.intersectionOf, list_node))
 
-    def get_class_expressions(self, class_name: str = None) -> List[Dict[str, Any]]:
+    def get_class_expressions(
+        self, class_name: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
         """Get class expressions for a class or all classes."""
         expressions = []
 
@@ -1930,7 +2177,7 @@ class OntologyManager:
             (OWL.unionOf, "unionOf"),
             (OWL.intersectionOf, "intersectionOf"),
             (OWL.complementOf, "complementOf"),
-            (OWL.oneOf, "oneOf")
+            (OWL.oneOf, "oneOf"),
         ]
 
         for pred, expr_type in expression_types:
@@ -1949,7 +2196,11 @@ class OntologyManager:
                         # It's a list
                         try:
                             members = list(Collection(self.graph, obj))
-                            expr["members"] = [self._local_name(m) for m in members if isinstance(m, URIRef)]
+                            expr["members"] = [
+                                self._local_name(m)
+                                for m in members
+                                if isinstance(m, URIRef)
+                            ]
                         except Exception:
                             pass
 
@@ -1963,7 +2214,7 @@ class OntologyManager:
         all_diff = BNode()
         self.graph.add((all_diff, RDF.type, OWL.AllDifferent))
 
-        ind_uris = [self._uri(i) for i in individuals]
+        ind_uris: List[Node] = [self._uri(i) for i in individuals]
         list_node = BNode()
         Collection(self.graph, list_node, ind_uris)
         self.graph.add((all_diff, OWL.distinctMembers, list_node))
@@ -1976,7 +2227,9 @@ class OntologyManager:
             if members_list:
                 try:
                     members = list(Collection(self.graph, members_list))
-                    all_diffs.append([self._local_name(m) for m in members if isinstance(m, URIRef)])
+                    all_diffs.append(
+                        [self._local_name(m) for m in members if isinstance(m, URIRef)]
+                    )
                 except Exception:
                     pass
         return all_diffs
@@ -1984,13 +2237,13 @@ class OntologyManager:
     def add_has_key(self, class_name: str, properties: List[str]):
         """Add an owl:hasKey axiom to a class."""
         class_uri = self._uri(class_name)
-        prop_uris = [self._uri(p) for p in properties]
+        prop_uris: List[Node] = [self._uri(p) for p in properties]
 
         list_node = BNode()
         Collection(self.graph, list_node, prop_uris)
         self.graph.add((class_uri, OWL.hasKey, list_node))
 
-    def get_has_keys(self, class_name: str = None) -> List[Dict[str, Any]]:
+    def get_has_keys(self, class_name: Optional[str] = None) -> List[Dict[str, Any]]:
         """Get owl:hasKey axioms."""
         keys = []
         for subj, key_list in self.graph.subject_objects(OWL.hasKey):
@@ -2000,10 +2253,16 @@ class OntologyManager:
                     continue
                 try:
                     props = list(Collection(self.graph, key_list))
-                    keys.append({
-                        "class": subj_name,
-                        "properties": [self._local_name(p) for p in props if isinstance(p, URIRef)]
-                    })
+                    keys.append(
+                        {
+                            "class": subj_name,
+                            "properties": [
+                                self._local_name(p)
+                                for p in props
+                                if isinstance(p, URIRef)
+                            ],
+                        }
+                    )
                 except Exception:
                     pass
         return keys
@@ -2011,7 +2270,7 @@ class OntologyManager:
     def add_disjoint_union(self, class_name: str, disjoint_classes: List[str]):
         """Add an owl:disjointUnionOf axiom (class is disjoint union of listed classes)."""
         class_uri = self._uri(class_name)
-        class_uris = [self._uri(c) for c in disjoint_classes]
+        class_uris: List[Node] = [self._uri(c) for c in disjoint_classes]
 
         list_node = BNode()
         Collection(self.graph, list_node, class_uris)
@@ -2024,10 +2283,16 @@ class OntologyManager:
             if isinstance(subj, URIRef):
                 try:
                     members = list(Collection(self.graph, union_list))
-                    unions.append({
-                        "class": self._local_name(subj),
-                        "members": [self._local_name(m) for m in members if isinstance(m, URIRef)]
-                    })
+                    unions.append(
+                        {
+                            "class": self._local_name(subj),
+                            "members": [
+                                self._local_name(m)
+                                for m in members
+                                if isinstance(m, URIRef)
+                            ],
+                        }
+                    )
                 except Exception:
                     pass
         return unions
@@ -2036,7 +2301,7 @@ class OntologyManager:
 
     def load_from_file(self, file_path: str, format: str = "turtle"):
         """Load ontology from a file."""
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, "r", encoding="utf-8") as f:
             content = f.read()
         if format == "turtle":
             self._loaded_prefixes = self._extract_prefixes_from_ttl(content)
@@ -2079,8 +2344,12 @@ class OntologyManager:
         # Compute incoming stats
         incoming_stats = {
             "classes": sum(1 for _ in temp.subjects(RDF.type, OWL.Class)),
-            "object_properties": sum(1 for _ in temp.subjects(RDF.type, OWL.ObjectProperty)),
-            "data_properties": sum(1 for _ in temp.subjects(RDF.type, OWL.DatatypeProperty)),
+            "object_properties": sum(
+                1 for _ in temp.subjects(RDF.type, OWL.ObjectProperty)
+            ),
+            "data_properties": sum(
+                1 for _ in temp.subjects(RDF.type, OWL.DatatypeProperty)
+            ),
             "individuals": sum(1 for _ in temp.subjects(RDF.type, OWL.NamedIndividual)),
             "total_triples": len(temp),
         }
@@ -2110,8 +2379,12 @@ class OntologyManager:
         values are semantically problematic.
         """
         conflict_preds = {
-            RDFS.label, RDFS.domain, RDFS.range, RDFS.comment,
-            OWL.versionIRI, DCTERMS.creator,
+            RDFS.label,
+            RDFS.domain,
+            RDFS.range,
+            RDFS.comment,
+            OWL.versionIRI,
+            DCTERMS.creator,
         }
 
         conflicts = []
@@ -2123,18 +2396,21 @@ class OntologyManager:
                 continue
             incoming_value = o
             if incoming_value not in current_values:
-                conflicts.append({
-                    "subject": self._local_name(s),
-                    "predicate": self._local_name(p),
-                    "current_values": [
-                        self._local_name(v) if isinstance(v, URIRef) else str(v)
-                        for v in current_values
-                    ],
-                    "incoming_value": (
-                        self._local_name(incoming_value)
-                        if isinstance(incoming_value, URIRef) else str(incoming_value)
-                    ),
-                })
+                conflicts.append(
+                    {
+                        "subject": self._local_name(s),
+                        "predicate": self._local_name(p),
+                        "current_values": [
+                            self._local_name(v) if isinstance(v, URIRef) else str(v)
+                            for v in current_values
+                        ],
+                        "incoming_value": (
+                            self._local_name(incoming_value)
+                            if isinstance(incoming_value, URIRef)
+                            else str(incoming_value)
+                        ),
+                    }
+                )
 
         # Deduplicate (same subject+predicate can appear multiple times)
         seen = set()
@@ -2146,8 +2422,9 @@ class OntologyManager:
                 unique.append(c)
         return unique
 
-    def merge_from_graph(self, other_graph: Graph,
-                         strategy: str = IMPORT_MERGE) -> Dict[str, Any]:
+    def merge_from_graph(
+        self, other_graph: Graph, strategy: str = IMPORT_MERGE
+    ) -> Dict[str, Any]:
         """Merge another graph into the current graph using the specified strategy.
 
         Returns a dict with:
@@ -2176,8 +2453,12 @@ class OntologyManager:
         elif strategy == IMPORT_MERGE_OVERWRITE:
             # For conflict predicates: remove current, add incoming
             conflict_preds = {
-                RDFS.label, RDFS.domain, RDFS.range, RDFS.comment,
-                OWL.versionIRI, DCTERMS.creator,
+                RDFS.label,
+                RDFS.domain,
+                RDFS.range,
+                RDFS.comment,
+                OWL.versionIRI,
+                DCTERMS.creator,
             }
             conflicts_resolved = 0
             for s, p, o in other_graph:
@@ -2208,8 +2489,9 @@ class OntologyManager:
             "conflicts_resolved": 0,
         }
 
-    def merge_from_string(self, data: str, format: str = "turtle",
-                          strategy: str = IMPORT_MERGE) -> Dict[str, Any]:
+    def merge_from_string(
+        self, data: str, format: str = "turtle", strategy: str = IMPORT_MERGE
+    ) -> Dict[str, Any]:
         """Parse data and merge into current graph."""
         temp = Graph()
         temp.parse(data=data, format=format)
@@ -2222,20 +2504,24 @@ class OntologyManager:
         for prefix, ns in other_graph.namespaces():
             ns_str = str(ns)
             if prefix in current_ns and current_ns[prefix] != ns_str:
-                conflicts.append({
-                    "prefix": prefix,
-                    "current_namespace": current_ns[prefix],
-                    "incoming_namespace": ns_str,
-                })
+                conflicts.append(
+                    {
+                        "prefix": prefix,
+                        "current_namespace": current_ns[prefix],
+                        "incoming_namespace": ns_str,
+                    }
+                )
         return conflicts
 
-    def _reconcile_prefixes_after_merge(self, other_graph: Graph,
-                                         prefix_resolution: Dict[str, str] = None):
+    def _reconcile_prefixes_after_merge(
+        self, other_graph: Graph, prefix_resolution: Optional[Dict[str, str]] = None
+    ):
         """Re-bind prefixes after a merge operation."""
         for prefix, ns in other_graph.namespaces():
             if prefix_resolution and prefix in prefix_resolution:
-                self.graph.bind(prefix, Namespace(prefix_resolution[prefix]),
-                                override=True)
+                self.graph.bind(
+                    prefix, Namespace(prefix_resolution[prefix]), override=True
+                )
             else:
                 # Current bindings take precedence
                 self.graph.bind(prefix, ns, override=False)
@@ -2279,7 +2565,7 @@ class OntologyManager:
 
         sample_uri = self._find_sample_resource_uri()
         if sample_uri and uri_str in sample_uri:
-            remainder = sample_uri[len(uri_str):]
+            remainder = sample_uri[len(uri_str) :]
             if remainder.startswith("/"):
                 return uri_str + "/"
             elif remainder.startswith("#"):
@@ -2288,8 +2574,12 @@ class OntologyManager:
 
     def _find_sample_resource_uri(self) -> Optional[str]:
         """Find a sample resource URI from classes or properties in the graph."""
-        for rdf_type in (OWL.Class, OWL.ObjectProperty, OWL.DatatypeProperty,
-                         OWL.NamedIndividual):
+        for rdf_type in (
+            OWL.Class,
+            OWL.ObjectProperty,
+            OWL.DatatypeProperty,
+            OWL.NamedIndividual,
+        ):
             for s in self.graph.subjects(RDF.type, rdf_type):
                 if isinstance(s, URIRef):
                     return str(s)
@@ -2298,8 +2588,13 @@ class OntologyManager:
     def _infer_namespace_from_graph(self) -> Optional[str]:
         """Infer namespace from graph prefixes and resource URIs when no owl:Ontology exists."""
         STANDARD_NAMESPACES = {
-            str(OWL), str(RDF), str(RDFS), str(XSD),
-            str(SKOS), str(DC), str(DCTERMS),
+            str(OWL),
+            str(RDF),
+            str(RDFS),
+            str(XSD),
+            str(SKOS),
+            str(DC),
+            str(DCTERMS),
         }
 
         # Try the default prefix first (most likely the ontology namespace)
@@ -2310,16 +2605,21 @@ class OntologyManager:
 
         # Try to find the most common namespace among typed resources
         from collections import Counter
+
         ns_counter: Counter = Counter()
-        for rdf_type in (OWL.Class, OWL.ObjectProperty, OWL.DatatypeProperty,
-                         OWL.NamedIndividual):
+        for rdf_type in (
+            OWL.Class,
+            OWL.ObjectProperty,
+            OWL.DatatypeProperty,
+            OWL.NamedIndividual,
+        ):
             for s in self.graph.subjects(RDF.type, rdf_type):
                 if isinstance(s, URIRef):
                     uri_str = str(s)
                     for sep in ("#", "/"):
                         idx = uri_str.rfind(sep)
                         if idx != -1:
-                            candidate = uri_str[:idx + 1]
+                            candidate = uri_str[: idx + 1]
                             if candidate not in STANDARD_NAMESPACES:
                                 ns_counter[candidate] += 1
                             break
@@ -2375,13 +2675,15 @@ class OntologyManager:
                     match_field = "comment"
 
                 if match_field:
-                    results.append({
-                        "name": name,
-                        "uri": str(subj),
-                        "type": type_label,
-                        "label": label,
-                        "match_field": match_field,
-                    })
+                    results.append(
+                        {
+                            "name": name,
+                            "uri": str(subj),
+                            "type": type_label,
+                            "label": label,
+                            "match_field": match_field,
+                        }
+                    )
 
         results.sort(key=lambda r: (r["match_field"] != "name", r["name"].lower()))
         return results
@@ -2399,35 +2701,44 @@ class OntologyManager:
         uri = self._uri(name)
 
         structural_preds = {
-            RDF.type, RDFS.subClassOf, RDFS.subPropertyOf,
-            OWL.equivalentClass, OWL.disjointWith,
+            RDF.type,
+            RDFS.subClassOf,
+            RDFS.subPropertyOf,
+            OWL.equivalentClass,
+            OWL.disjointWith,
         }
 
         outbound: List[Dict[str, str]] = []
         for p, o in self.graph.predicate_objects(uri):
             if p in structural_preds:
                 continue
-            outbound.append({
-                "predicate": self._local_name(p),
-                "object": self._local_name(o) if isinstance(o, URIRef) else str(o),
-                "object_type": "uri" if isinstance(o, URIRef) else "literal",
-            })
+            outbound.append(
+                {
+                    "predicate": self._local_name(p),
+                    "object": self._local_name(o) if isinstance(o, URIRef) else str(o),
+                    "object_type": "uri" if isinstance(o, URIRef) else "literal",
+                }
+            )
 
         inbound: List[Dict[str, str]] = []
         for s, p in self.graph.subject_predicates(uri):
             if isinstance(s, BNode):
                 continue
-            inbound.append({
-                "subject": self._local_name(s) if isinstance(s, URIRef) else str(s),
-                "predicate": self._local_name(p),
-            })
+            inbound.append(
+                {
+                    "subject": self._local_name(s) if isinstance(s, URIRef) else str(s),
+                    "predicate": self._local_name(p),
+                }
+            )
 
         as_predicate: List[Dict[str, str]] = []
         for s, o in self.graph.subject_objects(uri):
-            as_predicate.append({
-                "subject": self._local_name(s) if isinstance(s, URIRef) else str(s),
-                "object": self._local_name(o) if isinstance(o, URIRef) else str(o),
-            })
+            as_predicate.append(
+                {
+                    "subject": self._local_name(s) if isinstance(s, URIRef) else str(s),
+                    "object": self._local_name(o) if isinstance(o, URIRef) else str(o),
+                }
+            )
 
         return {
             "outbound": outbound,
@@ -2483,24 +2794,30 @@ class OntologyManager:
                 subj, set(added_by_subj.keys()), set(removed_by_subj.keys())
             )
             counts[change_type] = counts.get(change_type, 0) + 1
-            modified_resources.append({
-                "name": subj,
-                "change_type": change_type,
-                "added_triples": added_by_subj.get(subj, []),
-                "removed_triples": removed_by_subj.get(subj, []),
-            })
+            modified_resources.append(
+                {
+                    "name": subj,
+                    "change_type": change_type,
+                    "added_triples": added_by_subj.get(subj, []),
+                    "removed_triples": removed_by_subj.get(subj, []),
+                }
+            )
 
         # Build string representations for triple lists
         added_triples = [
-            (self._local_name(s) if isinstance(s, URIRef) else str(s),
-             self._local_name(p),
-             self._local_name(o) if isinstance(o, URIRef) else str(o))
+            (
+                self._local_name(s) if isinstance(s, URIRef) else str(s),
+                self._local_name(p),
+                self._local_name(o) if isinstance(o, URIRef) else str(o),
+            )
             for s, p, o in named_added
         ]
         removed_triples = [
-            (self._local_name(s) if isinstance(s, URIRef) else str(s),
-             self._local_name(p),
-             self._local_name(o) if isinstance(o, URIRef) else str(o))
+            (
+                self._local_name(s) if isinstance(s, URIRef) else str(s),
+                self._local_name(p),
+                self._local_name(o) if isinstance(o, URIRef) else str(o),
+            )
             for s, p, o in named_removed
         ]
 
@@ -2540,16 +2857,18 @@ class OntologyManager:
             name = self._local_name(s) if isinstance(s, URIRef) else str(s)
             if name not in groups:
                 groups[name] = []
-            groups[name].append({
-                "predicate": self._local_name(p),
-                "object": self._local_name(o) if isinstance(o, URIRef) else str(o),
-                "object_type": "uri" if isinstance(o, URIRef) else "literal",
-            })
+            groups[name].append(
+                {
+                    "predicate": self._local_name(p),
+                    "object": self._local_name(o) if isinstance(o, URIRef) else str(o),
+                    "object_type": "uri" if isinstance(o, URIRef) else "literal",
+                }
+            )
         return groups
 
-    def _classify_resource_change(self, subject: str,
-                                   added_subjects: Set[str],
-                                   removed_subjects: Set[str]) -> str:
+    def _classify_resource_change(
+        self, subject: str, added_subjects: Set[str], removed_subjects: Set[str]
+    ) -> str:
         """Classify what happened to a resource: 'added', 'removed', or 'modified'."""
         in_added = subject in added_subjects
         in_removed = subject in removed_subjects
@@ -2573,9 +2892,15 @@ class OntologyManager:
             for t in all_triples:
                 if t["predicate"] == "type":
                     obj = t["object"]
-                    if obj in ("Class", "ObjectProperty", "DatatypeProperty",
-                               "NamedIndividual", "Ontology", "AnnotationProperty",
-                               "Restriction"):
+                    if obj in (
+                        "Class",
+                        "ObjectProperty",
+                        "DatatypeProperty",
+                        "NamedIndividual",
+                        "Ontology",
+                        "AnnotationProperty",
+                        "Restriction",
+                    ):
                         res_type = obj
                         break
 
@@ -2621,8 +2946,9 @@ class OntologyManager:
 
         return summaries
 
-    def format_diff_report(self, diff: Dict[str, Any],
-                           report_format: str = "markdown") -> str:
+    def format_diff_report(
+        self, diff: Dict[str, Any], report_format: str = "markdown"
+    ) -> str:
         """Format a diff result as a human-readable report."""
         stats = diff["stats"]
         lines = []
@@ -2630,23 +2956,34 @@ class OntologyManager:
         if report_format == "markdown":
             lines.append("# Ontology Change Report\n")
             lines.append("## Summary\n")
-            lines.append(f"- **Added:** {stats['added']} triples across "
-                         f"{stats['resources_added']} resources")
-            lines.append(f"- **Removed:** {stats['removed']} triples across "
-                         f"{stats['resources_removed']} resources")
+            lines.append(
+                f"- **Added:** {stats['added']} triples across "
+                f"{stats['resources_added']} resources"
+            )
+            lines.append(
+                f"- **Removed:** {stats['removed']} triples across "
+                f"{stats['resources_removed']} resources"
+            )
             lines.append(f"- **Modified:** {stats['resources_modified']} resources")
             lines.append(f"- **Unchanged:** {stats['unchanged']} triples")
             if stats["bnode_added"] or stats["bnode_removed"]:
-                lines.append(f"- **Anonymous nodes:** {stats['bnode_added']} added, "
-                             f"{stats['bnode_removed']} removed")
+                lines.append(
+                    f"- **Anonymous nodes:** {stats['bnode_added']} added, "
+                    f"{stats['bnode_removed']} removed"
+                )
             lines.append("")
 
             # Group resources by change type
-            for change_type, heading in [("added", "Added Resources"),
-                                          ("removed", "Removed Resources"),
-                                          ("modified", "Modified Resources")]:
-                resources = [r for r in diff["modified_resources"]
-                             if r["change_type"] == change_type]
+            for change_type, heading in [
+                ("added", "Added Resources"),
+                ("removed", "Removed Resources"),
+                ("modified", "Modified Resources"),
+            ]:
+                resources = [
+                    r
+                    for r in diff["modified_resources"]
+                    if r["change_type"] == change_type
+                ]
                 if resources:
                     lines.append(f"## {heading}\n")
                     for res in resources:
@@ -2660,9 +2997,11 @@ class OntologyManager:
             # Plain text format
             lines.append("Ontology Change Report")
             lines.append("=" * 40)
-            lines.append(f"Added: {stats['added']} triples, "
-                         f"Removed: {stats['removed']} triples, "
-                         f"Modified: {stats['resources_modified']} resources")
+            lines.append(
+                f"Added: {stats['added']} triples, "
+                f"Removed: {stats['removed']} triples, "
+                f"Modified: {stats['resources_modified']} resources"
+            )
             lines.append("")
             for line in diff["summary"]:
                 lines.append(f"  {line}")
@@ -2674,18 +3013,25 @@ class OntologyManager:
     def validate(self, check_missing_domain_range: bool = True) -> List[Dict[str, str]]:
         """Validate the ontology and return issues."""
         issues = []
+        # ``pred`` is reused across loops that bind it to both predicate URIRefs
+        # and arbitrary graph terms; declare the broader rdflib type up front.
+        pred: Node
 
         # Check for classes without labels
         for class_uri in self.graph.subjects(RDF.type, OWL.Class):
             if isinstance(class_uri, BNode):
                 continue
-            if not self.graph.value(class_uri, RDFS.label) and not self.graph.value(class_uri, SKOS.prefLabel):
-                issues.append({
-                    "severity": "warning",
-                    "type": "missing_label",
-                    "subject": self._local_name(class_uri),
-                    "message": f"Class '{self._local_name(class_uri)}' has no label (rdfs:label or skos:prefLabel)"
-                })
+            if not self.graph.value(class_uri, RDFS.label) and not self.graph.value(
+                class_uri, SKOS.prefLabel
+            ):
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "type": "missing_label",
+                        "subject": self._local_name(class_uri),
+                        "message": f"Class '{self._local_name(class_uri)}' has no label (rdfs:label or skos:prefLabel)",
+                    }
+                )
 
         # Check for properties without domain/range
         # Also accept schema:domainIncludes / gist:domainIncludes (and rangeIncludes)
@@ -2704,30 +3050,36 @@ class OntologyManager:
                 if isinstance(prop_uri, BNode):
                     continue
                 if not _has_domain(prop_uri):
-                    issues.append({
-                        "severity": "info",
-                        "type": "missing_domain",
-                        "subject": self._local_name(prop_uri),
-                        "message": f"Object property '{self._local_name(prop_uri)}' has no domain"
-                    })
+                    issues.append(
+                        {
+                            "severity": "info",
+                            "type": "missing_domain",
+                            "subject": self._local_name(prop_uri),
+                            "message": f"Object property '{self._local_name(prop_uri)}' has no domain",
+                        }
+                    )
                 if not _has_range(prop_uri):
-                    issues.append({
-                        "severity": "info",
-                        "type": "missing_range",
-                        "subject": self._local_name(prop_uri),
-                        "message": f"Object property '{self._local_name(prop_uri)}' has no range"
-                    })
+                    issues.append(
+                        {
+                            "severity": "info",
+                            "type": "missing_range",
+                            "subject": self._local_name(prop_uri),
+                            "message": f"Object property '{self._local_name(prop_uri)}' has no range",
+                        }
+                    )
 
             for prop_uri in self.graph.subjects(RDF.type, OWL.DatatypeProperty):
                 if isinstance(prop_uri, BNode):
                     continue
                 if not _has_domain(prop_uri):
-                    issues.append({
-                        "severity": "info",
-                        "type": "missing_domain",
-                        "subject": self._local_name(prop_uri),
-                        "message": f"Data property '{self._local_name(prop_uri)}' has no domain"
-                    })
+                    issues.append(
+                        {
+                            "severity": "info",
+                            "type": "missing_domain",
+                            "subject": self._local_name(prop_uri),
+                            "message": f"Data property '{self._local_name(prop_uri)}' has no domain",
+                        }
+                    )
 
         # Check for orphan classes (no parent, no children, not used)
         all_classes = set()
@@ -2790,24 +3142,31 @@ class OntologyManager:
         orphan_classes = all_classes - used_classes
         for orphan_uri in orphan_classes:
             name = self._local_name(URIRef(orphan_uri))
-            issues.append({
-                "severity": "info",
-                "type": "orphan_class",
-                "subject": name,
-                "message": f"Class '{name}' is not used in any hierarchy, property domain/range, restriction, or instance typing"
-            })
+            issues.append(
+                {
+                    "severity": "info",
+                    "type": "orphan_class",
+                    "subject": name,
+                    "message": f"Class '{name}' is not used in any hierarchy, property domain/range, restriction, or instance typing",
+                }
+            )
 
         # Check individuals have at least one class
         for ind_uri in self.graph.subjects(RDF.type, OWL.NamedIndividual):
-            classes = [c for c in self.graph.objects(ind_uri, RDF.type)
-                      if c != OWL.NamedIndividual]
+            classes = [
+                c
+                for c in self.graph.objects(ind_uri, RDF.type)
+                if c != OWL.NamedIndividual
+            ]
             if not classes:
-                issues.append({
-                    "severity": "warning",
-                    "type": "untyped_individual",
-                    "subject": self._local_name(ind_uri),
-                    "message": f"Individual '{self._local_name(ind_uri)}' has no class type"
-                })
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "type": "untyped_individual",
+                        "subject": self._local_name(ind_uri),
+                        "message": f"Individual '{self._local_name(ind_uri)}' has no class type",
+                    }
+                )
 
         # Check domain/range usage for property assertions on individuals
         def _expand_superclasses(class_uris: Set[str]) -> Set[str]:
@@ -2828,8 +3187,11 @@ class OntologyManager:
             if not isinstance(ind_uri, URIRef):
                 continue
             ind_name = self._local_name(ind_uri)
-            ind_direct_classes = {str(c) for c in self.graph.objects(ind_uri, RDF.type)
-                                  if isinstance(c, URIRef) and c != OWL.NamedIndividual}
+            ind_direct_classes = {
+                str(c)
+                for c in self.graph.objects(ind_uri, RDF.type)
+                if isinstance(c, URIRef) and c != OWL.NamedIndividual
+            }
             ind_all_classes = _expand_superclasses(ind_direct_classes)
 
             for pred, obj in self.graph.predicate_objects(ind_uri):
@@ -2839,40 +3201,62 @@ class OntologyManager:
                 # Check object properties
                 if (pred, RDF.type, OWL.ObjectProperty) in self.graph:
                     domain = self.graph.value(pred, RDFS.domain)
-                    if domain and isinstance(domain, URIRef) and str(domain) not in ind_all_classes:
-                        issues.append({
-                            "severity": "warning",
-                            "type": "domain_mismatch",
-                            "subject": ind_name,
-                            "message": f"Individual '{ind_name}' uses property '{self._local_name(pred)}' but is not typed as '{self._local_name(domain)}'"
-                        })
+                    if (
+                        domain
+                        and isinstance(domain, URIRef)
+                        and str(domain) not in ind_all_classes
+                    ):
+                        issues.append(
+                            {
+                                "severity": "warning",
+                                "type": "domain_mismatch",
+                                "subject": ind_name,
+                                "message": f"Individual '{ind_name}' uses property '{self._local_name(pred)}' but is not typed as '{self._local_name(domain)}'",
+                            }
+                        )
 
                     range_ = self.graph.value(pred, RDFS.range)
-                    if range_ and isinstance(range_, URIRef) and isinstance(obj, URIRef):
-                        obj_direct = {str(c) for c in self.graph.objects(obj, RDF.type)
-                                      if isinstance(c, URIRef) and c != OWL.NamedIndividual}
+                    if (
+                        range_
+                        and isinstance(range_, URIRef)
+                        and isinstance(obj, URIRef)
+                    ):
+                        obj_direct = {
+                            str(c)
+                            for c in self.graph.objects(obj, RDF.type)
+                            if isinstance(c, URIRef) and c != OWL.NamedIndividual
+                        }
                         obj_all_classes = _expand_superclasses(obj_direct)
                         if str(range_) not in obj_all_classes:
-                            issues.append({
-                                "severity": "warning",
-                                "type": "range_mismatch",
-                                "subject": ind_name,
-                                "message": f"Property '{self._local_name(pred)}' on '{ind_name}' expects range '{self._local_name(range_)}' but '{self._local_name(obj)}' is not typed as such"
-                            })
+                            issues.append(
+                                {
+                                    "severity": "warning",
+                                    "type": "range_mismatch",
+                                    "subject": ind_name,
+                                    "message": f"Property '{self._local_name(pred)}' on '{ind_name}' expects range '{self._local_name(range_)}' but '{self._local_name(obj)}' is not typed as such",
+                                }
+                            )
 
                 # Check data properties
                 elif (pred, RDF.type, OWL.DatatypeProperty) in self.graph:
                     domain = self.graph.value(pred, RDFS.domain)
-                    if domain and isinstance(domain, URIRef) and str(domain) not in ind_all_classes:
-                        issues.append({
-                            "severity": "warning",
-                            "type": "domain_mismatch",
-                            "subject": ind_name,
-                            "message": f"Individual '{ind_name}' uses data property '{self._local_name(pred)}' but is not typed as '{self._local_name(domain)}'"
-                        })
+                    if (
+                        domain
+                        and isinstance(domain, URIRef)
+                        and str(domain) not in ind_all_classes
+                    ):
+                        issues.append(
+                            {
+                                "severity": "warning",
+                                "type": "domain_mismatch",
+                                "subject": ind_name,
+                                "message": f"Individual '{ind_name}' uses data property '{self._local_name(pred)}' but is not typed as '{self._local_name(domain)}'",
+                            }
+                        )
 
         # Check for duplicate rdfs:label values across resources
         from collections import defaultdict
+
         label_to_resources: Dict[str, List[str]] = defaultdict(list)
         for subj, label_val in self.graph.subject_objects(RDFS.label):
             if isinstance(subj, URIRef) and isinstance(label_val, Literal):
@@ -2881,12 +3265,14 @@ class OntologyManager:
                 label_to_resources[label_str].append(name)
         for label_str, resources in label_to_resources.items():
             if len(resources) > 1:
-                issues.append({
-                    "severity": "warning",
-                    "type": "duplicate_label",
-                    "subject": ", ".join(sorted(resources)),
-                    "message": f"Duplicate label '{label_str}' shared by: {', '.join(sorted(resources))}"
-                })
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "type": "duplicate_label",
+                        "subject": ", ".join(sorted(resources)),
+                        "message": f"Duplicate label '{label_str}' shared by: {', '.join(sorted(resources))}",
+                    }
+                )
 
         return issues
 
@@ -2917,7 +3303,7 @@ class OntologyManager:
             "individuals": 0,
             "restrictions": 0,
             "total_triples": len(self.graph),
-            "content_triples": len(self.graph) - ontology_meta_count
+            "content_triples": len(self.graph) - ontology_meta_count,
         }
 
         for _ in self.graph.subjects(RDF.type, OWL.Class):
@@ -2935,7 +3321,9 @@ class OntologyManager:
         for _ in self.graph.subjects(RDF.type, OWL.Restriction):
             stats["restrictions"] += 1
 
-        stats["concept_schemes"] = sum(1 for _ in self.graph.subjects(RDF.type, SKOS.ConceptScheme))
+        stats["concept_schemes"] = sum(
+            1 for _ in self.graph.subjects(RDF.type, SKOS.ConceptScheme)
+        )
         stats["concepts"] = sum(1 for _ in self.graph.subjects(RDF.type, SKOS.Concept))
 
         return stats

--- a/orionbelt_ontology_builder/templates.py
+++ b/orionbelt_ontology_builder/templates.py
@@ -4,6 +4,7 @@ import hashlib
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Optional
 
 TEMPLATES = [
     {
@@ -323,7 +324,7 @@ def get_template_names() -> list:
     return [t["name"] for t in TEMPLATES]
 
 
-def get_template(name: str) -> dict:
+def get_template(name: str) -> Optional[dict]:
     """Return a template by name, or None if not found."""
     for t in TEMPLATES:
         if t["name"] == name:
@@ -416,7 +417,7 @@ def get_upper_ontology_names() -> list:
     return sorted((o["name"] for o in UPPER_ONTOLOGIES), key=str.lower)
 
 
-def get_upper_ontology(name: str) -> dict:
+def get_upper_ontology(name: str) -> Optional[dict]:
     """Return an upper ontology definition by name, or None if not found."""
     for o in UPPER_ONTOLOGIES:
         if o["name"] == name:
@@ -506,7 +507,7 @@ def get_reference_ontology_names() -> list:
     return sorted((o["name"] for o in REFERENCE_ONTOLOGIES), key=str.lower)
 
 
-def get_reference_ontology(name: str) -> dict:
+def get_reference_ontology(name: str) -> Optional[dict]:
     """Return a reference ontology definition by name, or None if not found."""
     for o in REFERENCE_ONTOLOGIES:
         if o["name"] == name:
@@ -526,9 +527,7 @@ def load_reference_ontology_module(module: dict) -> str:
         return (SAMPLES_DIR / module["file"]).read_text(encoding="utf-8")
     if "url" in module:
         return _fetch_with_cache(module["url"], module.get("sha256"))
-    raise ValueError(
-        f"Module '{module.get('name')}' has neither 'file' nor 'url'"
-    )
+    raise ValueError(f"Module '{module.get('name')}' has neither 'file' nor 'url'")
 
 
 def _fetch_with_cache(url: str, expected_sha256: str | None = None) -> str:
@@ -548,9 +547,7 @@ def _fetch_with_cache(url: str, expected_sha256: str | None = None) -> str:
         with urllib.request.urlopen(req, timeout=30) as resp:
             data = resp.read()
     except urllib.error.URLError as e:
-        raise RuntimeError(
-            f"Could not download ontology from {url}: {e.reason}"
-        ) from e
+        raise RuntimeError(f"Could not download ontology from {url}: {e.reason}") from e
 
     if expected_sha256:
         actual = hashlib.sha256(data).hexdigest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "ruff>=0.6",
+    "mypy>=1.10",
 ]
 
 [project.urls]
@@ -40,6 +42,10 @@ Homepage = "https://github.com/ralforion/orionbelt-ontology-builder"
 Repository = "https://github.com/ralforion/orionbelt-ontology-builder"
 Issues = "https://github.com/ralforion/orionbelt-ontology-builder/issues"
 Demo = "https://orionbelt.streamlit.app"
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -136,7 +136,12 @@ class TestBulkUpdateAnnotations:
     def test_delete_annotation(self, om_with_classes):
         # Person already has label "Person"
         updates = [
-            {"resource": "Person", "predicate": "label", "value": "Person", "action": "delete"},
+            {
+                "resource": "Person",
+                "predicate": "label",
+                "value": "Person",
+                "action": "delete",
+            },
         ]
         result = om_with_classes.bulk_update_annotations(updates)
         assert result["applied"] == 1

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -65,7 +65,7 @@ class TestCrossNamespaceDuplicates:
     """
 
     def _make_two_orgs(self):
-        from rdflib import Graph, RDF, OWL, RDFS, Literal, URIRef
+        from rdflib import RDF, OWL, RDFS, Literal, URIRef
         from ontology_manager import OntologyManager
 
         om = OntologyManager(base_uri="http://example.org/myont#")
@@ -108,7 +108,8 @@ class TestCrossNamespaceDuplicates:
 
     def test_class_relations_expose_uris(self):
         """Regression for Relations tab key collisions."""
-        from rdflib import URIRef, RDF, OWL
+        from rdflib import URIRef, OWL
+
         om, foaf_uri, gist_uri = self._make_two_orgs()
         om.graph.add((URIRef(foaf_uri), OWL.equivalentClass, URIRef(gist_uri)))
         rels = om.get_class_relations()
@@ -122,7 +123,6 @@ class TestCrossNamespaceDuplicates:
         """Regression: editing an object property with a foaf:Organization
         domain must not silently rewrite the domain to myont:Organization
         even though both share the local name 'Organization'."""
-        from rdflib import RDFS
         om, foaf_uri, gist_uri = self._make_two_orgs()
         om.add_object_property("memberOf")
         # Save with the foaf URI as domain
@@ -139,10 +139,13 @@ class TestCrossNamespaceDuplicates:
         """Regression: Add Class Relation must place the triple between the
         URIs the user picked, not synthesise new base-namespace classes."""
         from rdflib import URIRef, OWL
+
         om, foaf_uri, gist_uri = self._make_two_orgs()
         om.add_class_relation(foaf_uri, "equivalentClass", gist_uri)
         # The triple must reference the imported URIs, not myont:Organization
-        triples = list(om.graph.triples((URIRef(foaf_uri), OWL.equivalentClass, URIRef(gist_uri))))
+        triples = list(
+            om.graph.triples((URIRef(foaf_uri), OWL.equivalentClass, URIRef(gist_uri)))
+        )
         assert len(triples) == 1
         my_org = om._uri("Organization")
         bogus = list(om.graph.triples((my_org, OWL.equivalentClass, None)))
@@ -151,7 +154,8 @@ class TestCrossNamespaceDuplicates:
     def test_individuals_expose_class_uris(self):
         """Regression: get_individuals must expose class_uris so the graph
         viewer can target the correct duplicate-named class."""
-        from rdflib import URIRef, RDF, OWL, Literal
+        from rdflib import URIRef, RDF, OWL
+
         om, foaf_uri, _gist_uri = self._make_two_orgs()
         alice = om.namespace["alice"]
         om.graph.add((alice, RDF.type, OWL.NamedIndividual))

--- a/tests/test_delete_impact.py
+++ b/tests/test_delete_impact.py
@@ -28,13 +28,17 @@ def test_class_impact_total_triples_positive(populated_om):
 
 
 def test_property_impact_shows_assertions(populated_om):
-    populated_om.add_individual_property("alice", "worksFor", "acme", is_object_property=True)
+    populated_om.add_individual_property(
+        "alice", "worksFor", "acme", is_object_property=True
+    )
     impact = populated_om.get_delete_impact("worksFor", "property")
     assert len(impact["property_assertions"]) >= 1
 
 
 def test_individual_impact_shows_relations(populated_om):
-    populated_om.add_individual_property("alice", "worksFor", "acme", is_object_property=True)
+    populated_om.add_individual_property(
+        "alice", "worksFor", "acme", is_object_property=True
+    )
     impact = populated_om.get_delete_impact("acme", "individual")
     assert len(impact["relations"]) >= 1
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -13,6 +13,7 @@ def base_om():
     m.add_class("Dog", parent="Animal", label="Dog")
     return m
 
+
 class TestCompareGraphs:
     def test_identical_graphs_produce_empty_diff(self, base_om):
         other = Graph()
@@ -36,8 +37,9 @@ class TestCompareGraphs:
         assert diff["stats"]["added"] >= 2
         assert diff["stats"]["resources_added"] >= 1
         # Cat should appear in added resources
-        added_names = [r["name"] for r in diff["modified_resources"]
-                       if r["change_type"] == "added"]
+        added_names = [
+            r["name"] for r in diff["modified_resources"] if r["change_type"] == "added"
+        ]
         assert "Cat" in added_names
 
     def test_removed_triples_detected(self, base_om):
@@ -53,8 +55,11 @@ class TestCompareGraphs:
 
         diff = base_om.compare_graphs(other)
         assert diff["stats"]["removed"] > 0
-        removed_names = [r["name"] for r in diff["modified_resources"]
-                         if r["change_type"] == "removed"]
+        removed_names = [
+            r["name"]
+            for r in diff["modified_resources"]
+            if r["change_type"] == "removed"
+        ]
         assert "Dog" in removed_names
 
     def test_modified_resource_detected(self, base_om):
@@ -67,8 +72,9 @@ class TestCompareGraphs:
         other.add((dog_uri, RDFS.label, Literal("Puppy")))
 
         diff = base_om.compare_graphs(other)
-        modified = [r for r in diff["modified_resources"]
-                    if r["change_type"] == "modified"]
+        modified = [
+            r for r in diff["modified_resources"] if r["change_type"] == "modified"
+        ]
         assert any(r["name"] == "Dog" for r in modified)
 
     def test_bnode_triples_counted_but_not_surfaced(self):

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -4,7 +4,7 @@ import pytest
 from ontology_manager import OntologyManager
 
 
-JSONLD_MINIMAL = '''{
+JSONLD_MINIMAL = """{
   "@context": {
     "owl": "http://www.w3.org/2002/07/owl#",
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
@@ -28,9 +28,9 @@ JSONLD_MINIMAL = '''{
       "rdfs:subClassOf": {"@id": "ex:Animal"}
     }
   ]
-}'''
+}"""
 
-JSONLD_NO_CONTEXT = '''{
+JSONLD_NO_CONTEXT = """{
   "@graph": [
     {
       "@id": "http://example.org/ont",
@@ -41,7 +41,7 @@ JSONLD_NO_CONTEXT = '''{
       "@type": "http://www.w3.org/2002/07/owl#Class"
     }
   ]
-}'''
+}"""
 
 
 @pytest.fixture
@@ -88,13 +88,13 @@ class TestJsonLdPrefixExtraction:
         assert prefixes == []
 
     def test_list_context_merged(self, om):
-        data = '''{
+        data = """{
           "@context": [
             {"ex": "http://example.org/"},
             {"foaf": "http://xmlns.com/foaf/0.1/"}
           ],
           "@graph": []
-        }'''
+        }"""
         prefixes = om._extract_prefixes_from_jsonld(data)
         names = [p["prefix"] for p in prefixes]
         assert "ex" in names
@@ -115,5 +115,5 @@ class TestJsonLdRoundTrip:
 
     def test_loaded_prefixes_populated(self, om):
         om.load_from_string(JSONLD_MINIMAL, format="json-ld")
-        assert hasattr(om, '_loaded_prefixes')
+        assert hasattr(om, "_loaded_prefixes")
         assert len(om._loaded_prefixes) > 0

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -4,7 +4,10 @@ import pytest
 from rdflib import Graph, URIRef
 from rdflib.namespace import RDFS
 from ontology_manager import (
-    OntologyManager, IMPORT_REPLACE, IMPORT_MERGE, IMPORT_MERGE_OVERWRITE,
+    OntologyManager,
+    IMPORT_REPLACE,
+    IMPORT_MERGE,
+    IMPORT_MERGE_OVERWRITE,
 )
 
 

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -14,11 +14,19 @@ SAMPLES_DIR = os.path.join(
 )
 
 SAMPLE_FILES = {
-    "pizza": ("pizza.owl", "xml", "https://protege.stanford.edu/ontologies/pizza/pizza.owl"),
+    "pizza": (
+        "pizza.owl",
+        "xml",
+        "https://protege.stanford.edu/ontologies/pizza/pizza.owl",
+    ),
     "foaf": ("foaf.rdf", "xml", "http://xmlns.com/foaf/spec/index.rdf"),
     "wine": ("wine.owl", "xml", "https://www.w3.org/TR/owl-guide/wine.rdf"),
     "prov-o": ("prov-o.ttl", "turtle", "https://www.w3.org/ns/prov-o"),
-    "goodrelations": ("goodrelations.owl", "xml", "http://purl.org/goodrelations/v1.owl"),
+    "goodrelations": (
+        "goodrelations.owl",
+        "xml",
+        "http://purl.org/goodrelations/v1.owl",
+    ),
     "geography": ("geography-thesaurus.ttl", "turtle", None),
 }
 
@@ -30,9 +38,14 @@ def _download(filename, url):
     try:
         subprocess.run(
             ["curl", "-sL", "-o", path, url],
-            timeout=30, check=True,
+            timeout=30,
+            check=True,
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ):
         pytest.skip(f"Could not download {filename}")
     if not os.path.exists(path) or os.path.getsize(path) == 0:
         pytest.skip(f"Download produced empty file for {filename}")
@@ -51,6 +64,7 @@ def _load(name):
 
 
 # ---------- Import & basic stats ----------
+
 
 class TestSampleImport:
     """Verify all samples load without errors and contain expected content."""
@@ -95,10 +109,13 @@ class TestSampleImport:
 
 # ---------- Validation ----------
 
+
 class TestSampleValidation:
     """Run validation on real ontologies and check it doesn't crash."""
 
-    @pytest.mark.parametrize("name", ["pizza", "wine", "foaf", "prov-o", "goodrelations"])
+    @pytest.mark.parametrize(
+        "name", ["pizza", "wine", "foaf", "prov-o", "goodrelations"]
+    )
     def test_validation_runs(self, name):
         om = _load(name)
         issues = om.validate()
@@ -116,6 +133,7 @@ class TestSampleValidation:
 
 
 # ---------- Search ----------
+
 
 class TestSampleSearch:
     """Test search on real ontologies."""
@@ -137,6 +155,7 @@ class TestSampleSearch:
 
 
 # ---------- Export round-trip ----------
+
 
 class TestSampleRoundTrip:
     """Export and re-import to check round-trip stability."""
@@ -167,6 +186,7 @@ class TestSampleRoundTrip:
 
 # ---------- Diff ----------
 
+
 class TestSampleDiff:
     """Test diff engine against real ontologies."""
 
@@ -179,6 +199,7 @@ class TestSampleDiff:
     def test_diff_after_adding_class(self):
         om = _load("foaf")
         from rdflib import Graph
+
         original = Graph()
         for t in om.graph:
             original.add(t)
@@ -191,6 +212,7 @@ class TestSampleDiff:
 
 
 # ---------- Hierarchy ----------
+
 
 class TestSampleHierarchy:
     """Test hierarchy extraction on real ontologies."""
@@ -207,6 +229,7 @@ class TestSampleHierarchy:
 
 
 # ---------- Statistics ----------
+
 
 class TestSampleStatistics:
     """Test statistics on real ontologies."""

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -7,10 +7,14 @@ import pytest
 from rdflib import Graph
 from orionbelt_ontology_builder import templates as templates_module
 from orionbelt_ontology_builder.templates import (
-    get_template_names, get_template, render_template,
-    get_upper_ontology_names, get_upper_ontology,
+    get_template_names,
+    get_template,
+    render_template,
+    get_upper_ontology_names,
+    get_upper_ontology,
     load_upper_ontology_module,
-    get_reference_ontology_names, get_reference_ontology,
+    get_reference_ontology_names,
+    get_reference_ontology,
     load_reference_ontology_module,
     _fetch_with_cache,
 )
@@ -224,7 +228,9 @@ class TestReferenceOntologies:
         cache_file = tmp_path / f"{sha}.dat"
         cache_file.write_bytes(payload)
 
-        with patch("orionbelt_ontology_builder.templates.urllib.request.urlopen") as mock_urlopen:
+        with patch(
+            "orionbelt_ontology_builder.templates.urllib.request.urlopen"
+        ) as mock_urlopen:
             result = _fetch_with_cache("https://example.invalid/x", sha)
             mock_urlopen.assert_not_called()
         assert result == payload.decode("utf-8")
@@ -244,7 +250,10 @@ class TestReferenceOntologies:
             def read(self):
                 return payload
 
-        with patch("orionbelt_ontology_builder.templates.urllib.request.urlopen", return_value=_Resp()):
+        with patch(
+            "orionbelt_ontology_builder.templates.urllib.request.urlopen",
+            return_value=_Resp(),
+        ):
             with pytest.raises(RuntimeError, match="SHA256 mismatch"):
                 _fetch_with_cache("https://example.invalid/x", wrong_sha)
 
@@ -266,7 +275,10 @@ class TestReferenceOntologies:
             def read(self):
                 return payload
 
-        with patch("orionbelt_ontology_builder.templates.urllib.request.urlopen", return_value=_Resp()) as mock:
+        with patch(
+            "orionbelt_ontology_builder.templates.urllib.request.urlopen",
+            return_value=_Resp(),
+        ) as mock:
             result1 = _fetch_with_cache("https://example.invalid/x", sha)
             result2 = _fetch_with_cache("https://example.invalid/x", sha)
             # Second call should hit the cache, not the network

--- a/tests/test_usages.py
+++ b/tests/test_usages.py
@@ -16,14 +16,20 @@ def test_class_no_outbound_structural(populated_om):
 
 
 def test_individual_inbound_after_assertion(populated_om):
-    populated_om.add_individual_property("alice", "worksFor", "acme", is_object_property=True)
+    populated_om.add_individual_property(
+        "alice", "worksFor", "acme", is_object_property=True
+    )
     usages = populated_om.get_resource_usages("acme")
-    assert any(u["subject"] == "alice" and u["predicate"] == "worksFor"
-               for u in usages["inbound"])
+    assert any(
+        u["subject"] == "alice" and u["predicate"] == "worksFor"
+        for u in usages["inbound"]
+    )
 
 
 def test_property_as_predicate(populated_om):
-    populated_om.add_individual_property("alice", "worksFor", "acme", is_object_property=True)
+    populated_om.add_individual_property(
+        "alice", "worksFor", "acme", is_object_property=True
+    )
     usages = populated_om.get_resource_usages("worksFor")
     assert len(usages["as_predicate"]) >= 1
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,36 +4,48 @@
 def test_missing_label_warning(om):
     om.add_class("Unlabeled")
     issues = om.validate()
-    assert any(i["type"] == "missing_label" and i["subject"] == "Unlabeled" for i in issues)
+    assert any(
+        i["type"] == "missing_label" and i["subject"] == "Unlabeled" for i in issues
+    )
 
 
 def test_no_warning_when_label_present(om):
     om.add_class("Labeled", label="Labeled")
     issues = om.validate()
-    assert not any(i["type"] == "missing_label" and i["subject"] == "Labeled" for i in issues)
+    assert not any(
+        i["type"] == "missing_label" and i["subject"] == "Labeled" for i in issues
+    )
 
 
 def test_no_warning_when_skos_preflabel_present(om):
     """Classes with skos:prefLabel should not trigger missing label warning (issue #1)."""
     from rdflib import Literal
     from rdflib.namespace import SKOS
+
     om.add_class("SKOSLabeled")
     class_uri = om.namespace["SKOSLabeled"]
     om.graph.add((class_uri, SKOS.prefLabel, Literal("SKOS Labeled")))
     issues = om.validate()
-    assert not any(i["type"] == "missing_label" and i["subject"] == "SKOSLabeled" for i in issues)
+    assert not any(
+        i["type"] == "missing_label" and i["subject"] == "SKOSLabeled" for i in issues
+    )
 
 
 def test_missing_domain_range(om):
     om.add_object_property("orphanProp")
     issues = om.validate()
-    assert any(i["type"] == "missing_domain" and i["subject"] == "orphanProp" for i in issues)
-    assert any(i["type"] == "missing_range" and i["subject"] == "orphanProp" for i in issues)
+    assert any(
+        i["type"] == "missing_domain" and i["subject"] == "orphanProp" for i in issues
+    )
+    assert any(
+        i["type"] == "missing_range" and i["subject"] == "orphanProp" for i in issues
+    )
 
 
 def test_no_missing_domain_when_domain_includes_present(om):
     """Properties with schema:domainIncludes or gist:domainIncludes should not warn (issue #2)."""
     from ontology_manager import _SCHEMA, _GIST
+
     om.add_class("Person")
     om.add_object_property("schemaProp")
     om.add_object_property("gistProp")
@@ -42,13 +54,18 @@ def test_no_missing_domain_when_domain_includes_present(om):
     om.graph.add((prop1, _SCHEMA.domainIncludes, om.namespace["Person"]))
     om.graph.add((prop2, _GIST.domainIncludes, om.namespace["Person"]))
     issues = om.validate()
-    assert not any(i["type"] == "missing_domain" and i["subject"] == "schemaProp" for i in issues)
-    assert not any(i["type"] == "missing_domain" and i["subject"] == "gistProp" for i in issues)
+    assert not any(
+        i["type"] == "missing_domain" and i["subject"] == "schemaProp" for i in issues
+    )
+    assert not any(
+        i["type"] == "missing_domain" and i["subject"] == "gistProp" for i in issues
+    )
 
 
 def test_no_missing_range_when_range_includes_present(om):
     """Properties with schema:rangeIncludes or gist:rangeIncludes should not warn (issue #2)."""
     from ontology_manager import _SCHEMA, _GIST
+
     om.add_class("Person")
     om.add_object_property("schemaProp", domain="Person")
     om.add_object_property("gistProp", domain="Person")
@@ -57,8 +74,12 @@ def test_no_missing_range_when_range_includes_present(om):
     om.graph.add((prop1, _SCHEMA.rangeIncludes, om.namespace["Person"]))
     om.graph.add((prop2, _GIST.rangeIncludes, om.namespace["Person"]))
     issues = om.validate()
-    assert not any(i["type"] == "missing_range" and i["subject"] == "schemaProp" for i in issues)
-    assert not any(i["type"] == "missing_range" and i["subject"] == "gistProp" for i in issues)
+    assert not any(
+        i["type"] == "missing_range" and i["subject"] == "schemaProp" for i in issues
+    )
+    assert not any(
+        i["type"] == "missing_range" and i["subject"] == "gistProp" for i in issues
+    )
 
 
 def test_untyped_individual(om):
@@ -67,19 +88,25 @@ def test_untyped_individual(om):
     om.add_individual("x", "Temp")
     om.delete_class("Temp")
     issues = om.validate()
-    assert any(i["type"] == "untyped_individual" and i["subject"] == "x" for i in issues)
+    assert any(
+        i["type"] == "untyped_individual" and i["subject"] == "x" for i in issues
+    )
 
 
 def test_no_untyped_warning_for_typed_individual(populated_om):
     issues = populated_om.validate()
-    assert not any(i["type"] == "untyped_individual" and i["subject"] == "alice" for i in issues)
+    assert not any(
+        i["type"] == "untyped_individual" and i["subject"] == "alice" for i in issues
+    )
 
 
 def test_orphan_class_detected(om):
     """A class with no hierarchy, domain/range, or instances is orphaned."""
     om.add_class("Isolated", label="Isolated")
     issues = om.validate()
-    assert any(i["type"] == "orphan_class" and i["subject"] == "Isolated" for i in issues)
+    assert any(
+        i["type"] == "orphan_class" and i["subject"] == "Isolated" for i in issues
+    )
 
 
 def test_class_in_hierarchy_not_orphan(om):
@@ -132,7 +159,9 @@ def test_domain_mismatch_detected(om):
     om.add_individual("fido", "Animal")
     om.add_individual_property("fido", "worksFor", "fido", is_object_property=True)
     issues = om.validate()
-    assert any(i["type"] == "domain_mismatch" and i["subject"] == "fido" for i in issues)
+    assert any(
+        i["type"] == "domain_mismatch" and i["subject"] == "fido" for i in issues
+    )
 
 
 def test_range_mismatch_detected(om):
@@ -145,12 +174,20 @@ def test_range_mismatch_detected(om):
     om.add_individual("fido", "Animal")
     om.add_individual_property("alice", "worksFor", "fido", is_object_property=True)
     issues = om.validate()
-    assert any(i["type"] == "range_mismatch" and i["subject"] == "alice" for i in issues)
+    assert any(
+        i["type"] == "range_mismatch" and i["subject"] == "alice" for i in issues
+    )
 
 
 def test_no_mismatch_when_types_match(populated_om):
     """Correctly typed assertions should produce no domain/range warnings."""
-    populated_om.add_individual_property("alice", "worksFor", "acme", is_object_property=True)
+    populated_om.add_individual_property(
+        "alice", "worksFor", "acme", is_object_property=True
+    )
     issues = populated_om.validate()
-    assert not any(i["type"] == "domain_mismatch" and i["subject"] == "alice" for i in issues)
-    assert not any(i["type"] == "range_mismatch" and i["subject"] == "alice" for i in issues)
+    assert not any(
+        i["type"] == "domain_mismatch" and i["subject"] == "alice" for i in issues
+    )
+    assert not any(
+        i["type"] == "range_mismatch" and i["subject"] == "alice" for i in issues
+    )


### PR DESCRIPTION
## Summary
Adopt a CI pipeline and make the codebase pass it cleanly.

- **`.github/workflows/ci.yml`** — runs on push/PR to `main`: ruff lint, ruff format check, mypy, pytest (via `uv`)
- **Tooling config** — add `ruff` + `mypy` to the `dev` extras and a `[tool.mypy]` table (`python_version = "3.10"`, `ignore_missing_imports = true`)
- **Lint/format cleanup** — fix ruff findings (unused imports, placeholder f-strings, dead locals) and apply `ruff format` to the package and tests
- **Typing** — annotate the engine (`ontology_manager.py`) and fix `templates.py` return types so mypy passes with **zero** errors

Adapted from the provided template: corrected paths (this repo has no `src/`), targets the package + shims + `tests/`.

## Safety
Annotations only — **no runtime behavior change**:
- Engine AST is byte-identical to `main` after stripping annotations/`cast()`/import additions (19,612 nodes both sides)
- Full suite stays green: **240 passed**

## Gates (all green locally)
- `ruff check` → All checks passed
- `ruff format --check` → all formatted
- `mypy orionbelt_ontology_builder` → Success: no issues found
- `pytest` → 240 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)