### PR TITLE
feat: make import file-size limit configurable

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,2 +1,9 @@
 [theme]
 primaryColor = "#0D2B7A"
+
+[server]
+# Maximum upload size in MB for the Import page file uploader.
+# Streamlit's default is 200. Raise this to import larger ontologies — but
+# note that parsing happens in memory, so the practical ceiling is the host's
+# available RAM (the hosted demo on Streamlit Community Cloud is RAM-limited).
+maxUploadSize = 200

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.5.0](https://img.shields.io/badge/version-1.5.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.5.1](https://img.shields.io/badge/version-1.5.1-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -147,7 +147,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.5.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.5.1` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,26 @@ docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 
 The container runs Streamlit headless on `0.0.0.0:8501` as a non-root user.
 
+### Upload size limit
+
+Imported files are capped at **200 MB** by default (Streamlit's `maxUploadSize`).
+To import larger ontologies, raise the limit in `.streamlit/config.toml`:
+
+```toml
+[server]
+maxUploadSize = 1000   # MB
+```
+
+or pass it at launch:
+
+```bash
+streamlit run app.py --server.maxUploadSize 1000
+```
+
+Parsing happens in memory, so the practical ceiling is the host machine's
+available RAM rather than this setting. The hosted demo is RAM-limited and keeps
+the 200 MB default; raise the value only when self-hosting with enough memory.
+
 ---
 
 ## Pages

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path as _Path
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.5.0"
+APP_VERSION = "1.5.1"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -3477,10 +3477,16 @@ def render_import_export():
             import_method = st.radio("Import Method", ["Upload File", "Paste Content"])
 
             if import_method == "Upload File":
+                _max_upload_mb = st.get_option("server.maxUploadSize")
                 uploaded_file = st.file_uploader(
                     "Choose an ontology file",
                     type=["ttl", "owl", "rdf", "xml", "n3", "nt", "jsonld", "json"],
-                    help="Supported formats: Turtle (.ttl), RDF/XML (.owl, .rdf, .xml), N3 (.n3), N-Triples (.nt), JSON-LD (.jsonld, .json)",
+                    help=(
+                        "Supported formats: Turtle (.ttl), RDF/XML (.owl, .rdf, .xml), "
+                        "N3 (.n3), N-Triples (.nt), JSON-LD (.jsonld, .json). "
+                        f"Maximum file size: {_max_upload_mb} MB — raise it via "
+                        "server.maxUploadSize in .streamlit/config.toml."
+                    ),
                     key=f"import_uploader_{st.session_state.get('import_uploader_key', 0)}",
                 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.5.0"
+version = "1.5.1"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
## Summary

Addresses #35 — let users adjust the file-size limit on the Import page.

There was no app-level size cap in our own code; the limit was Streamlit's built-in `maxUploadSize` (200 MB default), which lives entirely in config. This PR makes that dial explicit and documented.

## Changes

- **`.streamlit/config.toml`** — add `[server] maxUploadSize = 200` with a comment explaining how to raise it and the RAM caveat.
- **`app.py`** — surface the active limit in the file uploader's help text (read live via `st.get_option`), so users see the current cap and where to change it.
- **`README.md`** — new "Upload size limit" section documenting both ways to raise it (config file or `--server.maxUploadSize`) and noting the practical ceiling is host RAM since `rdflib` parses in memory.

## Notes

The hosted demo intentionally keeps the 200 MB default — Community Cloud is RAM-limited, and a very large ontology would OOM the parse well before the upload limit mattered. Raising the value is meant for self-hosters with adequate memory.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)