### PR TITLE
feat(viz): focus on one node with depth, fix Clear-all filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.5.1](https://img.shields.io/badge/version-1.5.1-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.6.0](https://img.shields.io/badge/version-1.6.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -147,7 +147,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.5.1` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.6.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -4419,6 +4419,8 @@ def render_visualization():
             "node_spacing": 150,
             "maximize": False,
             "highlight_issues": False,
+            "focus_mode": False,
+            "focus_depth": 1,
         }
         for _k, _v in _viz_cfg.items():
             cfg_key = f"_viz_cfg_{_k}"
@@ -4576,26 +4578,95 @@ def render_visualization():
             st.session_state["_viz_cfg_selected_classes"] = all_class_names
             st.session_state["_viz_cfg_classes_at_mutation"] = current_mutation
         else:
-            valid = [
+            # Drop names that no longer exist, but keep an intentionally empty
+            # selection empty — repopulating here would make "Clear all" (the
+            # multiselect's ✕) snap straight back to every class. The mutation
+            # branch above is what resets to "all" when the ontology changes.
+            st.session_state["_viz_cfg_selected_classes"] = [
                 c
                 for c in st.session_state["_viz_cfg_selected_classes"]
                 if c in all_class_set
             ]
-            if not valid and all_class_names:
-                valid = all_class_names
-            st.session_state["_viz_cfg_selected_classes"] = valid
         st.session_state["viz_selected_classes"] = st.session_state[
             "_viz_cfg_selected_classes"
         ]
+
+        # Focus mode: centre the view on one node (class, individual or SKOS
+        # concept) and show only its neighbourhood within N hops. The pruning
+        # runs after the full graph is built (see below), so "depth" counts real
+        # links of every type — not just subclass chains. Seed options are keyed
+        # to the same node ids the graph builder assigns.
+        focus_targets: dict[str, str] = {}
+        if show_classes:
+            for c in classes:
+                focus_targets[f"Class: {c['name']}"] = _uid(c["uri"])
+        if show_individuals:
+            for ind in individuals:
+                focus_targets[f"Individual: {ind['name']}"] = f"ind_{_uid(ind['uri'])}"
+        if show_skos and _has_skos:
+            for concept in ont.get_concepts():
+                focus_targets[f"Concept: {concept['name']}"] = f"skos_{concept['name']}"
+
+        focus_seed_id = None
+        focus_depth = 0
         with st.expander("Filter Classes", expanded=False):
-            selected_classes = st.multiselect(
-                "Select classes to display",
-                options=all_class_names,
-                help="Choose which classes to show in the graph",
-                key="viz_selected_classes",
+            focus_mode = st.checkbox(
+                "Focus on one node",
+                key="viz_focus_mode",
                 on_change=_viz_sync,
-                args=("_viz_cfg_selected_classes", "viz_selected_classes"),
+                args=("_viz_cfg_focus_mode", "viz_focus_mode"),
+                help=(
+                    "Show only a chosen node plus everything linked to it within "
+                    "N hops, across all node types — handy for large ontologies "
+                    "where showing everything at once is overwhelming."
+                ),
             )
+            if focus_mode and focus_targets:
+                focus_labels = list(focus_targets.keys())
+                saved_seed = st.session_state.get("_viz_cfg_focus_seed")
+                if saved_seed not in set(focus_labels):
+                    saved_seed = focus_labels[0]
+                st.session_state["_viz_cfg_focus_seed"] = saved_seed
+                st.session_state["viz_focus_seed"] = saved_seed
+                fcol1, fcol2 = st.columns([3, 1])
+                with fcol1:
+                    focus_seed = st.selectbox(
+                        "Focus node",
+                        options=focus_labels,
+                        key="viz_focus_seed",
+                        on_change=_viz_sync,
+                        args=("_viz_cfg_focus_seed", "viz_focus_seed"),
+                        help="Class, individual or SKOS concept to centre on. "
+                        "Toggle the entity-type checkboxes above to list more.",
+                    )
+                with fcol2:
+                    focus_depth = st.slider(
+                        "Depth (hops)",
+                        1,
+                        5,
+                        key="viz_focus_depth",
+                        on_change=_viz_sync,
+                        args=("_viz_cfg_focus_depth", "viz_focus_depth"),
+                        help="1 = direct neighbours only; higher pulls in further links.",
+                    )
+                focus_seed_id = focus_targets.get(focus_seed)
+                # Build the full graph so the neighbourhood isn't pre-limited;
+                # the post-build prune narrows it to the chosen node's links.
+                selected_classes = all_class_names
+            elif focus_mode:
+                st.info(
+                    "Enable Classes, Individuals or SKOS above to pick a focus node."
+                )
+                selected_classes = []
+            else:
+                selected_classes = st.multiselect(
+                    "Select classes to display",
+                    options=all_class_names,
+                    help="Choose which classes to show in the graph",
+                    key="viz_selected_classes",
+                    on_change=_viz_sync,
+                    args=("_viz_cfg_selected_classes", "viz_selected_classes"),
+                )
 
         # Store graph settings in session state for caching
         selected_classes_key = (
@@ -4606,7 +4677,7 @@ def render_visualization():
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.
         ont_mutation = st.session_state.get("_ont_mutation_count", 0)
-        graph_key = f"v{_graph_ver}_m{ont_mutation}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{height}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}"
+        graph_key = f"v{_graph_ver}_m{ont_mutation}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{height}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}_{focus_mode}_{focus_seed_id}_{focus_depth}"
         if "last_graph_key" not in st.session_state:
             st.session_state.last_graph_key = None
             st.session_state.last_graph_data = None
@@ -5172,6 +5243,36 @@ def render_visualization():
                                 color="#B0BEC5",
                                 arrows="to",
                             )
+
+            # Focus mode: keep only the chosen node's neighbourhood within
+            # focus_depth hops over the assembled edges (BFS over all node
+            # types, so depth counts real graph links rather than class hops).
+            if focus_mode and focus_seed_id:
+                present_ids = {n["id"] for n in net.nodes}
+                if focus_seed_id in present_ids:
+                    adj: dict = {}
+                    for edge in net.edges:
+                        adj.setdefault(edge["from"], set()).add(edge["to"])
+                        adj.setdefault(edge["to"], set()).add(edge["from"])
+                    keep = {focus_seed_id}
+                    frontier = {focus_seed_id}
+                    for _ in range(focus_depth):
+                        nxt = set()
+                        for nid in frontier:
+                            nxt |= adj.get(nid, set()) - keep
+                        if not nxt:
+                            break
+                        keep |= nxt
+                        frontier = nxt
+                    net.nodes = [n for n in net.nodes if n["id"] in keep]
+                    net.edges = [
+                        e for e in net.edges if e["from"] in keep and e["to"] in keep
+                    ]
+                else:
+                    # Seed wasn't built (e.g. beyond the node cap) — show nothing
+                    # rather than the whole graph, which would be misleading.
+                    net.nodes = []
+                    net.edges = []
 
             # Spread parallel edges so they don't overlap
             from collections import defaultdict as _defaultdict

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path as _Path
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.5.1"
+APP_VERSION = "1.6.0"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.5.1"
+version = "1.6.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Addresses #23 — both parts.

## 1. Focus on one node (with depth)

New **Focus on one node** toggle in the Visualization graph's *Filter Classes* panel. Pick a **class, individual, or SKOS concept** as the seed, set a **Depth (1–5 hops)** slider, and the graph shows only that node's neighbourhood.

The pruning happens **after the full graph is built**, by BFS over the actual rendered edges — so "depth" counts real links of *every* node type (subclass, object-property, individual assertions, SKOS broader/narrower, …), not just class→subclass chains. Seed options are keyed to the same node ids the builder assigns, and focus params feed the existing graph cache so changes re-render correctly.

Verified locally on the Organization template:
- Focus *Department*, depth 1 → Department + Person + Organization (Role correctly excluded — it's 2 hops).
- Depth 2 → Role appears via Person.

## 2. Fix "Clear all" under Filter Classes

The native multiselect ✕ ("Clear all") didn't work: an empty selection was repopulated with *every* class on the next rerun, so clearing snapped right back to all. That auto-refill was only meant to reset a stale filter after the ontology **mutates** (load/import/undo) — it was running on every rerun. Now an intentionally-cleared filter stays empty (empty graph), while the mutation reset still protects against hiding freshly-loaded content.

Verified: clicking Clear all now leaves the multiselect empty and the graph blank.

## Notes
- In focus mode the seed selector replaces the class multiselect; entity-type checkboxes (Classes/Individuals/SKOS) gate which node types are eligible as seeds and neighbours.
- The graph build still caps at 500 nodes for browser performance; if a seed sits beyond that cap the focus view shows nothing rather than the whole graph.
- `ruff`, `mypy`, and the 240-test suite pass.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)