### PR TITLE
feat: add console entry point to launch the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.6.1](https://img.shields.io/badge/version-1.6.1-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.6.2](https://img.shields.io/badge/version-1.6.2-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -165,7 +165,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.6.1` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.6.2` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ streamlit run app.py
 
 Open http://localhost:8501
 
+### Run as a command
+
+Installing the package also provides an `orionbelt-ontology-builder` command that
+launches the app for you, so there is no need to call `streamlit run` yourself:
+
+```bash
+# Install as an isolated tool and run it (uv or pipx)
+uv tool install orionbelt-ontology-builder
+orionbelt-ontology-builder            # boots the app, opens the browser
+
+# Or run it one-off without installing
+uvx orionbelt-ontology-builder
+pipx run orionbelt-ontology-builder
+```
+
+Any extra arguments are forwarded to Streamlit, e.g.
+`orionbelt-ontology-builder --server.port 8502`.
+
 ### Run with Docker
 
 A prebuilt image is published to Docker Hub. No local Python setup required:

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path as _Path
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.6.1"
+APP_VERSION = "1.6.2"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/orionbelt_ontology_builder/cli.py
+++ b/orionbelt_ontology_builder/cli.py
@@ -1,0 +1,28 @@
+"""Console entry point for launching the OrionBelt Streamlit app.
+
+Exposed as the ``orionbelt-ontology-builder`` command (see
+``[project.scripts]`` in ``pyproject.toml``) so the app can be installed and
+run without ``streamlit run`` — e.g. ``uv tool install`` / ``uvx`` / ``pipx``.
+"""
+
+import sys
+from pathlib import Path
+
+
+def run() -> None:
+    """Launch the app via Streamlit, forwarding any extra CLI args.
+
+    Equivalent to ``streamlit run <package>/streamlit_entry.py [args...]``, so
+    users can still pass Streamlit flags, e.g.::
+
+        orionbelt-ontology-builder --server.port 8502
+    """
+    from streamlit.web import cli as stcli
+
+    entry = Path(__file__).parent / "streamlit_entry.py"
+    sys.argv = ["streamlit", "run", str(entry), *sys.argv[1:]]
+    sys.exit(stcli.main())
+
+
+if __name__ == "__main__":
+    run()

--- a/orionbelt_ontology_builder/streamlit_entry.py
+++ b/orionbelt_ontology_builder/streamlit_entry.py
@@ -1,0 +1,13 @@
+"""Streamlit entry script used by the console launcher (``cli.run``).
+
+Streamlit executes this file as ``__main__``, so it uses an absolute import of
+the package (the package's own ``app.py`` uses relative imports and therefore
+cannot be handed to ``streamlit run`` directly). This mirrors the top-level
+``app.py`` shim but lives inside the package so the launcher can locate it
+reliably via ``Path(__file__)``.
+"""
+
+from orionbelt_ontology_builder.app import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
     "streamlit-local-storage>=0.0.25",
 ]
 
+[project.scripts]
+orionbelt-ontology-builder = "orionbelt_ontology_builder.cli:run"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.6.1"
+version = "1.6.2"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,49 @@
+"""Tests for the console entry point (``orionbelt-ontology-builder``)."""
+
+import sys
+from importlib.metadata import entry_points
+from pathlib import Path
+
+import orionbelt_ontology_builder.cli as cli
+
+
+def test_entry_point_registered():
+    """The console_scripts entry point should map to ``cli:run``."""
+    eps = [
+        ep
+        for ep in entry_points(group="console_scripts")
+        if ep.name == "orionbelt-ontology-builder"
+    ]
+    assert eps, "orionbelt-ontology-builder console script not registered"
+    assert eps[0].value == "orionbelt_ontology_builder.cli:run"
+
+
+def test_streamlit_entry_file_exists():
+    """The launcher targets an in-package Streamlit entry script."""
+    entry = Path(cli.__file__).parent / "streamlit_entry.py"
+    assert entry.is_file()
+
+
+def test_run_invokes_streamlit_with_entry_and_forwards_args(monkeypatch):
+    """``run()`` should call ``streamlit run <entry>`` and forward extra args."""
+    captured = {}
+
+    class _FakeStcli:
+        @staticmethod
+        def main():
+            captured["argv"] = list(sys.argv)
+
+    import streamlit.web
+
+    monkeypatch.setattr(streamlit.web, "cli", _FakeStcli, raising=False)
+    monkeypatch.setattr(
+        sys, "argv", ["orionbelt-ontology-builder", "--server.port", "8502"]
+    )
+    monkeypatch.setattr(sys, "exit", lambda code=0: None)
+
+    cli.run()
+
+    argv = captured["argv"]
+    assert argv[:2] == ["streamlit", "run"]
+    assert argv[2].endswith("streamlit_entry.py")
+    assert argv[-2:] == ["--server.port", "8502"]


### PR DESCRIPTION
Closes #40 (the packaging part).

## Problem
`uv tool install orionbelt_ontology_builder` collected the dependencies but found no executable to install, so it dropped the install. The package had no `[project.scripts]` entry point, and the app could only be started with `streamlit run app.py`.

## Change
Adds an `orionbelt-ontology-builder` console script:

```toml
[project.scripts]
orionbelt-ontology-builder = "orionbelt_ontology_builder.cli:run"
```

Now the app installs and runs as a command, no manual `streamlit run` needed:

```bash
uv tool install orionbelt-ontology-builder
orionbelt-ontology-builder
# or one-off:
uvx orionbelt-ontology-builder
pipx run orionbelt-ontology-builder
```

`cli.run()` shells into `streamlit run` against a small in-package entry script (`streamlit_entry.py`) that uses absolute imports. This indirection is needed because the package's own `app.py` uses relative imports (`from .ontology_manager import ...`) and so cannot be handed to `streamlit run` directly (it would execute as `__main__` with no package context). Extra CLI args are forwarded to Streamlit, e.g. `orionbelt-ontology-builder --server.port 8502`.

## Verification
- Editable install registers the `orionbelt-ontology-builder` console script; running it boots the app (health 200) from any working directory, and `--server.port` / `--server.headless` are forwarded.
- New `tests/test_cli.py` covers the entry-point registration and that `run()` builds the right `streamlit run <entry>` argv and forwards args. 243 tests pass; ruff/mypy clean.
- README gains a "Run as a command" section.

## Out of scope
The native desktop wrapper (`streamlit-desktop-app` / `stlite`) discussed in the issue is a larger follow-up; this PR covers the install/launch gap so `uvx` and friends work. Version bumped to 1.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)