### PR TITLE
feat(search): match skos:prefLabel and skos:altLabel, include concepts

### DIFF
--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2636,12 +2636,16 @@ class OntologyManager:
     # ==================== SEARCH ====================
 
     def search(self, query: str) -> List[Dict[str, str]]:
-        """Search across all resource names, labels, and comments.
+        """Search across resource names, labels, comments and SKOS labels.
+
+        Matches (case-insensitive, partial) against the local name, rdfs:label,
+        skos:prefLabel, skos:altLabel and rdfs:comment of every class, property,
+        individual and SKOS concept. altLabel matching in particular improves
+        discoverability for vocabularies with synonyms.
 
         Returns a list of dicts with keys: name, uri, type, label, match_field.
-        Results are case-insensitive partial matches. The full URI is included
-        so that callers can distinguish duplicate local names from different
-        namespaces.
+        The full URI is included so callers can distinguish duplicate local
+        names from different namespaces.
         """
         if not query or not query.strip():
             return []
@@ -2655,7 +2659,17 @@ class OntologyManager:
             (OWL.ObjectProperty, "Object Property"),
             (OWL.DatatypeProperty, "Data Property"),
             (OWL.NamedIndividual, "Individual"),
+            (SKOS.Concept, "SKOS Concept"),
         ]
+
+        # Lower rank = higher priority when ordering results.
+        field_rank = {
+            "name": 0,
+            "label": 1,
+            "prefLabel": 2,
+            "altLabel": 3,
+            "comment": 4,
+        }
 
         for rdf_type, type_label in type_map:
             for subj in self.graph.subjects(RDF.type, rdf_type):
@@ -2665,27 +2679,37 @@ class OntologyManager:
                 name = self._local_name(subj)
                 label = str(self.graph.value(subj, RDFS.label) or "")
                 comment = str(self.graph.value(subj, RDFS.comment) or "")
+                pref_label = str(self.graph.value(subj, SKOS.prefLabel) or "")
+                alt_labels = [str(o) for o in self.graph.objects(subj, SKOS.altLabel)]
 
                 match_field = None
                 if q in name.lower():
                     match_field = "name"
-                elif q in label.lower():
+                elif label and q in label.lower():
                     match_field = "label"
-                elif q in comment.lower():
+                elif pref_label and q in pref_label.lower():
+                    match_field = "prefLabel"
+                elif any(q in alt.lower() for alt in alt_labels):
+                    match_field = "altLabel"
+                elif comment and q in comment.lower():
                     match_field = "comment"
 
                 if match_field:
                     results.append(
                         {
+                            # Fall back to prefLabel so SKOS concepts (which
+                            # rarely carry rdfs:label) still show a label.
                             "name": name,
                             "uri": str(subj),
                             "type": type_label,
-                            "label": label,
+                            "label": label or pref_label,
                             "match_field": match_field,
                         }
                     )
 
-        results.sort(key=lambda r: (r["match_field"] != "name", r["name"].lower()))
+        results.sort(
+            key=lambda r: (field_rank.get(r["match_field"], 9), r["name"].lower())
+        )
         return results
 
     # ==================== RESOURCE USAGES ====================

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -49,3 +49,35 @@ def test_search_name_matches_rank_first(populated_om):
     results = populated_om.search("Alpha")
     names = [r["name"] for r in results]
     assert names.index("Alpha") < names.index("Zeta")
+
+
+def test_search_finds_concept_by_pref_label(skos_om):
+    results = skos_om.search("Dog")
+    assert any(r["name"] == "Dog" and r["type"] == "SKOS Concept" for r in results)
+
+
+def test_search_finds_concept_by_alt_label(skos_om):
+    """altLabel synonyms should be discoverable via search (issue #41)."""
+    skos_om.add_annotation("Dog", "altLabel", "Canine")
+    results = skos_om.search("Canine")
+    match = next((r for r in results if r["name"] == "Dog"), None)
+    assert match is not None
+    assert match["type"] == "SKOS Concept"
+    assert match["match_field"] == "altLabel"
+
+
+def test_search_alt_label_on_class(populated_om):
+    """altLabel matching applies to any resource, not only SKOS concepts."""
+    populated_om.add_class("Automobile")
+    populated_om.add_annotation("Automobile", "altLabel", "Motorcar")
+    results = populated_om.search("Motorcar")
+    assert any(r["name"] == "Automobile" for r in results)
+
+
+def test_search_name_ranks_above_alt_label(populated_om):
+    populated_om.add_class("Wolf")
+    populated_om.add_annotation("Wolf", "altLabel", "Doggo")
+    populated_om.add_class("Doggo")
+    results = populated_om.search("Doggo")
+    names = [r["name"] for r in results]
+    assert names.index("Doggo") < names.index("Wolf")


### PR DESCRIPTION
Addresses #41.

## Change
Global search (`OntologyManager.search`) now:
- includes **SKOS concepts** (`skos:Concept`) as a searchable type, and
- matches against **`skos:prefLabel`** and **`skos:altLabel`** in addition to the local name, `rdfs:label`, and `rdfs:comment`, for every resource.

`altLabel` is meant to capture synonyms, so matching it directly improves discoverability, especially for large vocabularies (the issue's point). altLabel/prefLabel matching applies to any resource, not just concepts, since classes and individuals can carry SKOS labels too.

Results are ranked name > label > prefLabel > altLabel > comment, then alphabetical. Concepts (which rarely have `rdfs:label`) fall back to `prefLabel` for the displayed label. The sidebar UI already renders the `SKOS Concept` result type and navigates to the concept, so no UI change was needed.

## Tests
`tests/test_search.py` gains coverage for concept-by-prefLabel, concept-by-altLabel (with `match_field == "altLabel"`), altLabel on a class, and name-ranks-above-altLabel. 247 tests pass; ruff/mypy clean.