### PR TITLE
feat: rename SKOS concepts/schemes + cross-type rename uniqueness

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -862,6 +862,9 @@ def render_classes():
                                 "Name (URI local part)",
                                 value=cls["name"],
                                 key=f"name_{cls_uid}",
+                                help="Renaming updates every reference to this "
+                                "class — no links are lost, unlike "
+                                "delete-and-recreate.",
                             )
                             new_label = st.text_input(
                                 "Label", value=cls["label"], key=f"lbl_{cls_uid}"
@@ -1350,6 +1353,9 @@ def render_properties():
                                 "Name (URI local part)",
                                 value=prop["name"],
                                 key=f"objp_name_{prop_uid}",
+                                help="Renaming updates every reference to this "
+                                "property, including assertions that use it — "
+                                "no links are lost.",
                             )
                             new_label = st.text_input(
                                 "Label", value=prop["label"], key=f"objp_lbl_{prop_uid}"
@@ -1545,6 +1551,9 @@ def render_properties():
                                 "Name (URI local part)",
                                 value=prop["name"],
                                 key=f"dp_name_{prop_uid}",
+                                help="Renaming updates every reference to this "
+                                "property, including assertions that use it — "
+                                "no links are lost.",
                             )
                             new_label = st.text_input(
                                 "Label", value=prop["label"], key=f"dp_lbl_{prop_uid}"
@@ -1980,6 +1989,9 @@ def render_individuals():
                                 "Name (URI local part)",
                                 value=ind["name"],
                                 key=f"ind_name_{_ik}",
+                                help="Renaming updates every reference to this "
+                                "individual — no links are lost, unlike "
+                                "delete-and-recreate.",
                             )
                             new_label = st.text_input(
                                 "Label", value=ind["label"], key=f"ind_lbl_{_ik}"
@@ -3007,6 +3019,14 @@ def render_skos_vocabulary():
                     if st.session_state.get(f"edit_scheme_{scheme['name']}", False):
                         st.divider()
                         with st.form(f"edit_scheme_form_{scheme['name']}"):
+                            new_name = st.text_input(
+                                "Name (URI local part)",
+                                value=scheme["name"],
+                                key=f"scheme_name_{scheme['name']}",
+                                help="Renaming updates every reference, including "
+                                "the inScheme links from its concepts — no "
+                                "membership is lost.",
+                            )
                             new_label = st.text_input(
                                 "Label",
                                 value=scheme["label"] or "",
@@ -3018,20 +3038,30 @@ def render_skos_vocabulary():
                                 key=f"scheme_cmt_{scheme['name']}",
                             )
                             if st.form_submit_button("Save Changes"):
-                                ont.update_concept_scheme(
-                                    scheme["name"],
-                                    new_label=new_label,
-                                    new_comment=new_comment,
-                                )
-                                save_checkpoint("Update concept scheme")
-                                st.session_state[f"edit_scheme_{scheme['name']}"] = (
-                                    False
-                                )
-                                st.session_state[f"view_scheme_{scheme['name']}"] = True
-                                show_message(
-                                    f"Scheme '{scheme['name']}' updated!", "success"
-                                )
-                                st.rerun()
+                                renamed = bool(new_name and new_name != scheme["name"])
+                                if renamed and not ont.rename_concept_scheme(
+                                    scheme["name"], new_name
+                                ):
+                                    show_message(
+                                        f"Cannot rename: '{new_name}' already exists!",
+                                        "error",
+                                    )
+                                else:
+                                    target = new_name if renamed else scheme["name"]
+                                    ont.update_concept_scheme(
+                                        target,
+                                        new_label=new_label,
+                                        new_comment=new_comment,
+                                    )
+                                    save_checkpoint("Update concept scheme")
+                                    st.session_state[
+                                        f"edit_scheme_{scheme['name']}"
+                                    ] = False
+                                    st.session_state[f"view_scheme_{target}"] = True
+                                    show_message(
+                                        f"Scheme '{target}' updated!", "success"
+                                    )
+                                    st.rerun()
 
         st.divider()
         st.subheader("Add Concept Scheme")
@@ -3204,6 +3234,14 @@ def render_skos_vocabulary():
                     if st.session_state.get(_ek, False):
                         st.divider()
                         with st.form(f"edit_concept_form_{_ck}"):
+                            new_name = st.text_input(
+                                "Name (URI local part)",
+                                value=concept["name"],
+                                key=f"cname_{_ck}",
+                                help="Renaming updates every reference to this "
+                                "concept (broader/narrower, inScheme, etc.) — "
+                                "nothing is lost, unlike delete-and-recreate.",
+                            )
                             new_pref = st.text_input(
                                 "Preferred Label",
                                 value=concept["prefLabel"] or "",
@@ -3255,51 +3293,72 @@ def render_skos_vocabulary():
                             )
 
                             if st.form_submit_button("Save Changes"):
-                                # Handle broader change
-                                broader_val = (
-                                    new_broader if new_broader != "None" else ""
-                                )
-                                old_broader = (
-                                    concept["broader"][0] if concept["broader"] else ""
-                                )
-                                broader_changed = broader_val != old_broader
+                                # Rename first (updates all references) so the
+                                # rest of the update targets the new name.
+                                renamed = bool(new_name and new_name != concept["name"])
+                                if renamed and not ont.rename_concept(
+                                    concept["name"], new_name
+                                ):
+                                    show_message(
+                                        f"Cannot rename: '{new_name}' already exists!",
+                                        "error",
+                                    )
+                                else:
+                                    target = new_name if renamed else concept["name"]
+                                    # Handle broader change
+                                    broader_val = (
+                                        new_broader if new_broader != "None" else ""
+                                    )
+                                    old_broader = (
+                                        concept["broader"][0]
+                                        if concept["broader"]
+                                        else ""
+                                    )
+                                    broader_changed = broader_val != old_broader
 
-                                # Handle scheme change
-                                old_scheme = (
-                                    concept["schemes"][0]
-                                    if concept.get("schemes")
-                                    else ""
-                                )
-                                new_scheme_val = (
-                                    new_scheme if new_scheme != "None" else ""
-                                )
-                                add_s = (
-                                    new_scheme_val
-                                    if new_scheme_val and new_scheme_val != old_scheme
-                                    else None
-                                )
-                                remove_s = (
-                                    old_scheme
-                                    if old_scheme and old_scheme != new_scheme_val
-                                    else None
-                                )
+                                    # Handle scheme change
+                                    old_scheme = (
+                                        concept["schemes"][0]
+                                        if concept.get("schemes")
+                                        else ""
+                                    )
+                                    new_scheme_val = (
+                                        new_scheme if new_scheme != "None" else ""
+                                    )
+                                    add_s = (
+                                        new_scheme_val
+                                        if new_scheme_val
+                                        and new_scheme_val != old_scheme
+                                        else None
+                                    )
+                                    remove_s = (
+                                        old_scheme
+                                        if old_scheme and old_scheme != new_scheme_val
+                                        else None
+                                    )
 
-                                _update_kwargs = dict(
-                                    new_pref_label=new_pref,
-                                    new_definition=new_def,
-                                    add_scheme=add_s,
-                                    remove_scheme=remove_s,
-                                )
-                                if broader_changed:
-                                    _update_kwargs["new_broader"] = broader_val
-                                ont.update_concept(concept["name"], **_update_kwargs)
-                                save_checkpoint("Update concept")
-                                st.session_state[_ek] = False
-                                st.session_state[_sk] = True
-                                show_message(
-                                    f"Concept '{concept['name']}' updated!", "success"
-                                )
-                                st.rerun()
+                                    _update_kwargs = dict(
+                                        new_pref_label=new_pref,
+                                        new_definition=new_def,
+                                        add_scheme=add_s,
+                                        remove_scheme=remove_s,
+                                    )
+                                    if broader_changed:
+                                        _update_kwargs["new_broader"] = broader_val
+                                    ont.update_concept(target, **_update_kwargs)
+                                    save_checkpoint("Update concept")
+                                    st.session_state[_ek] = False
+                                    if renamed:
+                                        _new_ck = str(
+                                            abs(hash(str(ont._uri(new_name))))
+                                        )[:8]
+                                        st.session_state[f"view_skos_{_new_ck}"] = True
+                                    else:
+                                        st.session_state[_sk] = True
+                                    show_message(
+                                        f"Concept '{target}' updated!", "success"
+                                    )
+                                    st.rerun()
 
         st.divider()
         st.subheader("Add Concept")

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -365,6 +365,22 @@ class OntologyManager:
         if new_parent:
             self.graph.add((class_uri, RDFS.subClassOf, self._uri(new_parent)))
 
+    # Entity types that share the local-name space; a rename target must not
+    # already be any of these, since they would collide on the same URI.
+    _ENTITY_TYPES = (
+        OWL.Class,
+        OWL.ObjectProperty,
+        OWL.DatatypeProperty,
+        OWL.NamedIndividual,
+        SKOS.Concept,
+        SKOS.ConceptScheme,
+    )
+
+    def _name_in_use(self, uri: URIRef) -> bool:
+        """True if `uri` is already defined as any class, property, individual,
+        SKOS concept or scheme. Guards renames against cross-type collisions."""
+        return any((uri, RDF.type, t) in self.graph for t in self._ENTITY_TYPES)
+
     def rename_class(self, old_name: str, new_name: str) -> bool:
         """Rename a class, updating all references."""
         if old_name == new_name:
@@ -373,8 +389,8 @@ class OntologyManager:
         old_uri = self._uri(old_name)
         new_uri = self._uri(new_name)
 
-        # Check if new name already exists
-        if (new_uri, RDF.type, OWL.Class) in self.graph:
+        # Refuse if the target name is already used by any entity (any type).
+        if self._name_in_use(new_uri):
             return False
 
         # Collect all triples to update
@@ -946,12 +962,8 @@ class OntologyManager:
         old_uri = self._uri(old_name)
         new_uri = self._uri(new_name)
 
-        # Check if new name already exists
-        if (new_uri, RDF.type, OWL.ObjectProperty) in self.graph or (
-            new_uri,
-            RDF.type,
-            OWL.DatatypeProperty,
-        ) in self.graph:
+        # Refuse if the target name is already used by any entity (any type).
+        if self._name_in_use(new_uri):
             return False
 
         # Collect all triples to update
@@ -1163,8 +1175,8 @@ class OntologyManager:
         old_uri = self._uri(old_name)
         new_uri = self._uri(new_name)
 
-        # Check if new name already exists
-        if (new_uri, RDF.type, OWL.NamedIndividual) in self.graph:
+        # Refuse if the target name is already used by any entity (any type).
+        if self._name_in_use(new_uri):
             return False
 
         # Collect all triples to update
@@ -1648,6 +1660,39 @@ class OntologyManager:
             if new_comment:
                 self.graph.add((uri, RDFS.comment, Literal(new_comment)))
 
+    def rename_concept_scheme(self, old_name: str, new_name: str) -> bool:
+        """Rename a SKOS ConceptScheme, updating all references.
+
+        Re-points every triple where the scheme is subject or object (including
+        the ``skos:inScheme`` links from its concepts), so no membership is lost.
+        """
+        if old_name == new_name:
+            return True
+
+        # Resolve the actual scheme URI from the graph (mirrors update/delete).
+        old_uri = self._uri(old_name)
+        for s_uri in self.graph.subjects(RDF.type, SKOS.ConceptScheme):
+            if self._local_name(s_uri) == old_name:
+                old_uri = cast(URIRef, s_uri)
+                break
+
+        new_uri = self._uri(new_name)
+        # Refuse if the target name is already used by any entity (any type).
+        if self._name_in_use(new_uri):
+            return False
+
+        updates: _TripleUpdates = []
+        for p, o in self.graph.predicate_objects(old_uri):
+            updates.append(((old_uri, p, o), (new_uri, p, o)))
+        for s, p in self.graph.subject_predicates(old_uri):
+            updates.append(((s, p, old_uri), (s, p, new_uri)))
+
+        for old_triple, new_triple in updates:
+            self.graph.remove(old_triple)
+            self.graph.add(new_triple)
+
+        return True
+
     def delete_concept_scheme(self, name: str):
         """Delete a ConceptScheme and remove inScheme references."""
         uri = self._uri(name)
@@ -1805,6 +1850,31 @@ class OntologyManager:
 
         if remove_scheme:
             self.graph.remove((uri, SKOS.inScheme, self._uri(remove_scheme)))
+
+    def rename_concept(self, old_name: str, new_name: str) -> bool:
+        """Rename a SKOS concept, updating all references."""
+        if old_name == new_name:
+            return True
+
+        old_uri = self._uri(old_name)
+        new_uri = self._uri(new_name)
+
+        # Refuse if the target name is already used by any entity (any type).
+        if self._name_in_use(new_uri):
+            return False
+
+        # Collect all triples to update (old_uri as subject and as object)
+        updates: _TripleUpdates = []
+        for p, o in self.graph.predicate_objects(old_uri):
+            updates.append(((old_uri, p, o), (new_uri, p, o)))
+        for s, p in self.graph.subject_predicates(old_uri):
+            updates.append(((s, p, old_uri), (s, p, new_uri)))
+
+        for old_triple, new_triple in updates:
+            self.graph.remove(old_triple)
+            self.graph.add(new_triple)
+
+        return True
 
     def add_concept_relation(self, concept1: str, relation: str, concept2: str):
         """Add a SKOS relation between two concepts.

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,0 +1,56 @@
+"""Tests for renaming entity names (URIs) with reference updates (issue #42)."""
+
+
+def _concept(om, name):
+    return next((c for c in om.get_concepts() if c["name"] == name), None)
+
+
+def test_rename_concept_updates_references(skos_om):
+    """Renaming a concept re-points broader/narrower links to the new name."""
+    assert skos_om.rename_concept("Animal", "Creature") is True
+    names = [c["name"] for c in skos_om.get_concepts()]
+    assert "Creature" in names
+    assert "Animal" not in names
+    # Dog was broader=Animal; it should now point to Creature.
+    dog = _concept(skos_om, "Dog")
+    assert dog is not None
+    assert "Creature" in dog["broader"]
+
+
+def test_rename_concept_scheme_preserves_membership(skos_om):
+    """Renaming a scheme keeps its concepts' inScheme membership."""
+    assert skos_om.rename_concept_scheme("MyScheme", "MyVocab") is True
+    scheme_names = [s["name"] for s in skos_om.get_concept_schemes()]
+    assert "MyVocab" in scheme_names
+    assert "MyScheme" not in scheme_names
+    members = [c["name"] for c in skos_om.get_concepts(scheme="MyVocab")]
+    assert {"Animal", "Dog", "Cat"} <= set(members)
+
+
+def test_rename_concept_duplicate_returns_false(skos_om):
+    assert skos_om.rename_concept("Dog", "Cat") is False
+    names = [c["name"] for c in skos_om.get_concepts()]
+    assert "Dog" in names
+
+
+def test_rename_class_blocked_by_individual(populated_om):
+    """Cross-type guard: a class cannot be renamed onto an individual's name."""
+    assert populated_om.rename_class("Person", "alice") is False
+    names = [c["name"] for c in populated_om.get_classes()]
+    assert "Person" in names
+
+
+def test_rename_class_blocked_by_property(populated_om):
+    assert populated_om.rename_class("Person", "worksFor") is False
+
+
+def test_rename_individual_blocked_by_class(populated_om):
+    assert populated_om.rename_individual("alice", "Person") is False
+    names = [i["name"] for i in populated_om.get_individuals()]
+    assert "alice" in names
+
+
+def test_rename_class_to_free_name_succeeds(populated_om):
+    assert populated_om.rename_class("Person", "Human") is True
+    names = [c["name"] for c in populated_om.get_classes()]
+    assert "Human" in names and "Person" not in names


### PR DESCRIPTION
Addresses #42.

## Finding
Renaming an entity's name/URI with reference updates already existed for **classes, properties, and individuals** (edit the "Name (URI local part)" field; `rename_*` rewrites every triple where the URI is subject or object). The reporter likely did not realise the Name field is a safe, non-destructive rename. Two real gaps remained, fixed here.

## Changes
**1. SKOS rename.** New `rename_concept` and `rename_concept_scheme` engine methods (mirroring `rename_class`, full reference updates), wired into the SKOS concept and scheme edit forms via a new "Name (URI local part)" field.
- Renaming a concept re-points its broader/narrower links and keeps its scheme membership.
- Renaming a scheme preserves every concept's `skos:inScheme` membership.

**2. Cross-type uniqueness.** Previously each rename only checked for a collision with the *same* entity type, so e.g. renaming a class onto an existing individual's name would collapse both onto one URI. A shared `_name_in_use` guard now refuses a rename if the target name is already any class / property / individual / concept / scheme.

**3. Discoverability.** Every "Name (URI local part)" field gains help text explaining that renaming updates all references (no delete-and-recreate needed).

## Verification
- Engine: `tests/test_rename.py` covers concept/scheme rename with reference preservation, same-type duplicates, and cross-type collisions (class↔individual, class↔property). 250 tests pass; ruff/mypy clean.
- Manual (SKOS Thesaurus template): renamed concept `NaturalScience` to `NatSci` and confirmed `Physics`/`Biology` broader links followed and narrower links were preserved; renamed scheme `MainScheme` to `CoreScheme` and confirmed all 6 concepts kept their membership. Edit view reopens on the renamed entity, no errors.