### PR TITLE
ci: publish to PyPI on version tags (Trusted Publishing)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+# Publishes the package to PyPI on every version tag (v*.*.*), using PyPI
+# Trusted Publishing (OIDC) — no API token is stored. workflow_dispatch is
+# also enabled so an existing tag can be backfilled (run against that tag's ref).
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    runs-on: ubuntu-latest
+    # Only run for version tags or a manual dispatch.
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    environment:
+      name: pypi
+      url: https://pypi.org/project/orionbelt-ontology-builder/
+    permissions:
+      id-token: write # required for Trusted Publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Check artifacts
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Addresses #40 (the `uv tool install` part, reported [here](https://github.com/ralforion/orionbelt-ontology-builder/issues/40#issuecomment-4811590370)).

## Problem
PyPI is stuck at **1.3.2**. Nothing in the release pipeline ever published to PyPI (it only does Docker + GitHub Releases), so every release since 1.3.2 — including the `orionbelt-ontology-builder` console entry point added in 1.6.2 — never reached PyPI. As a result `uv tool install orionbelt-ontology-builder` fetches 1.3.2, which predates the entry point, and fails to install an executable.

## Change
Adds `.github/workflows/pypi-publish.yml`: on every `v*.*.*` tag it builds the sdist + wheel and publishes to PyPI using **Trusted Publishing (OIDC)** — no API token stored. `workflow_dispatch` is enabled so an existing tag can be backfilled.

Verified the build locally: `twine check` passes for both artifacts, the wheel carries the `orionbelt-ontology-builder = orionbelt_ontology_builder.cli:run` entry point, and all 40 bundled data files (samples, lib, assets) are included — so the published package will run.

## One-time setup required (maintainer)
Trusted Publishing must be enabled on PyPI before the first run:
1. PyPI → project `orionbelt-ontology-builder` → **Settings → Publishing → Add a new trusted publisher** (GitHub Actions).
2. Owner: `ralforion`, Repository: `orionbelt-ontology-builder`, Workflow: `pypi-publish.yml`, Environment: `pypi`.

## Backfilling 1.7.0
After this merges and the publisher is configured, publish the current release without a new tag:
```
gh workflow run pypi-publish.yml --ref v1.7.0
```
Future tags publish automatically.