### PR TITLE
fix(annotations): make skos:example and other predicates deletable

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -2745,7 +2745,7 @@ def render_annotations():
                                 ):
                                     ont.delete_annotation(
                                         resource_name,
-                                        ann["predicate"],
+                                        ann.get("predicate_uri", ann["predicate"]),
                                         ann["value"],
                                         lang=ann.get("language"),
                                         datatype=ann.get("datatype"),
@@ -2872,7 +2872,9 @@ def render_annotations():
                 annotation_data.append(
                     {
                         "Resource": res["name"],
-                        "Predicate": a.get("predicate_label", ""),
+                        "Predicate": a.get(
+                            "predicate_prefixed", a.get("predicate", "")
+                        ),
                         "Value": a.get("value", ""),
                         "Language": a.get("language", ""),
                         "Action": "keep",

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -1374,6 +1374,49 @@ class OntologyManager:
 
     # ==================== ANNOTATION OPERATIONS ====================
 
+    # Common annotation predicate local names -> URIs. Shared by add and
+    # delete so the two never drift apart (a stale subset on delete is what
+    # made skos:example and others impossible to remove).
+    _ANNOTATION_PREDICATES = {
+        "label": RDFS.label,
+        "comment": RDFS.comment,
+        "seeAlso": RDFS.seeAlso,
+        "isDefinedBy": RDFS.isDefinedBy,
+        "prefLabel": SKOS.prefLabel,
+        "altLabel": SKOS.altLabel,
+        "definition": SKOS.definition,
+        "example": SKOS.example,
+        "note": SKOS.note,
+        "title": DCTERMS.title,
+        "description": DCTERMS.description,
+        "creator": DCTERMS.creator,
+        "contributor": DCTERMS.contributor,
+        "date": DCTERMS.date,
+        "deprecated": OWL.deprecated,
+    }
+
+    def _resolve_predicate_uri(self, predicate: str) -> URIRef:
+        """Resolve an annotation predicate to a URI.
+
+        Accepts a full URI, a known local name (label, comment, example, ...),
+        a ``prefix:local`` CURIE bound in the graph, or a bare local name
+        (falls back to the base namespace).
+        """
+        predicate = predicate.strip()
+        if predicate.startswith("http://") or predicate.startswith("https://"):
+            return URIRef(predicate)
+        mapped = self._ANNOTATION_PREDICATES.get(predicate)
+        if mapped is not None:
+            return mapped
+        if ":" in predicate:
+            prefix, _, local = predicate.partition(":")
+            for bound_prefix, ns in self.graph.namespaces():
+                if bound_prefix == prefix or (
+                    prefix == "(default)" and bound_prefix == ""
+                ):
+                    return URIRef(str(ns) + local)
+        return self._uri(predicate)
+
     def add_annotation(
         self, subject: str, predicate: str, value: str, lang: Optional[str] = None
     ):
@@ -1386,31 +1429,7 @@ class OntologyManager:
             lang: Optional language tag
         """
         subj_uri = self._uri(subject)
-
-        # Map common annotation names to URIs
-        annotation_predicates = {
-            "label": RDFS.label,
-            "comment": RDFS.comment,
-            "seeAlso": RDFS.seeAlso,
-            "isDefinedBy": RDFS.isDefinedBy,
-            "prefLabel": SKOS.prefLabel,
-            "altLabel": SKOS.altLabel,
-            "definition": SKOS.definition,
-            "example": SKOS.example,
-            "note": SKOS.note,
-            "title": DCTERMS.title,
-            "description": DCTERMS.description,
-            "creator": DCTERMS.creator,
-            "contributor": DCTERMS.contributor,
-            "date": DCTERMS.date,
-            "deprecated": OWL.deprecated,
-        }
-
-        # Check if predicate is a full URI
-        if predicate.startswith("http://") or predicate.startswith("https://"):
-            pred_uri = URIRef(predicate)
-        else:
-            pred_uri = annotation_predicates.get(predicate, self._uri(predicate))
+        pred_uri = self._resolve_predicate_uri(predicate)
 
         if lang:
             literal = Literal(value, lang=lang)
@@ -1552,17 +1571,7 @@ class OntologyManager:
         for any literal with a matching string value regardless of tag.
         """
         subj_uri = self._uri(subject)
-
-        annotation_predicates = {
-            "label": RDFS.label,
-            "comment": RDFS.comment,
-            "prefLabel": SKOS.prefLabel,
-            "altLabel": SKOS.altLabel,
-            "definition": SKOS.definition,
-            "note": SKOS.note,
-        }
-
-        pred_uri = annotation_predicates.get(predicate, self._uri(predicate))
+        pred_uri = self._resolve_predicate_uri(predicate)
 
         if value is None:
             self.graph.remove((subj_uri, pred_uri, None))

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -40,3 +40,59 @@ def test_delete_annotation_by_predicate_only(populated_om):
     populated_om.delete_annotation("Person", "comment")
     anns = populated_om.get_annotations("Person")
     assert not any(a["predicate"] == "comment" for a in anns)
+
+
+SKOS_EXAMPLE = "http://www.w3.org/2004/02/skos/core#example"
+
+
+def test_delete_skos_example_by_local_name(populated_om):
+    """Regression (#47): skos:example was undeletable because delete's
+    predicate map omitted it and fell back to the base namespace."""
+    populated_om.add_annotation("Person", "example", "An example")
+    populated_om.delete_annotation("Person", "example", "An example")
+    anns = populated_om.get_annotations("Person")
+    assert not any(a["predicate_uri"] == SKOS_EXAMPLE for a in anns)
+
+
+def test_delete_skos_example_by_full_uri(populated_om):
+    """The View Annotations bin button now passes the full predicate URI."""
+    populated_om.add_annotation("Person", "example", "An example")
+    populated_om.delete_annotation("Person", SKOS_EXAMPLE, "An example")
+    anns = populated_om.get_annotations("Person")
+    assert not any(a["predicate_uri"] == SKOS_EXAMPLE for a in anns)
+
+
+def test_delete_annotation_by_curie(populated_om):
+    """A bound prefix:local CURIE resolves to the right URI."""
+    populated_om.add_annotation("Person", "example", "An example")
+    populated_om.delete_annotation("Person", "skos:example", "An example")
+    anns = populated_om.get_annotations("Person")
+    assert not any(a["predicate_uri"] == SKOS_EXAMPLE for a in anns)
+
+
+def test_bulk_delete_skos_example(populated_om):
+    """Regression (#47): bulk 'delete' action must remove skos:example."""
+    populated_om.add_annotation("Person", "example", "An example")
+    result = populated_om.bulk_update_annotations(
+        [
+            {
+                "resource": "Person",
+                "predicate": "skos:example",
+                "value": "An example",
+                "action": "delete",
+            }
+        ]
+    )
+    assert result["applied"] == 1
+    assert not result["errors"]
+    anns = populated_om.get_annotations("Person")
+    assert not any(a["predicate_uri"] == SKOS_EXAMPLE for a in anns)
+
+
+def test_add_delete_roundtrip_all_common_predicates(populated_om):
+    """Every predicate add_annotation knows must also be deletable by name."""
+    for local in ("seeAlso", "definition", "note", "title", "example"):
+        populated_om.add_annotation("Person", local, f"v-{local}")
+        populated_om.delete_annotation("Person", local, f"v-{local}")
+    anns = populated_om.get_annotations("Person")
+    assert not any(a["value"].startswith("v-") for a in anns)


### PR DESCRIPTION
Addresses #47.

## Root cause
Three linked defects meant `skos:example` (and most non-core predicates) could not be deleted:

1. `delete_annotation` carried its **own** predicate-name map that was a stale subset of `add_annotation`'s (only label/comment/prefLabel/altLabel/definition/note). For anything else, it fell back to `self._uri(name)`, building a base-namespace URI like `…/ontology#example` that matches no triple, so the delete silently no-opped.
2. The **bin button** in *View Annotations* passed the predicate *local name* (`example`), feeding that broken lookup.
3. The **Bulk Edit** grid populated its Predicate column from `predicate_label`, a key `get_annotations` never returns, so the column was blank and every bulk `delete` failed with "Missing predicate".

## Fix
- New shared `_resolve_predicate_uri` (full URI / known local name / `prefix:local` CURIE bound in the graph / bare name → base ns), used by **both** `add_annotation` and `delete_annotation` so they can't drift apart again. The known-predicate map is now a single class constant.
- Bin button passes the full predicate URI (`predicate_uri`).
- Bulk grid shows the prefixed predicate (`predicate_prefixed`), which the CURIE resolver handles.

## Verification
- `tests/test_annotations.py` adds regressions: delete `skos:example` by local name, full URI, and CURIE; bulk delete of `skos:example`; and an add/delete roundtrip across seeAlso/definition/note/title/example. 259 tests pass; ruff/mypy clean.
- Manual (Organization template): added `skos:example` to a class, deleted it with the bin button (gone), and confirmed the Bulk Edit Predicate column is now populated (was blank).