### PR TITLE
feat(desktop): native desktop app launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.7.2](https://img.shields.io/badge/version-1.7.2-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.8.0](https://img.shields.io/badge/version-1.8.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -157,6 +157,22 @@ pipx run orionbelt-ontology-builder
 Any extra arguments are forwarded to Streamlit, e.g.
 `orionbelt-ontology-builder --server.port 8502`.
 
+### Run as a native desktop app
+
+Prefer a native window over a browser tab? Install the optional `desktop` extra
+and use the `orionbelt-ontology-builder-desktop` command. It runs the app in a
+native window (via [`streamlit-desktop-app`](https://pypi.org/project/streamlit-desktop-app/),
+pywebview + a real Streamlit server), so there is no browser tab to manage and no
+manual start/stop of the server:
+
+```bash
+pip install "orionbelt-ontology-builder[desktop]"
+orionbelt-ontology-builder-desktop    # opens a native window
+```
+
+This is fully opt-in: the plain install and the `orionbelt-ontology-builder`
+command above are unchanged.
+
 ### Run with Docker
 
 A prebuilt image is published to Docker Hub. No local Python setup required:
@@ -165,7 +181,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.7.2` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.8.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path as _Path
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.7.2"
+APP_VERSION = "1.8.0"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -1,0 +1,50 @@
+"""Native desktop launcher for the OrionBelt app.
+
+Exposed as the ``orionbelt-ontology-builder-desktop`` command (see
+``[project.scripts]`` in ``pyproject.toml``). It opens the app in a native
+window via :mod:`streamlit_desktop_app` (pywebview + a real Streamlit server),
+so there is no browser tab to manage and no manual start/stop of the server.
+
+``streamlit-desktop-app`` is an optional dependency; install it with the
+``desktop`` extra::
+
+    pip install "orionbelt-ontology-builder[desktop]"
+    orionbelt-ontology-builder-desktop
+
+This reuses the same in-package Streamlit entry script as the console launcher
+(:mod:`orionbelt_ontology_builder.cli`).
+"""
+
+import sys
+from pathlib import Path
+
+from .app import APP_NAME
+
+
+def run() -> None:
+    """Launch the app in a native desktop window.
+
+    Falls back to a helpful message (and a non-zero exit) when the optional
+    ``desktop`` extra is not installed.
+    """
+    try:
+        from streamlit_desktop_app import start_desktop_app
+    except ImportError:
+        print(
+            "The native desktop window needs the optional 'desktop' extra.\n"
+            'Install it with: pip install "orionbelt-ontology-builder[desktop]"',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    entry = Path(__file__).parent / "streamlit_entry.py"
+    start_desktop_app(
+        script_path=str(entry),
+        title=APP_NAME,
+        width=1280,
+        height=800,
+    )
+
+
+if __name__ == "__main__":
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.7.2"
+version = "1.8.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}
@@ -31,8 +31,12 @@ dependencies = [
 
 [project.scripts]
 orionbelt-ontology-builder = "orionbelt_ontology_builder.cli:run"
+orionbelt-ontology-builder-desktop = "orionbelt_ontology_builder.desktop:run"
 
 [project.optional-dependencies]
+desktop = [
+    "streamlit-desktop-app>=0.3.3",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -1,0 +1,48 @@
+"""Tests for the native desktop launcher (``orionbelt-ontology-builder-desktop``)."""
+
+import sys
+import types
+from importlib.metadata import entry_points
+
+import pytest
+
+import orionbelt_ontology_builder.desktop as desktop
+from orionbelt_ontology_builder.app import APP_NAME
+
+
+def test_entry_point_registered():
+    """The console_scripts entry point should map to ``desktop:run``."""
+    eps = [
+        ep
+        for ep in entry_points(group="console_scripts")
+        if ep.name == "orionbelt-ontology-builder-desktop"
+    ]
+    assert eps, "orionbelt-ontology-builder-desktop console script not registered"
+    assert eps[0].value == "orionbelt_ontology_builder.desktop:run"
+
+
+def test_run_invokes_start_desktop_app(monkeypatch):
+    """``run()`` should open the in-package entry script in a native window."""
+    captured = {}
+
+    def _fake_start_desktop_app(**kwargs):
+        captured.update(kwargs)
+
+    fake_module = types.ModuleType("streamlit_desktop_app")
+    fake_module.start_desktop_app = _fake_start_desktop_app
+    monkeypatch.setitem(sys.modules, "streamlit_desktop_app", fake_module)
+
+    desktop.run()
+
+    assert captured["script_path"].endswith("streamlit_entry.py")
+    assert captured["title"] == APP_NAME
+
+
+def test_run_without_dependency_exits_cleanly(monkeypatch):
+    """Missing the optional ``desktop`` extra should exit non-zero, not crash."""
+    monkeypatch.setitem(sys.modules, "streamlit_desktop_app", None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        desktop.run()
+
+    assert excinfo.value.code == 1


### PR DESCRIPTION
## What

Adds an opt-in **native desktop window** for the app, addressing the remaining native desktop request in #40 (the `uv tool install` console launcher already shipped in v1.6.2).

Uses [`streamlit-desktop-app`](https://pypi.org/project/streamlit-desktop-app/) (pywebview + a real Streamlit server), the dependable route from the issue discussion. Because it runs a real Streamlit server, every dependency works as-is, including `streamlit-local-storage` autosave (the part that would have been risky under stlite/Pyodide).

```bash
pip install "orionbelt-ontology-builder[desktop]"
orionbelt-ontology-builder-desktop    # opens a native window
```

## Changes

- New `orionbelt_ontology_builder/desktop.py`: `run()` opens the app in a native window (1280x800), reusing the in-package `streamlit_entry.py` already used by the console launcher. If the optional extra is missing it prints a friendly install hint and exits 1.
- New optional `desktop` extra (`streamlit-desktop-app>=0.3.3`) and a second console script `orionbelt-ontology-builder-desktop`.
- New `tests/test_desktop.py`: entry-point registration, the launch path (mocked), and the missing-dependency fallback.
- README: "Run as a native desktop app" subsection.
- Version bump 1.7.2 to 1.8.0.

## Notes

- Fully opt-in. The plain install and the existing `orionbelt-ontology-builder` (browser) command are unchanged.
- The extra installs and runs on Python 3.10 to 3.13 (`streamlit-desktop-app` metadata is `>=3.9`, no upper bound).
- Verified locally: full suite (262 passed), ruff clean, and the native window opens and autosaves on Python 3.13 / macOS.

## Scope

This covers the native window only. Standalone per-OS installers (PyInstaller + CI artifacts) are tracked as a follow-up in #54, so this intentionally does not close #40.

Refs #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
