### PR TITLE
feat(desktop): local file storage with crash recovery and a linked file

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,12 @@ command above are unchanged.
 When you launch the app locally (the `orionbelt-ontology-builder` command or the
 native desktop window), it persists to disk instead of browser storage:
 
-- **Crash recovery.** Your working ontology is mirrored to a recovery file under
-  `~/.orionbelt_ontology_builder/` on every change, so an unexpected close
-  (crash, freeze) is recovered automatically on the next launch.
+- **Crash recovery.** With no linked file set, your working ontology is saved to
+  a recovery file under `~/.orionbelt_ontology_builder/` on every change, so an
+  unexpected close (crash, freeze) is recovered automatically on the next launch.
+  When a linked file is set it becomes the store (below), and the recovery file
+  is only written as a fallback if a linked-file write fails — so each change is
+  one write, not two.
 - **Linked working file.** Use the sidebar's "Linked working file" control to
   point the app at any file path. If the file already exists, you choose whether
   to **load it** into the workspace (the default, so pointing at an existing

--- a/README.md
+++ b/README.md
@@ -199,7 +199,9 @@ that write completes, so a crash can lose at most the last second or two of
 edits. If a linked or recovery file can't be read or parsed on startup, disk
 autosave is paused (with a sidebar notice) so the unreadable file is never
 overwritten. The hosted demo on Streamlit Cloud has no local filesystem, so it
-keeps using per-browser autosave instead.
+keeps using per-browser autosave instead — which shares the same dirty/debounced
+scheduling and disables itself (until the graph shrinks) when an ontology exceeds
+the browser storage quota.
 
 ### Run with Docker
 

--- a/README.md
+++ b/README.md
@@ -182,13 +182,18 @@ native desktop window), it persists to disk instead of browser storage:
   `~/.orionbelt_ontology_builder/` on every change, so an unexpected close
   (crash, freeze) is recovered automatically on the next launch.
 - **Linked working file.** Use the sidebar's "Linked working file" control to
-  point the app at any file path. The app then tracks that file and reloads it on
-  startup. Point it at a synced folder (Nextcloud, Dropbox, ...) for fully
-  automatic off-machine backups.
+  point the app at any file path. If the file already exists, you choose whether
+  to **load it** into the workspace (the default, so pointing at an existing
+  ontology opens it) or **overwrite** it with the current ontology; a new path is
+  created from your current work. Once linked, the file tracks your working
+  ontology and is loaded again on startup. Point it at a synced folder
+  (Nextcloud, Dropbox, ...) for fully automatic off-machine backups.
 
-Writes are atomic, so a backup tool never sees a half-written file. The hosted
-demo on Streamlit Cloud has no local filesystem, so it keeps using per-browser
-autosave instead.
+Writes are atomic, so a backup tool never sees a half-written file. If a
+linked or recovery file can't be read or parsed on startup, disk autosave is
+paused (with a sidebar notice) so the unreadable file is never overwritten. The
+hosted demo on Streamlit Cloud has no local filesystem, so it keeps using
+per-browser autosave instead.
 
 ### Run with Docker
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,23 @@ orionbelt-ontology-builder-desktop    # opens a native window
 This is fully opt-in: the plain install and the `orionbelt-ontology-builder`
 command above are unchanged.
 
+### Local file storage
+
+When you launch the app locally (the `orionbelt-ontology-builder` command or the
+native desktop window), it persists to disk instead of browser storage:
+
+- **Crash recovery.** Your working ontology is mirrored to a recovery file under
+  `~/.orionbelt_ontology_builder/` on every change, so an unexpected close
+  (crash, freeze) is recovered automatically on the next launch.
+- **Linked working file.** Use the sidebar's "Linked working file" control to
+  point the app at any file path. The app then tracks that file and reloads it on
+  startup. Point it at a synced folder (Nextcloud, Dropbox, ...) for fully
+  automatic off-machine backups.
+
+Writes are atomic, so a backup tool never sees a half-written file. The hosted
+demo on Streamlit Cloud has no local filesystem, so it keeps using per-browser
+autosave instead.
+
 ### Run with Docker
 
 A prebuilt image is published to Docker Hub. No local Python setup required:

--- a/README.md
+++ b/README.md
@@ -187,13 +187,19 @@ native desktop window), it persists to disk instead of browser storage:
   ontology opens it) or **overwrite** it with the current ontology; a new path is
   created from your current work. Once linked, the file tracks your working
   ontology and is loaded again on startup. Point it at a synced folder
-  (Nextcloud, Dropbox, ...) for fully automatic off-machine backups.
+  (Nextcloud, Dropbox, ...) for fully automatic off-machine backups. The format
+  follows the file extension (`.ttl`, `.owl`/`.rdf`, `.nt`, `.n3`, `.jsonld`;
+  Turtle if unknown).
 
-Writes are atomic, so a backup tool never sees a half-written file. If a
-linked or recovery file can't be read or parsed on startup, disk autosave is
-paused (with a sidebar notice) so the unreadable file is never overwritten. The
-hosted demo on Streamlit Cloud has no local filesystem, so it keeps using
-per-browser autosave instead.
+Autosave is gated on actual edits and debounced, so normal clicking around does
+no work even for large ontologies — the graph is serialized straight to a temp
+file and atomically swapped in only after edits settle (and immediately after an
+import or a new-ontology action). The sidebar shows "Saved to disk" only once
+that write completes, so a crash can lose at most the last second or two of
+edits. If a linked or recovery file can't be read or parsed on startup, disk
+autosave is paused (with a sidebar notice) so the unreadable file is never
+overwritten. The hosted demo on Streamlit Cloud has no local filesystem, so it
+keeps using per-browser autosave instead.
 
 ### Run with Docker
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6,6 +6,7 @@ and managing OWL ontologies.
 import hashlib
 import logging
 import streamlit as st
+import time
 import traceback
 from datetime import datetime
 from pathlib import Path as _Path
@@ -27,6 +28,11 @@ GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/iss
 AUTOSAVE_KEY = "orionbelt_ontology_builder_autosave"
 # localStorage is ~5 MB per origin; stay well under to leave headroom.
 AUTOSAVE_MAX_BYTES = 4_000_000
+# Disk autosave (local/desktop) is gated on the mutation counter and debounced:
+# the graph is only serialized when it actually changed and edits have settled,
+# so normal UI reruns do no work even for large ontologies. Important actions
+# (import, new ontology, linking a file) force an immediate flush.
+AUTOSAVE_DEBOUNCE_SECONDS = 2.0
 
 _FAVICON = _Path(__file__).parent / "favicon.png"
 
@@ -183,6 +189,13 @@ def _get_local_storage():
     return ls
 
 
+def _rdf_format_for_path(path):
+    """rdflib format for a file path (Turtle if the extension is unknown)."""
+    from .ontology_manager import rdf_format_for_path
+
+    return rdf_format_for_path(path)
+
+
 def _disk_restore_source():
     """Return ``(path, label)`` to restore from on a local run, else ``(None, None)``.
 
@@ -208,18 +221,24 @@ def _block_disk_persist(message: str) -> None:
     st.session_state["_disk_persist_block_msg"] = message
 
 
-def _mark_disk_source_hash(label: str, h: str) -> None:
-    """Record the restored-from file's hash so it isn't immediately rewritten.
+def _current_mutation_count() -> int:
+    """The app's monotonic graph-change counter (bumped on every mutation)."""
+    return st.session_state.get("_ont_mutation_count", 0)
+
+
+def _mark_disk_source_saved(label: str) -> None:
+    """Record that the restored-from file is already current at this revision.
 
     Only the file we actually read is up to date; the other target is left
-    unset so the next persist refreshes it from the restored graph.
+    behind so the next persist refreshes it from the restored graph.
     """
+    mc = _current_mutation_count()
     if label == "linked file":
-        st.session_state["_linked_last_hash"] = h
-        st.session_state["_recovery_last_hash"] = None
+        st.session_state["_linked_saved_rev"] = mc
+        st.session_state["_recovery_saved_rev"] = None
     else:
-        st.session_state["_recovery_last_hash"] = h
-        st.session_state["_linked_last_hash"] = None
+        st.session_state["_recovery_saved_rev"] = mc
+        st.session_state["_linked_saved_rev"] = None
 
 
 def _restore_autosave_from_disk(ont):
@@ -227,33 +246,25 @@ def _restore_autosave_from_disk(ont):
 
     Disk reads are synchronous (unlike the browser component, which delivers
     data on a later rerun), so this resolves in a single pass and always marks
-    the session restored.
+    the session restored. Parses straight from the file (no whole-file string in
+    memory) and pauses disk autosave if the file can't be read or parsed, so a
+    bad file is never overwritten.
     """
     st.session_state["_autosave_restored"] = True
     path, label = _disk_restore_source()
     if path is None:
         return
-    saved = local_store.read_text(path)
-    if saved is None:
-        # The file exists (see _disk_restore_source) but is unreadable. Don't let
-        # persistence clobber it with the current graph.
-        _block_disk_persist(
-            f"Couldn't read the {label}. Disk autosave is paused so it isn't "
-            "overwritten — fix or re-link the file, then reload."
-        )
-        return
-    if not saved.strip():
-        return
+    fmt = "turtle" if label == "recovery file" else _rdf_format_for_path(path)
     try:
-        ont.load_from_string(saved, format="turtle")
+        ont.load_from_file(str(path), format=fmt)
     except Exception as e:
         log_error(e, context="Autosave restore (disk)")
         _block_disk_persist(
-            f"The {label} couldn't be parsed. Disk autosave is paused so the "
-            "file isn't overwritten — fix or re-link it, then reload."
+            f"The {label} couldn't be read or parsed. Disk autosave is paused so "
+            "it isn't overwritten — fix or re-link it, then reload."
         )
         return
-    _mark_disk_source_hash(label, _content_hash(saved))
+    _mark_disk_source_saved(label)
     # An empty-but-valid saved graph is loaded silently; nothing to announce.
     if _ontology_is_empty(ont):
         return
@@ -343,41 +354,58 @@ def maybe_restore_autosave():
 def _persist_autosave_to_disk():
     """Mirror the working ontology to disk on a local/desktop run.
 
-    Keeps the crash-recovery snapshot current and mirrors to the user's linked
-    file when one is set. No size cap (these are real files). The recovery and
-    linked targets are tracked with independent hashes so each is deduped on its
-    own and a failed write to one is retried on the next rerun even if the
-    ontology hasn't changed since — letting a transient permission/sync error
-    recover without waiting for the next edit.
+    Gated on the mutation counter so normal UI reruns do *no* work (no
+    serialization, no hashing) even for large ontologies: a target is written
+    only when the graph changed since it was last saved. Writes are debounced —
+    once edits settle for AUTOSAVE_DEBOUNCE_SECONDS — and coalesce rapid edits,
+    while important actions force an immediate flush via ``_force_disk_flush``.
+    Recovery and linked file track their save revisions independently, so one
+    failed linked write neither suppresses recovery nor blocks its own retry.
+
+    Tradeoff: edits made in the last debounce window before a crash may be lost;
+    the sidebar shows "Saved to disk" only once the flush has completed.
     """
     # A failed restore (unreadable/corrupt recovery or linked file) pauses disk
     # writes so we never overwrite a file we couldn't load.
     if st.session_state.get("_disk_persist_blocked"):
         return
 
-    try:
-        ttl = st.session_state.ontology.export_to_string(format="turtle")
-    except Exception as e:
-        log_error(e, context="Autosave export (disk)")
-        return
-
-    h = _content_hash(ttl)
-
-    if h != st.session_state.get("_recovery_last_hash"):
-        try:
-            local_store.atomic_write(local_store.recovery_file(), ttl)
-            st.session_state["_recovery_last_hash"] = h
-        except OSError as e:
-            # Leave the hash unset so the next rerun retries the recovery write.
-            log_error(e, context="Recovery write")
+    mc = _current_mutation_count()
+    # Stamp the time whenever the graph changes, so the debounce measures idle
+    # time since the last edit.
+    if mc != st.session_state.get("_disk_last_seen_rev"):
+        st.session_state["_disk_last_seen_rev"] = mc
+        st.session_state["_disk_last_mutation_at"] = time.time()
 
     linked = local_store.get_linked_path()
-    if linked is not None and h != st.session_state.get("_linked_last_hash"):
+    recovery_dirty = mc != st.session_state.get("_recovery_saved_rev")
+    linked_dirty = linked is not None and mc != st.session_state.get(
+        "_linked_saved_rev"
+    )
+    if not (recovery_dirty or linked_dirty):
+        return  # nothing changed — the common rerun does no work
+
+    force = st.session_state.pop("_force_disk_flush", False)
+    settled = (
+        time.time() - st.session_state.get("_disk_last_mutation_at", 0.0)
+        >= AUTOSAVE_DEBOUNCE_SECONDS
+    )
+    if not force and not settled:
+        return  # wait for edits to settle; a later rerun flushes
+
+    ont = st.session_state.ontology
+    if recovery_dirty:
         try:
-            local_store.atomic_write(linked, ttl)
-            # Only record the hash on success, so a failed write retries next
-            # rerun even though the content is unchanged.
-            st.session_state["_linked_last_hash"] = h
+            ont.save_to_file(local_store.recovery_file(), format="turtle")
+            st.session_state["_recovery_saved_rev"] = mc
+        except OSError as e:
+            # Leave the revision unset so the next rerun retries.
+            log_error(e, context="Recovery write")
+
+    if linked_dirty:
+        try:
+            ont.save_to_file(linked, format=_rdf_format_for_path(linked))
+            st.session_state["_linked_saved_rev"] = mc
             st.session_state["_linked_write_warned"] = False
         except OSError as e:
             log_error(e, context="Linked-file write")
@@ -435,33 +463,32 @@ def persist_autosave():
 def _load_linked_file(target) -> bool:
     """Replace the working ontology with the contents of ``target``.
 
-    Returns True on success. Used when linking to an existing, non-empty file so
-    "point at my Nextcloud ontology" opens that file instead of overwriting it.
+    Returns True on success. Used when linking to an existing file so "point at
+    my Nextcloud ontology" opens that file instead of overwriting it. Parses
+    straight from the path, in the format implied by its extension.
     """
-    saved = local_store.read_text(target)
-    if saved is None or not saved.strip():
-        return False
     try:
         OntologyManager = get_ontology_manager_class()
         new_ont = OntologyManager()
-        new_ont.load_from_string(saved, format="turtle")
+        new_ont.load_from_file(str(target), format=_rdf_format_for_path(target))
     except Exception as e:
         log_error(e, context="Linked file load")
         return False
     st.session_state.ontology = new_ont
-    h = _content_hash(saved)
-    # The linked file already holds this content; refresh recovery from it next.
-    st.session_state["_linked_last_hash"] = h
-    st.session_state["_recovery_last_hash"] = None
+    st.session_state["_ont_mutation_count"] = (
+        st.session_state.get("_ont_mutation_count", 0) + 1
+    )
+    # The linked file already holds this content at the new revision; recovery is
+    # left behind so the next flush refreshes it from the loaded graph.
+    mc = _current_mutation_count()
+    st.session_state["_linked_saved_rev"] = mc
+    st.session_state["_recovery_saved_rev"] = None
     try:
         from .ontology_manager import UndoManager
 
         st.session_state.undo_manager = UndoManager(new_ont)
     except ImportError:
         pass
-    st.session_state["_ont_mutation_count"] = (
-        st.session_state.get("_ont_mutation_count", 0) + 1
-    )
     return True
 
 
@@ -481,15 +508,20 @@ def _render_disk_autosave_sidebar():
             "set one below."
         ),
     )
-    if (
-        st.session_state.get("_autosave_enabled", True)
-        and (
-            st.session_state.get("_recovery_last_hash")
-            or st.session_state.get("_linked_last_hash")
-        )
-        and not _ontology_is_empty(st.session_state.ontology)
+    if st.session_state.get("_autosave_enabled", True) and not _ontology_is_empty(
+        st.session_state.ontology
     ):
-        st.sidebar.caption("✓ Saved to disk")
+        # Report saved state truthfully: only "saved" once the debounced flush
+        # has caught up to the current revision.
+        mc = _current_mutation_count()
+        saved = st.session_state.get("_recovery_saved_rev") == mc and (
+            local_store.get_linked_path() is None
+            or st.session_state.get("_linked_saved_rev") == mc
+        )
+        if saved:
+            st.sidebar.caption("✓ Saved to disk")
+        elif st.session_state.get("_recovery_saved_rev") is not None:
+            st.sidebar.caption("• Autosaving…")
 
     linked = local_store.get_linked_path()
     with st.sidebar.expander("Linked working file", expanded=linked is not None):
@@ -541,6 +573,9 @@ def _render_disk_autosave_sidebar():
                     # A fresh link clears any earlier restore-failure pause.
                     st.session_state["_disk_persist_blocked"] = False
                     st.session_state.pop("_disk_persist_block_msg", None)
+                    # Linking a file is an important action: flush immediately
+                    # rather than waiting out the debounce window.
+                    st.session_state["_force_disk_flush"] = True
                     if load_it:
                         if _load_linked_file(_Path(p).expanduser()):
                             st.toast(f"Linked and loaded {p}", icon="🔗")
@@ -553,7 +588,7 @@ def _render_disk_autosave_sidebar():
                             st.toast(f"Linked {p}, but couldn't load it", icon="⚠️")
                     else:
                         # New file or an explicit overwrite: write current state.
-                        st.session_state["_linked_last_hash"] = None
+                        st.session_state["_linked_saved_rev"] = None
                         st.toast(f"Linked working file: {p}", icon="🔗")
                     st.rerun()
         with clear_col:
@@ -626,6 +661,15 @@ def save_checkpoint(label: str = "Edit"):
     st.session_state["_ont_mutation_count"] = (
         st.session_state.get("_ont_mutation_count", 0) + 1
     )
+
+
+def request_disk_flush():
+    """Force the next disk autosave to write now, skipping the debounce window.
+
+    Call after important actions (import, new ontology) so a large, deliberate
+    change is persisted immediately rather than waiting for edits to settle.
+    """
+    st.session_state["_force_disk_flush"] = True
 
 
 def log_error(error: Exception, context: str = ""):
@@ -3832,6 +3876,7 @@ def render_import_export():
                 ont.load_from_string(content, format=format_)
                 st.session_state.ontology = ont
                 save_checkpoint("Import ontology")
+                request_disk_flush()
                 set_flash_message(
                     f"Ontology imported successfully! ({len(ont.graph)} triples)",
                     "success",
@@ -3992,6 +4037,7 @@ def render_import_export():
                             )
                         st.session_state.ontology = ont
                         save_checkpoint("Import ontology")
+                        request_disk_flush()
                         st.session_state.import_preview = None
                         st.session_state.import_content = None
                         st.session_state.import_format = None
@@ -4142,6 +4188,12 @@ def render_import_export():
                     st.session_state.undo_manager = UndoManager(
                         st.session_state.ontology
                     )
+                    # Replacing the graph is a deliberate change; bump the
+                    # revision and flush it to disk immediately.
+                    st.session_state["_ont_mutation_count"] = (
+                        st.session_state.get("_ont_mutation_count", 0) + 1
+                    )
+                    request_disk_flush()
                     show_message("New ontology created!", "success")
                     st.rerun()
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -10,6 +10,8 @@ import traceback
 from datetime import datetime
 from pathlib import Path as _Path
 
+from . import local_store
+
 APP_NAME = "OrionBelt Ontology Builder"
 APP_VERSION = "1.8.0"
 
@@ -181,6 +183,58 @@ def _get_local_storage():
     return ls
 
 
+def _disk_restore_source():
+    """Return ``(path, label)`` to restore from on a local run, else ``(None, None)``.
+
+    Prefers the user's linked working file; falls back to the crash-recovery
+    snapshot written by :func:`persist_autosave`.
+    """
+    linked = local_store.get_linked_path()
+    if linked is not None and linked.exists():
+        return linked, "linked file"
+    rec = local_store.recovery_file()
+    if rec.exists():
+        return rec, "recovery file"
+    return None, None
+
+
+def _restore_autosave_from_disk(ont):
+    """Restore the working ontology from disk on a local/desktop run.
+
+    Disk reads are synchronous (unlike the browser component, which delivers
+    data on a later rerun), so this resolves in a single pass and always marks
+    the session restored.
+    """
+    st.session_state["_autosave_restored"] = True
+    path, label = _disk_restore_source()
+    if path is None:
+        return
+    saved = local_store.read_text(path)
+    if not saved or not saved.strip():
+        return
+    try:
+        ont.load_from_string(saved, format="turtle")
+    except Exception as e:
+        log_error(e, context="Autosave restore (disk)")
+        return
+    st.session_state["_autosave_last_hash"] = _content_hash(saved)
+    # An empty-but-valid saved graph is loaded silently; nothing to announce.
+    if _ontology_is_empty(ont):
+        return
+    try:
+        from .ontology_manager import UndoManager
+
+        st.session_state.undo_manager = UndoManager(ont)
+    except ImportError:
+        pass
+    st.session_state["_ont_mutation_count"] = (
+        st.session_state.get("_ont_mutation_count", 0) + 1
+    )
+    if st.session_state.get("nav_radio") == "Import / Export":
+        st.session_state["nav_radio"] = "Dashboard"
+    st.toast(f"Restored your previous session from the {label}.", icon="💾")
+
+
 def maybe_restore_autosave():
     """Restore the ontology from browser localStorage when a session starts.
 
@@ -198,6 +252,11 @@ def maybe_restore_autosave():
     # there is nothing left to restore.
     if not _ontology_is_empty(ont):
         st.session_state["_autosave_restored"] = True
+        return
+
+    # Local/desktop runs persist to disk instead of browser localStorage.
+    if local_store.local_persist_enabled():
+        _restore_autosave_from_disk(ont)
         return
 
     ls = _get_local_storage()
@@ -245,6 +304,45 @@ def maybe_restore_autosave():
     st.toast("Restored your previous session from this browser's autosave.", icon="💾")
 
 
+def _persist_autosave_to_disk():
+    """Mirror the working ontology to disk on a local/desktop run.
+
+    Always keeps the crash-recovery snapshot current, and mirrors to the user's
+    linked file when one is set. No size cap (these are real files) and deduped
+    by content hash so an unchanged graph isn't rewritten — which would
+    otherwise churn a synced linked folder.
+    """
+    try:
+        ttl = st.session_state.ontology.export_to_string(format="turtle")
+    except Exception as e:
+        log_error(e, context="Autosave export (disk)")
+        return
+
+    h = _content_hash(ttl)
+    if h == st.session_state.get("_autosave_last_hash"):
+        return
+
+    try:
+        local_store.atomic_write(local_store.recovery_file(), ttl)
+    except OSError as e:
+        # Leave the hash unset so the next rerun retries the recovery write.
+        log_error(e, context="Recovery write")
+        return
+
+    linked = local_store.get_linked_path()
+    if linked is not None:
+        try:
+            local_store.atomic_write(linked, ttl)
+            st.session_state["_linked_write_warned"] = False
+        except OSError as e:
+            log_error(e, context="Linked-file write")
+            if not st.session_state.get("_linked_write_warned"):
+                st.session_state["_linked_write_warned"] = True
+                st.sidebar.warning(f"Couldn't write the linked file: {e}")
+
+    st.session_state["_autosave_last_hash"] = h
+
+
 def persist_autosave():
     """Mirror the current ontology into browser localStorage when it changed.
 
@@ -257,6 +355,12 @@ def persist_autosave():
     # would overwrite saved data before it can be read back on a later rerun.
     if not st.session_state.get("_autosave_restored"):
         return
+
+    # Local/desktop runs persist to disk instead of browser localStorage.
+    if local_store.local_persist_enabled():
+        _persist_autosave_to_disk()
+        return
+
     ls = _get_local_storage()
     if ls is None:
         return
@@ -285,8 +389,69 @@ def persist_autosave():
     st.session_state["_autosave_last_hash"] = h
 
 
+def _render_disk_autosave_sidebar():
+    """Sidebar controls for the local disk-backed autosave and linked file."""
+    st.sidebar.checkbox(
+        "Autosave to disk",
+        value=st.session_state.get("_autosave_enabled", True),
+        key="_autosave_enabled",
+        help=(
+            "Mirrors your ontology to a recovery file on this machine so an "
+            "unexpected close can be recovered, and to a linked file if you "
+            "set one below."
+        ),
+    )
+    if (
+        st.session_state.get("_autosave_enabled", True)
+        and st.session_state.get("_autosave_last_hash")
+        and not _ontology_is_empty(st.session_state.ontology)
+    ):
+        st.sidebar.caption("✓ Saved to disk")
+
+    linked = local_store.get_linked_path()
+    with st.sidebar.expander("Linked working file", expanded=linked is not None):
+        st.caption(
+            "Point this at a file in a synced folder (Nextcloud, Dropbox, ...) "
+            "for automatic off-machine backups. It tracks your working ontology "
+            "and is loaded again on startup."
+        )
+        path_str = st.text_input(
+            "File path",
+            value=str(linked) if linked else "",
+            key="_linked_path_input",
+            placeholder="/path/to/my-ontology.ttl",
+        )
+        set_col, clear_col = st.columns(2)
+        with set_col:
+            if st.button("Link", use_container_width=True, key="_linked_set"):
+                p = path_str.strip()
+                if p:
+                    local_store.set_linked_path(p)
+                    # Force a write to the new target on the next rerun.
+                    st.session_state["_autosave_last_hash"] = None
+                    st.session_state["_linked_write_warned"] = False
+                    st.toast(f"Linked working file: {p}", icon="🔗")
+                    st.rerun()
+        with clear_col:
+            if st.button(
+                "Unlink",
+                use_container_width=True,
+                key="_linked_clear",
+                disabled=linked is None,
+            ):
+                local_store.set_linked_path(None)
+                st.toast("Unlinked working file.", icon="🔗")
+                st.rerun()
+        if linked is not None:
+            st.caption(f"Linked: `{linked}`")
+
+
 def render_autosave_sidebar():
     """Sidebar controls: toggle autosave and discard the saved session."""
+    # Local/desktop runs persist to disk and get a different control set.
+    if local_store.local_persist_enabled():
+        _render_disk_autosave_sidebar()
+        return
     ls = _get_local_storage()
     if ls is None:
         return

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -395,12 +395,15 @@ def _persist_autosave_to_disk():
     """Mirror the working ontology to disk on a local/desktop run.
 
     Gated on the mutation counter so normal UI reruns do *no* work (no
-    serialization, no hashing) even for large ontologies: a target is written
-    only when the graph changed since it was last saved. Writes are debounced —
-    once edits settle for AUTOSAVE_DEBOUNCE_SECONDS — and coalesce rapid edits,
-    while important actions force an immediate flush via request_autosave_flush.
-    Recovery and linked file track their save revisions independently, so one
-    failed linked write neither suppresses recovery nor blocks its own retry.
+    serialization, no hashing) even for large ontologies: the graph is written
+    only when it changed since the last save. Writes are debounced — once edits
+    settle for AUTOSAVE_DEBOUNCE_SECONDS — and coalesce rapid edits, while
+    important actions force an immediate flush via request_autosave_flush.
+
+    One write per change, not two: when a linked file is set it *is* the
+    persistent store (restore prefers it), so the recovery snapshot is only
+    written as a fallback if the linked write fails (e.g. a synced folder is
+    offline). With no linked file, the recovery snapshot is the store.
 
     Tradeoff: edits made in the last debounce window before a crash may be lost;
     the sidebar shows "Saved to disk" only once the flush has completed.
@@ -411,38 +414,41 @@ def _persist_autosave_to_disk():
         return
 
     mc = _autosave_tick()
-    linked = local_store.get_linked_path()
-    recovery_dirty = mc != st.session_state.get("_recovery_saved_rev")
-    linked_dirty = linked is not None and mc != st.session_state.get(
-        "_linked_saved_rev"
-    )
-    if not (recovery_dirty or linked_dirty):
-        return  # nothing changed — the common rerun does no work
-    if not _autosave_ready():
-        return  # wait for edits to settle; a later rerun flushes
-
     ont = st.session_state.ontology
-    if recovery_dirty:
-        try:
-            ont.save_to_file(local_store.recovery_file(), format="turtle")
-            st.session_state["_recovery_saved_rev"] = mc
-        except OSError as e:
-            # Leave the revision unset so the next rerun retries.
-            log_error(e, context="Recovery write")
+    linked = local_store.get_linked_path()
 
-    if linked_dirty:
+    if linked is not None:
+        if mc == st.session_state.get("_linked_saved_rev"):
+            return  # linked store already current
+        if not _autosave_ready():
+            return
         try:
             ont.save_to_file(linked, format=_rdf_format_for_path(linked))
             st.session_state["_linked_saved_rev"] = mc
             st.session_state["_linked_write_warned"] = False
+            st.session_state.pop("_force_autosave_flush", None)
+            return  # linked file is the store; no second write
         except OSError as e:
             log_error(e, context="Linked-file write")
             if not st.session_state.get("_linked_write_warned"):
                 st.session_state["_linked_write_warned"] = True
-                st.sidebar.warning(f"Couldn't write the linked file: {e}")
+                st.sidebar.warning(
+                    f"Couldn't write the linked file: {e}. "
+                    "Falling back to the local recovery snapshot."
+                )
+            # Fall through to write recovery as a safety net for these edits.
 
-    # The forced flush is consumed once a write pass has run for any backend.
-    st.session_state.pop("_force_autosave_flush", None)
+    if mc == st.session_state.get("_recovery_saved_rev"):
+        return
+    if not _autosave_ready():
+        return
+    try:
+        ont.save_to_file(local_store.recovery_file(), format="turtle")
+        st.session_state["_recovery_saved_rev"] = mc
+        st.session_state.pop("_force_autosave_flush", None)
+    except OSError as e:
+        # Leave the revision unset so the next rerun retries.
+        log_error(e, context="Recovery write")
 
 
 def _persist_autosave_to_localstorage():
@@ -530,11 +536,10 @@ def _load_linked_file(target) -> bool:
     st.session_state["_ont_mutation_count"] = (
         st.session_state.get("_ont_mutation_count", 0) + 1
     )
-    # The linked file already holds this content at the new revision; recovery is
-    # left behind so the next flush refreshes it from the loaded graph.
-    mc = _current_mutation_count()
-    st.session_state["_linked_saved_rev"] = mc
-    st.session_state["_recovery_saved_rev"] = None
+    # The linked file already holds this content at the new revision, so it
+    # won't be rewritten on the next flush. (Recovery is a fallback only, so it
+    # isn't refreshed while a healthy linked file is the store.)
+    st.session_state["_linked_saved_rev"] = _current_mutation_count()
     try:
         from .ontology_manager import UndoManager
 
@@ -555,24 +560,26 @@ def _render_disk_autosave_sidebar():
         value=st.session_state.get("_autosave_enabled", True),
         key="_autosave_enabled",
         help=(
-            "Mirrors your ontology to a recovery file on this machine so an "
-            "unexpected close can be recovered, and to a linked file if you "
-            "set one below."
+            "Saves your ontology to a linked file if you set one below, "
+            "otherwise to a recovery file on this machine so an unexpected "
+            "close can be recovered."
         ),
     )
     if st.session_state.get("_autosave_enabled", True) and not _ontology_is_empty(
         st.session_state.ontology
     ):
-        # Report saved state truthfully: only "saved" once the debounced flush
-        # has caught up to the current revision.
+        # Track the active store: the linked file when set, else recovery. Report
+        # "saved" only once the debounced flush has caught up to the revision.
         mc = _current_mutation_count()
-        saved = st.session_state.get("_recovery_saved_rev") == mc and (
-            local_store.get_linked_path() is None
-            or st.session_state.get("_linked_saved_rev") == mc
+        active_key = (
+            "_linked_saved_rev"
+            if local_store.get_linked_path() is not None
+            else "_recovery_saved_rev"
         )
-        if saved:
+        saved_rev = st.session_state.get(active_key)
+        if saved_rev == mc:
             st.sidebar.caption("✓ Saved to disk")
-        elif st.session_state.get("_recovery_saved_rev") is not None:
+        elif saved_rev is not None:
             st.sidebar.caption("• Autosaving…")
 
     linked = local_store.get_linked_path()

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -3914,6 +3914,12 @@ def render_import_export():
                 from .ontology_manager import UndoManager
 
                 st.session_state.undo_manager = UndoManager(st.session_state.ontology)
+                # Replacing the graph is a deliberate change; bump the revision
+                # and flush so the cleared state is persisted immediately.
+                st.session_state["_ont_mutation_count"] = (
+                    st.session_state.get("_ont_mutation_count", 0) + 1
+                )
+                request_autosave_flush()
                 st.session_state["_ontology_cleared"] = "Ontology cleared!"
                 st.rerun()
 
@@ -4258,6 +4264,7 @@ def render_import_export():
             else:
                 ont.merge_from_string(rendered, "turtle")
             save_checkpoint(f"Apply template: {selected}")
+            request_autosave_flush()
             s = ont.get_statistics()
             st.session_state["_template_msg"] = (
                 f"Template '{selected}' applied! "
@@ -4328,6 +4335,7 @@ def render_import_export():
                         ont.merge_from_string(content, "turtle")
                 mod_names = ", ".join(m["name"] for m in selected_modules)
                 save_checkpoint(f"Load upper ontology: {upper['name']} ({mod_names})")
+                request_autosave_flush()
                 s = ont.get_statistics()
                 st.session_state["_upper_onto_msg"] = (
                     f"Loaded {upper['name']} ({mod_names})! "
@@ -4421,6 +4429,7 @@ def render_import_export():
                             ont.merge_from_string(content, fmt)
                 mod_names = ", ".join(m["name"] for m in selected_modules)
                 save_checkpoint(f"Load reference ontology: {ref['name']} ({mod_names})")
+                request_autosave_flush()
                 s = ont.get_statistics()
                 st.session_state["_ref_onto_msg"] = (
                     f"Loaded {ref['name']} ({mod_names})! "
@@ -4828,6 +4837,7 @@ def render_validation():
             try:
                 new_triples = ont.apply_reasoning(profile=profile[1])
                 save_checkpoint("Apply reasoning")
+                request_autosave_flush()
                 show_message(
                     f"Reasoning complete! {new_triples} new triples inferred.",
                     "success",

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -198,6 +198,30 @@ def _disk_restore_source():
     return None, None
 
 
+def _block_disk_persist(message: str) -> None:
+    """Stop disk autosave for the session and record why.
+
+    Used when an existing recovery/linked file can't be read or parsed, so the
+    end-of-rerun persistence never overwrites a file we failed to load.
+    """
+    st.session_state["_disk_persist_blocked"] = True
+    st.session_state["_disk_persist_block_msg"] = message
+
+
+def _mark_disk_source_hash(label: str, h: str) -> None:
+    """Record the restored-from file's hash so it isn't immediately rewritten.
+
+    Only the file we actually read is up to date; the other target is left
+    unset so the next persist refreshes it from the restored graph.
+    """
+    if label == "linked file":
+        st.session_state["_linked_last_hash"] = h
+        st.session_state["_recovery_last_hash"] = None
+    else:
+        st.session_state["_recovery_last_hash"] = h
+        st.session_state["_linked_last_hash"] = None
+
+
 def _restore_autosave_from_disk(ont):
     """Restore the working ontology from disk on a local/desktop run.
 
@@ -210,14 +234,26 @@ def _restore_autosave_from_disk(ont):
     if path is None:
         return
     saved = local_store.read_text(path)
-    if not saved or not saved.strip():
+    if saved is None:
+        # The file exists (see _disk_restore_source) but is unreadable. Don't let
+        # persistence clobber it with the current graph.
+        _block_disk_persist(
+            f"Couldn't read the {label}. Disk autosave is paused so it isn't "
+            "overwritten — fix or re-link the file, then reload."
+        )
+        return
+    if not saved.strip():
         return
     try:
         ont.load_from_string(saved, format="turtle")
     except Exception as e:
         log_error(e, context="Autosave restore (disk)")
+        _block_disk_persist(
+            f"The {label} couldn't be parsed. Disk autosave is paused so the "
+            "file isn't overwritten — fix or re-link it, then reload."
+        )
         return
-    st.session_state["_autosave_last_hash"] = _content_hash(saved)
+    _mark_disk_source_hash(label, _content_hash(saved))
     # An empty-but-valid saved graph is loaded silently; nothing to announce.
     if _ontology_is_empty(ont):
         return
@@ -307,11 +343,18 @@ def maybe_restore_autosave():
 def _persist_autosave_to_disk():
     """Mirror the working ontology to disk on a local/desktop run.
 
-    Always keeps the crash-recovery snapshot current, and mirrors to the user's
-    linked file when one is set. No size cap (these are real files) and deduped
-    by content hash so an unchanged graph isn't rewritten — which would
-    otherwise churn a synced linked folder.
+    Keeps the crash-recovery snapshot current and mirrors to the user's linked
+    file when one is set. No size cap (these are real files). The recovery and
+    linked targets are tracked with independent hashes so each is deduped on its
+    own and a failed write to one is retried on the next rerun even if the
+    ontology hasn't changed since — letting a transient permission/sync error
+    recover without waiting for the next edit.
     """
+    # A failed restore (unreadable/corrupt recovery or linked file) pauses disk
+    # writes so we never overwrite a file we couldn't load.
+    if st.session_state.get("_disk_persist_blocked"):
+        return
+
     try:
         ttl = st.session_state.ontology.export_to_string(format="turtle")
     except Exception as e:
@@ -319,28 +362,28 @@ def _persist_autosave_to_disk():
         return
 
     h = _content_hash(ttl)
-    if h == st.session_state.get("_autosave_last_hash"):
-        return
 
-    try:
-        local_store.atomic_write(local_store.recovery_file(), ttl)
-    except OSError as e:
-        # Leave the hash unset so the next rerun retries the recovery write.
-        log_error(e, context="Recovery write")
-        return
+    if h != st.session_state.get("_recovery_last_hash"):
+        try:
+            local_store.atomic_write(local_store.recovery_file(), ttl)
+            st.session_state["_recovery_last_hash"] = h
+        except OSError as e:
+            # Leave the hash unset so the next rerun retries the recovery write.
+            log_error(e, context="Recovery write")
 
     linked = local_store.get_linked_path()
-    if linked is not None:
+    if linked is not None and h != st.session_state.get("_linked_last_hash"):
         try:
             local_store.atomic_write(linked, ttl)
+            # Only record the hash on success, so a failed write retries next
+            # rerun even though the content is unchanged.
+            st.session_state["_linked_last_hash"] = h
             st.session_state["_linked_write_warned"] = False
         except OSError as e:
             log_error(e, context="Linked-file write")
             if not st.session_state.get("_linked_write_warned"):
                 st.session_state["_linked_write_warned"] = True
                 st.sidebar.warning(f"Couldn't write the linked file: {e}")
-
-    st.session_state["_autosave_last_hash"] = h
 
 
 def persist_autosave():
@@ -389,8 +432,45 @@ def persist_autosave():
     st.session_state["_autosave_last_hash"] = h
 
 
+def _load_linked_file(target) -> bool:
+    """Replace the working ontology with the contents of ``target``.
+
+    Returns True on success. Used when linking to an existing, non-empty file so
+    "point at my Nextcloud ontology" opens that file instead of overwriting it.
+    """
+    saved = local_store.read_text(target)
+    if saved is None or not saved.strip():
+        return False
+    try:
+        OntologyManager = get_ontology_manager_class()
+        new_ont = OntologyManager()
+        new_ont.load_from_string(saved, format="turtle")
+    except Exception as e:
+        log_error(e, context="Linked file load")
+        return False
+    st.session_state.ontology = new_ont
+    h = _content_hash(saved)
+    # The linked file already holds this content; refresh recovery from it next.
+    st.session_state["_linked_last_hash"] = h
+    st.session_state["_recovery_last_hash"] = None
+    try:
+        from .ontology_manager import UndoManager
+
+        st.session_state.undo_manager = UndoManager(new_ont)
+    except ImportError:
+        pass
+    st.session_state["_ont_mutation_count"] = (
+        st.session_state.get("_ont_mutation_count", 0) + 1
+    )
+    return True
+
+
 def _render_disk_autosave_sidebar():
     """Sidebar controls for the local disk-backed autosave and linked file."""
+    if st.session_state.get("_disk_persist_blocked"):
+        st.sidebar.warning(
+            st.session_state.get("_disk_persist_block_msg", "Disk autosave is paused.")
+        )
     st.sidebar.checkbox(
         "Autosave to disk",
         value=st.session_state.get("_autosave_enabled", True),
@@ -403,7 +483,10 @@ def _render_disk_autosave_sidebar():
     )
     if (
         st.session_state.get("_autosave_enabled", True)
-        and st.session_state.get("_autosave_last_hash")
+        and (
+            st.session_state.get("_recovery_last_hash")
+            or st.session_state.get("_linked_last_hash")
+        )
         and not _ontology_is_empty(st.session_state.ontology)
     ):
         st.sidebar.caption("✓ Saved to disk")
@@ -421,16 +504,57 @@ def _render_disk_autosave_sidebar():
             key="_linked_path_input",
             placeholder="/path/to/my-ontology.ttl",
         )
+
+        # Decide up front whether the chosen path is an existing, non-empty file.
+        # If so, default to LOADING it (the issue's "open my ontology" workflow)
+        # rather than silently overwriting it with the current graph.
+        typed = path_str.strip()
+        target = _Path(typed).expanduser() if typed else None
+        file_has_content = bool(
+            target
+            and target.exists()
+            and target.is_file()
+            and (local_store.read_text(target) or "").strip()
+        )
+        existing_action = None
+        if file_has_content:
+            existing_action = st.radio(
+                "That file already exists:",
+                [
+                    "Load it into the workspace",
+                    "Overwrite it with the current ontology",
+                ],
+                key="_linked_existing_action",
+            )
+
         set_col, clear_col = st.columns(2)
         with set_col:
             if st.button("Link", use_container_width=True, key="_linked_set"):
                 p = path_str.strip()
                 if p:
+                    load_it = (
+                        file_has_content
+                        and existing_action == "Load it into the workspace"
+                    )
                     local_store.set_linked_path(p)
-                    # Force a write to the new target on the next rerun.
-                    st.session_state["_autosave_last_hash"] = None
                     st.session_state["_linked_write_warned"] = False
-                    st.toast(f"Linked working file: {p}", icon="🔗")
+                    # A fresh link clears any earlier restore-failure pause.
+                    st.session_state["_disk_persist_blocked"] = False
+                    st.session_state.pop("_disk_persist_block_msg", None)
+                    if load_it:
+                        if _load_linked_file(_Path(p).expanduser()):
+                            st.toast(f"Linked and loaded {p}", icon="🔗")
+                        else:
+                            # Couldn't load it; don't overwrite either.
+                            _block_disk_persist(
+                                "Couldn't load the linked file. Disk autosave is "
+                                "paused so it isn't overwritten."
+                            )
+                            st.toast(f"Linked {p}, but couldn't load it", icon="⚠️")
+                    else:
+                        # New file or an explicit overwrite: write current state.
+                        st.session_state["_linked_last_hash"] = None
+                        st.toast(f"Linked working file: {p}", icon="🔗")
                     st.rerun()
         with clear_col:
             if st.button(

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -226,6 +226,43 @@ def _current_mutation_count() -> int:
     return st.session_state.get("_ont_mutation_count", 0)
 
 
+# ---- Shared autosave scheduling (backend-agnostic) -----------------------
+# Both backends (browser localStorage and local disk) use the same dirty +
+# debounce gate so a no-mutation rerun does zero work — no serialization, no
+# hashing — regardless of graph size. Each backend then implements its own
+# write (string into localStorage, or stream-to-temp-file on disk).
+
+
+def _autosave_tick() -> int:
+    """Stamp the time when the graph changes; return the current revision.
+
+    Idempotent within a rerun, so calling it from multiple targets is safe.
+    """
+    mc = _current_mutation_count()
+    if mc != st.session_state.get("_autosave_seen_rev"):
+        st.session_state["_autosave_seen_rev"] = mc
+        st.session_state["_autosave_mutated_at"] = time.time()
+    return mc
+
+
+def _autosave_ready() -> bool:
+    """True when a dirty target should be written now (forced or settled)."""
+    if st.session_state.get("_force_autosave_flush"):
+        return True
+    idle = time.time() - st.session_state.get("_autosave_mutated_at", 0.0)
+    return idle >= AUTOSAVE_DEBOUNCE_SECONDS
+
+
+def request_autosave_flush() -> None:
+    """Force the next autosave to write now, skipping the debounce window.
+
+    Call after important actions (import, new ontology, linking a file) so a
+    large, deliberate change is persisted immediately. Applies to whichever
+    backend is active.
+    """
+    st.session_state["_force_autosave_flush"] = True
+
+
 def _mark_disk_source_saved(label: str) -> None:
     """Record that the restored-from file is already current at this revision.
 
@@ -329,10 +366,11 @@ def maybe_restore_autosave():
         return
 
     st.session_state["_autosave_restored"] = True
-    st.session_state["_autosave_last_hash"] = _content_hash(saved)
     # An empty-but-valid saved graph (e.g. after a discard) is loaded silently;
     # there is no work to announce or navigate to.
     if _ontology_is_empty(ont):
+        # localStorage already holds this content; don't rewrite it.
+        st.session_state["_ls_saved_rev"] = _current_mutation_count()
         return
     # Rebuild undo history so the restored graph becomes the baseline state.
     try:
@@ -344,6 +382,8 @@ def maybe_restore_autosave():
     st.session_state["_ont_mutation_count"] = (
         st.session_state.get("_ont_mutation_count", 0) + 1
     )
+    # localStorage already holds this content at the new revision.
+    st.session_state["_ls_saved_rev"] = _current_mutation_count()
     # init_session_state parks empty sessions on Import/Export; with content
     # restored, the Dashboard is the more useful landing page.
     if st.session_state.get("nav_radio") == "Import / Export":
@@ -358,7 +398,7 @@ def _persist_autosave_to_disk():
     serialization, no hashing) even for large ontologies: a target is written
     only when the graph changed since it was last saved. Writes are debounced —
     once edits settle for AUTOSAVE_DEBOUNCE_SECONDS — and coalesce rapid edits,
-    while important actions force an immediate flush via ``_force_disk_flush``.
+    while important actions force an immediate flush via request_autosave_flush.
     Recovery and linked file track their save revisions independently, so one
     failed linked write neither suppresses recovery nor blocks its own retry.
 
@@ -370,13 +410,7 @@ def _persist_autosave_to_disk():
     if st.session_state.get("_disk_persist_blocked"):
         return
 
-    mc = _current_mutation_count()
-    # Stamp the time whenever the graph changes, so the debounce measures idle
-    # time since the last edit.
-    if mc != st.session_state.get("_disk_last_seen_rev"):
-        st.session_state["_disk_last_seen_rev"] = mc
-        st.session_state["_disk_last_mutation_at"] = time.time()
-
+    mc = _autosave_tick()
     linked = local_store.get_linked_path()
     recovery_dirty = mc != st.session_state.get("_recovery_saved_rev")
     linked_dirty = linked is not None and mc != st.session_state.get(
@@ -384,13 +418,7 @@ def _persist_autosave_to_disk():
     )
     if not (recovery_dirty or linked_dirty):
         return  # nothing changed — the common rerun does no work
-
-    force = st.session_state.pop("_force_disk_flush", False)
-    settled = (
-        time.time() - st.session_state.get("_disk_last_mutation_at", 0.0)
-        >= AUTOSAVE_DEBOUNCE_SECONDS
-    )
-    if not force and not settled:
+    if not _autosave_ready():
         return  # wait for edits to settle; a later rerun flushes
 
     ont = st.session_state.ontology
@@ -413,12 +441,62 @@ def _persist_autosave_to_disk():
                 st.session_state["_linked_write_warned"] = True
                 st.sidebar.warning(f"Couldn't write the linked file: {e}")
 
+    # The forced flush is consumed once a write pass has run for any backend.
+    st.session_state.pop("_force_autosave_flush", None)
+
+
+def _persist_autosave_to_localstorage():
+    """Mirror the working ontology into browser localStorage when it changed.
+
+    Same dirty + debounce gate as the disk backend, so a no-mutation rerun does
+    no work and a large ontology isn't re-serialized every rerun just to fail the
+    size check. An over-quota graph disables browser autosave until the next
+    mutation (e.g. the graph shrinks back under the cap).
+    """
+    ls = _get_local_storage()
+    if ls is None:
+        return
+
+    mc = _autosave_tick()
+    if mc == st.session_state.get("_ls_saved_rev"):
+        return  # unchanged — no serialize, no hashing
+    if st.session_state.get("_ls_oversized_rev") == mc:
+        return  # already known too big at this revision; wait for a change
+    if not _autosave_ready():
+        return
+
+    try:
+        ttl = st.session_state.ontology.export_to_string(format="turtle")
+    except Exception as e:
+        log_error(e, context="Autosave export")
+        return
+
+    if len(ttl.encode("utf-8")) > AUTOSAVE_MAX_BYTES:
+        # Disable until the next mutation rather than re-serializing every rerun.
+        st.session_state["_ls_oversized_rev"] = mc
+        if not st.session_state.get("_autosave_too_big_warned"):
+            st.session_state["_autosave_too_big_warned"] = True
+            st.sidebar.warning(
+                "Ontology is too large to autosave to this browser. "
+                "Export it manually so you don't lose work."
+            )
+        return
+
+    # Key the write by content hash so each distinct save mounts a fresh
+    # component instance — reusing one key across reruns can leave the component
+    # writing a stale/wrapped value.
+    h = _content_hash(ttl)
+    ls.setItem(AUTOSAVE_KEY, ttl, key=f"orionbelt_autosave_set_{h[:12]}")
+    st.session_state["_ls_saved_rev"] = mc
+    st.session_state["_autosave_too_big_warned"] = False
+    st.session_state.pop("_force_autosave_flush", None)
+
 
 def persist_autosave():
-    """Mirror the current ontology into browser localStorage when it changed.
+    """Persist the working ontology via the active backend (disk or browser).
 
-    Called at the end of each rerun. Skips when autosave is disabled, unchanged
-    since the last save, or too large for localStorage.
+    Called at the end of each rerun. Skips when autosave is disabled or before
+    restore has resolved; the backend itself does nothing when nothing changed.
     """
     if not st.session_state.get("_autosave_enabled", True):
         return
@@ -430,34 +508,8 @@ def persist_autosave():
     # Local/desktop runs persist to disk instead of browser localStorage.
     if local_store.local_persist_enabled():
         _persist_autosave_to_disk()
-        return
-
-    ls = _get_local_storage()
-    if ls is None:
-        return
-    try:
-        ttl = st.session_state.ontology.export_to_string(format="turtle")
-    except Exception as e:
-        log_error(e, context="Autosave export")
-        return
-
-    if len(ttl.encode("utf-8")) > AUTOSAVE_MAX_BYTES:
-        if not st.session_state.get("_autosave_too_big_warned"):
-            st.session_state["_autosave_too_big_warned"] = True
-            st.sidebar.warning(
-                "Ontology is too large to autosave to this browser. "
-                "Export it manually so you don't lose work."
-            )
-        return
-
-    h = _content_hash(ttl)
-    if h == st.session_state.get("_autosave_last_hash"):
-        return
-    # Key the write by content hash so each distinct save mounts a fresh
-    # component instance — reusing one key across reruns can leave the component
-    # writing a stale/wrapped value.
-    ls.setItem(AUTOSAVE_KEY, ttl, key=f"orionbelt_autosave_set_{h[:12]}")
-    st.session_state["_autosave_last_hash"] = h
+    else:
+        _persist_autosave_to_localstorage()
 
 
 def _load_linked_file(target) -> bool:
@@ -575,7 +627,7 @@ def _render_disk_autosave_sidebar():
                     st.session_state.pop("_disk_persist_block_msg", None)
                     # Linking a file is an important action: flush immediately
                     # rather than waiting out the debounce window.
-                    st.session_state["_force_disk_flush"] = True
+                    st.session_state["_force_autosave_flush"] = True
                     if load_it:
                         if _load_linked_file(_Path(p).expanduser()):
                             st.toast(f"Linked and loaded {p}", icon="🔗")
@@ -626,7 +678,7 @@ def render_autosave_sidebar():
     )
     if (
         st.session_state.get("_autosave_enabled", True)
-        and st.session_state.get("_autosave_last_hash")
+        and st.session_state.get("_ls_saved_rev") == _current_mutation_count()
         and not _ontology_is_empty(st.session_state.ontology)
     ):
         st.sidebar.caption("✓ Saved in this browser")
@@ -645,10 +697,14 @@ def render_autosave_sidebar():
             st.session_state.undo_manager = UndoManager(st.session_state.ontology)
         except ImportError:
             st.session_state.undo_manager = None
-        st.session_state["_autosave_last_hash"] = None
+        # Mark dirty and force an immediate flush so the now-empty graph
+        # overwrites the saved copy via the dependable setItem path.
+        st.session_state["_ls_saved_rev"] = None
+        st.session_state["_ls_oversized_rev"] = None
         st.session_state["_ont_mutation_count"] = (
             st.session_state.get("_ont_mutation_count", 0) + 1
         )
+        request_autosave_flush()
         st.toast("Cleared this browser's autosave and reset the workspace.", icon="🗑️")
         st.rerun()
 
@@ -661,15 +717,6 @@ def save_checkpoint(label: str = "Edit"):
     st.session_state["_ont_mutation_count"] = (
         st.session_state.get("_ont_mutation_count", 0) + 1
     )
-
-
-def request_disk_flush():
-    """Force the next disk autosave to write now, skipping the debounce window.
-
-    Call after important actions (import, new ontology) so a large, deliberate
-    change is persisted immediately rather than waiting for edits to settle.
-    """
-    st.session_state["_force_disk_flush"] = True
 
 
 def log_error(error: Exception, context: str = ""):
@@ -3876,7 +3923,7 @@ def render_import_export():
                 ont.load_from_string(content, format=format_)
                 st.session_state.ontology = ont
                 save_checkpoint("Import ontology")
-                request_disk_flush()
+                request_autosave_flush()
                 set_flash_message(
                     f"Ontology imported successfully! ({len(ont.graph)} triples)",
                     "success",
@@ -4037,7 +4084,7 @@ def render_import_export():
                             )
                         st.session_state.ontology = ont
                         save_checkpoint("Import ontology")
-                        request_disk_flush()
+                        request_autosave_flush()
                         st.session_state.import_preview = None
                         st.session_state.import_content = None
                         st.session_state.import_format = None
@@ -4193,7 +4240,7 @@ def render_import_export():
                     st.session_state["_ont_mutation_count"] = (
                         st.session_state.get("_ont_mutation_count", 0) + 1
                     )
-                    request_disk_flush()
+                    request_autosave_flush()
                     show_message("New ontology created!", "success")
                     st.rerun()
 

--- a/orionbelt_ontology_builder/cli.py
+++ b/orionbelt_ontology_builder/cli.py
@@ -9,7 +9,7 @@ import os
 import sys
 from pathlib import Path
 
-from .local_store import ENV_FLAG
+from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG
 
 
 def run() -> None:
@@ -26,6 +26,10 @@ def run() -> None:
     # disk-backed autosave / linked-file persistence (the cloud deployment runs
     # ``streamlit run app.py`` directly and never sets this).
     os.environ[ENV_FLAG] = "1"
+    # Apply the brand theme regardless of CWD: config.toml is only found when
+    # launched from the repo root, so without this the console/desktop runs fall
+    # back to Streamlit's default red. setdefault lets a user override win.
+    os.environ.setdefault("STREAMLIT_THEME_PRIMARY_COLOR", BRAND_PRIMARY_COLOR)
 
     entry = Path(__file__).parent / "streamlit_entry.py"
     sys.argv = ["streamlit", "run", str(entry), *sys.argv[1:]]

--- a/orionbelt_ontology_builder/cli.py
+++ b/orionbelt_ontology_builder/cli.py
@@ -5,8 +5,11 @@ Exposed as the ``orionbelt-ontology-builder`` command (see
 run without ``streamlit run`` — e.g. ``uv tool install`` / ``uvx`` / ``pipx``.
 """
 
+import os
 import sys
 from pathlib import Path
+
+from .local_store import ENV_FLAG
 
 
 def run() -> None:
@@ -18,6 +21,11 @@ def run() -> None:
         orionbelt-ontology-builder --server.port 8502
     """
     from streamlit.web import cli as stcli
+
+    # This is a local launch with full filesystem access, so opt into the
+    # disk-backed autosave / linked-file persistence (the cloud deployment runs
+    # ``streamlit run app.py`` directly and never sets this).
+    os.environ[ENV_FLAG] = "1"
 
     entry = Path(__file__).parent / "streamlit_entry.py"
     sys.argv = ["streamlit", "run", str(entry), *sys.argv[1:]]

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -15,10 +15,12 @@ This reuses the same in-package Streamlit entry script as the console launcher
 (:mod:`orionbelt_ontology_builder.cli`).
 """
 
+import os
 import sys
 from pathlib import Path
 
 from .app import APP_NAME
+from .local_store import ENV_FLAG
 
 
 def run() -> None:
@@ -36,6 +38,10 @@ def run() -> None:
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # Running locally with full filesystem access — opt into the disk-backed
+    # autosave / linked-file persistence (off by default on the cloud).
+    os.environ[ENV_FLAG] = "1"
 
     entry = Path(__file__).parent / "streamlit_entry.py"
     start_desktop_app(

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -20,7 +20,7 @@ import sys
 from pathlib import Path
 
 from .app import APP_NAME
-from .local_store import ENV_FLAG
+from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG
 
 
 def run() -> None:
@@ -42,6 +42,10 @@ def run() -> None:
     # Running locally with full filesystem access — opt into the disk-backed
     # autosave / linked-file persistence (off by default on the cloud).
     os.environ[ENV_FLAG] = "1"
+    # The desktop subprocess inherits this env, so the brand colour applies even
+    # though config.toml isn't found outside the repo (otherwise Streamlit's
+    # default red shows). setdefault lets a user override win.
+    os.environ.setdefault("STREAMLIT_THEME_PRIMARY_COLOR", BRAND_PRIMARY_COLOR)
 
     entry = Path(__file__).parent / "streamlit_entry.py"
     start_desktop_app(

--- a/orionbelt_ontology_builder/local_store.py
+++ b/orionbelt_ontology_builder/local_store.py
@@ -29,6 +29,12 @@ from pathlib import Path
 #: Env var the local launchers set to opt the filesystem features in.
 ENV_FLAG = "ORIONBELT_LOCAL_PERSIST"
 
+#: Brand primary colour, mirroring ``.streamlit/config.toml`` ``[theme]``. The
+#: launchers export it as ``STREAMLIT_THEME_PRIMARY_COLOR`` so the brand colour
+#: applies even when launched outside the repo (where config.toml isn't found
+#: and Streamlit would otherwise fall back to its default red).
+BRAND_PRIMARY_COLOR = "#0D2B7A"
+
 #: Per-user application data directory (created on demand).
 _DIR_NAME = ".orionbelt_ontology_builder"
 #: Crash-recovery snapshot the app mirrors the working ontology into.

--- a/orionbelt_ontology_builder/local_store.py
+++ b/orionbelt_ontology_builder/local_store.py
@@ -1,0 +1,133 @@
+"""Local-filesystem persistence for the desktop / locally launched app.
+
+The hosted Streamlit Cloud deployment must never write to the local filesystem,
+so every feature here is gated behind :func:`local_persist_enabled`, which only
+returns ``True`` when the launcher set the ``ORIONBELT_LOCAL_PERSIST`` env var.
+The local launchers (:mod:`orionbelt_ontology_builder.cli` and
+:mod:`orionbelt_ontology_builder.desktop`) set it; ``streamlit run app.py`` on
+the cloud does not, so the app falls back to its browser-``localStorage``
+autosave there.
+
+Two disk-backed mechanisms live on top of these helpers (wired up in
+``app.py``):
+
+* a **recovery file** (:func:`recovery_file`) that the app mirrors the working
+  ontology into on every change, so an unexpected close (crash, freeze) can be
+  recovered from on the next launch; and
+* an optional **linked working file** whose path the user chooses
+  (:func:`get_linked_path` / :func:`set_linked_path`). Pointing it at a synced
+  folder (Nextcloud, Dropbox, ...) gives fully automatic off-machine backups.
+
+No third-party dependencies: only the standard library is used.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+#: Env var the local launchers set to opt the filesystem features in.
+ENV_FLAG = "ORIONBELT_LOCAL_PERSIST"
+
+#: Per-user application data directory (created on demand).
+_DIR_NAME = ".orionbelt_ontology_builder"
+#: Crash-recovery snapshot the app mirrors the working ontology into.
+_RECOVERY_NAME = "recovery.ttl"
+#: Small JSON config persisting cross-session settings (e.g. the linked path).
+_CONFIG_NAME = "config.json"
+
+
+def local_persist_enabled() -> bool:
+    """True when the launcher opted this run into filesystem persistence.
+
+    Only the local launchers set :data:`ENV_FLAG`; the cloud deployment runs
+    ``streamlit run app.py`` without it, so disk access stays off there.
+    """
+    return os.environ.get(ENV_FLAG, "").strip() not in ("", "0", "false", "False")
+
+
+def data_dir() -> Path:
+    """Return (creating if needed) the per-user application data directory."""
+    d = Path.home() / _DIR_NAME
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def recovery_file() -> Path:
+    """Path of the crash-recovery snapshot inside :func:`data_dir`."""
+    return data_dir() / _RECOVERY_NAME
+
+
+def config_file() -> Path:
+    """Path of the JSON settings file inside :func:`data_dir`."""
+    return data_dir() / _CONFIG_NAME
+
+
+def atomic_write(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` atomically.
+
+    Writes to a temp file in the same directory and ``os.replace``s it into
+    place, so a crash or a backup tool reading mid-write never sees a partial
+    or corrupt file.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        # Never leave the partial temp file behind on failure.
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def read_text(path: Path) -> str | None:
+    """Return the text contents of ``path``, or ``None`` if it can't be read."""
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def load_config() -> dict:
+    """Load the settings dict, returning ``{}`` when absent or unreadable."""
+    raw = read_text(config_file())
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_config(config: dict) -> None:
+    """Persist the settings dict to :func:`config_file`."""
+    atomic_write(config_file(), json.dumps(config, indent=2))
+
+
+def get_linked_path() -> Path | None:
+    """Return the user's linked working-file path, or ``None`` if unset."""
+    p = load_config().get("linked_path")
+    if isinstance(p, str) and p.strip():
+        return Path(p).expanduser()
+    return None
+
+
+def set_linked_path(path: str | os.PathLike | None) -> None:
+    """Set (or clear, when ``path`` is falsy) the linked working-file path."""
+    config = load_config()
+    if path:
+        config["linked_path"] = str(path)
+    else:
+        config.pop("linked_path", None)
+    save_config(config)

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2,12 +2,35 @@
 OntologyManager - Core class for managing OWL ontologies using rdflib.
 """
 
+import os
+import tempfile
+from pathlib import Path
 from rdflib import Graph, Namespace, URIRef, Literal, BNode
 from rdflib.namespace import RDF, RDFS, OWL, XSD, SKOS, DC, DCTERMS
 from rdflib.term import Node
 from rdflib.collection import Collection
 from typing import Optional, List, Dict, Tuple, Any, Set, cast
 import owlrl
+
+#: RDF serialization format for a file, keyed by lower-case extension. Used so a
+#: linked working file can be a format other than Turtle (e.g. .owl/.rdf).
+RDF_FORMAT_BY_SUFFIX = {
+    ".ttl": "turtle",
+    ".turtle": "turtle",
+    ".owl": "xml",
+    ".rdf": "xml",
+    ".xml": "xml",
+    ".nt": "nt",
+    ".n3": "n3",
+    ".jsonld": "json-ld",
+    ".json": "json-ld",
+}
+
+
+def rdf_format_for_path(path, default: str = "turtle") -> str:
+    """Return the rdflib format for ``path`` based on its extension."""
+    return RDF_FORMAT_BY_SUFFIX.get(Path(path).suffix.lower(), default)
+
 
 _UNSET: Any = object()  # sentinel: "parameter not provided"
 
@@ -2391,6 +2414,32 @@ class OntologyManager:
         self.graph = Graph()
         self.graph.parse(file_path, format=format)
         self._update_namespace_from_graph()
+
+    def save_to_file(self, file_path, format: Optional[str] = None) -> None:
+        """Serialize the graph straight to ``file_path``, atomically.
+
+        Streams the serialization to a temp file in the same directory via
+        ``Graph.serialize(destination=...)`` and then ``os.replace``s it into
+        place, so no giant in-memory string is built and a reader/backup tool
+        never sees a half-written file. ``format`` defaults to the file's
+        extension (Turtle if unknown).
+        """
+        fmt = format or rdf_format_for_path(file_path)
+        p = Path(file_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            dir=str(p.parent), prefix=p.name + ".", suffix=".tmp"
+        )
+        os.close(fd)
+        try:
+            self.graph.serialize(destination=tmp, format=fmt)
+            os.replace(tmp, str(p))
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
 
     def load_from_string(self, data: str, format: str = "turtle"):
         """Load ontology from a string."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from importlib.metadata import entry_points
 from pathlib import Path
 
 import orionbelt_ontology_builder.cli as cli
-from orionbelt_ontology_builder.local_store import ENV_FLAG
+from orionbelt_ontology_builder.local_store import BRAND_PRIMARY_COLOR, ENV_FLAG
 
 
 def test_entry_point_registered():
@@ -65,7 +65,10 @@ def test_run_opts_into_local_persistence(monkeypatch):
     monkeypatch.setattr(streamlit.web, "cli", _FakeStcli, raising=False)
     monkeypatch.setattr(sys, "argv", ["orionbelt-ontology-builder"])
     monkeypatch.setattr(sys, "exit", lambda code=0: None)
+    monkeypatch.delenv("STREAMLIT_THEME_PRIMARY_COLOR", raising=False)
 
     cli.run()
 
     assert os.environ[ENV_FLAG] == "1"
+    # Brand theme is applied via env so config.toml isn't needed.
+    assert os.environ["STREAMLIT_THEME_PRIMARY_COLOR"] == BRAND_PRIMARY_COLOR

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,12 @@
 """Tests for the console entry point (``orionbelt-ontology-builder``)."""
 
+import os
 import sys
 from importlib.metadata import entry_points
 from pathlib import Path
 
 import orionbelt_ontology_builder.cli as cli
+from orionbelt_ontology_builder.local_store import ENV_FLAG
 
 
 def test_entry_point_registered():
@@ -47,3 +49,23 @@ def test_run_invokes_streamlit_with_entry_and_forwards_args(monkeypatch):
     assert argv[:2] == ["streamlit", "run"]
     assert argv[2].endswith("streamlit_entry.py")
     assert argv[-2:] == ["--server.port", "8502"]
+
+
+def test_run_opts_into_local_persistence(monkeypatch):
+    """A local launch should enable disk-backed persistence via the env flag."""
+    monkeypatch.delenv(ENV_FLAG, raising=False)
+
+    class _FakeStcli:
+        @staticmethod
+        def main():
+            pass
+
+    import streamlit.web
+
+    monkeypatch.setattr(streamlit.web, "cli", _FakeStcli, raising=False)
+    monkeypatch.setattr(sys, "argv", ["orionbelt-ontology-builder"])
+    monkeypatch.setattr(sys, "exit", lambda code=0: None)
+
+    cli.run()
+
+    assert os.environ[ENV_FLAG] == "1"

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -1,5 +1,6 @@
 """Tests for the native desktop launcher (``orionbelt-ontology-builder-desktop``)."""
 
+import os
 import sys
 import types
 from importlib.metadata import entry_points
@@ -8,6 +9,7 @@ import pytest
 
 import orionbelt_ontology_builder.desktop as desktop
 from orionbelt_ontology_builder.app import APP_NAME
+from orionbelt_ontology_builder.local_store import ENV_FLAG
 
 
 def test_entry_point_registered():
@@ -32,10 +34,14 @@ def test_run_invokes_start_desktop_app(monkeypatch):
     fake_module.start_desktop_app = _fake_start_desktop_app
     monkeypatch.setitem(sys.modules, "streamlit_desktop_app", fake_module)
 
+    monkeypatch.delenv(ENV_FLAG, raising=False)
+
     desktop.run()
 
     assert captured["script_path"].endswith("streamlit_entry.py")
     assert captured["title"] == APP_NAME
+    # A native launch runs locally, so disk-backed persistence is opted in.
+    assert os.environ[ENV_FLAG] == "1"
 
 
 def test_run_without_dependency_exits_cleanly(monkeypatch):

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -9,7 +9,7 @@ import pytest
 
 import orionbelt_ontology_builder.desktop as desktop
 from orionbelt_ontology_builder.app import APP_NAME
-from orionbelt_ontology_builder.local_store import ENV_FLAG
+from orionbelt_ontology_builder.local_store import BRAND_PRIMARY_COLOR, ENV_FLAG
 
 
 def test_entry_point_registered():
@@ -35,6 +35,7 @@ def test_run_invokes_start_desktop_app(monkeypatch):
     monkeypatch.setitem(sys.modules, "streamlit_desktop_app", fake_module)
 
     monkeypatch.delenv(ENV_FLAG, raising=False)
+    monkeypatch.delenv("STREAMLIT_THEME_PRIMARY_COLOR", raising=False)
 
     desktop.run()
 
@@ -42,6 +43,8 @@ def test_run_invokes_start_desktop_app(monkeypatch):
     assert captured["title"] == APP_NAME
     # A native launch runs locally, so disk-backed persistence is opted in.
     assert os.environ[ENV_FLAG] == "1"
+    # Brand theme is applied via env so config.toml isn't needed in the subprocess.
+    assert os.environ["STREAMLIT_THEME_PRIMARY_COLOR"] == BRAND_PRIMARY_COLOR
 
 
 def test_run_without_dependency_exits_cleanly(monkeypatch):

--- a/tests/test_local_file_persist.py
+++ b/tests/test_local_file_persist.py
@@ -304,8 +304,9 @@ def test_localstorage_oversized_disables_until_mutation(fake_st, monkeypatch):
     monkeypatch.setattr(
         type(om),
         "export_to_string",
-        lambda self, format="turtle": serialized.append(1)
-        or real_export(self, format=format),
+        lambda self, format="turtle": (
+            serialized.append(1) or real_export(self, format=format)
+        ),
     )
 
     app._persist_autosave_to_localstorage()  # serializes once, finds it too big

--- a/tests/test_local_file_persist.py
+++ b/tests/test_local_file_persist.py
@@ -83,8 +83,8 @@ def _set_state(st, *, mc, recovery=None, linked=None, settled=True):
     st.session_state["_ont_mutation_count"] = mc
     st.session_state["_recovery_saved_rev"] = recovery
     st.session_state["_linked_saved_rev"] = linked
-    st.session_state["_disk_last_seen_rev"] = mc  # avoid re-stamping
-    st.session_state["_disk_last_mutation_at"] = 0.0 if settled else time.time()
+    st.session_state["_autosave_seen_rev"] = mc  # avoid re-stamping
+    st.session_state["_autosave_mutated_at"] = 0.0 if settled else time.time()
 
 
 # ---- format detection / destination serialization ------------------------
@@ -136,7 +136,7 @@ def test_debounce_skips_then_flushes(fake_st, monkeypatch):
     app._persist_autosave_to_disk()
     assert calls == []  # dirty but not settled -> debounced
 
-    fake_st.session_state["_disk_last_mutation_at"] = 0.0  # edits settle
+    fake_st.session_state["_autosave_mutated_at"] = 0.0  # edits settle
     app._persist_autosave_to_disk()
     assert any("recovery" in path for path, _ in calls)
     assert fake_st.session_state["_recovery_saved_rev"] == 1
@@ -146,12 +146,12 @@ def test_force_flush_bypasses_debounce(fake_st, monkeypatch):
     om = _populated()
     fake_st.session_state.ontology = om
     _set_state(fake_st, mc=1, recovery=None, settled=False)
-    fake_st.session_state["_force_disk_flush"] = True
+    fake_st.session_state["_force_autosave_flush"] = True
     calls = _spy_save(monkeypatch, om)
 
     app._persist_autosave_to_disk()
     assert calls  # saved despite not settled
-    assert not fake_st.session_state.get("_force_disk_flush")  # consumed
+    assert not fake_st.session_state.get("_force_autosave_flush")  # consumed
 
 
 # ---- separate recovery/linked state + retry ------------------------------
@@ -180,7 +180,7 @@ def test_linked_failure_neither_suppresses_recovery_nor_blocks_retry(
     assert fake_st.session_state.get("_linked_saved_rev") is None  # not recorded
 
     # Same revision (no new edit): recovery is deduped, linked is retried.
-    fake_st.session_state["_disk_last_mutation_at"] = 0.0
+    fake_st.session_state["_autosave_mutated_at"] = 0.0
     calls = []
     monkeypatch.setattr(
         type(om),
@@ -196,7 +196,7 @@ def test_blocked_persist_writes_nothing(fake_st, monkeypatch):
     fake_st.session_state.ontology = om
     _set_state(fake_st, mc=1, recovery=None, settled=True)
     fake_st.session_state["_disk_persist_blocked"] = True
-    fake_st.session_state["_force_disk_flush"] = True
+    fake_st.session_state["_force_autosave_flush"] = True
     calls = _spy_save(monkeypatch, om)
     app._persist_autosave_to_disk()
     assert calls == []
@@ -216,7 +216,7 @@ def test_restore_corrupt_recovery_blocks_persist(fake_st):
     # Even a forced flush must not overwrite the file we couldn't load.
     before = local_store.read_text(local_store.recovery_file())
     fake_st.session_state.ontology = _populated()
-    fake_st.session_state["_force_disk_flush"] = True
+    fake_st.session_state["_force_autosave_flush"] = True
     _set_state(fake_st, mc=1, recovery=None, settled=True)
     fake_st.session_state["_disk_persist_blocked"] = True
     app._persist_autosave_to_disk()
@@ -249,9 +249,79 @@ def test_link_load_does_not_overwrite_existing_file(fake_st, tmp_path):
     assert app._load_linked_file(target) is True
     # Persist pass: linked is already at the current revision, so it isn't
     # rewritten with the (now non-empty, but freshly loaded) graph anyway.
-    fake_st.session_state["_disk_last_mutation_at"] = 0.0
+    fake_st.session_state["_autosave_mutated_at"] = 0.0
     app._persist_autosave_to_disk()
 
     reloaded = OntologyManager()
     reloaded.load_from_file(str(target), "turtle")
     assert {c["name"] for c in reloaded.get_classes()} == {"A", "B"}
+
+
+# ---- browser localStorage backend uses the same gate ---------------------
+
+
+class _FakeLS:
+    def __init__(self):
+        self.items = {}
+
+    def setItem(self, k, v, key=None):
+        self.items[k] = v
+
+
+def _use_fake_ls(monkeypatch):
+    ls = _FakeLS()
+    monkeypatch.setattr(app, "_get_local_storage", lambda: ls)
+    return ls
+
+
+def test_localstorage_no_serialize_when_not_dirty(fake_st, monkeypatch):
+    ls = _use_fake_ls(monkeypatch)
+    om = _populated()
+    fake_st.session_state.ontology = om
+    _set_state(fake_st, mc=2, settled=True)
+    fake_st.session_state["_ls_saved_rev"] = 2  # already saved
+
+    calls = []
+    monkeypatch.setattr(
+        type(om),
+        "export_to_string",
+        lambda self, format="turtle": calls.append(1) or "",
+    )
+    app._persist_autosave_to_localstorage()
+    assert calls == []  # not dirty -> never serialized
+    assert ls.items == {}
+
+
+def test_localstorage_oversized_disables_until_mutation(fake_st, monkeypatch):
+    ls = _use_fake_ls(monkeypatch)
+    monkeypatch.setattr(app, "AUTOSAVE_MAX_BYTES", 5)  # force "too big"
+    om = _populated()
+    fake_st.session_state.ontology = om
+    _set_state(fake_st, mc=1, settled=True)
+
+    serialized = []
+    real_export = type(om).export_to_string
+    monkeypatch.setattr(
+        type(om),
+        "export_to_string",
+        lambda self, format="turtle": serialized.append(1)
+        or real_export(self, format=format),
+    )
+
+    app._persist_autosave_to_localstorage()  # serializes once, finds it too big
+    assert fake_st.session_state["_ls_oversized_rev"] == 1
+    assert ls.items == {}
+
+    app._persist_autosave_to_localstorage()  # same revision -> no re-serialize
+    assert len(serialized) == 1
+
+
+def test_localstorage_writes_when_dirty_and_settled(fake_st, monkeypatch):
+    ls = _use_fake_ls(monkeypatch)
+    om = _populated()
+    fake_st.session_state.ontology = om
+    _set_state(fake_st, mc=1, settled=True)
+
+    app._persist_autosave_to_localstorage()
+    assert app.AUTOSAVE_KEY in ls.items  # written
+    assert fake_st.session_state["_ls_saved_rev"] == 1

--- a/tests/test_local_file_persist.py
+++ b/tests/test_local_file_persist.py
@@ -1,0 +1,185 @@
+"""Tests for disk-backed autosave behaviour (PR #59 review fixes).
+
+These functions live in app.py and read/write ``st.session_state``, so we drive
+them with a tiny fake ``st`` and a temp home directory. Covered:
+
+* a failed restore pauses disk writes so an unreadable/corrupt file is never
+  overwritten;
+* linking to an existing file loads it instead of overwriting it;
+* recovery and linked targets use independent hashes, so a failed linked write
+  is retried even when the ontology hasn't changed.
+"""
+
+import pytest
+
+import orionbelt_ontology_builder.app as app
+from orionbelt_ontology_builder import local_store
+from ontology_manager import OntologyManager
+
+
+class _FakeSessionState(dict):
+    def __getattr__(self, k):
+        try:
+            return self[k]
+        except KeyError as e:
+            raise AttributeError(k) from e
+
+    def __setattr__(self, k, v):
+        self[k] = v
+
+
+class _FakeSidebar:
+    def warning(self, *a, **k):
+        pass
+
+
+class _FakeSt:
+    def __init__(self):
+        self.session_state = _FakeSessionState()
+        self.sidebar = _FakeSidebar()
+
+    def toast(self, *a, **k):
+        pass
+
+    def rerun(self):
+        pass
+
+
+@pytest.fixture
+def fake_st(tmp_path, monkeypatch):
+    """Patch app.st with a fake and redirect the data dir to a temp home."""
+    monkeypatch.setattr(local_store.Path, "home", lambda: tmp_path)
+    st = _FakeSt()
+    st.session_state.error_log = []  # log_error appends here
+    monkeypatch.setattr(app, "st", st)
+    local_store.set_linked_path(None)
+    return st
+
+
+def _populated():
+    om = OntologyManager()
+    om.add_class("A")
+    om.add_class("B")
+    om.add_object_property("relatedTo")
+    return om
+
+
+# ---- High: failed restore must pause disk writes -------------------------
+
+
+def test_restore_corrupt_recovery_blocks_persist(fake_st, tmp_path):
+    # A recovery file that exists but doesn't parse.
+    local_store.atomic_write(local_store.recovery_file(), "this is not turtle {{{")
+    ont = OntologyManager()
+    fake_st.session_state.ontology = ont
+
+    app._restore_autosave_from_disk(ont)
+
+    assert fake_st.session_state.get("_disk_persist_blocked") is True
+
+    # Persist must now be a no-op: the corrupt file is left intact.
+    before = local_store.read_text(local_store.recovery_file())
+    fake_st.session_state.ontology = _populated()
+    app._persist_autosave_to_disk()
+    assert local_store.read_text(local_store.recovery_file()) == before
+
+
+def test_restore_unreadable_file_blocks_persist(fake_st, tmp_path, monkeypatch):
+    local_store.atomic_write(local_store.recovery_file(), ":A a owl:Class .")
+    monkeypatch.setattr(local_store, "read_text", lambda p: None)  # simulate IO error
+    ont = OntologyManager()
+    fake_st.session_state.ontology = ont
+
+    app._restore_autosave_from_disk(ont)
+
+    assert fake_st.session_state.get("_disk_persist_blocked") is True
+
+
+# ---- High: linking an existing file loads it, never overwrites ------------
+
+
+def test_load_linked_file_replaces_working_ontology(fake_st, tmp_path):
+    target = tmp_path / "mine.ttl"
+    source = _populated()
+    local_store.atomic_write(target, source.export_to_string(format="turtle"))
+
+    fake_st.session_state.ontology = OntologyManager()  # empty workspace
+    assert app._load_linked_file(target) is True
+
+    loaded = fake_st.session_state.ontology
+    assert {c["name"] for c in loaded.get_classes()} == {"A", "B"}
+    # The linked hash matches the file, so persist won't immediately rewrite it.
+    assert fake_st.session_state.get("_linked_last_hash")
+
+
+def test_load_linked_file_does_not_overwrite_existing(fake_st, tmp_path):
+    """Loading must not clobber the file with the (empty) current graph."""
+    target = tmp_path / "mine.ttl"
+    original = _populated().export_to_string(format="turtle")
+    local_store.atomic_write(target, original)
+    local_store.set_linked_path(str(target))
+
+    # Simulate the link-and-load handler outcome, then run a persist pass.
+    fake_st.session_state.ontology = OntologyManager()
+    assert app._load_linked_file(target) is True
+    app._persist_autosave_to_disk()
+
+    # File still holds A and B, not an empty graph.
+    reloaded = OntologyManager()
+    reloaded.load_from_string(local_store.read_text(target), format="turtle")
+    assert {c["name"] for c in reloaded.get_classes()} == {"A", "B"}
+
+
+# ---- Medium: failed linked write is retried for unchanged content --------
+
+
+def test_failed_linked_write_retries_when_unchanged(fake_st, tmp_path, monkeypatch):
+    linked = tmp_path / "linked.ttl"
+    local_store.set_linked_path(str(linked))
+    fake_st.session_state.ontology = _populated()
+
+    calls = {"recovery": 0, "linked": 0}
+    real_write = local_store.atomic_write
+
+    def flaky_write(path, text):
+        if str(path) == str(linked):
+            calls["linked"] += 1
+            raise OSError("permission denied")
+        calls["recovery"] += 1
+        real_write(path, text)
+
+    monkeypatch.setattr(local_store, "atomic_write", flaky_write)
+
+    app._persist_autosave_to_disk()  # recovery ok, linked fails
+    app._persist_autosave_to_disk()  # content unchanged -> linked retried anyway
+
+    assert calls["linked"] == 2  # retried despite no content change
+    assert calls["recovery"] == 1  # recovery deduped after its first success
+    assert fake_st.session_state.get("_linked_last_hash") is None  # never recorded
+
+
+def test_successful_writes_are_deduped(fake_st, tmp_path):
+    linked = tmp_path / "linked.ttl"
+    local_store.set_linked_path(str(linked))
+    fake_st.session_state.ontology = _populated()
+
+    app._persist_autosave_to_disk()
+    h1 = fake_st.session_state.get("_linked_last_hash")
+    assert h1 and local_store.read_text(linked)
+
+    # Second pass with unchanged content shouldn't error and keeps the hash.
+    app._persist_autosave_to_disk()
+    assert fake_st.session_state.get("_linked_last_hash") == h1
+
+
+def test_blocked_persist_writes_nothing(fake_st, tmp_path, monkeypatch):
+    fake_st.session_state.ontology = _populated()
+    fake_st.session_state["_disk_persist_blocked"] = True
+    called = {"n": 0}
+    monkeypatch.setattr(
+        local_store,
+        "atomic_write",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1),
+    )
+    app._persist_autosave_to_disk()
+    assert called["n"] == 0

--- a/tests/test_local_file_persist.py
+++ b/tests/test_local_file_persist.py
@@ -1,20 +1,24 @@
-"""Tests for disk-backed autosave behaviour (PR #59 review fixes).
+"""Tests for disk-backed autosave (PR #59) and its large-file reshape.
 
 These functions live in app.py and read/write ``st.session_state``, so we drive
 them with a tiny fake ``st`` and a temp home directory. Covered:
 
-* a failed restore pauses disk writes so an unreadable/corrupt file is never
-  overwritten;
+* a failed restore pauses disk writes so a bad file is never overwritten;
 * linking to an existing file loads it instead of overwriting it;
-* recovery and linked targets use independent hashes, so a failed linked write
-  is retried even when the ontology hasn't changed.
+* mutation-count gating: an unchanged graph does no work on a rerun;
+* debounce: dirty edits flush only once settled, and force bypasses it;
+* recovery and linked file track save state separately, so a failed linked
+  write neither suppresses recovery nor blocks its own retry;
+* destination-based serialization and extension-based format detection.
 """
+
+import time
 
 import pytest
 
 import orionbelt_ontology_builder.app as app
 from orionbelt_ontology_builder import local_store
-from ontology_manager import OntologyManager
+from ontology_manager import OntologyManager, rdf_format_for_path
 
 
 class _FakeSessionState(dict):
@@ -64,122 +68,190 @@ def _populated():
     return om
 
 
-# ---- High: failed restore must pause disk writes -------------------------
+def _spy_save(monkeypatch, om):
+    """Record (path, format) for each save_to_file call; never touch disk."""
+    calls = []
+    monkeypatch.setattr(
+        type(om),
+        "save_to_file",
+        lambda self, path, format=None: calls.append((str(path), format)),
+    )
+    return calls
 
 
-def test_restore_corrupt_recovery_blocks_persist(fake_st, tmp_path):
-    # A recovery file that exists but doesn't parse.
+def _set_state(st, *, mc, recovery=None, linked=None, settled=True):
+    st.session_state["_ont_mutation_count"] = mc
+    st.session_state["_recovery_saved_rev"] = recovery
+    st.session_state["_linked_saved_rev"] = linked
+    st.session_state["_disk_last_seen_rev"] = mc  # avoid re-stamping
+    st.session_state["_disk_last_mutation_at"] = 0.0 if settled else time.time()
+
+
+# ---- format detection / destination serialization ------------------------
+
+
+def test_rdf_format_for_path():
+    assert rdf_format_for_path("x.ttl") == "turtle"
+    assert rdf_format_for_path("x.owl") == "xml"
+    assert rdf_format_for_path("x.rdf") == "xml"
+    assert rdf_format_for_path("x.nt") == "nt"
+    assert rdf_format_for_path("x.jsonld") == "json-ld"
+    assert rdf_format_for_path("x.unknown") == "turtle"  # default
+
+
+def test_save_to_file_is_atomic_and_parseable(tmp_path):
+    out = tmp_path / "o.ttl"
+    _populated().save_to_file(out, "turtle")
+    assert out.exists()
+    assert [p.name for p in tmp_path.iterdir()] == ["o.ttl"]  # no temp leftover
+    reloaded = OntologyManager()
+    reloaded.load_from_file(str(out), "turtle")
+    assert {c["name"] for c in reloaded.get_classes()} == {"A", "B"}
+
+
+def test_save_to_file_detects_format_from_extension(tmp_path):
+    out = tmp_path / "o.owl"
+    _populated().save_to_file(out)  # no format -> xml from .owl
+    assert "RDF" in out.read_text(encoding="utf-8")
+
+
+# ---- mutation-count gating + debounce ------------------------------------
+
+
+def test_no_work_when_not_dirty(fake_st, monkeypatch):
+    om = _populated()
+    fake_st.session_state.ontology = om
+    _set_state(fake_st, mc=3, recovery=3)  # already saved, no linked
+    calls = _spy_save(monkeypatch, om)
+    app._persist_autosave_to_disk()
+    assert calls == []
+
+
+def test_debounce_skips_then_flushes(fake_st, monkeypatch):
+    om = _populated()
+    fake_st.session_state.ontology = om
+    _set_state(fake_st, mc=1, recovery=None, settled=False)
+    calls = _spy_save(monkeypatch, om)
+
+    app._persist_autosave_to_disk()
+    assert calls == []  # dirty but not settled -> debounced
+
+    fake_st.session_state["_disk_last_mutation_at"] = 0.0  # edits settle
+    app._persist_autosave_to_disk()
+    assert any("recovery" in path for path, _ in calls)
+    assert fake_st.session_state["_recovery_saved_rev"] == 1
+
+
+def test_force_flush_bypasses_debounce(fake_st, monkeypatch):
+    om = _populated()
+    fake_st.session_state.ontology = om
+    _set_state(fake_st, mc=1, recovery=None, settled=False)
+    fake_st.session_state["_force_disk_flush"] = True
+    calls = _spy_save(monkeypatch, om)
+
+    app._persist_autosave_to_disk()
+    assert calls  # saved despite not settled
+    assert not fake_st.session_state.get("_force_disk_flush")  # consumed
+
+
+# ---- separate recovery/linked state + retry ------------------------------
+
+
+def test_linked_failure_neither_suppresses_recovery_nor_blocks_retry(
+    fake_st, tmp_path, monkeypatch
+):
+    linked = tmp_path / "linked.ttl"
+    local_store.set_linked_path(str(linked))
+    om = _populated()
+    fake_st.session_state.ontology = om
+    _set_state(fake_st, mc=1, recovery=None, linked=None, settled=True)
+
+    real_save = type(om).save_to_file
+
+    def flaky(self, path, format=None):
+        if str(path) == str(linked):
+            raise OSError("permission denied")
+        real_save(self, path, format=format)
+
+    monkeypatch.setattr(type(om), "save_to_file", flaky)
+
+    app._persist_autosave_to_disk()
+    assert fake_st.session_state["_recovery_saved_rev"] == 1  # recovery succeeded
+    assert fake_st.session_state.get("_linked_saved_rev") is None  # not recorded
+
+    # Same revision (no new edit): recovery is deduped, linked is retried.
+    fake_st.session_state["_disk_last_mutation_at"] = 0.0
+    calls = []
+    monkeypatch.setattr(
+        type(om),
+        "save_to_file",
+        lambda self, path, format=None: calls.append(str(path)),
+    )
+    app._persist_autosave_to_disk()
+    assert calls == [str(linked)]  # only the linked retry, no recovery rewrite
+
+
+def test_blocked_persist_writes_nothing(fake_st, monkeypatch):
+    om = _populated()
+    fake_st.session_state.ontology = om
+    _set_state(fake_st, mc=1, recovery=None, settled=True)
+    fake_st.session_state["_disk_persist_blocked"] = True
+    fake_st.session_state["_force_disk_flush"] = True
+    calls = _spy_save(monkeypatch, om)
+    app._persist_autosave_to_disk()
+    assert calls == []
+
+
+# ---- restore failure pauses persistence ----------------------------------
+
+
+def test_restore_corrupt_recovery_blocks_persist(fake_st):
     local_store.atomic_write(local_store.recovery_file(), "this is not turtle {{{")
     ont = OntologyManager()
     fake_st.session_state.ontology = ont
 
     app._restore_autosave_from_disk(ont)
-
     assert fake_st.session_state.get("_disk_persist_blocked") is True
 
-    # Persist must now be a no-op: the corrupt file is left intact.
+    # Even a forced flush must not overwrite the file we couldn't load.
     before = local_store.read_text(local_store.recovery_file())
     fake_st.session_state.ontology = _populated()
+    fake_st.session_state["_force_disk_flush"] = True
+    _set_state(fake_st, mc=1, recovery=None, settled=True)
+    fake_st.session_state["_disk_persist_blocked"] = True
     app._persist_autosave_to_disk()
     assert local_store.read_text(local_store.recovery_file()) == before
 
 
-def test_restore_unreadable_file_blocks_persist(fake_st, tmp_path, monkeypatch):
-    local_store.atomic_write(local_store.recovery_file(), ":A a owl:Class .")
-    monkeypatch.setattr(local_store, "read_text", lambda p: None)  # simulate IO error
-    ont = OntologyManager()
-    fake_st.session_state.ontology = ont
-
-    app._restore_autosave_from_disk(ont)
-
-    assert fake_st.session_state.get("_disk_persist_blocked") is True
+# ---- linking an existing file loads it (does not overwrite) ---------------
 
 
-# ---- High: linking an existing file loads it, never overwrites ------------
-
-
-def test_load_linked_file_replaces_working_ontology(fake_st, tmp_path):
+def test_load_linked_file_replaces_workspace_and_marks_saved(fake_st, tmp_path):
     target = tmp_path / "mine.ttl"
-    source = _populated()
-    local_store.atomic_write(target, source.export_to_string(format="turtle"))
+    _populated().save_to_file(target, "turtle")
 
     fake_st.session_state.ontology = OntologyManager()  # empty workspace
     assert app._load_linked_file(target) is True
 
     loaded = fake_st.session_state.ontology
     assert {c["name"] for c in loaded.get_classes()} == {"A", "B"}
-    # The linked hash matches the file, so persist won't immediately rewrite it.
-    assert fake_st.session_state.get("_linked_last_hash")
+    mc = fake_st.session_state["_ont_mutation_count"]
+    assert fake_st.session_state["_linked_saved_rev"] == mc  # won't be rewritten
+    assert fake_st.session_state["_recovery_saved_rev"] is None  # refreshed next
 
 
-def test_load_linked_file_does_not_overwrite_existing(fake_st, tmp_path):
-    """Loading must not clobber the file with the (empty) current graph."""
+def test_link_load_does_not_overwrite_existing_file(fake_st, tmp_path):
     target = tmp_path / "mine.ttl"
-    original = _populated().export_to_string(format="turtle")
-    local_store.atomic_write(target, original)
+    _populated().save_to_file(target, "turtle")
     local_store.set_linked_path(str(target))
 
-    # Simulate the link-and-load handler outcome, then run a persist pass.
     fake_st.session_state.ontology = OntologyManager()
     assert app._load_linked_file(target) is True
+    # Persist pass: linked is already at the current revision, so it isn't
+    # rewritten with the (now non-empty, but freshly loaded) graph anyway.
+    fake_st.session_state["_disk_last_mutation_at"] = 0.0
     app._persist_autosave_to_disk()
 
-    # File still holds A and B, not an empty graph.
     reloaded = OntologyManager()
-    reloaded.load_from_string(local_store.read_text(target), format="turtle")
+    reloaded.load_from_file(str(target), "turtle")
     assert {c["name"] for c in reloaded.get_classes()} == {"A", "B"}
-
-
-# ---- Medium: failed linked write is retried for unchanged content --------
-
-
-def test_failed_linked_write_retries_when_unchanged(fake_st, tmp_path, monkeypatch):
-    linked = tmp_path / "linked.ttl"
-    local_store.set_linked_path(str(linked))
-    fake_st.session_state.ontology = _populated()
-
-    calls = {"recovery": 0, "linked": 0}
-    real_write = local_store.atomic_write
-
-    def flaky_write(path, text):
-        if str(path) == str(linked):
-            calls["linked"] += 1
-            raise OSError("permission denied")
-        calls["recovery"] += 1
-        real_write(path, text)
-
-    monkeypatch.setattr(local_store, "atomic_write", flaky_write)
-
-    app._persist_autosave_to_disk()  # recovery ok, linked fails
-    app._persist_autosave_to_disk()  # content unchanged -> linked retried anyway
-
-    assert calls["linked"] == 2  # retried despite no content change
-    assert calls["recovery"] == 1  # recovery deduped after its first success
-    assert fake_st.session_state.get("_linked_last_hash") is None  # never recorded
-
-
-def test_successful_writes_are_deduped(fake_st, tmp_path):
-    linked = tmp_path / "linked.ttl"
-    local_store.set_linked_path(str(linked))
-    fake_st.session_state.ontology = _populated()
-
-    app._persist_autosave_to_disk()
-    h1 = fake_st.session_state.get("_linked_last_hash")
-    assert h1 and local_store.read_text(linked)
-
-    # Second pass with unchanged content shouldn't error and keeps the hash.
-    app._persist_autosave_to_disk()
-    assert fake_st.session_state.get("_linked_last_hash") == h1
-
-
-def test_blocked_persist_writes_nothing(fake_st, tmp_path, monkeypatch):
-    fake_st.session_state.ontology = _populated()
-    fake_st.session_state["_disk_persist_blocked"] = True
-    called = {"n": 0}
-    monkeypatch.setattr(
-        local_store,
-        "atomic_write",
-        lambda *a, **k: called.__setitem__("n", called["n"] + 1),
-    )
-    app._persist_autosave_to_disk()
-    assert called["n"] == 0

--- a/tests/test_local_file_persist.py
+++ b/tests/test_local_file_persist.py
@@ -154,10 +154,26 @@ def test_force_flush_bypasses_debounce(fake_st, monkeypatch):
     assert not fake_st.session_state.get("_force_autosave_flush")  # consumed
 
 
-# ---- separate recovery/linked state + retry ------------------------------
+# ---- one write per change: linked is the store, recovery is a fallback ----
 
 
-def test_linked_failure_neither_suppresses_recovery_nor_blocks_retry(
+def test_healthy_linked_file_does_not_also_write_recovery(fake_st, tmp_path):
+    """With a linked file set, recovery.ttl is not written on every change."""
+    linked = tmp_path / "linked.ttl"
+    local_store.set_linked_path(str(linked))
+    om = _populated()
+    fake_st.session_state.ontology = om
+    _set_state(fake_st, mc=1, recovery=None, linked=None, settled=True)
+
+    app._persist_autosave_to_disk()
+
+    assert linked.exists()  # linked written
+    assert not local_store.recovery_file().exists()  # recovery NOT written
+    assert fake_st.session_state["_linked_saved_rev"] == 1
+    assert fake_st.session_state.get("_recovery_saved_rev") is None
+
+
+def test_linked_failure_falls_back_to_recovery_and_retries(
     fake_st, tmp_path, monkeypatch
 ):
     linked = tmp_path / "linked.ttl"
@@ -237,7 +253,8 @@ def test_load_linked_file_replaces_workspace_and_marks_saved(fake_st, tmp_path):
     assert {c["name"] for c in loaded.get_classes()} == {"A", "B"}
     mc = fake_st.session_state["_ont_mutation_count"]
     assert fake_st.session_state["_linked_saved_rev"] == mc  # won't be rewritten
-    assert fake_st.session_state["_recovery_saved_rev"] is None  # refreshed next
+    # Recovery is a fallback only; loading a linked file doesn't mark it saved.
+    assert fake_st.session_state.get("_recovery_saved_rev") is None
 
 
 def test_link_load_does_not_overwrite_existing_file(fake_st, tmp_path):

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -1,0 +1,103 @@
+"""Tests for the local-filesystem persistence helpers."""
+
+import json
+
+import pytest
+
+from orionbelt_ontology_builder import local_store
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Redirect ``Path.home()`` to a temp dir so tests never touch the real home."""
+    monkeypatch.setattr(local_store.Path, "home", lambda: tmp_path)
+    return tmp_path
+
+
+def test_persist_disabled_by_default(monkeypatch):
+    """Without the env flag (the cloud case) disk persistence stays off."""
+    monkeypatch.delenv(local_store.ENV_FLAG, raising=False)
+    assert local_store.local_persist_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "False"])
+def test_persist_disabled_for_falsey_flag(monkeypatch, value):
+    monkeypatch.setenv(local_store.ENV_FLAG, value)
+    assert local_store.local_persist_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes"])
+def test_persist_enabled_for_truthy_flag(monkeypatch, value):
+    monkeypatch.setenv(local_store.ENV_FLAG, value)
+    assert local_store.local_persist_enabled() is True
+
+
+def test_data_dir_and_recovery_path(home):
+    assert local_store.data_dir() == home / ".orionbelt_ontology_builder"
+    assert local_store.data_dir().is_dir()
+    assert local_store.recovery_file() == local_store.data_dir() / "recovery.ttl"
+
+
+def test_atomic_write_roundtrip(home):
+    target = home / "sub" / "ont.ttl"
+    local_store.atomic_write(target, "hello world")
+    assert target.read_text(encoding="utf-8") == "hello world"
+    # No stray temp files left behind in the directory.
+    assert [p.name for p in target.parent.iterdir()] == ["ont.ttl"]
+
+
+def test_atomic_write_leaves_no_partial_file_on_failure(home, monkeypatch):
+    target = home / "ont.ttl"
+    target.write_text("original", encoding="utf-8")
+
+    def _boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(local_store.os, "replace", _boom)
+    with pytest.raises(OSError):
+        local_store.atomic_write(target, "new content")
+
+    # Original file is untouched and no temp file remains.
+    assert target.read_text(encoding="utf-8") == "original"
+    assert [p.name for p in target.parent.iterdir()] == ["ont.ttl"]
+
+
+def test_read_text_missing_returns_none(home):
+    assert local_store.read_text(home / "nope.ttl") is None
+
+
+def test_config_roundtrip(home):
+    assert local_store.load_config() == {}
+    local_store.save_config({"linked_path": "/tmp/x.ttl", "n": 1})
+    assert local_store.load_config() == {"linked_path": "/tmp/x.ttl", "n": 1}
+    # Written as readable JSON.
+    assert json.loads(local_store.config_file().read_text(encoding="utf-8"))["n"] == 1
+
+
+def test_load_config_handles_corrupt_file(home):
+    local_store.config_file().write_text("{not json", encoding="utf-8")
+    assert local_store.load_config() == {}
+
+
+def test_linked_path_set_get_clear(home):
+    assert local_store.get_linked_path() is None
+
+    local_store.set_linked_path("/data/backup/my.ttl")
+    assert local_store.get_linked_path() == local_store.Path("/data/backup/my.ttl")
+
+    local_store.set_linked_path(None)
+    assert local_store.get_linked_path() is None
+
+
+def test_set_linked_path_preserves_other_config(home):
+    local_store.save_config({"other": "keep"})
+    local_store.set_linked_path("/x.ttl")
+    config = local_store.load_config()
+    assert config["other"] == "keep"
+    assert config["linked_path"] == "/x.ttl"
+
+
+def test_get_linked_path_expands_user(home, monkeypatch):
+    monkeypatch.setenv("HOME", str(home))
+    local_store.set_linked_path("~/backup.ttl")
+    assert local_store.get_linked_path() == home / "backup.ttl"


### PR DESCRIPTION
## Summary

Local and desktop launches now persist the working ontology to the filesystem instead of browser `localStorage`, addressing #55. This gives two things the cloud-only autosave could not:

- **Crash recovery.** The working ontology is mirrored to a recovery file under `~/.orionbelt_ontology_builder/` on every change, so an unexpected close (crash, freeze) is recovered automatically on the next launch.
- **Linked working file.** A new sidebar control lets you point the app at any file path. The app tracks that file and reloads it on startup. Point it at a synced folder (Nextcloud, Dropbox, ...) for fully automatic off-machine backups, which is the original request in the issue.

## How it stays cloud-safe

Everything is gated behind the `ORIONBELT_LOCAL_PERSIST` env flag, which only the local launchers (`cli.run`, `desktop.run`) set. The hosted demo runs `streamlit run app.py` directly, never sets the flag, and keeps its existing per-browser `localStorage` autosave untouched.

## Changes

- New `orionbelt_ontology_builder/local_store.py`: standard-library only (no new deps). Per-user data dir, an atomic writer (temp file + `os.replace`, so a backup tool never sees a half-written file), the recovery snapshot path, and a JSON-backed linked-path config.
- `app.py` autosave functions branch to a disk backend on local runs. Writes are deduped by content hash so an unchanged graph never re-writes (avoids churning a synced folder), with no size cap since these are real files.
- Tests for the store helpers and the launcher env-flag opt-in.
- README: new "Local file storage" section.

## Testing

- `pytest` (280 passed)
- `ruff check` clean, `mypy` clean on the changed modules

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)