### PR TITLE
feat(visualization): Ctrl/Cmd-click a node to focus on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Imports on an empty ontology go straight through. Otherwise you get a review pan
 
 ### Visualization
 
-Interactive vis-network graph with class filtering, configurable node limits, click-to-navigate into the editor, Ctrl/Cmd-click a node to focus (center and zoom) on it, hierarchy tree view, and statistics charts.
+Interactive vis-network graph with class filtering, configurable node limits, click-to-navigate into the editor, Ctrl/Cmd-click a node to add it to the "Focus on one node" selection (narrowing the graph to its neighbourhood), hierarchy tree view, and statistics charts.
 
 ### Safety
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Imports on an empty ontology go straight through. Otherwise you get a review pan
 
 ### Visualization
 
-Interactive vis-network graph with class filtering, configurable node limits, click-to-navigate into the editor, hierarchy tree view, and statistics charts.
+Interactive vis-network graph with class filtering, configurable node limits, click-to-navigate into the editor, Ctrl/Cmd-click a node to focus (center and zoom) on it, hierarchy tree view, and statistics charts.
 
 ### Safety
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -5460,6 +5460,33 @@ def render_visualization():
                 default=None,
             )
 
+            # Ctrl/Cmd-click in the graph requests focusing on a node: add it to
+            # the "Focus on one node" seeds and enable focus mode (issue #56). The
+            # reqId guard ensures each click is applied once (the component value
+            # persists across reruns).
+            if isinstance(selection, dict) and selection.get("focusRequest"):
+                _req_id = selection.get("reqId")
+                if _req_id and _req_id != st.session_state.get("_viz_last_focus_req"):
+                    st.session_state["_viz_last_focus_req"] = _req_id
+                    _id_to_label = {v: k for k, v in focus_targets.items()}
+                    _focus_label = _id_to_label.get(selection.get("nodeId"))
+                    if _focus_label:
+                        st.session_state["_viz_cfg_focus_mode"] = True
+                        _seeds = list(
+                            st.session_state.get("_viz_cfg_focus_seeds") or []
+                        )
+                        if _focus_label not in _seeds:
+                            _seeds.append(_focus_label)
+                        st.session_state["_viz_cfg_focus_seeds"] = _seeds
+                        st.toast(f"Focusing on {_focus_label}", icon="🎯")
+                        st.rerun()
+                    else:
+                        st.toast(
+                            "Focus is available for classes, individuals, and "
+                            "SKOS concepts.",
+                            icon="ℹ️",
+                        )
+
             # Status bar outside iframe — dark styled
             _type_to_page = {
                 "Class": "Classes",

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -5489,7 +5489,10 @@ def render_visualization():
                 prefix = "Edge: " if selection.get("isEdge") else ""
                 sel_html = f"<b>{prefix}{selection.get('label', '')}</b> — {title_text}"
             else:
-                sel_html = "Click a node or edge to see details"
+                sel_html = (
+                    "Click a node or edge to see details · "
+                    "Ctrl/Cmd-click a node to focus on it"
+                )
 
             # Inject CSS to remove gap between status bar columns
             st.markdown(

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -163,6 +163,19 @@ function renderGraph(args) {
     network.on('deselectEdge', function() {
         sendToStreamlit("streamlit:setComponentValue", {value: {selected: false}});
     });
+
+    // Ctrl/Cmd-click a node to focus (center + zoom) on it — handy for
+    // exploring without typing the name into the class filter (issue #56).
+    network.on('click', function(params) {
+        if (!params.nodes.length) return;
+        var ev = params.event && params.event.srcEvent;
+        if (!ev || !(ev.ctrlKey || ev.metaKey)) return;
+        network.focus(params.nodes[0], {
+            scale: 1.6,
+            animation: { duration: 400, easingFunction: 'easeInOutQuad' }
+        });
+        network.selectNodes([params.nodes[0]]);
+    });
 }
 
 window.addEventListener("message", function(event) {

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -164,17 +164,18 @@ function renderGraph(args) {
         sendToStreamlit("streamlit:setComponentValue", {value: {selected: false}});
     });
 
-    // Ctrl/Cmd-click a node to focus (center + zoom) on it — handy for
-    // exploring without typing the name into the class filter (issue #56).
+    // Ctrl/Cmd-click a node to add it to the "Focus on one node" selection, so
+    // the graph narrows to that node's neighbourhood without typing its name
+    // into the focus picker (issue #56). reqId makes each request distinct so
+    // the Python side applies it once. Sent after the normal selectNode value,
+    // so this is the value Streamlit keeps for this interaction.
     network.on('click', function(params) {
         if (!params.nodes.length) return;
         var ev = params.event && params.event.srcEvent;
         if (!ev || !(ev.ctrlKey || ev.metaKey)) return;
-        network.focus(params.nodes[0], {
-            scale: 1.6,
-            animation: { duration: 400, easingFunction: 'easeInOutQuad' }
+        sendToStreamlit("streamlit:setComponentValue", {
+            value: {focusRequest: true, reqId: Date.now(), nodeId: params.nodes[0]}
         });
-        network.selectNodes([params.nodes[0]]);
     });
 }
 


### PR DESCRIPTION
## Summary

Implements #56. In the Visualization interactive graph, **Ctrl-click (or Cmd-click on macOS) a node to add it to the "Focus on one node" selection** — focus mode is enabled and the graph narrows to that node's neighbourhood (depth-N). This is the same result as opening Filter Classes and typing the node into the "Focus node(s)" picker, but done straight from the graph. Ctrl/Cmd-clicking more nodes appends them to the focus seeds.

A plain click is unchanged (shows the node's details and the View button). The status-bar hint now mentions the shortcut.

## Changes

- **`lib/graph_viewer/index.html`**: on a modifier-click, the component posts a `focusRequest` (node id + a `reqId`) back to Streamlit instead of acting locally.
- **`app.py`**: when a new `focusRequest` arrives, map the node id to its focus label, enable focus mode, append the label to the focus seeds, and rerun. The `reqId` guard applies each click exactly once (the component value persists across reruns). Nodes that aren't focusable (e.g. properties) show a hint toast.
- **README**: Visualization feature note.

## Testing

Driven in a browser against a local run with a large ontology (gist, 177 classes, 96-node graph):
- Ctrl/Cmd-click on a class node → graph narrowed from 96 nodes to the node + its depth-1 neighbour; the "Focus on one node" checkbox became checked and the "Focus node(s)" multiselect held the clicked class (e.g. "Class: Account").
- Plain click unchanged.

`pytest` (262 passed), `ruff check`/`ruff format --check` (pinned 0.15.19), and `mypy` all clean.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)