### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.8.0](https://img.shields.io/badge/version-1.8.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.9.0](https://img.shields.io/badge/version-1.9.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -214,7 +214,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.8.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.9.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.8.0"
+APP_VERSION = "1.9.0"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.8.0"
+version = "1.9.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Bumps the version 1.8.0 -> 1.9.0 across pyproject.toml, the app's APP_VERSION, and the README (badge + Docker pin example) for the release that includes property reuse (#60), local file storage (#59), Ctrl/Cmd-click focus (#61), and the dark-mode pass (#64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)