### PR TITLE
fix(ui): keep brand colours under Streamlit Light/Dark theme presets

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -88,16 +88,59 @@ _CUSTOM_CSS = """
 </style>
 """
 
-# In dark mode the brand navy primary (#0D2B7A) reads fine as a filled
-# button/checkbox but is too dark as the *text/indicator* colour on the selected
-# tab and segmented-control pill. Lighten just those to a readable blue; only
-# injected when the active theme is dark.
+# Streamlit's built-in Light/Dark theme presets (the "⋮ → Settings → Theme"
+# menu) replace the whole theme — including primaryColor — with Streamlit's
+# default red, ignoring the configured brand colour. So we force the brand
+# primary onto the key controls with CSS, applied in every theme. Scoped to
+# stable data-testid / data-baseweb hooks (and :has(input:checked) for the
+# checked state) so unchecked controls are untouched.
+# NOTE: this targets Streamlit's internal DOM; re-verify on a Streamlit bump
+# (the version is pinned in pyproject.toml for exactly this reason).
+_BRAND = local_store.BRAND_PRIMARY_COLOR  # "#0D2B7A"
+_BRAND_TINT = "rgba(13, 43, 122, 0.12)"
+_BRAND_CSS = f"""
+<style>
+    /* Primary buttons */
+    [data-testid="stBaseButton-primary"] {{
+        background-color: {_BRAND} !important;
+        border-color: {_BRAND} !important;
+    }}
+    /* Checked checkbox box */
+    [data-testid="stCheckbox"] label[data-baseweb="checkbox"]:has(input:checked) > span {{
+        background-color: {_BRAND} !important;
+        border-color: {_BRAND} !important;
+    }}
+    /* Selected radio (its control circle; not the label wrapper) */
+    [data-testid="stRadio"] label[data-baseweb="radio"]:has(input:checked) > div:first-child {{
+        background-color: {_BRAND} !important;
+        border-color: {_BRAND} !important;
+    }}
+    /* Active segmented-control pill and tab */
+    [data-testid="stBaseButton-segmented_controlActive"] {{
+        color: {_BRAND} !important;
+        border-color: {_BRAND} !important;
+        background-color: {_BRAND_TINT} !important;
+    }}
+    .stTabs [data-baseweb="tab"][aria-selected="true"] {{
+        color: {_BRAND} !important;
+    }}
+    .stTabs [data-baseweb="tab-highlight"] {{
+        background-color: {_BRAND} !important;
+    }}
+</style>
+"""
+
+# The brand navy is fine as a filled button/checkbox/radio but too dark as the
+# *text/indicator* colour on the selected tab and pill against a dark backdrop.
+# Injected only in dark mode, after _BRAND_CSS, so it wins for those accents.
 _DARK_ACCENT = "#6EA8FE"
+_DARK_TINT = "rgba(110, 168, 254, 0.15)"
 _DARK_CSS = f"""
 <style>
     [data-testid="stBaseButton-segmented_controlActive"] {{
         color: {_DARK_ACCENT} !important;
         border-color: {_DARK_ACCENT} !important;
+        background-color: {_DARK_TINT} !important;
     }}
     .stTabs [data-baseweb="tab"][aria-selected="true"] {{
         color: {_DARK_ACCENT} !important;
@@ -122,6 +165,10 @@ def _configure_page() -> None:
         )
         st.session_state["_page_configured"] = True
     st.markdown(_CUSTOM_CSS, unsafe_allow_html=True)
+    # Force the brand primary on key controls in every theme (Streamlit's preset
+    # themes would otherwise revert it to red), then lighten tab/pill accents in
+    # dark mode (injected after, so it wins there).
+    st.markdown(_BRAND_CSS, unsafe_allow_html=True)
     try:
         if st.context.theme.get("type") == "dark":
             st.markdown(_DARK_CSS, unsafe_allow_html=True)

--- a/orionbelt_ontology_builder/cli.py
+++ b/orionbelt_ontology_builder/cli.py
@@ -26,13 +26,19 @@ def run() -> None:
     # disk-backed autosave / linked-file persistence (the cloud deployment runs
     # ``streamlit run app.py`` directly and never sets this).
     os.environ[ENV_FLAG] = "1"
-    # Apply the brand theme regardless of CWD: config.toml is only found when
-    # launched from the repo root, so without this the console/desktop runs fall
-    # back to Streamlit's default red. setdefault lets a user override win.
-    os.environ.setdefault("STREAMLIT_THEME_PRIMARY_COLOR", BRAND_PRIMARY_COLOR)
 
+    # Pass the brand theme as an explicit Streamlit flag so it applies regardless
+    # of CWD (config.toml is only found from the repo root) — otherwise the
+    # console/desktop runs fall back to Streamlit's default red. Placed before
+    # the user's args so an explicit --theme.primaryColor still wins.
     entry = Path(__file__).parent / "streamlit_entry.py"
-    sys.argv = ["streamlit", "run", str(entry), *sys.argv[1:]]
+    sys.argv = [
+        "streamlit",
+        "run",
+        str(entry),
+        f"--theme.primaryColor={BRAND_PRIMARY_COLOR}",
+        *sys.argv[1:],
+    ]
     sys.exit(stcli.main())
 
 

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -42,15 +42,15 @@ def run() -> None:
     # Running locally with full filesystem access — opt into the disk-backed
     # autosave / linked-file persistence (off by default on the cloud).
     os.environ[ENV_FLAG] = "1"
-    # The desktop subprocess inherits this env, so the brand colour applies even
-    # though config.toml isn't found outside the repo (otherwise Streamlit's
-    # default red shows). setdefault lets a user override win.
-    os.environ.setdefault("STREAMLIT_THEME_PRIMARY_COLOR", BRAND_PRIMARY_COLOR)
 
+    # Pass the brand colour as an explicit Streamlit option so it applies
+    # regardless of CWD (config.toml is only found from the repo root) and
+    # without relying on env inheritance into the Streamlit subprocess.
     entry = Path(__file__).parent / "streamlit_entry.py"
     start_desktop_app(
         script_path=str(entry),
         title=APP_NAME,
+        options={"theme.primaryColor": BRAND_PRIMARY_COLOR},
         width=1280,
         height=800,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "streamlit>=1.28.0",
+    "streamlit==1.49.1",
     "rdflib>=7.0.0",
     "owlrl>=6.0.2",
     "networkx>=3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.28.0
+streamlit==1.49.1
 rdflib>=7.0.0
 owlrl>=6.0.2
 networkx>=3.0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,24 +51,24 @@ def test_run_invokes_streamlit_with_entry_and_forwards_args(monkeypatch):
     assert argv[-2:] == ["--server.port", "8502"]
 
 
-def test_run_opts_into_local_persistence(monkeypatch):
-    """A local launch should enable disk-backed persistence via the env flag."""
+def test_run_opts_into_persistence_and_brand_theme(monkeypatch):
+    """A local launch enables disk persistence and passes the brand colour."""
     monkeypatch.delenv(ENV_FLAG, raising=False)
+    captured = {}
 
     class _FakeStcli:
         @staticmethod
         def main():
-            pass
+            captured["argv"] = list(sys.argv)
 
     import streamlit.web
 
     monkeypatch.setattr(streamlit.web, "cli", _FakeStcli, raising=False)
     monkeypatch.setattr(sys, "argv", ["orionbelt-ontology-builder"])
     monkeypatch.setattr(sys, "exit", lambda code=0: None)
-    monkeypatch.delenv("STREAMLIT_THEME_PRIMARY_COLOR", raising=False)
 
     cli.run()
 
     assert os.environ[ENV_FLAG] == "1"
-    # Brand theme is applied via env so config.toml isn't needed.
-    assert os.environ["STREAMLIT_THEME_PRIMARY_COLOR"] == BRAND_PRIMARY_COLOR
+    # Brand colour passed as an explicit flag so config.toml isn't needed.
+    assert f"--theme.primaryColor={BRAND_PRIMARY_COLOR}" in captured["argv"]

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -35,7 +35,6 @@ def test_run_invokes_start_desktop_app(monkeypatch):
     monkeypatch.setitem(sys.modules, "streamlit_desktop_app", fake_module)
 
     monkeypatch.delenv(ENV_FLAG, raising=False)
-    monkeypatch.delenv("STREAMLIT_THEME_PRIMARY_COLOR", raising=False)
 
     desktop.run()
 
@@ -43,8 +42,9 @@ def test_run_invokes_start_desktop_app(monkeypatch):
     assert captured["title"] == APP_NAME
     # A native launch runs locally, so disk-backed persistence is opted in.
     assert os.environ[ENV_FLAG] == "1"
-    # Brand theme is applied via env so config.toml isn't needed in the subprocess.
-    assert os.environ["STREAMLIT_THEME_PRIMARY_COLOR"] == BRAND_PRIMARY_COLOR
+    # Brand colour passed as an explicit Streamlit option (not via env) so it
+    # applies in the subprocess regardless of CWD.
+    assert captured["options"]["theme.primaryColor"] == BRAND_PRIMARY_COLOR
 
 
 def test_run_without_dependency_exits_cleanly(monkeypatch):


### PR DESCRIPTION
## Problem

The "⋮ → Settings → Theme" menu's built-in **Light and Dark presets replace the entire theme — including `primaryColor` — with Streamlit's default red**, ignoring the configured brand navy. So toggling the theme turned buttons, checkboxes, radios, and the active tab/pill red (a "mix of colours"), in both modes.

## Fix

- **Force the brand primary** onto the key controls (primary buttons, checked checkboxes, selected radios, active tab/pill) via CSS injected in **every** theme. Scoped to stable `data-testid` / `data-baseweb` hooks and `:has(input:checked)` so unchecked controls are untouched. In dark mode the tab/pill text/indicator (and its background tint) is lightened to a readable blue, since navy is too dark on a dark backdrop.
- **Launchers** now pass the brand colour as an explicit Streamlit flag/option (`cli`: `--theme.primaryColor`, `desktop`: `options={"theme.primaryColor": …}`) instead of an env var — applies regardless of CWD or subprocess env inheritance.
- **Pin `streamlit==1.49.1`** (pyproject + requirements). The CSS targets Streamlit's internal DOM, so the pin makes a Streamlit upgrade a deliberate, re-verify step (documented in a code comment).
- Launcher tests updated for the flag/option approach.

## Caveat (by design)

These overrides hook Streamlit's internal DOM. If a Streamlit upgrade renames a test ID or restructures a widget, an override can silently stop applying. The version pin is the guard: re-verify the theme when deliberately bumping Streamlit.

## Testing

Verified in a browser under **both** the Light and Dark menu presets: navy buttons/checkboxes/radios, light-blue tab/pill accents in dark, no red, no stray highlights; logo swaps colour↔white. `pytest` (306 passed), `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)