### PR TITLE
fix(desktop): add PySide6 webview backend to the desktop extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.9.0](https://img.shields.io/badge/version-1.9.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.9.1](https://img.shields.io/badge/version-1.9.1-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -218,7 +218,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.9.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.9.1` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ pip install "orionbelt-ontology-builder[desktop]"
 orionbelt-ontology-builder-desktop    # opens a native window
 ```
 
+On Linux and Windows the extra also installs PySide6 to give pywebview a native
+rendering backend (macOS uses the system WebKit backend, so it is not needed
+there).
+
 This is fully opt-in: the plain install and the `orionbelt-ontology-builder`
 command above are unchanged.
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.9.0"
+APP_VERSION = "1.9.1"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ orionbelt-ontology-builder-desktop = "orionbelt_ontology_builder.desktop:run"
 [project.optional-dependencies]
 desktop = [
     "streamlit-desktop-app>=0.3.3",
+    # pywebview needs a native GUI/web-rendering backend at runtime. macOS
+    # bundles one (Cocoa/WebKit via pywebview's pyobjc deps), but on Linux and
+    # Windows none ships by default, so the desktop launcher fails without an
+    # explicit backend. PySide6 (Qt + QtWebEngine) provides a portable one.
+    "pyside6; sys_platform != 'darwin'",
 ]
 dev = [
     "pytest>=7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.9.0"
+version = "1.9.1"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
## What

Adds `pyside6` (Qt + QtWebEngine) to the optional `desktop` extra so the native
desktop launcher has a working pywebview backend on Linux and Windows.

## Why

The `desktop` extra installed only `streamlit-desktop-app`, which renders the app
through pywebview. pywebview requires a native GUI/web-rendering backend at
runtime:

- **macOS** bundles one (Cocoa/WebKit, via pywebview's `pyobjc-*` dependencies),
  so `orionbelt-ontology-builder-desktop` works out of the box.
- **Linux and Windows** ship no backend by default, so `webview.start()` has
  nothing to render with and the launcher fails.

This is what issue #68 reports. PySide6 is a portable Qt backend that fixes it.

## How

`pyproject.toml`:

```toml
desktop = [
    "streamlit-desktop-app>=0.3.3",
    "pyside6; sys_platform != 'darwin'",
]
```

The `sys_platform != 'darwin'` marker keeps PySide6 off macOS, where the system
WebKit backend already works, avoiding a large unnecessary dependency there.

README updated to note the backend. Existing `tests/test_desktop.py` still
passes (3 passed).

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)