### PR TITLE
fix(desktop): pull qtpy alongside PySide6 so pywebview's Qt backend loads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,42 @@ jobs:
 
       - name: Test (pytest)
         run: uv run pytest
+
+  # Guards against regression of issue #68: the `desktop` extra must install a
+  # resolvable pywebview Qt backend (qtpy + PySide6) on Linux. We only need the
+  # GUI base libraries so PySide6.QtGui imports; the full QtWebEngine widget
+  # additionally needs Chromium runtime libs that are the host desktop's concern.
+  desktop-extra:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Qt GUI runtime libraries
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            libgl1 libegl1 libxkbcommon0 libdbus-1-3 libglib2.0-0 \
+            libfontconfig1 libfreetype6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install with desktop extra
+        run: uv sync --extra desktop
+
+      - name: Verify Qt backend resolves
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          uv run python - <<'PY'
+          from qtpy import QtCore  # raised ModuleNotFoundError: qtpy before the fix (issue #68)
+          import qtpy
+          print("qtpy binding ->", qtpy.API_NAME)
+          assert qtpy.API_NAME == "PySide6", qtpy.API_NAME
+          print("PASS: desktop extra provides a resolvable Qt backend")
+          PY

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.9.1](https://img.shields.io/badge/version-1.9.1-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.9.2](https://img.shields.io/badge/version-1.9.2-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -170,9 +170,9 @@ pip install "orionbelt-ontology-builder[desktop]"
 orionbelt-ontology-builder-desktop    # opens a native window
 ```
 
-On Linux and Windows the extra also installs PySide6 to give pywebview a native
-rendering backend (macOS uses the system WebKit backend, so it is not needed
-there).
+On Linux and Windows the extra also installs PySide6 and qtpy to give pywebview a
+native Qt rendering backend (macOS uses the system WebKit backend, so they are
+not needed there).
 
 This is fully opt-in: the plain install and the `orionbelt-ontology-builder`
 command above are unchanged.
@@ -218,7 +218,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.9.1` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.9.2` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.9.1"
+APP_VERSION = "1.9.2"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.9.1"
+version = "1.9.2"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}
@@ -39,8 +39,10 @@ desktop = [
     # pywebview needs a native GUI/web-rendering backend at runtime. macOS
     # bundles one (Cocoa/WebKit via pywebview's pyobjc deps), but on Linux and
     # Windows none ships by default, so the desktop launcher fails without an
-    # explicit backend. PySide6 (Qt + QtWebEngine) provides a portable one.
-    "pyside6; sys_platform != 'darwin'",
+    # explicit backend. pywebview's Qt backend loads through qtpy, so PySide6
+    # alone is not enough; pulling pywebview's own pyside6 extra installs both
+    # qtpy and PySide6 (Qt + QtWebEngine), the combination it expects.
+    "pywebview[pyside6]; sys_platform != 'darwin'",
 ]
 dev = [
     "pytest>=7.0",


### PR DESCRIPTION
## What

Follow-up to #69 / v1.9.1. The `desktop` extra now installs **qtpy + PySide6** (via pywebview's own `pyside6` extra) instead of PySide6 alone, and a new CI job guards the backend.

## Why

#69 added `pyside6` to the desktop extra, but the reporter's log on #68 showed it still failed on Linux:

```
File ".../webview/platforms/qt.py", line 23, in <module>
    from qtpy import QtCore
ModuleNotFoundError: No module named 'qtpy'
```

pywebview's Qt backend loads through **qtpy**, not PySide6 directly, so PySide6 alone is not enough. pywebview's own `pyside6` extra declares exactly `QtPy` + `PySide6`, so depending on that pulls the combination it expects rather than hardcoding bindings.

## How

`pyproject.toml`:

```toml
desktop = [
    "streamlit-desktop-app>=0.3.3",
    "pywebview[pyside6]; sys_platform != 'darwin'",
]
```

## Verification

Tested in a clean `python:3.13-slim` Linux container:

- `pip install .[desktop]` now installs `qtpy 2.4.3` and `PySide6 6.11.1`
- `from qtpy import QtCore` (the exact import from #68) succeeds, with qtpy resolving the `PySide6` binding

A new `desktop-extra` CI job reproduces this on `ubuntu-latest`: it installs the Qt GUI runtime libs, `uv sync --extra desktop`, then asserts the backend resolves. Loading the full QtWebEngine widget needs Chromium runtime libs (libnss3, libsnappy, ...) that are the host desktop's responsibility, so the check stops at backend resolution.

Bumps version to 1.9.2. README updated.

Relates to #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)