### PR TITLE
fix(desktop): persist webview storage so Streamlit settings survive restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.9.2](https://img.shields.io/badge/version-1.9.2-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.9.3](https://img.shields.io/badge/version-1.9.3-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -174,6 +174,9 @@ On Linux and Windows the extra also installs PySide6 and qtpy to give pywebview 
 native Qt rendering backend (macOS uses the system WebKit backend, so they are
 not needed there).
 
+The desktop window also remembers your Streamlit settings (such as the chosen
+theme) between launches.
+
 This is fully opt-in: the plain install and the `orionbelt-ontology-builder`
 command above are unchanged.
 
@@ -218,7 +221,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.9.2` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.9.3` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -20,7 +20,7 @@ import sys
 from pathlib import Path
 
 from .app import APP_NAME
-from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG
+from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG, data_dir
 
 
 def run() -> None:
@@ -43,17 +43,39 @@ def run() -> None:
     # autosave / linked-file persistence (off by default on the cloud).
     os.environ[ENV_FLAG] = "1"
 
+    # streamlit_desktop_app calls ``webview.start()`` with no arguments, so
+    # pywebview runs in its default private mode and discards cookies /
+    # localStorage when the window closes. Streamlit persists the user's theme
+    # choice (and similar UI settings) in localStorage, so without persistent
+    # storage it reverts to the bundled brand theme on every launch (issue #70).
+    # The library doesn't expose pywebview's storage options, so wrap
+    # ``webview.start`` to opt into a persistent per-user storage directory.
+    import webview
+
+    storage_path = data_dir() / "webview"
+    storage_path.mkdir(parents=True, exist_ok=True)
+    original_start = webview.start
+
+    def _start_with_persistent_storage(*args, **kwargs):
+        kwargs.setdefault("private_mode", False)
+        kwargs.setdefault("storage_path", str(storage_path))
+        return original_start(*args, **kwargs)
+
     # Pass the brand colour as an explicit Streamlit option so it applies
     # regardless of CWD (config.toml is only found from the repo root) and
     # without relying on env inheritance into the Streamlit subprocess.
     entry = Path(__file__).parent / "streamlit_entry.py"
-    start_desktop_app(
-        script_path=str(entry),
-        title=APP_NAME,
-        options={"theme.primaryColor": BRAND_PRIMARY_COLOR},
-        width=1280,
-        height=800,
-    )
+    webview.start = _start_with_persistent_storage
+    try:
+        start_desktop_app(
+            script_path=str(entry),
+            title=APP_NAME,
+            options={"theme.primaryColor": BRAND_PRIMARY_COLOR},
+            width=1280,
+            height=800,
+        )
+    finally:
+        webview.start = original_start
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.9.2"
+version = "1.9.3"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -23,7 +23,7 @@ def test_entry_point_registered():
     assert eps[0].value == "orionbelt_ontology_builder.desktop:run"
 
 
-def test_run_invokes_start_desktop_app(monkeypatch):
+def test_run_invokes_start_desktop_app(monkeypatch, tmp_path):
     """``run()`` should open the in-package entry script in a native window."""
     captured = {}
 
@@ -34,6 +34,8 @@ def test_run_invokes_start_desktop_app(monkeypatch):
     fake_module.start_desktop_app = _fake_start_desktop_app
     monkeypatch.setitem(sys.modules, "streamlit_desktop_app", fake_module)
 
+    # Keep the persistent-storage setup off the real home directory.
+    monkeypatch.setattr(desktop, "data_dir", lambda: tmp_path)
     monkeypatch.delenv(ENV_FLAG, raising=False)
 
     desktop.run()
@@ -45,6 +47,47 @@ def test_run_invokes_start_desktop_app(monkeypatch):
     # Brand colour passed as an explicit Streamlit option (not via env) so it
     # applies in the subprocess regardless of CWD.
     assert captured["options"]["theme.primaryColor"] == BRAND_PRIMARY_COLOR
+
+
+def test_run_enables_persistent_webview_storage(monkeypatch, tmp_path):
+    """The launcher should make pywebview persist localStorage across launches.
+
+    streamlit_desktop_app calls ``webview.start()`` with no arguments, which
+    defaults to private mode and wipes the saved Streamlit theme on close
+    (issue #70). ``run()`` should inject a persistent ``storage_path`` and
+    disable private mode, then restore the original ``webview.start``.
+    """
+    captured = {}
+
+    fake_webview = types.ModuleType("webview")
+
+    def _record_start(*args, **kwargs):
+        captured.update(kwargs)
+
+    fake_webview.start = _record_start
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+
+    fake_sda = types.ModuleType("streamlit_desktop_app")
+
+    def _start_desktop_app(**kwargs):
+        # The real library starts pywebview with no storage arguments.
+        import webview
+
+        webview.start()
+
+    fake_sda.start_desktop_app = _start_desktop_app
+    monkeypatch.setitem(sys.modules, "streamlit_desktop_app", fake_sda)
+
+    monkeypatch.setattr(desktop, "data_dir", lambda: tmp_path)
+    monkeypatch.delenv(ENV_FLAG, raising=False)
+
+    desktop.run()
+
+    assert captured["private_mode"] is False
+    assert captured["storage_path"] == str(tmp_path / "webview")
+    assert (tmp_path / "webview").is_dir()
+    # The wrapper must not leak: the original start is restored afterwards.
+    assert fake_webview.start is _record_start
 
 
 def test_run_without_dependency_exits_cleanly(monkeypatch):

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -34,6 +34,12 @@ def test_run_invokes_start_desktop_app(monkeypatch, tmp_path):
     fake_module.start_desktop_app = _fake_start_desktop_app
     monkeypatch.setitem(sys.modules, "streamlit_desktop_app", fake_module)
 
+    # pywebview ships only with the optional desktop extra, so stub it out to
+    # keep this test runnable without that extra installed.
+    fake_webview = types.ModuleType("webview")
+    fake_webview.start = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+
     # Keep the persistent-storage setup off the real home directory.
     monkeypatch.setattr(desktop, "data_dir", lambda: tmp_path)
     monkeypatch.delenv(ENV_FLAG, raising=False)


### PR DESCRIPTION
Closes #70

## What

The native desktop app now remembers your Streamlit settings (theme, etc.) between launches.

## Why

`streamlit_desktop_app.start_desktop_app` calls `webview.start()` with no arguments, so pywebview runs in its default **private mode** and discards cookies / localStorage when the window closes. Streamlit persists the user's theme choice in localStorage, so every launch reset it back to the bundled brand ("Custom") theme. This is the sequel to #63: the documented dark-mode workaround there is to pick the theme manually in Settings, but that choice didn't stick.

## How

The library doesn't expose pywebview's storage options, so the launcher wraps `webview.start` to inject persistent storage, then restores it:

```python
import webview
storage_path = data_dir() / "webview"
storage_path.mkdir(parents=True, exist_ok=True)
original_start = webview.start

def _start_with_persistent_storage(*args, **kwargs):
    kwargs.setdefault("private_mode", False)
    kwargs.setdefault("storage_path", str(storage_path))
    return original_start(*args, **kwargs)
```

Storage lives under the existing per-user app data dir (`~/.orionbelt_ontology_builder/webview`), alongside the crash-recovery file. `setdefault` means a future library version that forwards these options would still win.

## Tests

- New test asserts `run()` injects `private_mode=False` + a `storage_path` and restores the original `webview.start`.
- Existing launch test updated to keep storage setup off the real home dir.
- Full suite: 307 passed.

Note: end-to-end persistence (close the window, reopen, theme retained) needs manual verification in a real desktop session, since it depends on the GUI backend writing localStorage to disk.

Bumps version to 1.9.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)