### PR TITLE
feat(desktop): add qt/gtk backend extras and deterministic backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.9.3](https://img.shields.io/badge/version-1.9.3-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.10.0](https://img.shields.io/badge/version-1.10.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -177,6 +177,26 @@ not needed there).
 The desktop window also remembers your Streamlit settings (such as the chosen
 theme) between launches.
 
+#### Choosing a rendering backend
+
+The `desktop` extra uses the Qt backend, which works out of the box. On Linux you
+can use GTK instead with the `gtk` extra (`qt` is an explicit alias for the Qt
+default):
+
+```bash
+pip install "orionbelt-ontology-builder[gtk]"
+```
+
+GTK needs system packages that pip cannot install. On Debian/Ubuntu:
+
+```bash
+sudo apt install python3-gi gir1.2-gtk-3.0 gir1.2-webkit2-4.1 \
+    libgirepository1.0-dev
+```
+
+The launcher auto-selects whichever backend is installed; set `PYWEBVIEW_GUI=qt`
+or `PYWEBVIEW_GUI=gtk` to override.
+
 This is fully opt-in: the plain install and the `orionbelt-ontology-builder`
 command above are unchanged.
 
@@ -221,7 +241,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.9.3` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.10.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.9.2"
+APP_VERSION = "1.10.0"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -11,16 +11,45 @@ so there is no browser tab to manage and no manual start/stop of the server.
     pip install "orionbelt-ontology-builder[desktop]"
     orionbelt-ontology-builder-desktop
 
+The ``desktop`` extra uses the Qt backend (PySide6). ``qt`` is an explicit alias
+for it, and ``gtk`` selects pywebview's GTK backend instead (Linux only). See the
+README for the GTK system-package prerequisites.
+
 This reuses the same in-package Streamlit entry script as the console launcher
 (:mod:`orionbelt_ontology_builder.cli`).
 """
 
+import importlib.util
 import os
 import sys
 from pathlib import Path
 
 from .app import APP_NAME
 from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG, data_dir
+
+
+def _preferred_gui() -> str | None:
+    """Pick a pywebview GUI backend deterministically from what is installed.
+
+    On Linux pywebview tries GTK before Qt regardless of which is actually
+    present, logging a noisy ``ImportError`` traceback when only Qt is installed
+    (issue #73). Returning an explicit backend (exported via ``PYWEBVIEW_GUI``)
+    makes the choice match the installed extra and silences that traceback.
+
+    Returns ``None`` when the platform or the user should decide: on macOS, where
+    Cocoa is the right default, or when ``PYWEBVIEW_GUI`` is already set.
+    """
+    if sys.platform == "darwin":
+        return None
+    if os.environ.get("PYWEBVIEW_GUI"):
+        return None
+    # find_spec only checks importability — it does not import the backend (and
+    # so never loads the heavy Qt/GTK shared libraries) as a side effect.
+    if importlib.util.find_spec("gi") is not None:
+        return "gtk"
+    if importlib.util.find_spec("qtpy") is not None:
+        return "qt"
+    return None
 
 
 def run() -> None:
@@ -42,6 +71,12 @@ def run() -> None:
     # Running locally with full filesystem access — opt into the disk-backed
     # autosave / linked-file persistence (off by default on the cloud).
     os.environ[ENV_FLAG] = "1"
+
+    # Force pywebview onto the installed backend so it doesn't try (and noisily
+    # fail) GTK before Qt on Linux (issue #73).
+    gui = _preferred_gui()
+    if gui:
+        os.environ["PYWEBVIEW_GUI"] = gui
 
     # streamlit_desktop_app calls ``webview.start()`` with no arguments, so
     # pywebview runs in its default private mode and discards cookies /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.9.3"
+version = "1.10.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}
@@ -43,6 +43,21 @@ desktop = [
     # alone is not enough; pulling pywebview's own pyside6 extra installs both
     # qtpy and PySide6 (Qt + QtWebEngine), the combination it expects.
     "pywebview[pyside6]; sys_platform != 'darwin'",
+]
+# Explicit Qt backend, identical to `desktop`. PySide6 is the LGPL Qt for
+# Python; we deliberately use pywebview's `pyside6` extra rather than its `qt`
+# extra (which would pull a second, conflicting binding, PyQt6).
+qt = [
+    "streamlit-desktop-app>=0.3.3",
+    "pywebview[pyside6]; sys_platform != 'darwin'",
+]
+# GTK backend (Linux only; macOS uses Cocoa and Windows uses Qt/EdgeChromium).
+# pywebview[gtk] installs PyGObject, but a working GTK backend ALSO needs system
+# packages pip cannot provide (gobject-introspection, libgirepository and the
+# WebKit typelib gir1.2-webkit2-4.x). See the README for the apt prerequisites.
+gtk = [
+    "streamlit-desktop-app>=0.3.3",
+    "pywebview[gtk]; sys_platform == 'linux'",
 ]
 dev = [
     "pytest>=7.0",

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -1,5 +1,6 @@
 """Tests for the native desktop launcher (``orionbelt-ontology-builder-desktop``)."""
 
+import importlib.util
 import os
 import sys
 import types
@@ -94,6 +95,70 @@ def test_run_enables_persistent_webview_storage(monkeypatch, tmp_path):
     assert (tmp_path / "webview").is_dir()
     # The wrapper must not leak: the original start is restored afterwards.
     assert fake_webview.start is _record_start
+
+
+def _fake_find_spec(available):
+    """Return a ``find_spec`` stub reporting only ``available`` modules present."""
+
+    def _find_spec(name, *args, **kwargs):
+        return object() if name in available else None
+
+    return _find_spec
+
+
+def test_preferred_gui_prefers_gtk_when_pygobject_present(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("PYWEBVIEW_GUI", raising=False)
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec({"gi", "qtpy"}))
+    assert desktop._preferred_gui() == "gtk"
+
+
+def test_preferred_gui_falls_back_to_qt(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("PYWEBVIEW_GUI", raising=False)
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec({"qtpy"}))
+    assert desktop._preferred_gui() == "qt"
+
+
+def test_preferred_gui_none_without_any_backend(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("PYWEBVIEW_GUI", raising=False)
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec(set()))
+    assert desktop._preferred_gui() is None
+
+
+def test_preferred_gui_respects_user_override(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("PYWEBVIEW_GUI", "gtk")
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec({"qtpy"}))
+    assert desktop._preferred_gui() is None
+
+
+def test_preferred_gui_none_on_macos(monkeypatch):
+    """macOS should keep Cocoa as the default rather than forcing Qt/GTK."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.delenv("PYWEBVIEW_GUI", raising=False)
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec({"qtpy"}))
+    assert desktop._preferred_gui() is None
+
+
+def test_run_exports_selected_gui_backend(monkeypatch, tmp_path):
+    """``run()`` should export the chosen backend via PYWEBVIEW_GUI."""
+    fake_module = types.ModuleType("streamlit_desktop_app")
+    fake_module.start_desktop_app = lambda **kwargs: None
+    monkeypatch.setitem(sys.modules, "streamlit_desktop_app", fake_module)
+
+    fake_webview = types.ModuleType("webview")
+    fake_webview.start = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+
+    monkeypatch.setattr(desktop, "data_dir", lambda: tmp_path)
+    monkeypatch.setattr(desktop, "_preferred_gui", lambda: "qt")
+    monkeypatch.delenv("PYWEBVIEW_GUI", raising=False)
+
+    desktop.run()
+
+    assert os.environ["PYWEBVIEW_GUI"] == "qt"
 
 
 def test_run_without_dependency_exits_cleanly(monkeypatch):

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,36 @@
+"""Guards that the version is in sync across the places that declare it.
+
+A 1.9.3 release shipped with ``pyproject.toml`` at 1.9.3 but ``APP_VERSION``
+left at 1.9.2 (the bump was edited but never staged), so the package reported
+the wrong version at runtime (issue #74). These tests fail CI on any such drift.
+"""
+
+import re
+from pathlib import Path
+
+from orionbelt_ontology_builder.app import APP_VERSION
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _pyproject_version() -> str:
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version = "(.+?)"', text, re.MULTILINE)
+    assert match, "could not find version in pyproject.toml"
+    return match.group(1)
+
+
+def test_app_version_matches_pyproject():
+    assert APP_VERSION == _pyproject_version(), (
+        "APP_VERSION in app.py is out of sync with pyproject.toml "
+        f"({APP_VERSION!r} != {_pyproject_version()!r})"
+    )
+
+
+def test_readme_badge_matches_pyproject():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    version = _pyproject_version()
+    assert f"version-{version}-" in readme, (
+        "README version badge is out of sync with pyproject.toml "
+        f"(expected version-{version}-)"
+    )


### PR DESCRIPTION
Closes #73

## What

- Two new install extras: **`qt`** (explicit alias of `desktop`, PySide6) and **`gtk`** (Linux-only, PyGObject).
- The launcher now **selects the pywebview backend deterministically** instead of relying on import order.

## Why

pywebview picks its backend by import order, not by what you installed. On Linux it tries **GTK before Qt** regardless, so:
- Qt-only users saw a scary `[pywebview] GTK cannot be loaded` traceback on every launch before it fell back to Qt (visible in #68's log).
- Simply adding a `gtk` extra would make the active backend depend on import order, not on the extra you chose.

## How

`_preferred_gui()` checks importability (no heavy imports) and exports `PYWEBVIEW_GUI`:
- `gi` present -> `gtk`; else `qtpy` present -> `qt`
- respects a user-set `PYWEBVIEW_GUI`; returns `None` on macOS (Cocoa stays default)

`pyproject.toml`:
```toml
qt  = [ "streamlit-desktop-app>=0.3.3", "pywebview[pyside6]; sys_platform != 'darwin'" ]
gtk = [ "streamlit-desktop-app>=0.3.3", "pywebview[gtk]; sys_platform == 'linux'" ]
```
We keep `pywebview[pyside6]` (LGPL PySide6) for `qt`, not pywebview's `qt` extra (which would pull a conflicting PyQt6).

## Notes / caveats

- `pywebview[gtk]` needs system packages pip cannot install (gobject-introspection, libgirepository, the WebKit typelib). README documents the `apt` line.
- Tests cover backend selection (gtk/qt/none/override/macOS) and that `run()` exports `PYWEBVIEW_GUI`. Full suite: 313 passed.
- No GTK CI job: a resolution-only check adds little over docs, and GTK headless is the most flake-prone piece. The existing `desktop-extra` (Qt) job still guards the default.

Bumps version to 1.10.0 (new user-facing capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)