### PR TITLE
fix(desktop): persist theme server-side instead of via browser storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.10.0](https://img.shields.io/badge/version-1.10.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.10.1](https://img.shields.io/badge/version-1.10.1-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -241,7 +241,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.10.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.10.1` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.10.0"
+APP_VERSION = "1.10.1"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -6279,10 +6279,18 @@ def main():
     # dark on transparent). st.context.theme reflects the active theme on recent
     # Streamlit; older versions fall back to the colour logo.
     _dark_mode = False
+    _theme_type = None
     try:
-        _dark_mode = st.context.theme.type == "dark"
+        _theme_type = st.context.theme.type
+        _dark_mode = _theme_type == "dark"
     except Exception:
         pass
+    # Persist the active light/dark theme so the desktop launcher can re-apply it
+    # on the next launch (issue #70). Disk persistence is off on the cloud, where
+    # the browser keeps the choice in localStorage instead.
+    if _theme_type in ("light", "dark") and local_store.local_persist_enabled():
+        if local_store.get_theme_base() != _theme_type:
+            local_store.set_theme_base(_theme_type)
     _logo_file = "ORIONBELT Logo w.png" if _dark_mode else "ORIONBELT_Logo.png"
     _logo_path = _Path(__file__).parent / "assets" / _logo_file
     st.sidebar.image(str(_logo_path), width=200)

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6278,11 +6278,9 @@ def main():
     # Use the white logo in dark mode so it stays legible (the colour logo is
     # dark on transparent). st.context.theme reflects the active theme on recent
     # Streamlit; older versions fall back to the colour logo.
-    _dark_mode = False
     _theme_type = None
     try:
         _theme_type = st.context.theme.type
-        _dark_mode = _theme_type == "dark"
     except Exception:
         pass
     # Persist the active light/dark theme so the desktop launcher can re-apply it
@@ -6291,6 +6289,14 @@ def main():
     if _theme_type in ("light", "dark") and local_store.local_persist_enabled():
         if local_store.get_theme_base() != _theme_type:
             local_store.set_theme_base(_theme_type)
+    # st.context.theme lags on the very first render, so the logo would flash the
+    # light (blue) variant even when the launcher opened the app in dark. Fall
+    # back to the persisted preference (which set --theme.base) to pick the right
+    # logo immediately (issue #70).
+    _effective_type = _theme_type
+    if _effective_type not in ("light", "dark") and local_store.local_persist_enabled():
+        _effective_type = local_store.get_theme_base()
+    _dark_mode = _effective_type == "dark"
     _logo_file = "ORIONBELT Logo w.png" if _dark_mode else "ORIONBELT_Logo.png"
     _logo_path = _Path(__file__).parent / "assets" / _logo_file
     st.sidebar.image(str(_logo_path), width=200)

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6283,20 +6283,27 @@ def main():
         _theme_type = st.context.theme.type
     except Exception:
         pass
-    # Persist the active light/dark theme so the desktop launcher can re-apply it
-    # on the next launch (issue #70). Disk persistence is off on the cloud, where
-    # the browser keeps the choice in localStorage instead.
-    if _theme_type in ("light", "dark") and local_store.local_persist_enabled():
-        if local_store.get_theme_base() != _theme_type:
-            local_store.set_theme_base(_theme_type)
-    # st.context.theme lags on the very first render, so the logo would flash the
-    # light (blue) variant even when the launcher opened the app in dark. Fall
-    # back to the persisted preference (which set --theme.base) to pick the right
-    # logo immediately (issue #70).
-    _effective_type = _theme_type
-    if _effective_type not in ("light", "dark") and local_store.local_persist_enabled():
-        _effective_type = local_store.get_theme_base()
-    _dark_mode = _effective_type == "dark"
+    # st.context.theme is stale on the first render of a session — it reports the
+    # default ("light") until the browser tells the server the active theme. So
+    # persist the choice only from the second render on; doing it on the first
+    # render would clobber the saved preference the launcher just applied with a
+    # stale "light" before the user touches anything (issue #70). Disk
+    # persistence is off on the cloud, where the browser keeps the choice itself.
+    if (
+        _theme_type in ("light", "dark")
+        and st.session_state.get("_theme_settled")
+        and local_store.local_persist_enabled()
+        and local_store.get_theme_base() != _theme_type
+    ):
+        local_store.set_theme_base(_theme_type)
+    st.session_state["_theme_settled"] = True
+    # Choose the logo from the persisted preference in local mode (what the
+    # launcher opened the app with via --theme.base), since st.context.theme lags
+    # on first render and would otherwise flash the light/blue logo in dark mode.
+    if local_store.local_persist_enabled():
+        _dark_mode = local_store.get_theme_base() == "dark"
+    else:
+        _dark_mode = _theme_type == "dark"
     _logo_file = "ORIONBELT Logo w.png" if _dark_mode else "ORIONBELT_Logo.png"
     _logo_path = _Path(__file__).parent / "assets" / _logo_file
     st.sidebar.image(str(_logo_path), width=200)

--- a/orionbelt_ontology_builder/cli.py
+++ b/orionbelt_ontology_builder/cli.py
@@ -9,7 +9,7 @@ import os
 import sys
 from pathlib import Path
 
-from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG
+from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG, get_theme_base
 
 
 def run() -> None:
@@ -31,12 +31,19 @@ def run() -> None:
     # of CWD (config.toml is only found from the repo root) — otherwise the
     # console/desktop runs fall back to Streamlit's default red. Placed before
     # the user's args so an explicit --theme.primaryColor still wins.
+    # Re-apply the user's saved light/dark theme so the app opens the way they
+    # left it (issue #70). Placed before the user's args so an explicit
+    # --theme.base still wins.
     entry = Path(__file__).parent / "streamlit_entry.py"
+    theme_args = [f"--theme.primaryColor={BRAND_PRIMARY_COLOR}"]
+    saved_base = get_theme_base()
+    if saved_base:
+        theme_args.append(f"--theme.base={saved_base}")
     sys.argv = [
         "streamlit",
         "run",
         str(entry),
-        f"--theme.primaryColor={BRAND_PRIMARY_COLOR}",
+        *theme_args,
         *sys.argv[1:],
     ]
     sys.exit(stcli.main())

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -25,7 +25,7 @@ import sys
 from pathlib import Path
 
 from .app import APP_NAME
-from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG, data_dir
+from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG, data_dir, get_theme_base
 
 
 def _preferred_gui() -> str | None:
@@ -99,13 +99,20 @@ def run() -> None:
     # Pass the brand colour as an explicit Streamlit option so it applies
     # regardless of CWD (config.toml is only found from the repo root) and
     # without relying on env inheritance into the Streamlit subprocess.
+    # Re-apply the saved light/dark theme so the app opens the way it was left
+    # (issue #70).
+    options = {"theme.primaryColor": BRAND_PRIMARY_COLOR}
+    saved_base = get_theme_base()
+    if saved_base:
+        options["theme.base"] = saved_base
+
     entry = Path(__file__).parent / "streamlit_entry.py"
     webview.start = _start_with_persistent_storage
     try:
         start_desktop_app(
             script_path=str(entry),
             title=APP_NAME,
-            options={"theme.primaryColor": BRAND_PRIMARY_COLOR},
+            options=options,
             width=1280,
             height=800,
         )

--- a/orionbelt_ontology_builder/local_store.py
+++ b/orionbelt_ontology_builder/local_store.py
@@ -121,6 +121,27 @@ def save_config(config: dict) -> None:
     atomic_write(config_file(), json.dumps(config, indent=2))
 
 
+def get_theme_base() -> str | None:
+    """Return the saved light/dark theme preference, or ``None`` if unset.
+
+    Persisted server-side (desktop / local mode only) so the launcher can
+    re-apply it on the next launch; the cloud keeps the choice in the browser's
+    localStorage instead (issue #70).
+    """
+    base = load_config().get("theme_base")
+    return base if base in ("light", "dark") else None
+
+
+def set_theme_base(base: str | None) -> None:
+    """Save (or clear, when ``base`` is not light/dark) the theme preference."""
+    config = load_config()
+    if base in ("light", "dark"):
+        config["theme_base"] = base
+    else:
+        config.pop("theme_base", None)
+    save_config(config)
+
+
 def get_linked_path() -> Path | None:
     """Return the user's linked working-file path, or ``None`` if unset."""
     p = load_config().get("linked_path")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.10.0"
+version = "1.10.1"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,3 +72,44 @@ def test_run_opts_into_persistence_and_brand_theme(monkeypatch):
     assert os.environ[ENV_FLAG] == "1"
     # Brand colour passed as an explicit flag so config.toml isn't needed.
     assert f"--theme.primaryColor={BRAND_PRIMARY_COLOR}" in captured["argv"]
+
+
+def test_run_reapplies_saved_theme_base(monkeypatch):
+    """A saved light/dark preference is forwarded as --theme.base (issue #70)."""
+    captured = {}
+
+    class _FakeStcli:
+        @staticmethod
+        def main():
+            captured["argv"] = list(sys.argv)
+
+    import streamlit.web
+
+    monkeypatch.setattr(streamlit.web, "cli", _FakeStcli, raising=False)
+    monkeypatch.setattr(cli, "get_theme_base", lambda: "dark")
+    monkeypatch.setattr(sys, "argv", ["orionbelt-ontology-builder"])
+    monkeypatch.setattr(sys, "exit", lambda code=0: None)
+
+    cli.run()
+
+    assert "--theme.base=dark" in captured["argv"]
+
+
+def test_run_omits_theme_base_when_unset(monkeypatch):
+    captured = {}
+
+    class _FakeStcli:
+        @staticmethod
+        def main():
+            captured["argv"] = list(sys.argv)
+
+    import streamlit.web
+
+    monkeypatch.setattr(streamlit.web, "cli", _FakeStcli, raising=False)
+    monkeypatch.setattr(cli, "get_theme_base", lambda: None)
+    monkeypatch.setattr(sys, "argv", ["orionbelt-ontology-builder"])
+    monkeypatch.setattr(sys, "exit", lambda code=0: None)
+
+    cli.run()
+
+    assert not any(a.startswith("--theme.base") for a in captured["argv"])

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -161,6 +161,47 @@ def test_run_exports_selected_gui_backend(monkeypatch, tmp_path):
     assert os.environ["PYWEBVIEW_GUI"] == "qt"
 
 
+def test_run_reapplies_saved_theme_base(monkeypatch, tmp_path):
+    """A saved light/dark preference is passed to start_desktop_app (issue #70)."""
+    captured = {}
+
+    fake_module = types.ModuleType("streamlit_desktop_app")
+    fake_module.start_desktop_app = lambda **kwargs: captured.update(kwargs)
+    monkeypatch.setitem(sys.modules, "streamlit_desktop_app", fake_module)
+
+    fake_webview = types.ModuleType("webview")
+    fake_webview.start = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+
+    monkeypatch.setattr(desktop, "data_dir", lambda: tmp_path)
+    monkeypatch.setattr(desktop, "get_theme_base", lambda: "dark")
+    monkeypatch.delenv(ENV_FLAG, raising=False)
+
+    desktop.run()
+
+    assert captured["options"]["theme.base"] == "dark"
+
+
+def test_run_omits_theme_base_when_unset(monkeypatch, tmp_path):
+    captured = {}
+
+    fake_module = types.ModuleType("streamlit_desktop_app")
+    fake_module.start_desktop_app = lambda **kwargs: captured.update(kwargs)
+    monkeypatch.setitem(sys.modules, "streamlit_desktop_app", fake_module)
+
+    fake_webview = types.ModuleType("webview")
+    fake_webview.start = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+
+    monkeypatch.setattr(desktop, "data_dir", lambda: tmp_path)
+    monkeypatch.setattr(desktop, "get_theme_base", lambda: None)
+    monkeypatch.delenv(ENV_FLAG, raising=False)
+
+    desktop.run()
+
+    assert "theme.base" not in captured["options"]
+
+
 def test_run_without_dependency_exits_cleanly(monkeypatch):
     """Missing the optional ``desktop`` extra should exit non-zero, not crash."""
     monkeypatch.setitem(sys.modules, "streamlit_desktop_app", None)

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -101,3 +101,33 @@ def test_get_linked_path_expands_user(home, monkeypatch):
     monkeypatch.setenv("HOME", str(home))
     local_store.set_linked_path("~/backup.ttl")
     assert local_store.get_linked_path() == home / "backup.ttl"
+
+
+def test_theme_base_set_get_clear(home):
+    assert local_store.get_theme_base() is None
+
+    local_store.set_theme_base("dark")
+    assert local_store.get_theme_base() == "dark"
+
+    local_store.set_theme_base("light")
+    assert local_store.get_theme_base() == "light"
+
+    local_store.set_theme_base(None)
+    assert local_store.get_theme_base() is None
+
+
+@pytest.mark.parametrize("value", ["", "Dark", "blue", "system", None])
+def test_theme_base_ignores_invalid_values(home, value):
+    local_store.save_config({"theme_base": "dark"})
+    local_store.set_theme_base(value)
+    # Anything that isn't light/dark clears the preference rather than storing it.
+    assert local_store.get_theme_base() is None
+    assert "theme_base" not in local_store.load_config()
+
+
+def test_set_theme_base_preserves_other_config(home):
+    local_store.set_linked_path("/x.ttl")
+    local_store.set_theme_base("dark")
+    config = local_store.load_config()
+    assert config["linked_path"] == "/x.ttl"
+    assert config["theme_base"] == "dark"


### PR DESCRIPTION
Closes #70

## Why the previous attempts failed

1.9.3 added persistent pywebview storage; 1.10.0 added the backend extras. Neither made the desktop theme stick, because the real problem is elsewhere:

- `streamlit-desktop-app` serves the app on a **random free port every launch** (`http://localhost:<random>`).
- Browser `localStorage` is keyed by **origin**, which includes the port. Streamlit saves the theme under that origin.
- Next launch uses a different port, so the window looks under a new, empty origin. The data is on disk but filed under a key nobody asks for.

A fixed port would give a stable origin but is fragile: an orphaned Streamlit child (they get orphaned to PPID 1 on unclean window close) or anything else can hold it, silently dropping us back to a random port.

## The fix

Stop relying on the browser for this. Persist the theme as our own setting:

- **app.py** reads the active `st.context.theme.type` and saves `light`/`dark` to the on-disk config (`config.json`) - gated by `local_persist_enabled()`, so desktop/local only.
- **cli.py / desktop.py** read it back on launch and pass `--theme.base=<saved>`.
- **Cloud**: `local_persist_enabled()` is off, so nothing is written server-side and Streamlit's native browser `localStorage` keeps the choice (stable origin in a real browser), exactly as before. Browser storage stays as the backup everywhere.

Tradeoff: "Use system setting" gets pinned to whatever it resolved to (dark/light) at save time rather than following the OS live. For #63/#70 (open in dark, stay dark) that's the desired behaviour.

## Tests

- `local_store` theme helpers (set/get/clear, invalid-value handling, preserves other config).
- Both launchers re-apply `--theme.base` when saved and omit it when unset.
- Full suite: 326 passed; desktop/cli/local_store also pass with pywebview absent (CI's `check` job).

Bumps version to 1.10.1.

## Please test before release

I can't verify GUI persistence headlessly. Could you run this branch on your machine - pick Dark, close, reopen - and confirm it stays dark, before I merge and release? `pip install -e .` then `orionbelt-ontology-builder-desktop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)