### PR TITLE
feat(desktop): follow OS theme by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ On Linux and Windows the extra also installs PySide6 and qtpy to give pywebview 
 native Qt rendering backend (macOS uses the system WebKit backend, so they are
 not needed there).
 
-The desktop window also remembers your theme between launches. A **Startup
-theme** control in the sidebar lets you choose **Follow system** (match the OS
-light/dark appearance), **Light**, or **Dark**; the choice applies on the next
-launch (Streamlit can't switch theme live).
+The desktop window follows your OS light/dark appearance by default. Once you
+pick a specific theme in the toolbar's Settings menu, that choice is remembered
+across launches. To go back to following the system, clear the stored setting
+(delete `theme_base` from `~/.orionbelt_ontology_builder/config.json`).
 
 #### Choosing a rendering backend
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.10.1](https://img.shields.io/badge/version-1.10.1-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.11.0](https://img.shields.io/badge/version-1.11.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -174,8 +174,10 @@ On Linux and Windows the extra also installs PySide6 and qtpy to give pywebview 
 native Qt rendering backend (macOS uses the system WebKit backend, so they are
 not needed there).
 
-The desktop window also remembers your Streamlit settings (such as the chosen
-theme) between launches.
+The desktop window also remembers your theme between launches. A **Startup
+theme** control in the sidebar lets you choose **Follow system** (match the OS
+light/dark appearance), **Light**, or **Dark**; the choice applies on the next
+launch (Streamlit can't switch theme live).
 
 #### Choosing a rendering backend
 
@@ -241,7 +243,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.10.1` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.11.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.10.1"
+APP_VERSION = "1.11.0"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -6284,24 +6284,30 @@ def main():
     except Exception:
         pass
     # st.context.theme is stale on the first render of a session — it reports the
-    # default ("light") until the browser tells the server the active theme. So
-    # persist the choice only from the second render on; doing it on the first
-    # render would clobber the saved preference the launcher just applied with a
-    # stale "light" before the user touches anything (issue #70). Disk
-    # persistence is off on the cloud, where the browser keeps the choice itself.
-    if (
-        _theme_type in ("light", "dark")
-        and st.session_state.get("_theme_settled")
-        and local_store.local_persist_enabled()
-        and local_store.get_theme_base() != _theme_type
-    ):
-        local_store.set_theme_base(_theme_type)
+    # default ("light") until the browser tells the server the active theme, so
+    # only trust it from the second render on (issues #70, #78).
+    _theme_settled = st.session_state.get("_theme_settled", False)
     st.session_state["_theme_settled"] = True
-    # Choose the logo from the persisted preference in local mode (what the
-    # launcher opened the app with via --theme.base), since st.context.theme lags
-    # on first render and would otherwise flash the light/blue logo in dark mode.
     if local_store.local_persist_enabled():
-        _dark_mode = local_store.get_theme_base() == "dark"
+        _mode = local_store.get_theme_mode()
+        # Keep a pinned light/dark mode in sync with the toolbar Settings menu.
+        # Skip the first (stale) render, and skip "system" mode, where the
+        # resolved value is the OS appearance rather than a deliberate choice.
+        if (
+            _theme_settled
+            and _mode != "system"
+            and _theme_type in ("light", "dark")
+            and _theme_type != _mode
+        ):
+            local_store.set_theme_mode(_theme_type)
+            _mode = _theme_type
+        # Logo: use the live theme once the client reports it; on the first
+        # render fall back to what the launcher opened the app with, so the dark
+        # logo doesn't flash the light/blue variant.
+        if _theme_settled and _theme_type in ("light", "dark"):
+            _dark_mode = _theme_type == "dark"
+        else:
+            _dark_mode = local_store.resolved_startup_base() == "dark"
     else:
         _dark_mode = _theme_type == "dark"
     _logo_file = "ORIONBELT Logo w.png" if _dark_mode else "ORIONBELT_Logo.png"
@@ -6318,6 +6324,24 @@ def main():
         f'<a href="{GITHUB_ISSUES_URL}/new">Report Issue</a></small>',
         unsafe_allow_html=True,
     )
+
+    # Startup theme control (local / desktop launches only). The cloud relies on
+    # Streamlit's own per-browser theme persistence, so this is hidden there.
+    # Streamlit can't switch theme live from Python, so the choice applies on the
+    # next launch (issues #70, #78).
+    if local_store.local_persist_enabled():
+        _mode_labels = {"system": "Follow system", "light": "Light", "dark": "Dark"}
+        _current_mode = local_store.get_theme_mode()
+        _picked_mode = st.sidebar.selectbox(
+            "Startup theme",
+            list(_mode_labels),
+            index=list(_mode_labels).index(_current_mode),
+            format_func=lambda m: _mode_labels[m],
+            help="Applies on the next launch (Streamlit can't switch theme live).",
+        )
+        if _picked_mode != _current_mode:
+            local_store.set_theme_mode(_picked_mode)
+            st.rerun()
 
     pages = {
         "Dashboard": render_dashboard,

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6289,25 +6289,32 @@ def main():
     _theme_settled = st.session_state.get("_theme_settled", False)
     st.session_state["_theme_settled"] = True
     if local_store.local_persist_enabled():
-        _mode = local_store.get_theme_mode()
-        # Keep a pinned light/dark mode in sync with the toolbar Settings menu.
-        # Skip the first (stale) render, and skip "system" mode, where the
-        # resolved value is the OS appearance rather than a deliberate choice.
-        if (
-            _theme_settled
-            and _mode != "system"
-            and _theme_type in ("light", "dark")
-            and _theme_type != _mode
-        ):
-            local_store.set_theme_mode(_theme_type)
-            _mode = _theme_type
+        # Detect the OS appearance once per session (cached) — calling darkdetect
+        # every render shells out to the OS and made the UI lag.
+        if "_system_base" not in st.session_state:
+            st.session_state["_system_base"] = local_store.detect_system_base()
+        _system_base = st.session_state["_system_base"]
+        _pinned = local_store.get_theme_base()
+        # Persist a pin only when the user actually changes the theme: while
+        # following the OS (no pin), store only a deviation from the OS theme; a
+        # match is left unstored so it keeps following the system. Once pinned,
+        # keep it in sync with the toolbar Settings menu. To return to "follow
+        # system", clear the saved setting. Skip the stale first render.
+        if _theme_settled and _theme_type in ("light", "dark"):
+            if _pinned is None:
+                if _system_base in ("light", "dark") and _theme_type != _system_base:
+                    local_store.set_theme_base(_theme_type)
+                    _pinned = _theme_type
+            elif _theme_type != _pinned:
+                local_store.set_theme_base(_theme_type)
+                _pinned = _theme_type
         # Logo: use the live theme once the client reports it; on the first
-        # render fall back to what the launcher opened the app with, so the dark
-        # logo doesn't flash the light/blue variant.
+        # render fall back to what the launcher opened the app with (pin, else
+        # detected OS), so the dark logo doesn't flash the light/blue variant.
         if _theme_settled and _theme_type in ("light", "dark"):
             _dark_mode = _theme_type == "dark"
         else:
-            _dark_mode = local_store.resolved_startup_base() == "dark"
+            _dark_mode = (_pinned or _system_base) == "dark"
     else:
         _dark_mode = _theme_type == "dark"
     _logo_file = "ORIONBELT Logo w.png" if _dark_mode else "ORIONBELT_Logo.png"
@@ -6324,24 +6331,6 @@ def main():
         f'<a href="{GITHUB_ISSUES_URL}/new">Report Issue</a></small>',
         unsafe_allow_html=True,
     )
-
-    # Startup theme control (local / desktop launches only). The cloud relies on
-    # Streamlit's own per-browser theme persistence, so this is hidden there.
-    # Streamlit can't switch theme live from Python, so the choice applies on the
-    # next launch (issues #70, #78).
-    if local_store.local_persist_enabled():
-        _mode_labels = {"system": "Follow system", "light": "Light", "dark": "Dark"}
-        _current_mode = local_store.get_theme_mode()
-        _picked_mode = st.sidebar.selectbox(
-            "Startup theme",
-            list(_mode_labels),
-            index=list(_mode_labels).index(_current_mode),
-            format_func=lambda m: _mode_labels[m],
-            help="Applies on the next launch (Streamlit can't switch theme live).",
-        )
-        if _picked_mode != _current_mode:
-            local_store.set_theme_mode(_picked_mode)
-            st.rerun()
 
     pages = {
         "Dashboard": render_dashboard,

--- a/orionbelt_ontology_builder/cli.py
+++ b/orionbelt_ontology_builder/cli.py
@@ -9,7 +9,7 @@ import os
 import sys
 from pathlib import Path
 
-from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG, get_theme_base
+from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG, resolved_startup_base
 
 
 def run() -> None:
@@ -31,12 +31,12 @@ def run() -> None:
     # of CWD (config.toml is only found from the repo root) — otherwise the
     # console/desktop runs fall back to Streamlit's default red. Placed before
     # the user's args so an explicit --theme.primaryColor still wins.
-    # Re-apply the user's saved light/dark theme so the app opens the way they
-    # left it (issue #70). Placed before the user's args so an explicit
+    # Apply the user's saved startup theme so the app opens the way they left it
+    # (issues #70, #78). Placed before the user's args so an explicit
     # --theme.base still wins.
     entry = Path(__file__).parent / "streamlit_entry.py"
     theme_args = [f"--theme.primaryColor={BRAND_PRIMARY_COLOR}"]
-    saved_base = get_theme_base()
+    saved_base = resolved_startup_base()
     if saved_base:
         theme_args.append(f"--theme.base={saved_base}")
     sys.argv = [

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -25,7 +25,7 @@ import sys
 from pathlib import Path
 
 from .app import APP_NAME
-from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG, data_dir, get_theme_base
+from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG, data_dir, resolved_startup_base
 
 
 def _preferred_gui() -> str | None:
@@ -99,10 +99,10 @@ def run() -> None:
     # Pass the brand colour as an explicit Streamlit option so it applies
     # regardless of CWD (config.toml is only found from the repo root) and
     # without relying on env inheritance into the Streamlit subprocess.
-    # Re-apply the saved light/dark theme so the app opens the way it was left
-    # (issue #70).
+    # Apply the saved startup theme so the app opens the way it was left
+    # (issues #70, #78).
     options = {"theme.primaryColor": BRAND_PRIMARY_COLOR}
-    saved_base = get_theme_base()
+    saved_base = resolved_startup_base()
     if saved_base:
         options["theme.base"] = saved_base
 

--- a/orionbelt_ontology_builder/local_store.py
+++ b/orionbelt_ontology_builder/local_store.py
@@ -123,52 +123,36 @@ def save_config(config: dict) -> None:
     atomic_write(config_file(), json.dumps(config, indent=2))
 
 
-#: Valid startup theme modes. ``system`` follows the OS appearance; the others
-#: pin a fixed theme.
-THEME_MODES = ("system", "light", "dark")
+def get_theme_base() -> str | None:
+    """Return the pinned light/dark theme, or ``None`` to follow the OS.
 
-
-def get_theme_mode() -> str:
-    """Return the saved startup theme mode (``system`` / ``light`` / ``dark``).
-
-    Persisted server-side (desktop / local mode only) so the launcher can apply
-    it on the next launch; the cloud keeps the choice in the browser's
-    localStorage instead (issues #70, #78). Defaults to ``system``; migrates the
-    older ``theme_base`` (light/dark) preference when present.
+    A pin is only stored once the user actually changes the theme away from the
+    OS appearance (issues #70, #78); otherwise the app follows the system. Saved
+    server-side (desktop / local mode only); the cloud keeps the choice in the
+    browser's localStorage instead.
     """
-    config = load_config()
-    mode = config.get("theme_mode")
-    if mode in THEME_MODES:
-        return mode
-    legacy = config.get("theme_base")  # migrate the 1.10.1 light/dark preference
-    if legacy in ("light", "dark"):
-        return legacy
-    return "system"
+    base = load_config().get("theme_base")
+    return base if base in ("light", "dark") else None
 
 
-def set_theme_mode(mode: str | None) -> None:
-    """Save the startup theme mode; anything invalid clears it (back to system)."""
+def set_theme_base(base: str | None) -> None:
+    """Pin a light/dark theme, or clear the pin (back to following the OS)."""
     config = load_config()
-    if mode in THEME_MODES:
-        config["theme_mode"] = mode
+    if base in ("light", "dark"):
+        config["theme_base"] = base
     else:
-        config.pop("theme_mode", None)
-    config.pop("theme_base", None)  # superseded by theme_mode
+        config.pop("theme_base", None)
     save_config(config)
 
 
-def resolved_startup_base() -> str | None:
-    """Resolve the saved mode to a Streamlit ``theme.base`` (``light``/``dark``).
+def detect_system_base() -> str | None:
+    """Read the OS light/dark appearance, or ``None`` if it can't be determined.
 
-    Returns ``None`` when there is nothing to force: an unresolved ``system``
-    mode (e.g. ``darkdetect`` missing), so the caller omits ``--theme.base`` and
-    lets the browser's own system preference apply.
+    Reads the OS directly via ``darkdetect`` (shipped with the desktop extra),
+    since the embedded webview can't be relied on to report the system colour
+    scheme. Returns ``None`` when ``darkdetect`` is absent or undecided, so the
+    caller can let the browser's own system preference apply.
     """
-    mode = get_theme_mode()
-    if mode in ("light", "dark"):
-        return mode
-    # system: read the OS appearance directly (the embedded webview can't be
-    # relied on to report it). darkdetect ships with the desktop extra.
     try:
         import darkdetect
 
@@ -178,6 +162,11 @@ def resolved_startup_base() -> str | None:
     if isinstance(detected, str) and detected.lower() in ("light", "dark"):
         return detected.lower()
     return None
+
+
+def resolved_startup_base() -> str | None:
+    """Theme to open with: the pin if set, else the detected OS appearance."""
+    return get_theme_base() or detect_system_base()
 
 
 def get_linked_path() -> Path | None:

--- a/orionbelt_ontology_builder/local_store.py
+++ b/orionbelt_ontology_builder/local_store.py
@@ -18,7 +18,9 @@ Two disk-backed mechanisms live on top of these helpers (wired up in
   (:func:`get_linked_path` / :func:`set_linked_path`). Pointing it at a synced
   folder (Nextcloud, Dropbox, ...) gives fully automatic off-machine backups.
 
-No third-party dependencies: only the standard library is used.
+Standard library only, except :func:`resolved_startup_base`, which optionally
+imports ``darkdetect`` (shipped with the ``desktop`` extra) to read the OS
+appearance for the ``system`` theme mode, degrading gracefully when it is absent.
 """
 
 import json
@@ -121,25 +123,61 @@ def save_config(config: dict) -> None:
     atomic_write(config_file(), json.dumps(config, indent=2))
 
 
-def get_theme_base() -> str | None:
-    """Return the saved light/dark theme preference, or ``None`` if unset.
+#: Valid startup theme modes. ``system`` follows the OS appearance; the others
+#: pin a fixed theme.
+THEME_MODES = ("system", "light", "dark")
 
-    Persisted server-side (desktop / local mode only) so the launcher can
-    re-apply it on the next launch; the cloud keeps the choice in the browser's
-    localStorage instead (issue #70).
+
+def get_theme_mode() -> str:
+    """Return the saved startup theme mode (``system`` / ``light`` / ``dark``).
+
+    Persisted server-side (desktop / local mode only) so the launcher can apply
+    it on the next launch; the cloud keeps the choice in the browser's
+    localStorage instead (issues #70, #78). Defaults to ``system``; migrates the
+    older ``theme_base`` (light/dark) preference when present.
     """
-    base = load_config().get("theme_base")
-    return base if base in ("light", "dark") else None
-
-
-def set_theme_base(base: str | None) -> None:
-    """Save (or clear, when ``base`` is not light/dark) the theme preference."""
     config = load_config()
-    if base in ("light", "dark"):
-        config["theme_base"] = base
+    mode = config.get("theme_mode")
+    if mode in THEME_MODES:
+        return mode
+    legacy = config.get("theme_base")  # migrate the 1.10.1 light/dark preference
+    if legacy in ("light", "dark"):
+        return legacy
+    return "system"
+
+
+def set_theme_mode(mode: str | None) -> None:
+    """Save the startup theme mode; anything invalid clears it (back to system)."""
+    config = load_config()
+    if mode in THEME_MODES:
+        config["theme_mode"] = mode
     else:
-        config.pop("theme_base", None)
+        config.pop("theme_mode", None)
+    config.pop("theme_base", None)  # superseded by theme_mode
     save_config(config)
+
+
+def resolved_startup_base() -> str | None:
+    """Resolve the saved mode to a Streamlit ``theme.base`` (``light``/``dark``).
+
+    Returns ``None`` when there is nothing to force: an unresolved ``system``
+    mode (e.g. ``darkdetect`` missing), so the caller omits ``--theme.base`` and
+    lets the browser's own system preference apply.
+    """
+    mode = get_theme_mode()
+    if mode in ("light", "dark"):
+        return mode
+    # system: read the OS appearance directly (the embedded webview can't be
+    # relied on to report it). darkdetect ships with the desktop extra.
+    try:
+        import darkdetect
+
+        detected = darkdetect.theme()  # "Dark" / "Light" / None
+    except Exception:
+        return None
+    if isinstance(detected, str) and detected.lower() in ("light", "dark"):
+        return detected.lower()
+    return None
 
 
 def get_linked_path() -> Path | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.10.1"
+version = "1.11.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}
@@ -43,6 +43,10 @@ desktop = [
     # alone is not enough; pulling pywebview's own pyside6 extra installs both
     # qtpy and PySide6 (Qt + QtWebEngine), the combination it expects.
     "pywebview[pyside6]; sys_platform != 'darwin'",
+    # Detect the OS light/dark appearance for the "follow system" theme mode.
+    # The embedded webview does not report the system colour scheme reliably, so
+    # we read it from the OS directly.
+    "darkdetect>=0.8.0",
 ]
 # Explicit Qt backend, identical to `desktop`. PySide6 is the LGPL Qt for
 # Python; we deliberately use pywebview's `pyside6` extra rather than its `qt`
@@ -50,6 +54,7 @@ desktop = [
 qt = [
     "streamlit-desktop-app>=0.3.3",
     "pywebview[pyside6]; sys_platform != 'darwin'",
+    "darkdetect>=0.8.0",
 ]
 # GTK backend (Linux only; macOS uses Cocoa and Windows uses Qt/EdgeChromium).
 # pywebview[gtk] installs PyGObject, but a working GTK backend ALSO needs system
@@ -58,6 +63,7 @@ qt = [
 gtk = [
     "streamlit-desktop-app>=0.3.3",
     "pywebview[gtk]; sys_platform == 'linux'",
+    "darkdetect>=0.8.0",
 ]
 dev = [
     "pytest>=7.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,7 +86,7 @@ def test_run_reapplies_saved_theme_base(monkeypatch):
     import streamlit.web
 
     monkeypatch.setattr(streamlit.web, "cli", _FakeStcli, raising=False)
-    monkeypatch.setattr(cli, "get_theme_base", lambda: "dark")
+    monkeypatch.setattr(cli, "resolved_startup_base", lambda: "dark")
     monkeypatch.setattr(sys, "argv", ["orionbelt-ontology-builder"])
     monkeypatch.setattr(sys, "exit", lambda code=0: None)
 
@@ -106,7 +106,7 @@ def test_run_omits_theme_base_when_unset(monkeypatch):
     import streamlit.web
 
     monkeypatch.setattr(streamlit.web, "cli", _FakeStcli, raising=False)
-    monkeypatch.setattr(cli, "get_theme_base", lambda: None)
+    monkeypatch.setattr(cli, "resolved_startup_base", lambda: None)
     monkeypatch.setattr(sys, "argv", ["orionbelt-ontology-builder"])
     monkeypatch.setattr(sys, "exit", lambda code=0: None)
 

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -174,7 +174,7 @@ def test_run_reapplies_saved_theme_base(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "webview", fake_webview)
 
     monkeypatch.setattr(desktop, "data_dir", lambda: tmp_path)
-    monkeypatch.setattr(desktop, "get_theme_base", lambda: "dark")
+    monkeypatch.setattr(desktop, "resolved_startup_base", lambda: "dark")
     monkeypatch.delenv(ENV_FLAG, raising=False)
 
     desktop.run()
@@ -194,7 +194,7 @@ def test_run_omits_theme_base_when_unset(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "webview", fake_webview)
 
     monkeypatch.setattr(desktop, "data_dir", lambda: tmp_path)
-    monkeypatch.setattr(desktop, "get_theme_base", lambda: None)
+    monkeypatch.setattr(desktop, "resolved_startup_base", lambda: None)
     monkeypatch.delenv(ENV_FLAG, raising=False)
 
     desktop.run()

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -105,61 +105,58 @@ def test_get_linked_path_expands_user(home, monkeypatch):
     assert local_store.get_linked_path() == home / "backup.ttl"
 
 
-def test_theme_mode_defaults_to_system(home):
-    assert local_store.get_theme_mode() == "system"
+def test_theme_base_default_is_none(home):
+    # No pin stored means "follow the OS".
+    assert local_store.get_theme_base() is None
 
 
-def test_theme_mode_set_get(home):
-    for mode in ("light", "dark", "system"):
-        local_store.set_theme_mode(mode)
-        assert local_store.get_theme_mode() == mode
-
-
-def test_theme_mode_migrates_legacy_theme_base(home):
-    # A config written by 1.10.1 (theme_base) should still be honoured.
-    local_store.save_config({"theme_base": "dark"})
-    assert local_store.get_theme_mode() == "dark"
+def test_theme_base_set_get_clear(home):
+    local_store.set_theme_base("dark")
+    assert local_store.get_theme_base() == "dark"
+    local_store.set_theme_base("light")
+    assert local_store.get_theme_base() == "light"
+    local_store.set_theme_base(None)  # clearing returns to follow-system
+    assert local_store.get_theme_base() is None
 
 
 @pytest.mark.parametrize("value", ["", "blue", "System", None])
-def test_set_theme_mode_invalid_clears(home, value):
-    local_store.set_theme_mode("dark")
-    local_store.set_theme_mode(value)
-    assert local_store.get_theme_mode() == "system"  # default once cleared
-    assert "theme_mode" not in local_store.load_config()
+def test_set_theme_base_invalid_clears_pin(home, value):
+    local_store.set_theme_base("dark")
+    local_store.set_theme_base(value)
+    assert local_store.get_theme_base() is None
+    assert "theme_base" not in local_store.load_config()
 
 
-def test_set_theme_mode_supersedes_legacy_base(home):
-    local_store.save_config({"theme_base": "light"})
-    local_store.set_theme_mode("dark")
-    config = local_store.load_config()
-    assert config["theme_mode"] == "dark"
-    assert "theme_base" not in config
-
-
-def test_set_theme_mode_preserves_other_config(home):
+def test_set_theme_base_preserves_other_config(home):
     local_store.set_linked_path("/x.ttl")
-    local_store.set_theme_mode("dark")
+    local_store.set_theme_base("dark")
     assert local_store.load_config()["linked_path"] == "/x.ttl"
 
 
-@pytest.mark.parametrize("mode", ["light", "dark"])
-def test_resolved_startup_base_pinned(home, mode):
-    local_store.set_theme_mode(mode)
-    assert local_store.resolved_startup_base() == mode
-
-
-def test_resolved_startup_base_system_uses_darkdetect(home, monkeypatch):
+def test_detect_system_base_uses_darkdetect(home, monkeypatch):
     fake = types.ModuleType("darkdetect")
     fake.theme = lambda: "Dark"
     monkeypatch.setitem(sys.modules, "darkdetect", fake)
-    local_store.set_theme_mode("system")
+    assert local_store.detect_system_base() == "dark"
+
+
+def test_detect_system_base_without_darkdetect_returns_none(home, monkeypatch):
+    monkeypatch.setitem(sys.modules, "darkdetect", None)  # makes import fail
+    assert local_store.detect_system_base() is None
+
+
+def test_resolved_startup_base_prefers_pin(home, monkeypatch):
+    fake = types.ModuleType("darkdetect")
+    fake.theme = lambda: "Light"
+    monkeypatch.setitem(sys.modules, "darkdetect", fake)
+    local_store.set_theme_base("dark")
+    # A stored pin wins over the detected OS appearance.
     assert local_store.resolved_startup_base() == "dark"
 
 
-def test_resolved_startup_base_system_without_darkdetect_returns_none(
-    home, monkeypatch
-):
-    monkeypatch.setitem(sys.modules, "darkdetect", None)  # makes import fail
-    local_store.set_theme_mode("system")
-    assert local_store.resolved_startup_base() is None
+def test_resolved_startup_base_falls_back_to_system(home, monkeypatch):
+    fake = types.ModuleType("darkdetect")
+    fake.theme = lambda: "Dark"
+    monkeypatch.setitem(sys.modules, "darkdetect", fake)
+    # No pin -> follow the OS.
+    assert local_store.resolved_startup_base() == "dark"

--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -1,6 +1,8 @@
 """Tests for the local-filesystem persistence helpers."""
 
 import json
+import sys
+import types
 
 import pytest
 
@@ -103,31 +105,61 @@ def test_get_linked_path_expands_user(home, monkeypatch):
     assert local_store.get_linked_path() == home / "backup.ttl"
 
 
-def test_theme_base_set_get_clear(home):
-    assert local_store.get_theme_base() is None
-
-    local_store.set_theme_base("dark")
-    assert local_store.get_theme_base() == "dark"
-
-    local_store.set_theme_base("light")
-    assert local_store.get_theme_base() == "light"
-
-    local_store.set_theme_base(None)
-    assert local_store.get_theme_base() is None
+def test_theme_mode_defaults_to_system(home):
+    assert local_store.get_theme_mode() == "system"
 
 
-@pytest.mark.parametrize("value", ["", "Dark", "blue", "system", None])
-def test_theme_base_ignores_invalid_values(home, value):
+def test_theme_mode_set_get(home):
+    for mode in ("light", "dark", "system"):
+        local_store.set_theme_mode(mode)
+        assert local_store.get_theme_mode() == mode
+
+
+def test_theme_mode_migrates_legacy_theme_base(home):
+    # A config written by 1.10.1 (theme_base) should still be honoured.
     local_store.save_config({"theme_base": "dark"})
-    local_store.set_theme_base(value)
-    # Anything that isn't light/dark clears the preference rather than storing it.
-    assert local_store.get_theme_base() is None
-    assert "theme_base" not in local_store.load_config()
+    assert local_store.get_theme_mode() == "dark"
 
 
-def test_set_theme_base_preserves_other_config(home):
-    local_store.set_linked_path("/x.ttl")
-    local_store.set_theme_base("dark")
+@pytest.mark.parametrize("value", ["", "blue", "System", None])
+def test_set_theme_mode_invalid_clears(home, value):
+    local_store.set_theme_mode("dark")
+    local_store.set_theme_mode(value)
+    assert local_store.get_theme_mode() == "system"  # default once cleared
+    assert "theme_mode" not in local_store.load_config()
+
+
+def test_set_theme_mode_supersedes_legacy_base(home):
+    local_store.save_config({"theme_base": "light"})
+    local_store.set_theme_mode("dark")
     config = local_store.load_config()
-    assert config["linked_path"] == "/x.ttl"
-    assert config["theme_base"] == "dark"
+    assert config["theme_mode"] == "dark"
+    assert "theme_base" not in config
+
+
+def test_set_theme_mode_preserves_other_config(home):
+    local_store.set_linked_path("/x.ttl")
+    local_store.set_theme_mode("dark")
+    assert local_store.load_config()["linked_path"] == "/x.ttl"
+
+
+@pytest.mark.parametrize("mode", ["light", "dark"])
+def test_resolved_startup_base_pinned(home, mode):
+    local_store.set_theme_mode(mode)
+    assert local_store.resolved_startup_base() == mode
+
+
+def test_resolved_startup_base_system_uses_darkdetect(home, monkeypatch):
+    fake = types.ModuleType("darkdetect")
+    fake.theme = lambda: "Dark"
+    monkeypatch.setitem(sys.modules, "darkdetect", fake)
+    local_store.set_theme_mode("system")
+    assert local_store.resolved_startup_base() == "dark"
+
+
+def test_resolved_startup_base_system_without_darkdetect_returns_none(
+    home, monkeypatch
+):
+    monkeypatch.setitem(sys.modules, "darkdetect", None)  # makes import fail
+    local_store.set_theme_mode("system")
+    assert local_store.resolved_startup_base() is None


### PR DESCRIPTION
Closes #78

## What

The desktop app now **follows your OS light/dark appearance by default**. No new UI.

## Behaviour

- **Default**: follow the OS theme. The launcher detects it (via `darkdetect`, which reads the OS directly, so it works where the embedded webview can't report it - the #63 limitation) and opens with it.
- **Pin on change**: if you pick a theme in the toolbar Settings menu that differs from the OS appearance, it's stored and remembered across launches (extends the 1.10.1 persistence). Once pinned, it stays in sync with further menu changes.
- **Back to system**: clear the saved setting (delete `theme_base` from `~/.orionbelt_ontology_builder/config.json`).

This also delivers the automatic OS dark-mode detection that #63 originally wanted.

## Notes on the design (after review)

An earlier revision of this PR added a sidebar "Startup theme" selectbox. That was dropped per feedback: it cluttered the nav, and its `st.rerun()` plus per-render `darkdetect` calls caused UI lag/fading. The current version has no control - the OS is detected **once per session** (cached) and only at launch, so there's no per-render cost.

## Implementation

- `local_store`: `theme_base` pin (light/dark/None) + `detect_system_base()` (guarded `darkdetect`) + `resolved_startup_base()` = pin or detected OS.
- `cli.py` / `desktop.py`: open with `--theme.base = resolved_startup_base()`.
- `app.py`: persist a pin only when the active theme deviates from the cached OS appearance; logo resolves from pin/OS on first render to avoid a flash.
- `darkdetect` added to the `desktop`/`qt`/`gtk` extras (guarded import; absent -> falls back to the browser's own system preference).

## Tests

`local_store` (theme_base get/set/clear, `detect_system_base` with/without darkdetect, `resolved_startup_base` pin-vs-system) and the launchers applying the resolved base. Full suite: 330 passed, including with `webview` and `darkdetect` both blocked, and the version-consistency guard. Bumps to 1.11.0.

## Please test before release

In the desktop app: with no pin set it should match your OS theme; flip the OS dark/light and relaunch to confirm it follows. Then pick a theme in the toolbar menu and confirm it sticks across launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)