### PR TITLE
feat(viz): open a clicked class directly in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.11.0](https://img.shields.io/badge/version-1.11.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.12.0](https://img.shields.io/badge/version-1.12.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -243,7 +243,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.11.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.12.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.11.0"
+APP_VERSION = "1.12.0"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -6166,7 +6166,7 @@ def render_visualization():
             )
 
             if show_view:
-                col_info, col_btn = st.columns([20, 1])
+                col_info, col_btn = st.columns([7, 2])
                 with col_info:
                     st.markdown(
                         f'<div id="graph-status-bar" style="background:#1e1e1e;color:#fff;padding:6px 12px;'
@@ -6177,15 +6177,37 @@ def render_visualization():
                         unsafe_allow_html=True,
                     )
                 with col_btn:
+                    # For classes we can land directly in the editor with the
+                    # entity preselected (no scrolling): switch to the
+                    # Edit/Delete tab and set its selectbox. Other types keep the
+                    # existing inline-view jump for now (issue #80).
+                    _btn_label = "Open full editor" if ntype == "Class" else "View"
                     if st.button(
-                        "View", key="graph_view_btn", use_container_width=True
+                        _btn_label, key="graph_view_btn", use_container_width=True
                     ):
                         page = _type_to_page[ntype]
-                        vk = _view_key_map[ntype](ename)
                         st.session_state.search_navigate_to = page
-                        st.session_state[vk] = True
-                        if ntype == "SKOS Concept":
-                            st.session_state["_skos_navigate_to_concept"] = True
+                        _jumped = False
+                        if ntype == "Class":
+                            _target = next(
+                                (c for c in classes if _uid(c["uri"]) == ename), None
+                            )
+                            if _target:
+                                _, _lookup = build_class_options(classes)
+                                _disp = {v: k for k, v in _lookup.items()}.get(
+                                    _target["uri"]
+                                )
+                                if _disp:
+                                    st.session_state["cls_active_tab"] = (
+                                        "Edit/Delete Class"
+                                    )
+                                    st.session_state["edit_class_select"] = _disp
+                                    _jumped = True
+                        if not _jumped:
+                            vk = _view_key_map[ntype](ename)
+                            st.session_state[vk] = True
+                            if ntype == "SKOS Concept":
+                                st.session_state["_skos_navigate_to_concept"] = True
                         st.rerun()
             else:
                 st.markdown(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.11.0"
+version = "1.12.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Part 1 of #80 (the editing-from-visualization idea).

## What

When you select a **class** in the graph, the selection button now reads **"Open full editor"** and jumps straight into **Classes → Edit/Delete** with that class **preselected** in the dropdown. The edit form renders at the top of the tab.

## Why

The old "View" button switched to the page but left you to scroll a long list to find the entity (the problem you flagged). By landing in the Edit/Delete tab and presetting its selectbox, the form appears at the top, so **there's no scrolling** and no JS scroll hack needed.

## How

The clicked node's `ename` is `_uid(uri)`, so we map it back to the class, resolve its Edit/Delete selectbox display value via `build_class_options`, and set `cls_active_tab` + `edit_class_select` in session state before rerunning.

## Scope

- **Classes only** for now, to validate the approach end to end. Other types (properties, individuals, SKOS concepts) keep their existing inline-view jump; I'll migrate them the same way once this feels right.
- This is the first of two steps; the second is the WebVOWL-style **right-side Details/Edit panel** on the Visualization page (collapsible), so you can view/edit a selection in place without leaving the graph.

## Tests

Lint/format/import clean; full suite 330 passing incl. the version-consistency guard. The click→jump itself is GUI behavior, so it needs a manual check (see below). Bumps to 1.12.0.

## Please test

In the graph, click a class node, then click **"Open full editor"** - it should land you on Classes → Edit/Delete with that class already selected and its edit form shown, no scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)