### PR TITLE
feat(viz): auto-fit the graph to the window height

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -5073,7 +5073,7 @@ def render_visualization():
             "show_triples": False,
             "graph_height": 670,
             "node_spacing": 150,
-            "maximize": False,
+            "fit": True,
             "highlight_issues": False,
             "focus_mode": False,
             "focus_depth": 1,
@@ -5184,7 +5184,7 @@ def render_visualization():
                     help="Show all RDF triples for visible nodes",
                 )
 
-        # Row 2: sliders + maximize + highlight issues + render button
+        # Row 2: sliders + fit-to-window + highlight issues + render button
         col1, col2, col3, col4, col5 = st.columns([2, 2, 1, 1, 1])
         with col1:
             height = st.slider(
@@ -5195,6 +5195,8 @@ def render_visualization():
                 key="viz_graph_height",
                 on_change=_viz_sync,
                 args=("_viz_cfg_graph_height", "viz_graph_height"),
+                disabled=st.session_state.get("_viz_cfg_fit", True),
+                help="Used when 'Fit to window' is off.",
             )
         with col2:
             node_spacing = st.slider(
@@ -5207,15 +5209,14 @@ def render_visualization():
                 args=("_viz_cfg_node_spacing", "viz_node_spacing"),
             )
         with col3:
-            maximize = st.checkbox(
-                "Maximize",
-                help="Expand graph to full height",
-                key="viz_maximize",
+            fit = st.checkbox(
+                "Fit to window",
+                help="Resize the graph to fill the window height. "
+                "Turn off to use the Graph Height slider.",
+                key="viz_fit",
                 on_change=_viz_sync,
-                args=("_viz_cfg_maximize", "viz_maximize"),
+                args=("_viz_cfg_fit", "viz_fit"),
             )
-            if maximize:
-                height = 1200
         with col4:
             highlight_issues = st.checkbox(
                 "Highlight Issues",
@@ -6075,6 +6076,7 @@ def render_visualization():
                 edges=gdata["edges"],
                 options=gdata["options"],
                 height=height,
+                autofit=fit,
                 theme=_gv_theme,
                 seq=st.session_state.viz_render_seq,
                 key="graph_viewer",

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -43,6 +43,32 @@ function sendToStreamlit(type, data) {
 var visLoaded = false;
 var pendingArgs = null;
 var network = null;
+var autofitOn = false;
+
+// When "Fit to window" is on, fill the available window height instead of using
+// the fixed Graph Height. Reads the parent window's height and this iframe's
+// position in it (same-origin), reserving room for the status bar below.
+function autofitHeight() {
+    try {
+        var fe = window.frameElement;
+        var top = fe ? fe.getBoundingClientRect().top : 0;
+        var avail = window.parent.innerHeight - top - 90;
+        return Math.max(Math.round(avail), 300);
+    } catch (e) {
+        return null;  // cross-origin or unavailable: fall back to fixed height
+    }
+}
+
+function applyHeight(h) {
+    document.getElementById('graph').style.height = h + 'px';
+    sendToStreamlit("streamlit:setFrameHeight", {height: h});
+}
+
+window.addEventListener('resize', function() {
+    if (!autofitOn || !network) return;
+    var h = autofitHeight();
+    if (h) { applyHeight(h); network.redraw(); }
+});
 
 function downloadGraph() {
     if (!network) return;
@@ -55,7 +81,12 @@ function downloadGraph() {
 
 function renderGraph(args) {
     if (!visLoaded) { pendingArgs = args; return; }
+    autofitOn = !!args.autofit;
     var height = args.height || 600;
+    if (autofitOn) {
+        var af = autofitHeight();
+        if (af) height = af;
+    }
     var el = document.getElementById('graph');
     el.style.height = height + 'px';
     sendToStreamlit("streamlit:setFrameHeight", {height: height});


### PR DESCRIPTION
Addresses the wasted vertical space below the graph (raised while testing #81).

## What

The graph now fills the available window height by default instead of a fixed 670px, so there's no empty space below it on tall windows (desktop or a tall browser window - same logic either way).

## How

- Replaces the **"Maximize"** toggle with **"Fit to window"** (on by default).
- When on, the component (`lib/graph_viewer/index.html`) reads `window.parent.innerHeight` and its own position in the page, sizes itself to fill the space (reserving ~90px for the status bar), and re-fits on window resize. Falls back to the fixed height if the measurement isn't available.
- The **Graph Height** slider stays as a manual override and is disabled while fitting.

## Notes

- No version bump in this PR - batching changes for the next release per your request.
- GUI behavior, so it needs a manual check.

## Please test

On the Visualization tab, the graph should now fill down to near the bottom of the window (status bar still visible), and re-fit when you resize the window. Turn off "Fit to window" to get the manual Graph Height slider back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)