### PR TITLE
fix(export): Save-to-disk so export works in the desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.14.0](https://img.shields.io/badge/version-1.14.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.15.0](https://img.shields.io/badge/version-1.15.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -243,7 +243,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.14.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.15.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -4554,20 +4554,48 @@ def render_import_export():
             "json-ld": "jsonld",
         }
 
+        ext = file_extensions[format_]
         if st.button("Generate Export"):
             try:
-                content = ont.export_to_string(format=format_)
-                st.text_area("Exported Content", value=content, height=400)
-
-                ext = file_extensions[format_]
-                st.download_button(
-                    label=f"Download .{ext} file",
-                    data=content,
-                    file_name=f"ontology.{ext}",
-                    mime="text/plain",
+                st.session_state["_export_content"] = ont.export_to_string(
+                    format=format_
                 )
+                st.session_state["_export_ext"] = ext
             except Exception as e:
+                st.session_state.pop("_export_content", None)
                 show_message(f"Error exporting ontology: {str(e)}", "error")
+
+        # Kept in session_state so the save/download controls (which each cause a
+        # rerun) still have the generated content.
+        content = st.session_state.get("_export_content")
+        if content is not None:
+            ext = st.session_state.get("_export_ext", ext)
+            st.text_area("Exported Content", value=content, height=400)
+            st.download_button(
+                label=f"Download .{ext} file",
+                data=content,
+                file_name=f"ontology.{ext}",
+                mime="text/plain",
+            )
+            # The desktop webview can't perform browser downloads, so offer a
+            # direct save to disk (defaulting to Downloads) in local mode (#86).
+            if local_store.local_persist_enabled():
+                _default_path = str(_Path.home() / "Downloads" / f"ontology.{ext}")
+                _save_path = st.text_input(
+                    "Or save to a file",
+                    value=_default_path,
+                    key="export_save_path",
+                    help="Desktop download isn't supported by the embedded "
+                    "browser; save directly to a path instead.",
+                )
+                if st.button("Save to disk"):
+                    try:
+                        local_store.atomic_write(
+                            _Path(_save_path).expanduser(), content
+                        )
+                        show_message(f"Saved to {_save_path}", "success")
+                    except OSError as e:
+                        show_message(f"Could not save: {e}", "error")
 
     if _ie_tab == "New Ontology":
         st.subheader("Create New Ontology")

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.14.0"
+APP_VERSION = "1.15.0"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.14.0"
+version = "1.15.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Closes #86

## Problem

In the desktop app the export "Download .ttl file" button does nothing: the embedded webview has no browser download handler, so `st.download_button` can't save the file.

## Fix

The generated export is now kept in `session_state`, and in local/desktop mode (`local_persist_enabled()`) the Export tab shows a **"Save to disk"** control that writes the file directly (via `atomic_write`), defaulting to `~/Downloads/ontology.<ext>`. The browser `download_button` remains for the web/cloud app, where it works.

## Verified

Playwright end-to-end on a local-persist instance: Generate Export, then Save to disk writes a valid Turtle file to Downloads (confirmed on disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)