### PR TITLE
fix(desktop): make all downloads work (export, change report, graph PNG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.15.0](https://img.shields.io/badge/version-1.15.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.15.1](https://img.shields.io/badge/version-1.15.1-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -243,7 +243,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.15.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.15.1` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1225,6 +1225,34 @@ def _render_panel_entity_editor(
     return entity
 
 
+def _download_or_save(label, data, file_name, mime="text/plain", key=None):
+    """Offer a file to the user, working in both the web and desktop apps.
+
+    The web shows a normal download button. The desktop / local app's embedded
+    webview can't perform browser downloads (#86), so there we instead show a
+    Save-to-disk control (path input defaulting to Downloads) that writes the
+    file directly. The dead download button is not shown on the desktop.
+    """
+    _k = key or file_name
+    if not local_store.local_persist_enabled():
+        st.download_button(
+            label=label, data=data, file_name=file_name, mime=mime, key=f"dl_{_k}"
+        )
+        return
+    path = st.text_input(
+        "Save to file",
+        value=str(_Path.home() / "Downloads" / file_name),
+        key=f"savepath_{_k}",
+    )
+    save_label = label.replace("Download", "Save") if "Download" in label else label
+    if st.button(f"💾 {save_label}", key=f"savebtn_{_k}"):
+        try:
+            local_store.atomic_write(_Path(path).expanduser(), data)
+            show_message(f"Saved to {path}", "success")
+        except OSError as e:
+            show_message(f"Could not save: {e}", "error")
+
+
 def render_dashboard():
     """Render the dashboard/overview page."""
     st.header("Dashboard")
@@ -4523,11 +4551,12 @@ def render_import_export():
 
             # Change report download
             report = ont.format_diff_report(diff, report_format="markdown")
-            st.download_button(
+            _download_or_save(
                 "Download Change Report",
-                data=report,
-                file_name="change_report.md",
+                report,
+                "change_report.md",
                 mime="text/markdown",
+                key="change_report",
             )
 
     if _ie_tab == "Export":
@@ -4571,31 +4600,12 @@ def render_import_export():
         if content is not None:
             ext = st.session_state.get("_export_ext", ext)
             st.text_area("Exported Content", value=content, height=400)
-            st.download_button(
-                label=f"Download .{ext} file",
-                data=content,
-                file_name=f"ontology.{ext}",
-                mime="text/plain",
+            _download_or_save(
+                f"Download .{ext} file",
+                content,
+                f"ontology.{ext}",
+                key="export",
             )
-            # The desktop webview can't perform browser downloads, so offer a
-            # direct save to disk (defaulting to Downloads) in local mode (#86).
-            if local_store.local_persist_enabled():
-                _default_path = str(_Path.home() / "Downloads" / f"ontology.{ext}")
-                _save_path = st.text_input(
-                    "Or save to a file",
-                    value=_default_path,
-                    key="export_save_path",
-                    help="Desktop download isn't supported by the embedded "
-                    "browser; save directly to a path instead.",
-                )
-                if st.button("Save to disk"):
-                    try:
-                        local_store.atomic_write(
-                            _Path(_save_path).expanduser(), content
-                        )
-                        show_message(f"Saved to {_save_path}", "success")
-                    except OSError as e:
-                        show_message(f"Could not save: {e}", "error")
 
     if _ie_tab == "New Ontology":
         st.subheader("Create New Ontology")

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6355,10 +6355,31 @@ def render_visualization():
                     autofit=fit,
                     theme=_gv_theme,
                     selected_node=(_prev_sel.get("nodeId") if _prev_has_sel else None),
+                    # On desktop the webview can't download; the component sends
+                    # the PNG back for us to save instead (#86).
+                    web_download=not local_store.local_persist_enabled(),
                     seq=st.session_state.viz_render_seq,
                     key="graph_viewer",
                     default=None,
                 )
+
+            # Desktop "Download PNG": the component hands us the image data URL to
+            # save to disk (the webview can't download). Guard by reqId so it's
+            # written once.
+            if isinstance(selection, dict) and selection.get("pngData"):
+                _png_req = selection.get("reqId")
+                if _png_req and _png_req != st.session_state.get("_viz_last_png_req"):
+                    st.session_state["_viz_last_png_req"] = _png_req
+                    try:
+                        import base64
+
+                        _b64 = selection["pngData"].split(",", 1)[-1]
+                        _png_path = _Path.home() / "Downloads" / "ontology-graph.png"
+                        _png_path.parent.mkdir(parents=True, exist_ok=True)
+                        _png_path.write_bytes(base64.b64decode(_b64))
+                        st.toast(f"Saved graph image to {_png_path}", icon="💾")
+                    except (OSError, ValueError) as e:
+                        st.toast(f"Could not save image: {e}", icon="⚠️")
 
             # Ctrl/Cmd-click in the graph requests focusing on a node: add it to
             # the "Focus on one node" seeds and enable focus mode (issue #56). The

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1248,9 +1248,11 @@ def _download_or_save(label, data, file_name, mime="text/plain", key=None):
     if st.button(f"💾 {save_label}", key=f"savebtn_{_k}"):
         try:
             local_store.atomic_write(_Path(path).expanduser(), data)
-            show_message(f"Saved to {path}", "success")
+            # Use a toast (floating popup) rather than an inline banner, which can
+            # render below the fold where it isn't visible.
+            st.toast(f"Saved to {path}", icon="💾")
         except OSError as e:
-            show_message(f"Could not save: {e}", "error")
+            st.toast(f"Could not save: {e}", icon="⚠️")
 
 
 def render_dashboard():

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.15.0"
+APP_VERSION = "1.15.1"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -44,6 +44,7 @@ var visLoaded = false;
 var pendingArgs = null;
 var network = null;
 var autofitOn = false;
+var webDownload = true;  // browser download works on the web; on desktop we save via Python
 var lastSeq = null;
 var lastNodes = null;
 var lastEdges = null;
@@ -96,15 +97,22 @@ window.addEventListener('resize', function() {
 function downloadGraph() {
     if (!network) return;
     var canvas = network.canvas.frame.canvas;
-    var a = document.createElement('a');
-    a.download = 'ontology-graph.png';
-    a.href = canvas.toDataURL('image/png');
-    a.click();
+    var dataUrl = canvas.toDataURL('image/png');
+    if (webDownload) {
+        var a = document.createElement('a');
+        a.download = 'ontology-graph.png';
+        a.href = dataUrl;
+        a.click();
+    } else {
+        // Desktop webview can't download; hand the PNG to Python to save to disk.
+        sendToStreamlit('streamlit:setComponentValue', {value: {pngData: dataUrl, reqId: Date.now()}});
+    }
 }
 
 function renderGraph(args) {
     if (!visLoaded) { pendingArgs = args; return; }
     autofitOn = !!args.autofit;
+    webDownload = args.web_download !== false;
 
     // Rebuild only when the graph data actually changes: the render seq (Render
     // button) or the node/edge set (filters, focus). A selection click is a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.15.0"
+version = "1.15.1"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Follow-up to #86.

## Problem

The export tab still showed the browser **Download** button on the desktop app (where it does nothing) next to the Save-to-disk control — a dead button.

## Fix

Introduce a `_download_or_save(label, data, file_name, ...)` helper:
- **Web/cloud:** a normal `st.download_button`.
- **Desktop/local:** only a **Save-to-disk** control (path input defaulting to Downloads + a "💾 Save …" button) — no dead download button.

Applied to both the **Export** tab and the import **Change Report** download.

## Verified

Playwright on a local-persist instance: the export shows only "💾 Save .ttl file" (the "Download .ttl file" button is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)