### PR TITLE
feat(namespace): create entities in a chosen namespace (#87 part A)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1048,6 +1048,25 @@ def build_namespace_options(ont) -> tuple:
     return options, lookup
 
 
+def _renamed_ref(ont, old_uri, new_name):
+    """Full URI a rename produces for ``new_name``, preserving ``old_uri``'s
+    namespace (mirrors the engine's rename logic). Used so post-rename updates
+    target the resource in its own namespace rather than the base namespace."""
+    return str(ont._uri(new_name, ont._namespace_of(old_uri)))
+
+
+def _namespace_display(ont, uri):
+    """Human-readable namespace label for ``uri``: '(default) <base>' for the
+    base namespace, 'prefix: <ns>' when a prefix is bound, else the bare
+    namespace URI. Shown read-only on edit forms so the user can see which
+    namespace an entity lives in (renaming keeps it there)."""
+    ns = ont._namespace_of(uri)
+    if ns == ont.base_uri:
+        return f"(default) {ns}"
+    prefix = _prefix_for_uri(ns)
+    return f"{prefix}: {ns}" if prefix else ns
+
+
 def _apply_class_edit(ont, class_info, new_name, new_label, new_comment, new_parent):
     """Apply a class edit (rename + label/comment/parent). Returns True on success.
 
@@ -1059,7 +1078,7 @@ def _apply_class_edit(ont, class_info, new_name, new_label, new_comment, new_par
     current_ref = class_info["uri"]
     if new_name and new_name != class_info["name"]:
         if ont.rename_class(class_info["uri"], new_name):
-            current_ref = new_name
+            current_ref = _renamed_ref(ont, class_info["uri"], new_name)
         else:
             show_message(f"Cannot rename: '{new_name}' already exists!", "error")
             return False
@@ -1088,7 +1107,7 @@ def _apply_property_edit(
     current_ref = prop["uri"]
     if new_name and new_name != prop["name"]:
         if ont.rename_property(prop["uri"], new_name):
-            current_ref = new_name
+            current_ref = _renamed_ref(ont, prop["uri"], new_name)
         else:
             show_message(f"Cannot rename: '{new_name}' already exists!", "error")
             return False
@@ -1113,7 +1132,7 @@ def _apply_individual_edit(
     current_ref = ind["uri"]
     if new_name and new_name != ind["name"]:
         if ont.rename_individual(ind["uri"], new_name):
-            current_ref = new_name
+            current_ref = _renamed_ref(ont, ind["uri"], new_name)
         else:
             show_message(f"Cannot rename: '{new_name}' already exists!", "error")
             return False
@@ -1741,6 +1760,9 @@ def render_classes():
                         value=class_info["name"],
                         help="Renaming updates every reference to this class — "
                         "no links are lost, unlike delete-and-recreate.",
+                    )
+                    st.caption(
+                        f"Namespace: {_namespace_display(ont, class_info['uri'])}"
                     )
                     new_label = st.text_input("Label", value=class_info["label"])
                     new_comment = st.text_area("Comment", value=class_info["comment"])

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1055,32 +1055,53 @@ def _renamed_ref(ont, old_uri, new_name):
     return str(ont._uri(new_name, ont._namespace_of(old_uri)))
 
 
-def _namespace_display(ont, uri):
-    """Human-readable namespace label for ``uri``: '(default) <base>' for the
-    base namespace, 'prefix: <ns>' when a prefix is bound, else the bare
-    namespace URI. Shown read-only on edit forms so the user can see which
-    namespace an entity lives in (renaming keeps it there)."""
+def _namespace_option_index(ont, ns_options, ns_lookup, uri):
+    """Index of the :func:`build_namespace_options` entry matching ``uri``'s
+    current namespace, so an edit form pre-selects where the resource already
+    lives. Falls back to 0 (the default/base namespace)."""
     ns = ont._namespace_of(uri)
-    if ns == ont.base_uri:
-        return f"(default) {ns}"
-    prefix = _prefix_for_uri(ns)
-    return f"{prefix}: {ns}" if prefix else ns
+    current = None if ns == ont.base_uri else ns
+    for i, opt in enumerate(ns_options):
+        if ns_lookup.get(opt) == current:
+            return i
+    return 0
 
 
-def _apply_class_edit(ont, class_info, new_name, new_label, new_comment, new_parent):
+_KEEP_NAMESPACE = object()  # sentinel: leave a resource in its current namespace
+
+
+def _apply_class_edit(
+    ont,
+    class_info,
+    new_name,
+    new_label,
+    new_comment,
+    new_parent,
+    new_namespace=_KEEP_NAMESPACE,
+):
     """Apply a class edit (rename + label/comment/parent). Returns True on success.
 
-    Shared by the Edit/Delete form and the Visualization side panel. Renames
-    first so the remaining updates target the renamed class; shows an error and
-    returns False if the new name collides. The caller is responsible for the
-    undo checkpoint and rerun.
+    Shared by the Edit/Delete form and the Visualization side panel. A change to
+    the local name and/or ``new_namespace`` is applied as a single rename to the
+    new full URI (every reference is re-pointed, so no links are lost); the
+    remaining updates then target the class at its new URI. ``new_namespace`` is
+    ``None`` for the base namespace, a namespace URI string, or the
+    ``_KEEP_NAMESPACE`` sentinel to leave the class where it is (used by callers
+    without a namespace selector). Shows an error and returns False if the target
+    URI is already taken. The caller owns the undo checkpoint and rerun.
     """
     current_ref = class_info["uri"]
-    if new_name and new_name != class_info["name"]:
-        if ont.rename_class(class_info["uri"], new_name):
-            current_ref = _renamed_ref(ont, class_info["uri"], new_name)
+    target_ns = (
+        ont._namespace_of(class_info["uri"])
+        if new_namespace is _KEEP_NAMESPACE
+        else new_namespace
+    )
+    target_uri = str(ont._uri(new_name or class_info["name"], target_ns))
+    if target_uri != class_info["uri"]:
+        if ont.rename_class(class_info["uri"], target_uri):
+            current_ref = target_uri
         else:
-            show_message(f"Cannot rename: '{new_name}' already exists!", "error")
+            show_message(f"Cannot move/rename: '{target_uri}' already exists!", "error")
             return False
     if class_info["parents"] and new_parent != class_info["parents"][0]:
         ont.update_class(current_ref, remove_parent=class_info["parents"][0])
@@ -1761,9 +1782,18 @@ def render_classes():
                         help="Renaming updates every reference to this class — "
                         "no links are lost, unlike delete-and-recreate.",
                     )
-                    st.caption(
-                        f"Namespace: {_namespace_display(ont, class_info['uri'])}"
+                    ns_options, ns_lookup = build_namespace_options(ont)
+                    ns_index = _namespace_option_index(
+                        ont, ns_options, ns_lookup, class_info["uri"]
                     )
+                    new_ns_display = st.selectbox(
+                        "Namespace",
+                        options=ns_options,
+                        index=ns_index,
+                        help="Moving to another namespace re-points every "
+                        "reference to this class.",
+                    )
+                    new_namespace = ns_lookup.get(new_ns_display)
                     new_label = st.text_input("Label", value=class_info["label"])
                     new_comment = st.text_area("Comment", value=class_info["comment"])
 
@@ -1799,6 +1829,7 @@ def render_classes():
                             new_label,
                             new_comment,
                             new_parent,
+                            new_namespace=new_namespace,
                         ):
                             save_checkpoint("Update class")
                             show_message(

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1018,6 +1018,36 @@ def build_class_options(classes: list, include_none: bool = False) -> tuple:
     return options, lookup
 
 
+def build_namespace_options(ont) -> tuple:
+    """Build namespace dropdown options for creating an entity in a chosen
+    namespace.
+
+    Offers the base (default) namespace first, then any namespace already used
+    by an entity or explicitly bound by the user (see
+    :meth:`OntologyManager.get_creatable_namespaces`). Each option is labelled
+    with its bound prefix when one exists.
+
+    Returns:
+        tuple: (display_options, namespace_lookup). The lookup maps each display
+        string to a namespace URI, or ``None`` for the default (base) namespace
+        so callers can pass it straight to ``add_*(namespace=...)``.
+    """
+    options = []
+    lookup = {}
+
+    for i, ns in enumerate(ont.get_creatable_namespaces()):
+        if i == 0:
+            display = f"(default) {ns}"
+            lookup[display] = None
+        else:
+            prefix = _prefix_for_uri(ns)
+            display = f"{prefix}: {ns}" if prefix else ns
+            lookup[display] = ns
+        options.append(display)
+
+    return options, lookup
+
+
 def _apply_class_edit(ont, class_info, new_name, new_label, new_comment, new_parent):
     """Apply a class edit (rename + label/comment/parent). Returns True on success.
 
@@ -1653,16 +1683,29 @@ def render_classes():
                 options=parent_options,
                 help="Select a parent class for hierarchy",
             )
+            ns_options, ns_lookup = build_namespace_options(ont)
+            ns_display = st.selectbox(
+                "Namespace",
+                options=ns_options,
+                help="Namespace the class is created in (default is the base URI)",
+            )
 
             submitted = st.form_submit_button("Add Class")
             if submitted:
+                ns_val = ns_lookup.get(ns_display)
                 if not name:
                     show_message("Class name is required!", "error")
-                elif name in [c["name"] for c in classes]:
+                elif str(ont._uri(name, ns_val)) in {c["uri"] for c in classes}:
                     show_message(f"Class '{name}' already exists!", "error")
                 else:
                     parent_val = parent_lookup.get(parent_display)
-                    ont.add_class(name, parent=parent_val, label=label, comment=comment)
+                    ont.add_class(
+                        name,
+                        parent=parent_val,
+                        label=label,
+                        comment=comment,
+                        namespace=ns_val,
+                    )
                     save_checkpoint("Add class")
                     show_message(f"Class '{name}' added successfully!", "success")
                     st.rerun()
@@ -2444,12 +2487,22 @@ def render_properties():
                     symmetric = st.checkbox("Symmetric")
 
                 inverse_disp = st.selectbox("Inverse Of", options=obj_prop_opts)
+                ns_options, ns_lookup = build_namespace_options(ont)
+                ns_display = st.selectbox(
+                    "Namespace",
+                    options=ns_options,
+                    help="Namespace the property is created in (default is the base URI)",
+                )
 
                 submitted = st.form_submit_button("Add Object Property")
                 if submitted:
+                    ns_val = ns_lookup.get(ns_display)
+                    prop_uris = {p["uri"] for p in object_props} | {
+                        p["uri"] for p in data_props
+                    }
                     if not name:
                         show_message("Property name is required!", "error")
-                    elif name in obj_prop_names or name in data_prop_names:
+                    elif str(ont._uri(name, ns_val)) in prop_uris:
                         show_message(f"Property '{name}' already exists!", "error")
                     else:
                         ont.add_object_property(
@@ -2466,6 +2519,7 @@ def render_properties():
                             reflexive=reflexive,
                             irreflexive=irreflexive,
                             inverse_of=obj_prop_lookup.get(inverse_disp),
+                            namespace=ns_val,
                         )
                         save_checkpoint("Add object property")
                         show_message(f"Object property '{name}' added!", "success")
@@ -2492,12 +2546,23 @@ def render_properties():
                 )
 
             functional = st.checkbox("Functional", key="data_prop_functional")
+            ns_options, ns_lookup = build_namespace_options(ont)
+            ns_display = st.selectbox(
+                "Namespace",
+                options=ns_options,
+                help="Namespace the property is created in (default is the base URI)",
+                key="data_prop_namespace",
+            )
 
             submitted = st.form_submit_button("Add Data Property")
             if submitted:
+                ns_val = ns_lookup.get(ns_display)
+                prop_uris = {p["uri"] for p in object_props} | {
+                    p["uri"] for p in data_props
+                }
                 if not name:
                     show_message("Property name is required!", "error")
-                elif name in obj_prop_names or name in data_prop_names:
+                elif str(ont._uri(name, ns_val)) in prop_uris:
                     show_message(f"Property '{name}' already exists!", "error")
                 else:
                     ont.add_data_property(
@@ -2507,6 +2572,7 @@ def render_properties():
                         label=label,
                         comment=comment,
                         functional=functional,
+                        namespace=ns_val,
                     )
                     save_checkpoint("Add data property")
                     show_message(f"Data property '{name}' added!", "success")
@@ -2853,16 +2919,27 @@ def render_individuals():
                 label = st.text_input("Label")
                 comment = st.text_area("Comment")
                 class_type = st.selectbox("Class Type *", options=class_names)
+                ns_options, ns_lookup = build_namespace_options(ont)
+                ns_display = st.selectbox(
+                    "Namespace",
+                    options=ns_options,
+                    help="Namespace the individual is created in (default is the base URI)",
+                )
 
                 submitted = st.form_submit_button("Add Individual")
                 if submitted:
+                    ns_val = ns_lookup.get(ns_display)
                     if not name:
                         show_message("Individual name is required!", "error")
-                    elif name in ind_names:
+                    elif str(ont._uri(name, ns_val)) in {i["uri"] for i in individuals}:
                         show_message(f"Individual '{name}' already exists!", "error")
                     else:
                         ont.add_individual(
-                            name, class_type, label=label, comment=comment
+                            name,
+                            class_type,
+                            label=label,
+                            comment=comment,
+                            namespace=ns_val,
                         )
                         save_checkpoint("Add individual")
                         show_message(f"Individual '{name}' added!", "success")

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1070,6 +1070,30 @@ def _namespace_option_index(ont, ns_options, ns_lookup, uri):
 _KEEP_NAMESPACE = object()  # sentinel: leave a resource in its current namespace
 
 
+def _rename_or_move(ont, rename_fn, old_uri, old_local, new_name, new_namespace):
+    """Resolve the target URI from the (possibly changed) local name and
+    namespace and rename via ``rename_fn`` if it differs from ``old_uri``.
+
+    A namespace change is just a rename to a full URI in the new namespace, so
+    ``rename_fn`` re-points every reference and no links are lost. Returns
+    ``(ok, current_ref)``: ``ok`` is False only when ``rename_fn`` refuses
+    because the target URI already exists. ``new_namespace`` is ``None`` (base),
+    a namespace URI, or the ``_KEEP_NAMESPACE`` sentinel to keep the current
+    namespace.
+    """
+    target_ns = (
+        ont._namespace_of(old_uri)
+        if new_namespace is _KEEP_NAMESPACE
+        else new_namespace
+    )
+    target_uri = str(ont._uri(new_name or old_local, target_ns))
+    if target_uri == old_uri:
+        return True, old_uri
+    if rename_fn(old_uri, target_uri):
+        return True, target_uri
+    return False, old_uri
+
+
 def _apply_class_edit(
     ont,
     class_info,
@@ -1090,19 +1114,20 @@ def _apply_class_edit(
     without a namespace selector). Shows an error and returns False if the target
     URI is already taken. The caller owns the undo checkpoint and rerun.
     """
-    current_ref = class_info["uri"]
-    target_ns = (
-        ont._namespace_of(class_info["uri"])
-        if new_namespace is _KEEP_NAMESPACE
-        else new_namespace
+    ok, current_ref = _rename_or_move(
+        ont,
+        ont.rename_class,
+        class_info["uri"],
+        class_info["name"],
+        new_name,
+        new_namespace,
     )
-    target_uri = str(ont._uri(new_name or class_info["name"], target_ns))
-    if target_uri != class_info["uri"]:
-        if ont.rename_class(class_info["uri"], target_uri):
-            current_ref = target_uri
-        else:
-            show_message(f"Cannot move/rename: '{target_uri}' already exists!", "error")
-            return False
+    if not ok:
+        show_message(
+            f"Cannot move/rename: '{new_name or class_info['name']}' already exists!",
+            "error",
+        )
+        return False
     if class_info["parents"] and new_parent != class_info["parents"][0]:
         ont.update_class(current_ref, remove_parent=class_info["parents"][0])
     ont.update_class(
@@ -1660,7 +1685,10 @@ def render_classes():
                                 current_ref = cls["uri"]
                                 if new_name and new_name != cls["name"]:
                                     if ont.rename_class(cls["uri"], new_name):
-                                        current_ref = new_name  # post-rename, the resource lives in the base namespace
+                                        # Rename preserves the class's namespace.
+                                        current_ref = _renamed_ref(
+                                            ont, cls["uri"], new_name
+                                        )
                                         save_checkpoint("Rename class")
                                         show_message(
                                             f"Class renamed to '{new_name}'", "success"
@@ -2153,6 +2181,19 @@ def render_properties():
                                 "property, including assertions that use it — "
                                 "no links are lost.",
                             )
+                            ns_opts, ns_lookup = build_namespace_options(ont)
+                            new_namespace = ns_lookup.get(
+                                st.selectbox(
+                                    "Namespace",
+                                    options=ns_opts,
+                                    index=_namespace_option_index(
+                                        ont, ns_opts, ns_lookup, prop["uri"]
+                                    ),
+                                    key=f"objp_ns_{prop_uid}",
+                                    help="Moving to another namespace re-points "
+                                    "every reference to this property.",
+                                )
+                            )
                             new_label = st.text_input(
                                 "Label", value=prop["label"], key=f"objp_lbl_{prop_uid}"
                             )
@@ -2198,22 +2239,21 @@ def render_properties():
                                 )
 
                             if st.form_submit_button("Save Changes"):
-                                # Handle rename first — pass URI for cross-namespace safety
-                                current_ref = prop["uri"]
-                                if new_name and new_name != prop["name"]:
-                                    if ont.rename_property(prop["uri"], new_name):
-                                        current_ref = new_name
-                                        save_checkpoint("Rename property")
-                                        show_message(
-                                            f"Property renamed to '{new_name}'",
-                                            "success",
-                                        )
-                                    else:
-                                        show_message(
-                                            f"Cannot rename: '{new_name}' already exists!",
-                                            "error",
-                                        )
-                                        st.rerun()
+                                # Rename/move first so later updates hit the new URI.
+                                ok, current_ref = _rename_or_move(
+                                    ont,
+                                    ont.rename_property,
+                                    prop["uri"],
+                                    prop["name"],
+                                    new_name,
+                                    new_namespace,
+                                )
+                                if not ok:
+                                    show_message(
+                                        f"Cannot move/rename: '{new_name}' already exists!",
+                                        "error",
+                                    )
+                                    st.rerun()
 
                                 new_dom_uri = cls_lookup.get(dom_disp) or ""
                                 new_rng_uri = cls_lookup.get(rng_disp) or ""
@@ -2351,6 +2391,19 @@ def render_properties():
                                 "property, including assertions that use it — "
                                 "no links are lost.",
                             )
+                            ns_opts, ns_lookup = build_namespace_options(ont)
+                            new_namespace = ns_lookup.get(
+                                st.selectbox(
+                                    "Namespace",
+                                    options=ns_opts,
+                                    index=_namespace_option_index(
+                                        ont, ns_opts, ns_lookup, prop["uri"]
+                                    ),
+                                    key=f"dp_ns_{prop_uid}",
+                                    help="Moving to another namespace re-points "
+                                    "every reference to this property.",
+                                )
+                            )
                             new_label = st.text_input(
                                 "Label", value=prop["label"], key=f"dp_lbl_{prop_uid}"
                             )
@@ -2393,22 +2446,21 @@ def render_properties():
                                 )
 
                             if st.form_submit_button("Save Changes"):
-                                # Handle rename first — pass URI for cross-namespace safety
-                                current_ref = prop["uri"]
-                                if new_name and new_name != prop["name"]:
-                                    if ont.rename_property(prop["uri"], new_name):
-                                        current_ref = new_name
-                                        save_checkpoint("Rename property")
-                                        show_message(
-                                            f"Property renamed to '{new_name}'",
-                                            "success",
-                                        )
-                                    else:
-                                        show_message(
-                                            f"Cannot rename: '{new_name}' already exists!",
-                                            "error",
-                                        )
-                                        st.rerun()
+                                # Rename/move first so later updates hit the new URI.
+                                ok, current_ref = _rename_or_move(
+                                    ont,
+                                    ont.rename_property,
+                                    prop["uri"],
+                                    prop["name"],
+                                    new_name,
+                                    new_namespace,
+                                )
+                                if not ok:
+                                    show_message(
+                                        f"Cannot move/rename: '{new_name}' already exists!",
+                                        "error",
+                                    )
+                                    st.rerun()
 
                                 new_dom_uri = cls_lookup.get(dom_disp) or ""
                                 ont.update_property(
@@ -2900,6 +2952,19 @@ def render_individuals():
                                 "individual — no links are lost, unlike "
                                 "delete-and-recreate.",
                             )
+                            ns_opts, ns_lookup = build_namespace_options(ont)
+                            new_namespace = ns_lookup.get(
+                                st.selectbox(
+                                    "Namespace",
+                                    options=ns_opts,
+                                    index=_namespace_option_index(
+                                        ont, ns_opts, ns_lookup, ind["uri"]
+                                    ),
+                                    key=f"ind_ns_{_ik}",
+                                    help="Moving to another namespace re-points "
+                                    "every reference to this individual.",
+                                )
+                            )
                             new_label = st.text_input(
                                 "Label", value=ind["label"], key=f"ind_lbl_{_ik}"
                             )
@@ -2928,22 +2993,21 @@ def render_individuals():
                                 )
 
                             if st.form_submit_button("Save Changes"):
-                                # Handle rename first — pass URI for cross-namespace safety
-                                current_ref = ind["uri"]
-                                if new_name and new_name != ind["name"]:
-                                    if ont.rename_individual(ind["uri"], new_name):
-                                        current_ref = new_name
-                                        save_checkpoint("Rename individual")
-                                        show_message(
-                                            f"Individual renamed to '{new_name}'",
-                                            "success",
-                                        )
-                                    else:
-                                        show_message(
-                                            f"Cannot rename: '{new_name}' already exists!",
-                                            "error",
-                                        )
-                                        st.rerun()
+                                # Rename/move first so later updates hit the new URI.
+                                ok, current_ref = _rename_or_move(
+                                    ont,
+                                    ont.rename_individual,
+                                    ind["uri"],
+                                    ind["name"],
+                                    new_name,
+                                    new_namespace,
+                                )
+                                if not ok:
+                                    show_message(
+                                        f"Cannot move/rename: '{new_name}' already exists!",
+                                        "error",
+                                    )
+                                    st.rerun()
 
                                 ont.update_individual(
                                     current_ref,

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -98,11 +98,6 @@ class OntologyManager:
         self.graph.bind("dcterms", DCTERMS)
         self.graph.bind("", self.namespace)
 
-        # Namespaces the user explicitly bound (via add_prefix). Tracked so the
-        # "create in namespace" picker can offer them without also surfacing
-        # rdflib's ~30 auto-bound default prefixes.
-        self._custom_namespaces: Dict[str, str] = {}
-
         # Create ontology declaration
         self.ontology_uri = URIRef(base_uri.rstrip("#").rstrip("/"))
         self.graph.add((self.ontology_uri, RDF.type, OWL.Ontology))
@@ -196,13 +191,11 @@ class OntologyManager:
     def add_prefix(self, prefix: str, namespace: str):
         """Bind a custom prefix to a namespace URI in the graph."""
         self.graph.bind(prefix, Namespace(namespace), override=True)
-        self._custom_namespaces[prefix] = namespace
 
     def remove_prefix(self, prefix: str):
         """Remove a custom prefix binding. Standard prefixes cannot be removed."""
         if prefix in self.STANDARD_PREFIXES:
             raise ValueError(f"Cannot remove standard prefix '{prefix}'")
-        self._custom_namespaces.pop(prefix, None)
         # rdflib NamespaceManager doesn't support unbinding directly.
         # Rebuild the namespace manager by creating a new graph with the same triples.
         keep = [(p, ns) for p, ns in self.graph.namespaces() if p != prefix]
@@ -359,20 +352,37 @@ class OntologyManager:
         local = self._local_name(uri)
         return uri_str[: len(uri_str) - len(local)]
 
+    # Prefixes rdflib auto-binds on a fresh Graph() (foaf, schema, brick, ...).
+    # Excluded from the creation picker so it is not flooded with ~30 vocab
+    # prefixes the user never chose. Computed from the running rdflib so it
+    # stays correct across versions.
+    _RDFLIB_DEFAULT_PREFIXES = frozenset(p for p, _ in Graph().namespaces())
+
     def get_creatable_namespaces(self) -> List[str]:
         """Namespaces offered when creating a new entity, base namespace first.
 
         Includes the base (default) namespace, every namespace already used by
         an existing entity (so imported namespaces are offered), and every
-        prefix the user explicitly bound via ``add_prefix``. Pure-syntax
-        namespaces (owl, rdf, rdfs, xsd) and rdflib's auto-bound default
-        prefixes are excluded so the list stays relevant.
+        namespace bound under a user/import prefix. Pure-syntax namespaces (owl,
+        rdf, rdfs, xsd) and rdflib's auto-bound default prefixes are excluded so
+        the list stays relevant. Derived from the live graph, so it reflects the
+        current ontology after an import, undo, or session restore.
         """
         result = [self.base_uri]
         seen = {self.base_uri}
         syntax_ns = {str(OWL), str(RDF), str(RDFS), str(XSD)}
 
-        extra = set(self._custom_namespaces.values())
+        extra = set()
+        # Namespaces bound under a prefix the user or an import introduced
+        # (i.e. not one of rdflib's auto-bound defaults or our standards).
+        for prefix, ns in self.graph.namespaces():
+            if (
+                prefix
+                and prefix not in self._RDFLIB_DEFAULT_PREFIXES
+                and prefix not in self.STANDARD_PREFIXES
+            ):
+                extra.add(str(ns))
+        # Namespaces already used by an existing entity.
         for etype in self._ENTITY_TYPES:
             for subject in self.graph.subjects(RDF.type, etype):
                 if isinstance(subject, URIRef):
@@ -457,12 +467,17 @@ class OntologyManager:
         return any((uri, RDF.type, t) in self.graph for t in self._ENTITY_TYPES)
 
     def rename_class(self, old_name: str, new_name: str) -> bool:
-        """Rename a class, updating all references."""
+        """Rename a class, updating all references.
+
+        The renamed class keeps its current namespace: a new local name is
+        placed in the same namespace as ``old_name`` (a full URI passed as
+        ``new_name`` still overrides).
+        """
         if old_name == new_name:
             return True
 
         old_uri = self._uri(old_name)
-        new_uri = self._uri(new_name)
+        new_uri = self._uri(new_name, self._namespace_of(old_uri))
 
         # Refuse if the target name is already used by any entity (any type).
         if self._name_in_use(new_uri):
@@ -723,14 +738,34 @@ class OntologyManager:
         if not lines:
             return []
 
-        # Determine the delimiter from the first line that contains one. Picking
-        # whichever separator is more frequent on that single line keeps a stray
-        # ';' inside a comma CSV (or ',' inside a semicolon CSV) from flipping it.
+        # Determine the delimiter from the first line that contains one. When the
+        # column count is known, prefer whichever delimiter splits that line into
+        # exactly that many fields; if both do (equal numbers of ',' and ';'),
+        # break the tie by whichever appears first, since the leading field (the
+        # name) is delimiter-free and its terminator is the real delimiter.
+        # Otherwise fall back to whichever separator is more frequent on the
+        # line, so a stray ';' in a comma CSV (or ',' in a semicolon CSV) can't
+        # flip it.
+        expected = (
+            len(columns)
+            if columns
+            else (len(default_columns) if default_columns else None)
+        )
         delimiter = ","
         for line in lines:
-            if ";" in line or "," in line:
+            if ";" not in line and "," not in line:
+                continue
+            semi_exact = expected and ";" in line and len(line.split(";")) == expected
+            comma_exact = expected and "," in line and len(line.split(",")) == expected
+            if semi_exact and comma_exact:
+                delimiter = ";" if line.index(";") < line.index(",") else ","
+            elif semi_exact:
+                delimiter = ";"
+            elif comma_exact:
+                delimiter = ","
+            else:
                 delimiter = ";" if line.count(";") > line.count(",") else ","
-                break
+            break
 
         # Auto-detect CSV header
         if columns is None and delimiter in lines[0]:
@@ -764,18 +799,22 @@ class OntologyManager:
     def bulk_add_classes(self, entries: List[Dict[str, str]]) -> Dict[str, Any]:
         """Batch create classes.
 
-        Each entry dict can have: name, label, parent.
+        Each entry dict can have: name, label, parent, namespace. Duplicates are
+        detected by full URI, so the same local name in a different namespace is
+        not treated as existing.
         Returns {created: [], errors: [], skipped: []}.
         """
         result: Dict[str, Any] = {"created": [], "errors": [], "skipped": []}
-        existing = {c["name"] for c in self.get_classes()}
+        existing = {c["uri"] for c in self.get_classes()}
 
         for entry in entries:
             name = entry.get("name", "").strip()
             if not name:
                 result["errors"].append({"name": "", "error": "Empty name"})
                 continue
-            if name in existing:
+            namespace = entry.get("namespace", "").strip() or None
+            uri = str(self._uri(name, namespace))
+            if uri in existing:
                 result["skipped"].append(name)
                 continue
             try:
@@ -783,9 +822,10 @@ class OntologyManager:
                     name,
                     parent=entry.get("parent", "").strip() or None,
                     label=entry.get("label", "").strip() or None,
+                    namespace=namespace,
                 )
                 result["created"].append(name)
-                existing.add(name)
+                existing.add(uri)
             except Exception as e:
                 result["errors"].append({"name": name, "error": str(e)})
 
@@ -796,22 +836,24 @@ class OntologyManager:
     ) -> Dict[str, Any]:
         """Batch create properties.
 
-        Each entry dict can have: name, domain, range, label.
-        property_type: "object" or "data".
+        Each entry dict can have: name, domain, range, label, namespace.
+        property_type: "object" or "data". Duplicates are detected by full URI.
         Returns {created: [], errors: [], skipped: []}.
         """
         result: Dict[str, Any] = {"created": [], "errors": [], "skipped": []}
         if property_type == "object":
-            existing = {p["name"] for p in self.get_object_properties()}
+            existing = {p["uri"] for p in self.get_object_properties()}
         else:
-            existing = {p["name"] for p in self.get_data_properties()}
+            existing = {p["uri"] for p in self.get_data_properties()}
 
         for entry in entries:
             name = entry.get("name", "").strip()
             if not name:
                 result["errors"].append({"name": "", "error": "Empty name"})
                 continue
-            if name in existing:
+            namespace = entry.get("namespace", "").strip() or None
+            uri = str(self._uri(name, namespace))
+            if uri in existing:
                 result["skipped"].append(name)
                 continue
             try:
@@ -820,14 +862,22 @@ class OntologyManager:
                 label = entry.get("label", "").strip() or None
                 if property_type == "object":
                     self.add_object_property(
-                        name, domain=domain, range_=range_, label=label
+                        name,
+                        domain=domain,
+                        range_=range_,
+                        label=label,
+                        namespace=namespace,
                     )
                 else:
                     self.add_data_property(
-                        name, domain=domain, range_=range_ or "string", label=label
+                        name,
+                        domain=domain,
+                        range_=range_ or "string",
+                        label=label,
+                        namespace=namespace,
                     )
                 result["created"].append(name)
-                existing.add(name)
+                existing.add(uri)
             except Exception as e:
                 result["errors"].append({"name": name, "error": str(e)})
 
@@ -836,11 +886,12 @@ class OntologyManager:
     def bulk_add_individuals(self, entries: List[Dict[str, str]]) -> Dict[str, Any]:
         """Batch create individuals.
 
-        Each entry dict can have: name, class, label.
+        Each entry dict can have: name, class, label, namespace. Duplicates are
+        detected by full URI.
         Returns {created: [], errors: [], skipped: []}.
         """
         result: Dict[str, Any] = {"created": [], "errors": [], "skipped": []}
-        existing = {i["name"] for i in self.get_individuals()}
+        existing = {i["uri"] for i in self.get_individuals()}
 
         for entry in entries:
             name = entry.get("name", "").strip()
@@ -851,7 +902,9 @@ class OntologyManager:
             if not class_name:
                 result["errors"].append({"name": name, "error": "Missing class"})
                 continue
-            if name in existing:
+            namespace = entry.get("namespace", "").strip() or None
+            uri = str(self._uri(name, namespace))
+            if uri in existing:
                 result["skipped"].append(name)
                 continue
             try:
@@ -859,9 +912,10 @@ class OntologyManager:
                     name,
                     class_name=class_name,
                     label=entry.get("label", "").strip() or None,
+                    namespace=namespace,
                 )
                 result["created"].append(name)
-                existing.add(name)
+                existing.add(uri)
             except Exception as e:
                 result["errors"].append({"name": name, "error": str(e)})
 
@@ -1077,12 +1131,16 @@ class OntologyManager:
                     self.graph.add((prop_uri, RDFS.range, self._uri(new_range)))
 
     def rename_property(self, old_name: str, new_name: str) -> bool:
-        """Rename a property, updating all references."""
+        """Rename a property, updating all references.
+
+        The renamed property keeps its current namespace (see
+        :meth:`rename_class`).
+        """
         if old_name == new_name:
             return True
 
         old_uri = self._uri(old_name)
-        new_uri = self._uri(new_name)
+        new_uri = self._uri(new_name, self._namespace_of(old_uri))
 
         # Refuse if the target name is already used by any entity (any type).
         if self._name_in_use(new_uri):
@@ -1336,12 +1394,16 @@ class OntologyManager:
             self.graph.remove((ind_uri, RDF.type, self._uri(remove_class)))
 
     def rename_individual(self, old_name: str, new_name: str) -> bool:
-        """Rename an individual, updating all references."""
+        """Rename an individual, updating all references.
+
+        The renamed individual keeps its current namespace (see
+        :meth:`rename_class`).
+        """
         if old_name == new_name:
             return True
 
         old_uri = self._uri(old_name)
-        new_uri = self._uri(new_name)
+        new_uri = self._uri(new_name, self._namespace_of(old_uri))
 
         # Refuse if the target name is already used by any entity (any type).
         if self._name_in_use(new_uri):
@@ -1897,7 +1959,7 @@ class OntologyManager:
                 old_uri = cast(URIRef, s_uri)
                 break
 
-        new_uri = self._uri(new_name)
+        new_uri = self._uri(new_name, self._namespace_of(old_uri))
         # Refuse if the target name is already used by any entity (any type).
         if self._name_in_use(new_uri):
             return False
@@ -2073,12 +2135,16 @@ class OntologyManager:
             self.graph.remove((uri, SKOS.inScheme, self._uri(remove_scheme)))
 
     def rename_concept(self, old_name: str, new_name: str) -> bool:
-        """Rename a SKOS concept, updating all references."""
+        """Rename a SKOS concept, updating all references.
+
+        The renamed concept keeps its current namespace (see
+        :meth:`rename_class`).
+        """
         if old_name == new_name:
             return True
 
         old_uri = self._uri(old_name)
-        new_uri = self._uri(new_name)
+        new_uri = self._uri(new_name, self._namespace_of(old_uri))
 
         # Refuse if the target name is already used by any entity (any type).
         if self._name_in_use(new_uri):

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -98,6 +98,11 @@ class OntologyManager:
         self.graph.bind("dcterms", DCTERMS)
         self.graph.bind("", self.namespace)
 
+        # Namespaces the user explicitly bound (via add_prefix). Tracked so the
+        # "create in namespace" picker can offer them without also surfacing
+        # rdflib's ~30 auto-bound default prefixes.
+        self._custom_namespaces: Dict[str, str] = {}
+
         # Create ontology declaration
         self.ontology_uri = URIRef(base_uri.rstrip("#").rstrip("/"))
         self.graph.add((self.ontology_uri, RDF.type, OWL.Ontology))
@@ -191,11 +196,13 @@ class OntologyManager:
     def add_prefix(self, prefix: str, namespace: str):
         """Bind a custom prefix to a namespace URI in the graph."""
         self.graph.bind(prefix, Namespace(namespace), override=True)
+        self._custom_namespaces[prefix] = namespace
 
     def remove_prefix(self, prefix: str):
         """Remove a custom prefix binding. Standard prefixes cannot be removed."""
         if prefix in self.STANDARD_PREFIXES:
             raise ValueError(f"Cannot remove standard prefix '{prefix}'")
+        self._custom_namespaces.pop(prefix, None)
         # rdflib NamespaceManager doesn't support unbinding directly.
         # Rebuild the namespace manager by creating a new graph with the same triples.
         keep = [(p, ns) for p, ns in self.graph.namespaces() if p != prefix]
@@ -324,10 +331,18 @@ class OntologyManager:
         # Re-bind the default namespace
         self.graph.bind("", self.namespace)
 
-    def _uri(self, local_name: str) -> URIRef:
-        """Create a URI from a local name."""
+    def _uri(self, local_name: str, namespace: Optional[str] = None) -> URIRef:
+        """Create a URI from a local name.
+
+        A value that is already a full ``http(s)`` URI is returned unchanged.
+        Otherwise the local name is placed in ``namespace`` when one is given
+        (any bound namespace, e.g. a custom prefix), or in the base namespace
+        by default.
+        """
         if local_name.startswith("http://") or local_name.startswith("https://"):
             return URIRef(local_name)
+        if namespace:
+            return URIRef(namespace + local_name)
         return self.namespace[local_name]
 
     def _local_name(self, uri: Node) -> str:
@@ -337,6 +352,38 @@ class OntologyManager:
             return uri_str.split("#")[-1]
         return uri_str.split("/")[-1]
 
+    def _namespace_of(self, uri: Node) -> str:
+        """Return the namespace portion of a URI (everything before the local
+        name), e.g. 'http://ex.org/ns#Dog' -> 'http://ex.org/ns#'."""
+        uri_str = str(uri)
+        local = self._local_name(uri)
+        return uri_str[: len(uri_str) - len(local)]
+
+    def get_creatable_namespaces(self) -> List[str]:
+        """Namespaces offered when creating a new entity, base namespace first.
+
+        Includes the base (default) namespace, every namespace already used by
+        an existing entity (so imported namespaces are offered), and every
+        prefix the user explicitly bound via ``add_prefix``. Pure-syntax
+        namespaces (owl, rdf, rdfs, xsd) and rdflib's auto-bound default
+        prefixes are excluded so the list stays relevant.
+        """
+        result = [self.base_uri]
+        seen = {self.base_uri}
+        syntax_ns = {str(OWL), str(RDF), str(RDFS), str(XSD)}
+
+        extra = set(self._custom_namespaces.values())
+        for etype in self._ENTITY_TYPES:
+            for subject in self.graph.subjects(RDF.type, etype):
+                if isinstance(subject, URIRef):
+                    extra.add(self._namespace_of(subject))
+
+        for ns in sorted(extra):
+            if ns and ns not in seen and ns not in syntax_ns:
+                seen.add(ns)
+                result.append(ns)
+        return result
+
     # ==================== CLASS OPERATIONS ====================
 
     def add_class(
@@ -345,9 +392,14 @@ class OntologyManager:
         parent: Optional[str] = None,
         label: Optional[str] = None,
         comment: Optional[str] = None,
+        namespace: Optional[str] = None,
     ) -> URIRef:
-        """Add a new OWL class."""
-        class_uri = self._uri(name)
+        """Add a new OWL class.
+
+        ``namespace`` places the class in a specific namespace (any bound
+        prefix); when omitted the base namespace is used.
+        """
+        class_uri = self._uri(name, namespace)
         self.graph.add((class_uri, RDF.type, OWL.Class))
 
         if parent:
@@ -916,9 +968,14 @@ class OntologyManager:
         reflexive: bool = False,
         irreflexive: bool = False,
         inverse_of: Optional[str] = None,
+        namespace: Optional[str] = None,
     ) -> URIRef:
-        """Add a new object property."""
-        prop_uri = self._uri(name)
+        """Add a new object property.
+
+        ``namespace`` places the property in a specific namespace (any bound
+        prefix); when omitted the base namespace is used.
+        """
+        prop_uri = self._uri(name, namespace)
         self.graph.add((prop_uri, RDF.type, OWL.ObjectProperty))
 
         if domain:
@@ -958,9 +1015,14 @@ class OntologyManager:
         label: Optional[str] = None,
         comment: Optional[str] = None,
         functional: bool = False,
+        namespace: Optional[str] = None,
     ) -> URIRef:
-        """Add a new data property."""
-        prop_uri = self._uri(name)
+        """Add a new data property.
+
+        ``namespace`` places the property in a specific namespace (any bound
+        prefix); when omitted the base namespace is used.
+        """
+        prop_uri = self._uri(name, namespace)
         self.graph.add((prop_uri, RDF.type, OWL.DatatypeProperty))
 
         if domain:
@@ -1207,9 +1269,16 @@ class OntologyManager:
         class_name: str,
         label: Optional[str] = None,
         comment: Optional[str] = None,
+        namespace: Optional[str] = None,
     ) -> URIRef:
-        """Add a new individual (instance)."""
-        ind_uri = self._uri(name)
+        """Add a new individual (instance).
+
+        ``namespace`` places the individual in a specific namespace (any bound
+        prefix); when omitted the base namespace is used. The class reference is
+        resolved independently, so an individual can live in a different
+        namespace than its type.
+        """
+        ind_uri = self._uri(name, namespace)
         class_uri = self._uri(class_name)
 
         self.graph.add((ind_uri, RDF.type, OWL.NamedIndividual))

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -98,6 +98,12 @@ class OntologyManager:
         self.graph.bind("dcterms", DCTERMS)
         self.graph.bind("", self.namespace)
 
+        # Prefixes the user explicitly bound via add_prefix (prefix -> namespace).
+        # Tracked so the creation picker offers them even when the name collides
+        # with one of rdflib's auto-bound defaults (e.g. an explicit 'foaf').
+        # Reset on load/restore so it can never go stale against the graph.
+        self._user_added_prefixes: Dict[str, str] = {}
+
         # Create ontology declaration
         self.ontology_uri = URIRef(base_uri.rstrip("#").rstrip("/"))
         self.graph.add((self.ontology_uri, RDF.type, OWL.Ontology))
@@ -191,11 +197,13 @@ class OntologyManager:
     def add_prefix(self, prefix: str, namespace: str):
         """Bind a custom prefix to a namespace URI in the graph."""
         self.graph.bind(prefix, Namespace(namespace), override=True)
+        self._user_added_prefixes[prefix] = namespace
 
     def remove_prefix(self, prefix: str):
         """Remove a custom prefix binding. Standard prefixes cannot be removed."""
         if prefix in self.STANDARD_PREFIXES:
             raise ValueError(f"Cannot remove standard prefix '{prefix}'")
+        self._user_added_prefixes.pop(prefix, None)
         # rdflib NamespaceManager doesn't support unbinding directly.
         # Rebuild the namespace manager by creating a new graph with the same triples.
         keep = [(p, ns) for p, ns in self.graph.namespaces() if p != prefix]
@@ -362,18 +370,21 @@ class OntologyManager:
         """Namespaces offered when creating a new entity, base namespace first.
 
         Includes the base (default) namespace, every namespace already used by
-        an existing entity (so imported namespaces are offered), and every
-        namespace bound under a user/import prefix. Pure-syntax namespaces (owl,
-        rdf, rdfs, xsd) and rdflib's auto-bound default prefixes are excluded so
-        the list stays relevant. Derived from the live graph, so it reflects the
-        current ontology after an import, undo, or session restore.
+        an existing entity (so imported namespaces are offered), every namespace
+        the user explicitly bound via add_prefix, and any namespace bound under a
+        non-default import prefix. Pure-syntax namespaces (owl, rdf, rdfs, xsd)
+        and rdflib's auto-bound default prefixes are excluded so the list stays
+        relevant. Derived from the live graph plus the (load/restore-reset)
+        record of explicit user prefixes, so it reflects the current ontology.
         """
         result = [self.base_uri]
         seen = {self.base_uri}
         syntax_ns = {str(OWL), str(RDF), str(RDFS), str(XSD)}
 
-        extra = set()
-        # Namespaces bound under a prefix the user or an import introduced
+        # Namespaces the user explicitly bound — offered even when the prefix
+        # name matches one of rdflib's auto-bound defaults (e.g. 'foaf').
+        extra = set(self._user_added_prefixes.values())
+        # Namespaces bound under a prefix an import introduced
         # (i.e. not one of rdflib's auto-bound defaults or our standards).
         for prefix, ns in self.graph.namespaces():
             if (
@@ -2704,6 +2715,7 @@ class OntologyManager:
             self._loaded_prefixes = self._extract_prefixes_from_jsonld(data)
         else:
             self._loaded_prefixes = []
+        self._user_added_prefixes = {}
         self.graph = Graph()
         self.graph.parse(data=data, format=format)
         self._update_namespace_from_graph()
@@ -3160,7 +3172,13 @@ class OntologyManager:
         return self.graph.serialize(format="nt").encode("utf-8")
 
     def restore_snapshot(self, snapshot: bytes):
-        """Replace the current graph with a previously captured snapshot."""
+        """Replace the current graph with a previously captured snapshot.
+
+        Snapshots are N-Triples (no prefix bindings), so custom prefixes do not
+        survive an undo/redo; reset the explicit-prefix record to match rather
+        than leave it pointing at prefixes the restored graph no longer has.
+        """
+        self._user_added_prefixes = {}
         self.graph = Graph()
         self.graph.parse(data=snapshot.decode("utf-8"), format="nt")
         self._update_namespace_from_graph()

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -121,6 +121,27 @@ class TestParseBulkText:
             {"name": "Dog", "label": "A dog; domestic", "parent": "Animal"}
         ]
 
+    def test_semicolon_delimiter_with_multiple_commas_in_label(self):
+        # Review finding 4: a semicolon row whose label has several commas must
+        # still be read as semicolon-delimited (both split to 3 fields, so the
+        # column-count heuristic favours the semicolon escape hatch).
+        text = "Dog; A, friendly, domestic dog; Animal"
+        result = OntologyManager.parse_bulk_text(
+            text, default_columns=["name", "label", "parent"]
+        )
+        assert result == [
+            {"name": "Dog", "label": "A, friendly, domestic dog", "parent": "Animal"}
+        ]
+
+    def test_column_count_disambiguates_comma_csv(self):
+        # Comma split matches the expected 3 columns; semicolon in the label does
+        # not, so comma stays the delimiter.
+        text = "Dog, A; B; C, Animal"
+        result = OntologyManager.parse_bulk_text(
+            text, default_columns=["name", "label", "parent"]
+        )
+        assert result == [{"name": "Dog", "label": "A; B; C", "parent": "Animal"}]
+
 
 class TestBulkAddClasses:
     def test_add_multiple(self, om):
@@ -151,6 +172,30 @@ class TestBulkAddClasses:
         result = om.bulk_add_classes(entries)
         assert len(result["errors"]) == 1
         assert result["created"] == ["Valid"]
+
+    def test_same_local_name_other_namespace_not_skipped(self):
+        # Review finding 3: a base-namespace entry must not be skipped just
+        # because the local name exists in another namespace.
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Dog", namespace="http://other.example/ns#")
+        result = om.bulk_add_classes([{"name": "Dog"}])
+        assert result["created"] == ["Dog"]
+        assert result["skipped"] == []
+        assert "http://test.org/ont#Dog" in {c["uri"] for c in om.get_classes()}
+
+    def test_namespace_column_creates_in_namespace(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        entries = [{"name": "Dog", "namespace": "http://other.example/ns#"}]
+        result = om.bulk_add_classes(entries)
+        assert result["created"] == ["Dog"]
+        assert "http://other.example/ns#Dog" in {c["uri"] for c in om.get_classes()}
+
+    def test_duplicate_full_uri_still_skipped(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Dog")
+        result = om.bulk_add_classes([{"name": "Dog"}])
+        assert result["skipped"] == ["Dog"]
+        assert result["created"] == []
 
 
 class TestBulkAddProperties:

--- a/tests/test_namespace_create.py
+++ b/tests/test_namespace_create.py
@@ -163,6 +163,27 @@ class TestCreatableNamespaces:
         assert "http://www.w3.org/2002/07/owl#" not in nss
         assert "http://www.w3.org/1999/02/22-rdf-syntax-ns#" not in nss
 
+    def test_explicit_rdflib_default_prefix_is_offered(self):
+        # Review finding 2: explicitly binding a prefix whose name matches one of
+        # rdflib's auto-bound defaults (e.g. foaf) must still be offered.
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_prefix("foaf", "http://xmlns.com/foaf/0.1/")
+        assert "http://xmlns.com/foaf/0.1/" in om.get_creatable_namespaces()
+
+    def test_auto_bound_default_prefix_not_offered(self):
+        # But an untouched auto-bound default (never added by the user) stays out.
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        assert "http://xmlns.com/foaf/0.1/" not in om.get_creatable_namespaces()
+
+    def test_user_prefix_reset_on_restore(self):
+        # Snapshots are prefix-less, so an explicit prefix must not linger in the
+        # picker after an undo/redo that the graph no longer reflects.
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_prefix("ex", OTHER)
+        snapshot = om.take_snapshot()
+        om.restore_snapshot(snapshot)
+        assert OTHER not in om.get_creatable_namespaces()
+
     def test_reflects_graph_after_load(self):
         # Derived from the live graph, so a prefix bound before a load must not
         # linger once the loaded ontology no longer declares it (issue #87

--- a/tests/test_namespace_create.py
+++ b/tests/test_namespace_create.py
@@ -107,6 +107,25 @@ class TestRenamePreservesNamespace:
         uris = {c["uri"] for c in om.get_classes()}
         assert "http://test.org/ont#Hound" in uris
 
+    def test_move_class_between_namespaces_keeps_references(self):
+        # Moving a class = renaming it to a full URI in another namespace; every
+        # reference (subclass links, instance typing) must follow.
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Animal")
+        om.add_class("Dog", parent="Animal", namespace=OTHER)
+        om.add_individual("rex", OTHER + "Dog")
+        # Move OTHER#Dog to the base namespace.
+        assert om.rename_class(OTHER + "Dog", "http://test.org/ont#Dog") is True
+
+        classes = {c["uri"]: c for c in om.get_classes()}
+        assert "http://test.org/ont#Dog" in classes
+        assert OTHER + "Dog" not in classes
+        # Subclass link preserved (by local name and by URI).
+        assert "Animal" in classes["http://test.org/ont#Dog"]["parents"]
+        # Instance typing preserved.
+        rex = next(i for i in om.get_individuals() if i["name"] == "rex")
+        assert "http://test.org/ont#Dog" in rex.get("class_uris", [])
+
 
 class TestCreatableNamespaces:
     def test_base_namespace_is_first(self):

--- a/tests/test_namespace_create.py
+++ b/tests/test_namespace_create.py
@@ -63,6 +63,51 @@ def test_full_uri_overrides_namespace_argument():
     assert str(uri) == "http://verbatim.example/Thing"
 
 
+class TestRenamePreservesNamespace:
+    def test_rename_class_keeps_namespace(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Thing", namespace=OTHER, label="a thing")
+        assert om.rename_class(OTHER + "Thing", "Thing2") is True
+        uris = {c["uri"]: c for c in om.get_classes()}
+        assert OTHER + "Thing2" in uris
+        assert OTHER + "Thing" not in uris
+        # Base namespace must not have swallowed it.
+        assert "http://test.org/ont#Thing2" not in uris
+        # The label survives the rename (post-rename update targets the new URI).
+        assert uris[OTHER + "Thing2"]["label"] == "a thing"
+
+    def test_rename_property_keeps_namespace(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_object_property("knows", namespace=OTHER)
+        assert om.rename_property(OTHER + "knows", "knowsWell") is True
+        uris = {p["uri"] for p in om.get_object_properties()}
+        assert OTHER + "knowsWell" in uris
+        assert "http://test.org/ont#knowsWell" not in uris
+
+    def test_rename_individual_keeps_namespace(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Person")
+        om.add_individual("alice", "Person", namespace=OTHER)
+        assert om.rename_individual(OTHER + "alice", "alice2") is True
+        uris = {i["uri"] for i in om.get_individuals()}
+        assert OTHER + "alice2" in uris
+        assert "http://test.org/ont#alice2" not in uris
+
+    def test_rename_to_full_uri_still_overrides(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Thing", namespace=OTHER)
+        assert om.rename_class(OTHER + "Thing", "http://third.example/X") is True
+        uris = {c["uri"] for c in om.get_classes()}
+        assert "http://third.example/X" in uris
+
+    def test_base_namespace_rename_unchanged(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Dog")
+        assert om.rename_class("Dog", "Hound") is True
+        uris = {c["uri"] for c in om.get_classes()}
+        assert "http://test.org/ont#Hound" in uris
+
+
 class TestCreatableNamespaces:
     def test_base_namespace_is_first(self):
         om = OntologyManager(base_uri="http://test.org/ont#")
@@ -98,3 +143,22 @@ class TestCreatableNamespaces:
         nss = om.get_creatable_namespaces()
         assert "http://www.w3.org/2002/07/owl#" not in nss
         assert "http://www.w3.org/1999/02/22-rdf-syntax-ns#" not in nss
+
+    def test_reflects_graph_after_load(self):
+        # Derived from the live graph, so a prefix bound before a load must not
+        # linger once the loaded ontology no longer declares it (issue #87
+        # review, finding 2).
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_prefix("ex", OTHER)
+        assert OTHER in om.get_creatable_namespaces()
+
+        ttl = (
+            "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n"
+            "@prefix ex2: <http://second.example/ns#> .\n"
+            "ex2:Foo a owl:Class .\n"
+            "<http://loaded.example/ont> a owl:Ontology .\n"
+        )
+        om.load_from_string(ttl)
+        nss = om.get_creatable_namespaces()
+        assert OTHER not in nss
+        assert "http://second.example/ns#" in nss

--- a/tests/test_namespace_create.py
+++ b/tests/test_namespace_create.py
@@ -1,0 +1,100 @@
+"""Tests for creating entities in a chosen namespace (issue #87, part A)."""
+
+from ontology_manager import OntologyManager
+
+OTHER = "http://other.example/ns#"
+
+
+def test_add_class_default_namespace():
+    om = OntologyManager(base_uri="http://test.org/ont#")
+    uri = om.add_class("Dog")
+    assert str(uri) == "http://test.org/ont#Dog"
+
+
+def test_add_class_custom_namespace():
+    om = OntologyManager(base_uri="http://test.org/ont#")
+    uri = om.add_class("Dog", namespace=OTHER)
+    assert str(uri) == OTHER + "Dog"
+    cls = {c["uri"]: c for c in om.get_classes()}
+    assert OTHER + "Dog" in cls
+    assert cls[OTHER + "Dog"]["name"] == "Dog"
+
+
+def test_same_local_name_two_namespaces_coexist():
+    # The core of issue #87: reuse a name across namespaces without prefixing.
+    om = OntologyManager(base_uri="http://test.org/ont#")
+    om.add_class("Order", label="Sales order")
+    om.add_class("Order", namespace=OTHER, label="Military order")
+    uris = {c["uri"] for c in om.get_classes()}
+    assert "http://test.org/ont#Order" in uris
+    assert OTHER + "Order" in uris
+    assert len([c for c in om.get_classes() if c["name"] == "Order"]) == 2
+
+
+def test_add_object_property_custom_namespace():
+    om = OntologyManager(base_uri="http://test.org/ont#")
+    uri = om.add_object_property("knows", namespace=OTHER)
+    assert str(uri) == OTHER + "knows"
+    assert OTHER + "knows" in {p["uri"] for p in om.get_object_properties()}
+
+
+def test_add_data_property_custom_namespace():
+    om = OntologyManager(base_uri="http://test.org/ont#")
+    uri = om.add_data_property("age", range_="integer", namespace=OTHER)
+    assert str(uri) == OTHER + "age"
+    assert OTHER + "age" in {p["uri"] for p in om.get_data_properties()}
+
+
+def test_add_individual_custom_namespace_keeps_base_class():
+    # The individual lands in OTHER, but its class reference resolves in base.
+    om = OntologyManager(base_uri="http://test.org/ont#")
+    om.add_class("Person")
+    uri = om.add_individual("alice", "Person", namespace=OTHER)
+    assert str(uri) == OTHER + "alice"
+    alice = next(i for i in om.get_individuals() if i["uri"] == OTHER + "alice")
+    assert "Person" in alice.get("classes", [])
+    assert "http://test.org/ont#Person" in alice.get("class_uris", [])
+
+
+def test_full_uri_overrides_namespace_argument():
+    # A full URI passed as the name is used verbatim, ignoring the namespace.
+    om = OntologyManager(base_uri="http://test.org/ont#")
+    uri = om.add_class("http://verbatim.example/Thing", namespace=OTHER)
+    assert str(uri) == "http://verbatim.example/Thing"
+
+
+class TestCreatableNamespaces:
+    def test_base_namespace_is_first(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        nss = om.get_creatable_namespaces()
+        assert nss[0] == "http://test.org/ont#"
+
+    def test_excludes_rdflib_default_bindings(self):
+        # rdflib auto-binds ~30 prefixes (foaf, schema, brick, ...); none of
+        # them should appear as creation targets.
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        nss = om.get_creatable_namespaces()
+        assert nss == ["http://test.org/ont#"]
+
+    def test_user_added_prefix_is_offered(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_prefix("ex", OTHER)
+        assert OTHER in om.get_creatable_namespaces()
+
+    def test_removed_prefix_no_longer_offered(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_prefix("ex", OTHER)
+        om.remove_prefix("ex")
+        assert OTHER not in om.get_creatable_namespaces()
+
+    def test_namespace_in_use_by_entity_is_offered(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Dog", namespace=OTHER)
+        assert OTHER in om.get_creatable_namespaces()
+
+    def test_syntax_namespaces_excluded(self):
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_prefix("ex", OTHER)
+        nss = om.get_creatable_namespaces()
+        assert "http://www.w3.org/2002/07/owl#" not in nss
+        assert "http://www.w3.org/1999/02/22-rdf-syntax-ns#" not in nss


### PR DESCRIPTION
## What

Implements part A of #87: create classes, properties, and individuals in a namespace other than the base URI, so the same local name can be reused for different concepts without prefix clutter.

Each Add form (Class, Object Property, Data Property, Individual) gains a **Namespace** picker that defaults to the base URI. The engine `add_class` / `add_object_property` / `add_data_property` / `add_individual` methods accept an optional `namespace` argument; a full `http(s)` URI passed as the name still wins verbatim.

## Keeping the picker relevant

rdflib auto-binds ~30 default prefixes (foaf, schema, brick, ...), which would flood the dropdown. A new `OntologyManager.get_creatable_namespaces()` scopes the options to:

- the base (default) namespace,
- any namespace already used by an existing entity (so imported namespaces are offered),
- prefixes the user explicitly bound via `add_prefix`.

Pure-syntax namespaces (owl, rdf, rdfs, xsd) and rdflib's auto-bound defaults are excluded. To support this, `add_prefix` / `remove_prefix` now track user-bound namespaces.

Duplicate checks in the Add forms compare full URIs instead of local names, so `Order` in the base namespace and `Order` in another namespace can coexist.

## Tests

New `tests/test_namespace_create.py` (13 cases): creating in default vs custom namespace, same local name in two namespaces coexisting, object/data property and individual creation in a custom namespace, full-URI override, and `get_creatable_namespaces` behavior (base first, excludes rdflib defaults, includes user-added and in-use namespaces, drops removed prefixes and syntax namespaces).

Full suite: 351 passed. Ruff check and format clean.

## Manual verification

Ran the app, added prefix `ex: http://ex.example/ns#` on the Dashboard, then created class `Order` with the `ex` namespace selected. The Source (Turtle) view confirmed `ex:Order a owl:Class .` coexisting with the base-namespace classes, and the picker showed only the default and `ex` (no rdflib clutter).

Part B (editable URIs for existing entities) remains open on #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)