### PR TITLE
fix(names): reject invalid characters in entity names (#93)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1028,6 +1028,9 @@ def _apply_class_edit(ont, class_info, new_name, new_label, new_comment, new_par
     """
     current_ref = class_info["uri"]
     if new_name and new_name != class_info["name"]:
+        if reason := ont.invalid_name_reason(new_name):
+            show_message(reason, "error")
+            return False
         if ont.rename_class(class_info["uri"], new_name):
             current_ref = new_name
         else:
@@ -1057,6 +1060,9 @@ def _apply_property_edit(
     """
     current_ref = prop["uri"]
     if new_name and new_name != prop["name"]:
+        if reason := ont.invalid_name_reason(new_name):
+            show_message(reason, "error")
+            return False
         if ont.rename_property(prop["uri"], new_name):
             current_ref = new_name
         else:
@@ -1082,6 +1088,9 @@ def _apply_individual_edit(
     """
     current_ref = ind["uri"]
     if new_name and new_name != ind["name"]:
+        if reason := ont.invalid_name_reason(new_name):
+            show_message(reason, "error")
+            return False
         if ont.rename_individual(ind["uri"], new_name):
             current_ref = new_name
         else:
@@ -1589,6 +1598,9 @@ def render_classes():
                                 # Handle rename first — pass URI so cross-namespace duplicates resolve correctly
                                 current_ref = cls["uri"]
                                 if new_name and new_name != cls["name"]:
+                                    if reason := ont.invalid_name_reason(new_name):
+                                        show_message(reason, "error")
+                                        st.rerun()
                                     if ont.rename_class(cls["uri"], new_name):
                                         current_ref = new_name  # post-rename, the resource lives in the base namespace
                                         save_checkpoint("Rename class")
@@ -1658,6 +1670,8 @@ def render_classes():
             if submitted:
                 if not name:
                     show_message("Class name is required!", "error")
+                elif reason := ont.invalid_name_reason(name):
+                    show_message(reason, "error")
                 elif name in [c["name"] for c in classes]:
                     show_message(f"Class '{name}' already exists!", "error")
                 else:
@@ -2105,6 +2119,9 @@ def render_properties():
                                 # Handle rename first — pass URI for cross-namespace safety
                                 current_ref = prop["uri"]
                                 if new_name and new_name != prop["name"]:
+                                    if reason := ont.invalid_name_reason(new_name):
+                                        show_message(reason, "error")
+                                        st.rerun()
                                     if ont.rename_property(prop["uri"], new_name):
                                         current_ref = new_name
                                         save_checkpoint("Rename property")
@@ -2300,6 +2317,9 @@ def render_properties():
                                 # Handle rename first — pass URI for cross-namespace safety
                                 current_ref = prop["uri"]
                                 if new_name and new_name != prop["name"]:
+                                    if reason := ont.invalid_name_reason(new_name):
+                                        show_message(reason, "error")
+                                        st.rerun()
                                     if ont.rename_property(prop["uri"], new_name):
                                         current_ref = new_name
                                         save_checkpoint("Rename property")
@@ -2449,6 +2469,8 @@ def render_properties():
                 if submitted:
                     if not name:
                         show_message("Property name is required!", "error")
+                    elif reason := ont.invalid_name_reason(name):
+                        show_message(reason, "error")
                     elif name in obj_prop_names or name in data_prop_names:
                         show_message(f"Property '{name}' already exists!", "error")
                     else:
@@ -2497,6 +2519,8 @@ def render_properties():
             if submitted:
                 if not name:
                     show_message("Property name is required!", "error")
+                elif reason := ont.invalid_name_reason(name):
+                    show_message(reason, "error")
                 elif name in obj_prop_names or name in data_prop_names:
                     show_message(f"Property '{name}' already exists!", "error")
                 else:
@@ -2812,6 +2836,9 @@ def render_individuals():
                                 # Handle rename first — pass URI for cross-namespace safety
                                 current_ref = ind["uri"]
                                 if new_name and new_name != ind["name"]:
+                                    if reason := ont.invalid_name_reason(new_name):
+                                        show_message(reason, "error")
+                                        st.rerun()
                                     if ont.rename_individual(ind["uri"], new_name):
                                         current_ref = new_name
                                         save_checkpoint("Rename individual")
@@ -2858,6 +2885,8 @@ def render_individuals():
                 if submitted:
                     if not name:
                         show_message("Individual name is required!", "error")
+                    elif reason := ont.invalid_name_reason(name):
+                        show_message(reason, "error")
                     elif name in ind_names:
                         show_message(f"Individual '{name}' already exists!", "error")
                     else:
@@ -3843,6 +3872,10 @@ def render_skos_vocabulary():
                                 key=f"scheme_cmt_{scheme['name']}",
                             )
                             if st.form_submit_button("Save Changes"):
+                                if new_name and new_name != scheme["name"]:
+                                    if reason := ont.invalid_name_reason(new_name):
+                                        show_message(reason, "error")
+                                        st.rerun()
                                 renamed = bool(new_name and new_name != scheme["name"])
                                 if renamed and not ont.rename_concept_scheme(
                                     scheme["name"], new_name
@@ -3877,6 +3910,8 @@ def render_skos_vocabulary():
             if st.form_submit_button("Add Scheme"):
                 if not s_name:
                     show_message("Scheme name is required!", "error")
+                elif reason := ont.invalid_name_reason(s_name):
+                    show_message(reason, "error")
                 elif s_name in scheme_names:
                     show_message(f"Scheme '{s_name}' already exists!", "error")
                 else:
@@ -4100,6 +4135,10 @@ def render_skos_vocabulary():
                             if st.form_submit_button("Save Changes"):
                                 # Rename first (updates all references) so the
                                 # rest of the update targets the new name.
+                                if new_name and new_name != concept["name"]:
+                                    if reason := ont.invalid_name_reason(new_name):
+                                        show_message(reason, "error")
+                                        st.rerun()
                                 renamed = bool(new_name and new_name != concept["name"])
                                 if renamed and not ont.rename_concept(
                                     concept["name"], new_name
@@ -4183,6 +4222,8 @@ def render_skos_vocabulary():
             if st.form_submit_button("Add Concept"):
                 if not c_name:
                     show_message("Concept name is required!", "error")
+                elif reason := ont.invalid_name_reason(c_name):
+                    show_message(reason, "error")
                 elif c_name in concept_names:
                     show_message(f"Concept '{c_name}' already exists!", "error")
                 else:

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -425,6 +425,8 @@ class OntologyManager:
         remove_parent: Optional[str] = None,
     ):
         """Update an existing class."""
+        if new_parent:
+            self._require_valid_name(new_parent)
         class_uri = self._uri(name)
 
         if new_label is not None:
@@ -1049,6 +1051,12 @@ class OntologyManager:
         new_range: Optional[str] = None,
     ):
         """Update an existing property."""
+        if new_domain:
+            self._require_valid_name(new_domain)
+        # new_range may be a datatype (looked up below) or a class URI; only the
+        # class case reaches _uri() and needs validating.
+        if new_range and new_range not in self.XSD_DATATYPES:
+            self._require_valid_name(new_range)
         prop_uri = self._uri(name)
 
         if new_label is not None:
@@ -1314,6 +1322,8 @@ class OntologyManager:
         remove_class: Optional[str] = None,
     ):
         """Update an existing individual."""
+        if add_class:
+            self._require_valid_name(add_class)
         ind_uri = self._uri(name)
 
         if new_label is not None:
@@ -2047,6 +2057,10 @@ class OntologyManager:
         remove_scheme: Optional[str] = None,
     ):
         """Update a SKOS Concept's properties."""
+        if new_broader is not _UNSET and new_broader:
+            self._require_valid_name(new_broader)
+        if add_scheme:
+            self._require_valid_name(add_scheme)
         uri = self._uri(name)
 
         if new_pref_label is not _UNSET:

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -338,21 +338,29 @@ class OntologyManager:
     # allowing Unicode letters, digits, dots and hyphens (e.g. 'my-class.v2').
     _LOCAL_NAME_RE = re.compile(r"^\w[\w.\-]*$", re.UNICODE)
 
+    # Characters that make a full IRI unserializable in Turtle/N3 (mirrors
+    # rdflib's own check); whitespace is handled separately via str.isspace().
+    _INVALID_URI_CHARS = frozenset('<>"{}|\\^`')
+
     @classmethod
     def invalid_name_reason(cls, name: str) -> Optional[str]:
         """Return a human-readable reason ``name`` is not a valid entity name,
         or ``None`` if it is valid.
 
-        A full ``http(s)`` URI is accepted as an explicit identifier (only a
-        space makes one invalid). Otherwise the name must be a local name that
-        maps to a valid URI fragment (see :attr:`_LOCAL_NAME_RE`).
+        The name is validated verbatim (no stripping), so leading/trailing
+        whitespace is rejected — the string is used as-is to build the URI. A
+        full ``http(s)`` URI is accepted as an explicit identifier as long as it
+        contains no whitespace or characters that break serialization. Otherwise
+        the name must be a valid local name (see :attr:`_LOCAL_NAME_RE`).
         """
         if name is None or not name.strip():
             return "Name cannot be empty."
-        name = name.strip()
         if name.startswith("http://") or name.startswith("https://"):
-            if any(c.isspace() for c in name):
-                return "A full URI cannot contain spaces."
+            if any(c.isspace() or c in cls._INVALID_URI_CHARS for c in name):
+                return (
+                    "A full URI cannot contain spaces or any of the characters "
+                    '< > " { } | \\ ^ `.'
+                )
             return None
         if any(c.isspace() for c in name):
             return (
@@ -392,6 +400,8 @@ class OntologyManager:
     ) -> URIRef:
         """Add a new OWL class."""
         self._require_valid_name(name)
+        if parent:
+            self._require_valid_name(parent)
         class_uri = self._uri(name)
         self.graph.add((class_uri, RDF.type, OWL.Class))
 
@@ -965,6 +975,9 @@ class OntologyManager:
     ) -> URIRef:
         """Add a new object property."""
         self._require_valid_name(name)
+        for ref in (domain, range_, inverse_of):
+            if ref:
+                self._require_valid_name(ref)
         prop_uri = self._uri(name)
         self.graph.add((prop_uri, RDF.type, OWL.ObjectProperty))
 
@@ -1008,6 +1021,8 @@ class OntologyManager:
     ) -> URIRef:
         """Add a new data property."""
         self._require_valid_name(name)
+        if domain:
+            self._require_valid_name(domain)
         prop_uri = self._uri(name)
         self.graph.add((prop_uri, RDF.type, OWL.DatatypeProperty))
 
@@ -1259,6 +1274,7 @@ class OntologyManager:
     ) -> URIRef:
         """Add a new individual (instance)."""
         self._require_valid_name(name)
+        self._require_valid_name(class_name)
         ind_uri = self._uri(name)
         class_uri = self._uri(class_name)
 
@@ -1921,6 +1937,9 @@ class OntologyManager:
     ) -> URIRef:
         """Add a SKOS Concept with optional scheme/broader links."""
         self._require_valid_name(name)
+        for ref in (scheme, broader):
+            if ref:
+                self._require_valid_name(ref)
         concept_uri = self._uri(name)
         self.graph.add((concept_uri, RDF.type, SKOS.Concept))
 

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -3,6 +3,7 @@ OntologyManager - Core class for managing OWL ontologies using rdflib.
 """
 
 import os
+import re
 import tempfile
 from pathlib import Path
 from rdflib import Graph, Namespace, URIRef, Literal, BNode
@@ -330,6 +331,49 @@ class OntologyManager:
             return URIRef(local_name)
         return self.namespace[local_name]
 
+    # A valid local name is an NCName relaxed to also allow a leading digit:
+    # a word character (Unicode letter/digit/underscore) followed by any of
+    # word chars, '.' or '-'. This blocks the characters that corrupt a URI or
+    # the app — spaces, '/', '#', ':' and stray punctuation — while still
+    # allowing Unicode letters, digits, dots and hyphens (e.g. 'my-class.v2').
+    _LOCAL_NAME_RE = re.compile(r"^\w[\w.\-]*$", re.UNICODE)
+
+    @classmethod
+    def invalid_name_reason(cls, name: str) -> Optional[str]:
+        """Return a human-readable reason ``name`` is not a valid entity name,
+        or ``None`` if it is valid.
+
+        A full ``http(s)`` URI is accepted as an explicit identifier (only a
+        space makes one invalid). Otherwise the name must be a local name that
+        maps to a valid URI fragment (see :attr:`_LOCAL_NAME_RE`).
+        """
+        if name is None or not name.strip():
+            return "Name cannot be empty."
+        name = name.strip()
+        if name.startswith("http://") or name.startswith("https://"):
+            if any(c.isspace() for c in name):
+                return "A full URI cannot contain spaces."
+            return None
+        if any(c.isspace() for c in name):
+            return (
+                "Names cannot contain spaces. Put the readable name in the "
+                "Label field and use a name like 'MyClass' or 'my-class' here."
+            )
+        if not cls._LOCAL_NAME_RE.match(name):
+            return (
+                "Names may contain only letters, digits, '_', '-' and '.', and "
+                "cannot start with '-' or '.'. Characters like '/', '#', ':' or "
+                "spaces would produce an invalid URI. Put punctuation or spaces "
+                "in the Label instead."
+            )
+        return None
+
+    def _require_valid_name(self, name: str) -> None:
+        """Raise ``ValueError`` if ``name`` is not a valid entity name."""
+        reason = self.invalid_name_reason(name)
+        if reason:
+            raise ValueError(reason)
+
     def _local_name(self, uri: Node) -> str:
         """Extract local name from a URI."""
         uri_str = str(uri)
@@ -347,6 +391,7 @@ class OntologyManager:
         comment: Optional[str] = None,
     ) -> URIRef:
         """Add a new OWL class."""
+        self._require_valid_name(name)
         class_uri = self._uri(name)
         self.graph.add((class_uri, RDF.type, OWL.Class))
 
@@ -408,6 +453,7 @@ class OntologyManager:
         """Rename a class, updating all references."""
         if old_name == new_name:
             return True
+        self._require_valid_name(new_name)
 
         old_uri = self._uri(old_name)
         new_uri = self._uri(new_name)
@@ -918,6 +964,7 @@ class OntologyManager:
         inverse_of: Optional[str] = None,
     ) -> URIRef:
         """Add a new object property."""
+        self._require_valid_name(name)
         prop_uri = self._uri(name)
         self.graph.add((prop_uri, RDF.type, OWL.ObjectProperty))
 
@@ -960,6 +1007,7 @@ class OntologyManager:
         functional: bool = False,
     ) -> URIRef:
         """Add a new data property."""
+        self._require_valid_name(name)
         prop_uri = self._uri(name)
         self.graph.add((prop_uri, RDF.type, OWL.DatatypeProperty))
 
@@ -1018,6 +1066,7 @@ class OntologyManager:
         """Rename a property, updating all references."""
         if old_name == new_name:
             return True
+        self._require_valid_name(new_name)
 
         old_uri = self._uri(old_name)
         new_uri = self._uri(new_name)
@@ -1209,6 +1258,7 @@ class OntologyManager:
         comment: Optional[str] = None,
     ) -> URIRef:
         """Add a new individual (instance)."""
+        self._require_valid_name(name)
         ind_uri = self._uri(name)
         class_uri = self._uri(class_name)
 
@@ -1270,6 +1320,7 @@ class OntologyManager:
         """Rename an individual, updating all references."""
         if old_name == new_name:
             return True
+        self._require_valid_name(new_name)
 
         old_uri = self._uri(old_name)
         new_uri = self._uri(new_name)
@@ -1761,6 +1812,7 @@ class OntologyManager:
         self, name: str, label: Optional[str] = None, comment: Optional[str] = None
     ) -> URIRef:
         """Add a new SKOS ConceptScheme."""
+        self._require_valid_name(name)
         scheme_uri = self._uri(name)
         self.graph.add((scheme_uri, RDF.type, SKOS.ConceptScheme))
         if label:
@@ -1820,6 +1872,7 @@ class OntologyManager:
         """
         if old_name == new_name:
             return True
+        self._require_valid_name(new_name)
 
         # Resolve the actual scheme URI from the graph (mirrors update/delete).
         old_uri = self._uri(old_name)
@@ -1867,6 +1920,7 @@ class OntologyManager:
         lang: Optional[str] = None,
     ) -> URIRef:
         """Add a SKOS Concept with optional scheme/broader links."""
+        self._require_valid_name(name)
         concept_uri = self._uri(name)
         self.graph.add((concept_uri, RDF.type, SKOS.Concept))
 
@@ -2007,6 +2061,7 @@ class OntologyManager:
         """Rename a SKOS concept, updating all references."""
         if old_name == new_name:
             return True
+        self._require_valid_name(new_name)
 
         old_uri = self._uri(old_name)
         new_uri = self._uri(new_name)

--- a/tests/test_name_validation.py
+++ b/tests/test_name_validation.py
@@ -165,3 +165,47 @@ class TestReferenceValidation:
         with pytest.raises(ValueError):
             om.add_individual("alice", "Bad Class")
         assert om.get_individuals() == []
+
+
+class TestUpdateReferenceValidation:
+    """Review pass: update paths must validate add-side references too."""
+
+    def test_update_class_rejects_invalid_parent(self, om):
+        om.add_class("Good")
+        with pytest.raises(ValueError):
+            om.update_class("Good", new_parent="Bad Parent")
+        assert om.graph.serialize(format="turtle")
+
+    def test_update_property_rejects_invalid_domain(self, om):
+        om.add_class("Person")
+        om.add_object_property("likes", domain="Person", range_="Person")
+        with pytest.raises(ValueError):
+            om.update_property("likes", new_domain="Bad Domain")
+        assert om.graph.serialize(format="turtle")
+
+    def test_update_property_rejects_invalid_class_range(self, om):
+        om.add_class("Person")
+        om.add_object_property("likes", domain="Person", range_="Person")
+        with pytest.raises(ValueError):
+            om.update_property("likes", new_range="Bad Range")
+
+    def test_update_property_accepts_datatype_range(self, om):
+        om.add_class("Person")
+        om.add_data_property("age", domain="Person")
+        # A datatype range is not a name and must not be rejected.
+        om.update_property("age", new_range="integer")
+        assert om.graph.serialize(format="turtle")
+
+    def test_update_individual_rejects_invalid_class(self, om):
+        om.add_class("Person")
+        om.add_individual("alice", "Person")
+        with pytest.raises(ValueError):
+            om.update_individual("alice", add_class="Bad Class")
+        assert om.graph.serialize(format="turtle")
+
+    def test_update_concept_rejects_invalid_broader(self, om):
+        om.add_concept_scheme("Scheme")
+        om.add_concept("Animal", scheme="Scheme")
+        with pytest.raises(ValueError):
+            om.update_concept("Animal", new_broader="Bad Broader")
+        assert om.graph.serialize(format="turtle")

--- a/tests/test_name_validation.py
+++ b/tests/test_name_validation.py
@@ -105,3 +105,63 @@ class TestBulkAddReportsInvalid:
         assert "Good" in result["created"]
         assert any(e["name"] == "bad/name" for e in result["errors"])
         assert "bad/name" not in [c["name"] for c in om.get_classes()]
+
+    def test_bulk_add_records_invalid_parent(self, om):
+        # Review P3: an invalid reference must not leave an unserializable URI.
+        result = om.bulk_add_classes([{"name": "Good", "parent": "Bad Parent"}])
+        assert any(e["name"] == "Good" for e in result["errors"])
+        assert "Good" not in [c["name"] for c in om.get_classes()]
+        # The graph is still serializable (no half-written broken triple).
+        assert om.graph.serialize(format="turtle")
+
+
+class TestSurroundingWhitespace:
+    @pytest.mark.parametrize("name", ["Foo ", " Foo", "Foo\tBar", "Foo\nBar"])
+    def test_surrounding_or_inner_whitespace_rejected(self, name):
+        # Review P1: the validator no longer strips, so whitespace that would
+        # otherwise reach _uri() verbatim is rejected.
+        assert OntologyManager.invalid_name_reason(name) is not None
+
+    def test_add_class_trailing_space_no_partial_write(self, om):
+        with pytest.raises(ValueError):
+            om.add_class("Foo ")
+        assert om.get_classes() == []
+        assert om.graph.serialize(format="turtle")
+
+
+class TestFullUriValidation:
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            "http://ex.org/A<B",
+            "http://ex.org/A>B",
+            'http://ex.org/A"B',
+            "http://ex.org/A|B",
+            "http://ex.org/A^B",
+        ],
+    )
+    def test_full_uri_with_breaking_chars_rejected(self, uri):
+        # Review P2: characters rdflib refuses to serialize must be rejected.
+        assert OntologyManager.invalid_name_reason(uri) is not None
+
+    def test_add_class_bad_uri_no_partial_write(self, om):
+        with pytest.raises(ValueError):
+            om.add_class("http://ex.org/A<B")
+        assert om.get_classes() == []
+
+
+class TestReferenceValidation:
+    def test_add_class_rejects_invalid_parent(self, om):
+        with pytest.raises(ValueError):
+            om.add_class("Good", parent="Bad Parent")
+        assert om.get_classes() == []
+        assert om.graph.serialize(format="turtle")
+
+    def test_add_object_property_rejects_invalid_range(self, om):
+        with pytest.raises(ValueError):
+            om.add_object_property("likes", domain="Person", range_="Bad Range")
+
+    def test_add_individual_rejects_invalid_class(self, om):
+        with pytest.raises(ValueError):
+            om.add_individual("alice", "Bad Class")
+        assert om.get_individuals() == []

--- a/tests/test_name_validation.py
+++ b/tests/test_name_validation.py
@@ -1,0 +1,107 @@
+"""Tests for entity name validation (issue #93)."""
+
+import pytest
+from ontology_manager import OntologyManager
+
+
+VALID = [
+    "OutputTable",
+    "output-table",
+    "my-class.v2",
+    "3DModel",  # relaxed NCName allows a leading digit
+    "_private",
+    "Straße",  # Unicode letters are allowed
+    "日本語",
+    "http://other.example/ns#Thing",  # explicit full IRI
+]
+
+INVALID = [
+    "state/output-table",  # the reported case
+    "Output Table",  # space
+    "has space",
+    "a:b",  # colon (prefix separator)
+    "has#frag",
+    "-leading",
+    ".leading",
+    "",
+    "   ",
+    "http://ex.org/A B",  # full IRI with a space
+]
+
+
+class TestInvalidNameReason:
+    @pytest.mark.parametrize("name", VALID)
+    def test_valid(self, name):
+        assert OntologyManager.invalid_name_reason(name) is None
+
+    @pytest.mark.parametrize("name", INVALID)
+    def test_invalid(self, name):
+        assert OntologyManager.invalid_name_reason(name) is not None
+
+
+class TestAddRejectsInvalid:
+    def test_add_class_rejects_slash(self, om):
+        with pytest.raises(ValueError):
+            om.add_class("state/output-table")
+        assert om.get_classes() == []
+
+    def test_add_class_rejects_space(self, om):
+        with pytest.raises(ValueError):
+            om.add_class("Output Table")
+
+    def test_add_class_accepts_valid(self, om):
+        om.add_class("OutputTable")
+        assert "OutputTable" in [c["name"] for c in om.get_classes()]
+
+    def test_add_object_property_rejects_invalid(self, om):
+        with pytest.raises(ValueError):
+            om.add_object_property("has/friend")
+
+    def test_add_data_property_rejects_invalid(self, om):
+        with pytest.raises(ValueError):
+            om.add_data_property("has age")
+
+    def test_add_individual_rejects_invalid(self, om):
+        om.add_class("Person")
+        with pytest.raises(ValueError):
+            om.add_individual("alice/bob", "Person")
+
+    def test_add_concept_rejects_invalid(self, om):
+        with pytest.raises(ValueError):
+            om.add_concept("bad/concept")
+
+    def test_add_concept_scheme_rejects_invalid(self, om):
+        with pytest.raises(ValueError):
+            om.add_concept_scheme("bad scheme")
+
+
+class TestRenameRejectsInvalid:
+    def test_rename_class_rejects_invalid(self, om):
+        om.add_class("Dog")
+        with pytest.raises(ValueError):
+            om.rename_class("Dog", "state/output-table")
+        # The original class is untouched.
+        assert "Dog" in [c["name"] for c in om.get_classes()]
+
+    def test_rename_individual_rejects_space(self, om):
+        om.add_class("Person")
+        om.add_individual("alice", "Person")
+        with pytest.raises(ValueError):
+            om.rename_individual("alice", "alice bob")
+
+
+class TestSerializableAfterValidation:
+    def test_valid_ontology_serializes(self, om):
+        # The whole point: a validated ontology must still serialize (a space in
+        # a name would previously break Turtle export entirely).
+        om.add_class("OutputTable", label="Output Table")
+        ttl = om.graph.serialize(format="turtle")
+        assert "OutputTable" in ttl
+
+
+class TestBulkAddReportsInvalid:
+    def test_bulk_add_records_invalid_name(self, om):
+        result = om.bulk_add_classes([{"name": "Good"}, {"name": "bad/name"}])
+        assert "Good" in result["created"]
+        assert any(e["name"] == "bad/name" for e in result["errors"])
+        assert "bad/name" not in [c["name"] for c in om.get_classes()]


### PR DESCRIPTION
## Problem

Closes #93.

Creating an entity with an invalid name was silently accepted. `state/output-table` (the reported case) produces a malformed URI that breaks Visualization. A **space** is worse: `Output Table` makes the whole graph un-serializable — `graph.serialize(format="turtle")` throws, so the Source view, export, and download all fail for that ontology.

## Fix

A single validator, `OntologyManager.invalid_name_reason(name)` (plus a raising `_require_valid_name`), enforces a **relaxed NCName**:

- First char: a word character (Unicode letter/digit/underscore).
- Rest: word chars, `.` or `-`.

This blocks the footguns (spaces, `/`, `#`, `:`, stray punctuation) while still allowing:

- Unicode letters — `Straße`, `日本語`
- dots and hyphens — `my-class.v2`
- **leading digits** — `3DModel` (strict NCName forbids these; relaxing matches Turtle's own `PN_LOCAL` grammar, so names round-trip cleanly)

Full `http(s)://` URIs stay valid as explicit identifiers (only a space makes one invalid).

The validator runs in **every** `add_*` and `rename_*` entry point — classes, object/data properties, individuals, and SKOS concepts/schemes — so the UI, bulk add, and the API are all protected uniformly. Bulk add reports the bad row as an error instead of crashing. The Add and edit forms pre-check and surface the specific reason, pointing users to the **Label** field for readable, space-containing text.

Imported ontologies are unaffected (validation is only on interactive create/rename, not on parse).

## Tests

New `tests/test_name_validation.py` (30 cases): the validator across valid/invalid inputs (including Unicode, leading digits, full URIs); `add_*`/`rename_*` raising on invalid names; bulk add recording the error; and a regression that a validated ontology still serializes to Turtle.

Full suite: 368 passed. Ruff check and format clean.

## Verification note

Engine + tests verified thoroughly. End-to-end UI verification was blocked by an unrelated restored-session navigation gremlin in the local app; the UI change is a minimal `elif reason := ont.invalid_name_reason(name): show_message(reason)` that mirrors the existing `if not name:` validation already present in each form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)