### PR TITLE
chore: bump version to 1.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.15.1](https://img.shields.io/badge/version-1.15.1-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![Version 1.16.0](https://img.shields.io/badge/version-1.16.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
@@ -243,7 +243,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.15.1` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.16.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.15.1"
+APP_VERSION = "1.16.0"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.15.1"
+version = "1.16.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Batched 1.16.0 release. Bumps all four version references (pyproject.toml, README badge, README pin hint, app.py APP_VERSION).

Included since 1.15.1:
- #92 — bulk CSV: header-optional parsing + semicolon delimiter (issue #91)
- #94 — create and move entities in a chosen namespace (issue #87 part A)
- #96 — entity name validation (issue #93)

Minor bump because #94 adds a user-facing feature. Full suite: 417 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)