### PR TITLE
docs: dynamic PyPI badge in place of hand-bumped version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
-[![Version 1.16.0](https://img.shields.io/badge/version-1.16.0-purple.svg)](https://github.com/ralforion/orionbelt-ontology-builder/releases)
+[![PyPI](https://img.shields.io/pypi/v/orionbelt-ontology-builder?logo=pypi&logoColor=white&label=PyPI&color=purple)](https://pypi.org/project/orionbelt-ontology-builder/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 


### PR DESCRIPTION
Swaps the static `version-1.16.0` shields badge for a dynamic PyPI badge.

- Reads the published version straight from PyPI, so it updates itself on each release (one fewer spot to hand-bump).
- Links to the PyPI project page instead of the GitHub releases page.
- Kept the purple color to match the previous badge.

The package is already published on PyPI at 1.16.0, so the badge resolves immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)