### PR TITLE
test: fix version-consistency guard after PyPI badge swap

### DIFF
--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -27,10 +27,12 @@ def test_app_version_matches_pyproject():
     )
 
 
-def test_readme_badge_matches_pyproject():
+def test_readme_pin_hint_matches_pyproject():
+    # The version badge is now a dynamic PyPI badge (auto-updates), so the only
+    # hardcoded version left in the README is the Docker image pin example.
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     version = _pyproject_version()
-    assert f"version-{version}-" in readme, (
-        "README version badge is out of sync with pyproject.toml "
-        f"(expected version-{version}-)"
+    assert f"`:{version}`" in readme, (
+        "README Docker pin hint is out of sync with pyproject.toml "
+        f"(expected `:{version}`)"
     )


### PR DESCRIPTION
#98 replaced the static `version-1.16.0` README badge with a dynamic PyPI badge, which broke `test_readme_badge_matches_pyproject` (it looked for the removed `version-<n>-` pattern). My oversight for not running the suite after that merge.

The version badge is now self-updating, so the only hardcoded version left in the README is the Docker image pin example. This updates the guard to check that (`` `:<version>` ``) against pyproject instead. `test_app_version_matches_pyproject` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)