### PR TITLE
feat(desktop): native window title follows the ontology name (#90)

### DIFF
--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -52,6 +52,81 @@ def _preferred_gui() -> str | None:
     return None
 
 
+# Injected into the desktop webview: mirror the page's document.title (set by
+# st.set_page_config, so it carries the current ontology name) onto the native
+# window through the exposed bridge below. pywebview does not propagate
+# document.title to the OS window on its own, so the window would otherwise keep
+# its static launch title (issue #90).
+_TITLE_SYNC_JS = """
+(function () {
+  if (window.__orionbeltTitleSync) return;
+  window.__orionbeltTitleSync = true;
+  function push() {
+    try {
+      var api = window.pywebview && window.pywebview.api;
+      if (api && api.orionbelt_set_window_title) {
+        api.orionbelt_set_window_title(document.title);
+      }
+    } catch (e) {}
+  }
+  var head = document.head || document.documentElement;
+  new MutationObserver(push).observe(head, {
+    subtree: true, childList: true, characterData: true
+  });
+  push();
+})();
+"""
+
+
+def _install_window_title_sync(app_name: str):
+    """Make the native window title follow the page title (issue #90).
+
+    Hooks ``webview.create_window`` so each window (a) exposes a title setter to
+    JS and (b) once loaded, runs :data:`_TITLE_SYNC_JS`, a MutationObserver that
+    pushes ``document.title`` back through that setter. Every step is defensive:
+    any failure leaves the static launch title in place rather than breaking the
+    desktop launch. Returns the original ``create_window`` for restoration, or
+    ``None`` when there is nothing to hook (e.g. a stubbed webview in tests).
+    """
+    import webview
+
+    original_create = getattr(webview, "create_window", None)
+    if original_create is None:
+        return None
+
+    def _create(*args, **kwargs):
+        window = original_create(*args, **kwargs)
+
+        def orionbelt_set_window_title(title):
+            # Ignore the Streamlit default / empty title so the window keeps a
+            # meaningful name during the brief window before the app connects.
+            try:
+                window.set_title(title if title and title != "Streamlit" else app_name)
+            except Exception:
+                pass
+            return True
+
+        try:
+            window.expose(orionbelt_set_window_title)
+        except Exception:
+            pass
+
+        def _inject():
+            try:
+                window.evaluate_js(_TITLE_SYNC_JS)
+            except Exception:
+                pass
+
+        try:
+            window.events.loaded += _inject
+        except Exception:
+            pass
+        return window
+
+    webview.create_window = _create
+    return original_create
+
+
 def run() -> None:
     """Launch the app in a native desktop window.
 
@@ -108,6 +183,9 @@ def run() -> None:
 
     entry = Path(__file__).parent / "streamlit_entry.py"
     webview.start = _start_with_persistent_storage
+    # Mirror the page title onto the native window so it shows the current
+    # ontology name like the browser tab (issue #90).
+    original_create_window = _install_window_title_sync(APP_NAME)
     try:
         start_desktop_app(
             script_path=str(entry),
@@ -118,6 +196,8 @@ def run() -> None:
         )
     finally:
         webview.start = original_start
+        if original_create_window is not None:
+            webview.create_window = original_create_window
 
 
 if __name__ == "__main__":

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -202,6 +202,72 @@ def test_run_omits_theme_base_when_unset(monkeypatch, tmp_path):
     assert "theme.base" not in captured["options"]
 
 
+class _Event(list):
+    """Minimal stand-in for a pywebview event that supports ``+= handler``."""
+
+    def __iadd__(self, handler):
+        self.append(handler)
+        return self
+
+
+class _FakeWindow:
+    def __init__(self):
+        self.exposed = []
+        self.title = None
+        self.evaluated = None
+        self.events = types.SimpleNamespace(loaded=_Event())
+
+    def expose(self, *fns):
+        self.exposed.extend(fns)
+
+    def set_title(self, title):
+        self.title = title
+
+    def evaluate_js(self, js):
+        self.evaluated = js
+
+
+def test_window_title_sync_wiring(monkeypatch):
+    """The title-sync hook exposes a setter and injects the observer, and the
+    setter mirrors the page title onto the window (issue #90)."""
+    window = _FakeWindow()
+    fake_webview = types.ModuleType("webview")
+    fake_webview.create_window = lambda *a, **k: window
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+
+    original = desktop._install_window_title_sync("AppName")
+    assert original is not None  # a real create_window was hooked
+
+    # start_desktop_app would call create_window; simulate that.
+    import webview
+
+    returned = webview.create_window("AppName", "http://localhost")
+    assert returned is window
+
+    # The setter was exposed to JS, and mirrors a real title through.
+    assert window.exposed, "title setter was not exposed"
+    setter = window.exposed[0]
+    setter("Pizza Ontology · OrionBelt")
+    assert window.title == "Pizza Ontology · OrionBelt"
+    # The Streamlit default / empty title falls back to the app name.
+    setter("Streamlit")
+    assert window.title == "AppName"
+    setter("")
+    assert window.title == "AppName"
+
+    # On load, the MutationObserver script is injected.
+    assert window.events.loaded, "no loaded handler registered"
+    window.events.loaded[0]()
+    assert "MutationObserver" in window.evaluated
+
+
+def test_window_title_sync_noop_without_create_window(monkeypatch):
+    """A stubbed webview lacking create_window must not raise (returns None)."""
+    fake_webview = types.ModuleType("webview")  # no create_window attribute
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+    assert desktop._install_window_title_sync("AppName") is None
+
+
 def test_run_without_dependency_exits_cleanly(monkeypatch):
     """Missing the optional ``desktop`` extra should exit non-zero, not crash."""
     monkeypatch.setitem(sys.modules, "streamlit_desktop_app", None)


### PR DESCRIPTION
## What

The browser tab already shows the ontology name (#90/#101), but the **native desktop window** kept its static launch title (`OrionBelt Ontology Builder`), because pywebview does not propagate the page's `document.title` to the OS window.

This makes the native window title track the ontology name too, so multiple desktop instances are distinguishable.

## How

Hook `webview.create_window` (same monkeypatch pattern the launcher already uses for `webview.start`) so each window:
1. **Exposes a title setter** to JS (`orionbelt_set_window_title`) that calls `window.set_title(...)`.
2. **On load, injects a MutationObserver** on the page `<title>` that pushes `document.title` (which `st.set_page_config` keeps set to the ontology name) back through that setter.

The setter ignores the Streamlit default / empty title so the window keeps a meaningful name during the brief pre-connect window. Everything is wrapped defensively: any failure leaves the static title in place rather than breaking the desktop launch, and it no-ops entirely when `create_window` is absent (e.g. a stubbed webview in tests).

## Verification

- Unit tests: the hook exposes the setter and injects the observer; the setter mirrors a real title and falls back to the app name for the Streamlit default/empty; and it no-ops without `create_window`. (14 desktop tests, 419 total, ruff clean.)
- Smoke-tested against **real** pywebview: confirmed `Window.events.loaded += handler`, `Window.expose(func)`, `set_title`, and `evaluate_js` all exist and are used correctly.

**What I could not verify:** the actual native window title updating requires a real display + GUI event loop, which I don't have in this environment. Please run `orionbelt-ontology-builder-desktop` and confirm the window title shows the ontology name (and updates when you set the ontology's Label on the Dashboard). The change is defensive, so worst case the title stays static — it can't break the launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)