### PR TITLE
chore: bump version to 1.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.16.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.16.1` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.16.0"
+APP_VERSION = "1.16.1"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.16.0"
+version = "1.16.1"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Patch release since 1.16.0. Bumps the three hardcoded version references (pyproject.toml, app.py APP_VERSION, README Docker pin hint; the README badge is now the dynamic PyPI badge).

Included:
- #100 / #101 — dynamic browser tab title showing the ontology name, plus title-persistence and empty-session nav-landing fixes
- #102 — native desktop window title follows the ontology name
- #98 — dynamic PyPI badge; #99 — version-consistency test follow-up

Full suite: 419 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)