### PR TITLE
fix(types): resolve mypy errors so CI is green

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -186,16 +186,20 @@ def _configure_page() -> None:
     title is recomputed each run so it also tracks the current ontology. Only
     the first call steers the sidebar, so later runs don't fight a sidebar the
     user has collapsed."""
-    first = "_page_configured" not in st.session_state
-    kwargs = dict(
-        page_title=_page_title(),
-        page_icon=str(_FAVICON) if _FAVICON.exists() else None,
-        layout="wide",
-    )
-    if first:
-        kwargs["initial_sidebar_state"] = "expanded"
+    title = _page_title()
+    page_icon = str(_FAVICON) if _FAVICON.exists() else None
+    if "_page_configured" not in st.session_state:
+        # First run steers the sidebar open; later runs must not, so a title
+        # change doesn't fight a sidebar the user has collapsed.
         st.session_state["_page_configured"] = True
-    st.set_page_config(**kwargs)
+        st.set_page_config(
+            page_title=title,
+            page_icon=page_icon,
+            layout="wide",
+            initial_sidebar_state="expanded",
+        )
+    else:
+        st.set_page_config(page_title=title, page_icon=page_icon, layout="wide")
     st.markdown(_CUSTOM_CSS, unsafe_allow_html=True)
     # Force the brand primary on key controls in every theme (Streamlit's preset
     # themes would otherwise revert it to red), then lighten tab/pill accents in
@@ -1059,7 +1063,7 @@ def build_namespace_options(ont) -> tuple:
         so callers can pass it straight to ``add_*(namespace=...)``.
     """
     options = []
-    lookup = {}
+    lookup: dict[str, str | None] = {}
 
     for i, ns in enumerate(ont.get_creatable_namespaces()):
         if i == 0:

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -451,10 +451,10 @@ class OntologyManager:
                 if isinstance(subject, URIRef):
                     extra.add(self._namespace_of(subject))
 
-        for ns in sorted(extra):
-            if ns and ns not in seen and ns not in syntax_ns:
-                seen.add(ns)
-                result.append(ns)
+        for ns_str in sorted(extra):
+            if ns_str and ns_str not in seen and ns_str not in syntax_ns:
+                seen.add(ns_str)
+                result.append(ns_str)
         return result
 
     # ==================== CLASS OPERATIONS ====================


### PR DESCRIPTION
CI's mypy check has been failing on `main` since the namespace/title work merged — I was running pytest + ruff locally but not mypy, so these slipped through.

Fixes the 5 mypy errors (no runtime behavior change):
- `get_creatable_namespaces` reused `ns` (a `URIRef` from `graph.namespaces()`) as a `str` loop variable → renamed the second loop var to `ns_str`.
- `_configure_page` called `set_page_config(**kwargs)`, which erased the literal types its overloads require → call it with explicit literal args instead.
- annotate `build_namespace_options`' `lookup` as `dict[str, str | None]`.

`uv run mypy orionbelt_ontology_builder` → Success. 419 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)