### PR TITLE
feat(bulk): declare a referenced parent as a class (#106)

### DIFF
--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -875,23 +875,16 @@ class OntologyManager:
         A referenced parent that is not already a class is declared as a bare
         ``owl:Class`` (issue #106), so the ``rdfs:subClassOf`` target is a real
         class node (visible in Visualization), matching the manual flow of
-        creating the parent, creating the child, then setting the parent. A
-        parent that a row in the same batch creates explicitly is left to that
-        row so its label/comment are not lost.
+        creating the parent, creating the child, then setting the parent. This
+        is done as a backfill after all rows are processed, keyed by the parent's
+        full URI: a parent that another row actually creates (with its own
+        label/comment) is left alone, but one whose explicit row is missing,
+        skipped, or errors is still declared so no dangling parent remains.
         Returns {created: [], errors: [], skipped: []}.
         """
         result: Dict[str, Any] = {"created": [], "errors": [], "skipped": []}
         existing = {c["uri"] for c in self.get_classes()}
-        # Full URIs the batch creates, keyed by (name, namespace) so a same-named
-        # row in a *different* namespace doesn't suppress declaring the parent
-        # the child actually references (which resolves in the base namespace).
-        explicit_uris = set()
-        for e in entries:
-            n = e.get("name", "").strip()
-            if n:
-                explicit_uris.add(
-                    str(self._uri(n, e.get("namespace", "").strip() or None))
-                )
+        referenced_parents: set[str] = set()
 
         for entry in entries:
             name = entry.get("name", "").strip()
@@ -913,18 +906,20 @@ class OntologyManager:
                 )
                 result["created"].append(name)
                 existing.add(uri)
-                # Declare a missing parent as a class so the hierarchy is
-                # complete. Skip parents that already exist or that a row in this
-                # batch creates explicitly (compared by full URI, since the child
-                # references the parent in the base namespace).
                 if parent:
-                    parent_uri = str(self._uri(parent))
-                    if parent_uri not in existing and parent_uri not in explicit_uris:
-                        self.add_class(parent)
-                        existing.add(parent_uri)
-                        result["created"].append(parent)
+                    referenced_parents.add(str(self._uri(parent)))
             except Exception as e:
                 result["errors"].append({"name": name, "error": str(e)})
+
+        # Backfill: any referenced parent that no successful row declared as a
+        # class becomes a bare owl:Class, so the hierarchy has no dangling target.
+        for parent_uri in sorted(referenced_parents - existing):
+            try:
+                created_uri = self.add_class(parent_uri)
+                existing.add(parent_uri)
+                result["created"].append(self._local_name(created_uri))
+            except Exception as e:
+                result["errors"].append({"name": parent_uri, "error": str(e)})
 
         return result
 

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -882,7 +882,16 @@ class OntologyManager:
         """
         result: Dict[str, Any] = {"created": [], "errors": [], "skipped": []}
         existing = {c["uri"] for c in self.get_classes()}
-        explicit = {e.get("name", "").strip() for e in entries}
+        # Full URIs the batch creates, keyed by (name, namespace) so a same-named
+        # row in a *different* namespace doesn't suppress declaring the parent
+        # the child actually references (which resolves in the base namespace).
+        explicit_uris = set()
+        for e in entries:
+            n = e.get("name", "").strip()
+            if n:
+                explicit_uris.add(
+                    str(self._uri(n, e.get("namespace", "").strip() or None))
+                )
 
         for entry in entries:
             name = entry.get("name", "").strip()
@@ -905,11 +914,12 @@ class OntologyManager:
                 result["created"].append(name)
                 existing.add(uri)
                 # Declare a missing parent as a class so the hierarchy is
-                # complete. Skip parents that already exist or a later row will
-                # create explicitly.
+                # complete. Skip parents that already exist or that a row in this
+                # batch creates explicitly (compared by full URI, since the child
+                # references the parent in the base namespace).
                 if parent:
                     parent_uri = str(self._uri(parent))
-                    if parent_uri not in existing and parent not in explicit:
+                    if parent_uri not in existing and parent_uri not in explicit_uris:
                         self.add_class(parent)
                         existing.add(parent_uri)
                         result["created"].append(parent)

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -871,10 +871,18 @@ class OntologyManager:
         Each entry dict can have: name, label, parent, namespace. Duplicates are
         detected by full URI, so the same local name in a different namespace is
         not treated as existing.
+
+        A referenced parent that is not already a class is declared as a bare
+        ``owl:Class`` (issue #106), so the ``rdfs:subClassOf`` target is a real
+        class node (visible in Visualization), matching the manual flow of
+        creating the parent, creating the child, then setting the parent. A
+        parent that a row in the same batch creates explicitly is left to that
+        row so its label/comment are not lost.
         Returns {created: [], errors: [], skipped: []}.
         """
         result: Dict[str, Any] = {"created": [], "errors": [], "skipped": []}
         existing = {c["uri"] for c in self.get_classes()}
+        explicit = {e.get("name", "").strip() for e in entries}
 
         for entry in entries:
             name = entry.get("name", "").strip()
@@ -882,6 +890,7 @@ class OntologyManager:
                 result["errors"].append({"name": "", "error": "Empty name"})
                 continue
             namespace = entry.get("namespace", "").strip() or None
+            parent = entry.get("parent", "").strip() or None
             uri = str(self._uri(name, namespace))
             if uri in existing:
                 result["skipped"].append(name)
@@ -889,12 +898,21 @@ class OntologyManager:
             try:
                 self.add_class(
                     name,
-                    parent=entry.get("parent", "").strip() or None,
+                    parent=parent,
                     label=entry.get("label", "").strip() or None,
                     namespace=namespace,
                 )
                 result["created"].append(name)
                 existing.add(uri)
+                # Declare a missing parent as a class so the hierarchy is
+                # complete. Skip parents that already exist or a later row will
+                # create explicitly.
+                if parent:
+                    parent_uri = str(self._uri(parent))
+                    if parent_uri not in existing and parent not in explicit:
+                        self.add_class(parent)
+                        existing.add(parent_uri)
+                        result["created"].append(parent)
             except Exception as e:
                 result["errors"].append({"name": name, "error": str(e)})
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -2,6 +2,7 @@
 
 import pytest
 from ontology_manager import OntologyManager
+from rdflib.namespace import RDFS
 
 
 @pytest.fixture
@@ -209,6 +210,27 @@ class TestBulkAddClasses:
         classes = {c["name"]: c for c in om.get_classes()}
         assert classes["Animal"]["label"] == "An Animal"
         assert "Animal" in classes["Dog"]["parents"]
+
+    def test_explicit_row_in_other_namespace_does_not_suppress_parent(self, om):
+        # Review P1: a same-named explicit row in a DIFFERENT namespace must not
+        # suppress declaring the base-namespace parent the child references.
+        om.bulk_add_classes(
+            [
+                {"name": "Dog", "parent": "Animal"},
+                {"name": "Animal", "namespace": "http://other.example/ns#"},
+            ]
+        )
+        base_animal = str(om._uri("Animal"))  # base namespace
+        other_animal = "http://other.example/ns#Animal"
+        uris = {c["uri"] for c in om.get_classes()}
+        # The parent the child actually points at is a real class...
+        assert base_animal in uris
+        assert base_animal in {
+            str(o) for o in om.graph.objects(om._uri("Dog"), RDFS.subClassOf)
+        }
+        # ...and so is the unrelated other-namespace class.
+        assert other_animal in uris
+        assert om.graph.serialize(format="turtle")
 
     def test_same_local_name_other_namespace_not_skipped(self):
         # Review finding 3: a base-namespace entry must not be skipped just

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -232,6 +232,25 @@ class TestBulkAddClasses:
         assert other_animal in uris
         assert om.graph.serialize(format="turtle")
 
+    def test_failed_explicit_parent_row_still_backfills(self, om):
+        # Review P2: an explicit parent row that errors must not suppress
+        # declaring the parent the child actually references.
+        result = om.bulk_add_classes(
+            [
+                {"name": "Dog", "parent": "Animal"},
+                {"name": "Animal", "parent": "Bad Parent"},  # invalid -> errors
+            ]
+        )
+        assert any(e["name"] == "Animal" for e in result["errors"])
+        base_animal = str(om._uri("Animal"))
+        uris = {c["uri"] for c in om.get_classes()}
+        # Backfilled despite the failed explicit row, so no dangling parent.
+        assert base_animal in uris
+        assert base_animal in {
+            str(o) for o in om.graph.objects(om._uri("Dog"), RDFS.subClassOf)
+        }
+        assert om.graph.serialize(format="turtle")
+
     def test_same_local_name_other_namespace_not_skipped(self):
         # Review finding 3: a base-namespace entry must not be skipped just
         # because the local name exists in another namespace.

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -173,6 +173,43 @@ class TestBulkAddClasses:
         assert len(result["errors"]) == 1
         assert result["created"] == ["Valid"]
 
+    def test_missing_parent_declared_as_class(self, om):
+        # Issue #106: a referenced parent that isn't a class should be declared
+        # as one, so subClassOf points at a real class node.
+        result = om.bulk_add_classes([{"name": "Dog", "parent": "Animal"}])
+        assert "Dog" in result["created"]
+        assert "Animal" in result["created"]
+        classes = {c["name"]: c for c in om.get_classes()}
+        assert "Animal" in classes  # now a real owl:Class
+        assert "Animal" in classes["Dog"]["parents"]
+        # The whole graph still serializes.
+        assert om.graph.serialize(format="turtle")
+
+    def test_existing_parent_not_redeclared(self, om_with_classes):
+        # Person already exists; it must not be re-created or duplicated.
+        result = om_with_classes.bulk_add_classes(
+            [{"name": "Student", "parent": "Person"}]
+        )
+        assert result["created"] == ["Student"]  # Person not re-created
+        student = next(
+            c for c in om_with_classes.get_classes() if c["name"] == "Student"
+        )
+        assert "Person" in student["parents"]
+
+    def test_explicit_parent_row_keeps_its_label(self, om):
+        # When the parent is also an explicit row (even later), that row creates
+        # it with its label; it is not auto-declared as a bare class first.
+        result = om.bulk_add_classes(
+            [
+                {"name": "Dog", "parent": "Animal"},
+                {"name": "Animal", "label": "An Animal"},
+            ]
+        )
+        assert result["created"] == ["Dog", "Animal"]  # Animal once, from its row
+        classes = {c["name"]: c for c in om.get_classes()}
+        assert classes["Animal"]["label"] == "An Animal"
+        assert "Animal" in classes["Dog"]["parents"]
+
     def test_same_local_name_other_namespace_not_skipped(self):
         # Review finding 3: a base-namespace entry must not be skipped just
         # because the local name exists in another namespace.


### PR DESCRIPTION
## Problem

Closes #106 (follow-up from #91).

Bulk Add Classes with `Dog, A Dog, Animal` created `Dog` and the triple `Dog rdfs:subClassOf Animal`, but never declared `Animal` as an `owl:Class`. So `Animal` was absent from `get_classes()`, had no node in Visualization, and the subClassOf edge wasn't shown — a dangling parent reference.

## Fix

In `bulk_add_classes`, a referenced parent that isn't already a class is declared as a bare `owl:Class` (and included in the `created` count), matching the manual flow of creating the parent, creating the child, then setting the parent. Guards:
- A parent that already exists (including imported classes) is not re-declared.
- A parent that a row **in the same batch** creates explicitly is left to that row, so its label/comment aren't lost.

## Verification

Reporter's exact input now yields both classes:
```turtle
:Dog a owl:Class ; rdfs:label "A Dog" ; rdfs:subClassOf :Animal .
:Animal a owl:Class .
```

New tests: missing parent declared + subClassOf intact + graph serializes; existing parent not re-declared; an explicit parent row keeps its label. Full suite: 422 passed. mypy, ruff check + format all clean.

## Scope note

This covers the reported class-parent case. The same dangling-reference shape exists for bulk **individuals** (their class) and bulk **properties** (domain/range); per #106's open question I've left those as a possible follow-up rather than widen this PR. Happy to extend if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)