### PR TITLE
chore: bump version to 1.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.16.1` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.16.2` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.16.1"
+APP_VERSION = "1.16.2"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.16.1"
+version = "1.16.2"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Patch release since 1.16.1. Bumps the three hardcoded version refs (pyproject.toml, app.py APP_VERSION, README Docker pin hint).

Included:
- #107 — Bulk Add Classes now declares a referenced parent as a class (#106), so subClassOf points at a real class node visible in Visualization
- #104 — mypy/type fixes (CI green); #105 — uv tool upgrade recovery note

424 tests, mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)