### PR TITLE
fix(app): stop stale cached class and two navigation glitches

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -215,9 +215,18 @@ def _configure_page() -> None:
         logger.info(f"{APP_NAME} v{APP_VERSION}")
 
 
-@st.cache_resource
 def get_ontology_manager_class():
-    """Lazy load the OntologyManager class."""
+    """Lazy load the OntologyManager class.
+
+    Not cached with ``st.cache_resource``: that would pin the class object
+    captured at first import for the life of the server process. Streamlit
+    Community Cloud reruns the script on a git push without always restarting
+    the process, so a cached class survived across deploys and new instances
+    were built from the *old* class definition, missing methods added in the
+    new code (e.g. ``get_creatable_namespaces``) and raising ``AttributeError``
+    until the app was rebooted. The import below is already cached by Python's
+    module system, so re-importing each call is cheap and always current.
+    """
     from .ontology_manager import OntologyManager
 
     return OntologyManager
@@ -486,10 +495,13 @@ def maybe_restore_autosave():
     )
     # localStorage already holds this content at the new revision.
     st.session_state["_ls_saved_rev"] = _current_mutation_count()
-    # init_session_state parks empty sessions on Import/Export; with content
-    # restored, the Dashboard is the more useful landing page.
-    if st.session_state.get("nav_radio") == "Import / Export":
-        st.session_state["nav_radio"] = "Dashboard"
+    # Deliberately do NOT redirect navigation here. The browser localStorage
+    # component delivers the saved data on an arbitrary later rerun — usually the
+    # first one the user triggers (e.g. clicking a tab). Forcing nav to Dashboard
+    # then hijacked that interaction and yanked the user off the page they were
+    # on. Leaving nav untouched keeps the restore silent apart from the toast;
+    # the user stays wherever they are. (The synchronous disk-restore path can
+    # still land on Dashboard safely because it resolves before any interaction.)
     st.toast("Restored your previous session from this browser's autosave.", icon="💾")
 
 
@@ -1578,10 +1590,16 @@ def render_classes():
     classes = ont.get_classes()
     class_names = [c["name"] for c in classes]
 
+    # Seed the selection in session_state rather than passing ``default=``:
+    # graph-view "Open editor" pre-sets this key (see _open_full_editor) before
+    # the widget renders, and Streamlit warns when a keyed widget gets both a
+    # ``default`` and a session-state value. Seeding only when unset keeps that
+    # programmatic selection intact and silences the warning.
+    if "cls_active_tab" not in st.session_state:
+        st.session_state["cls_active_tab"] = "View Classes"
     _cls_tab = st.segmented_control(
         "Section",
         ["View Classes", "Add Class", "Edit/Delete Class", "Bulk Operations"],
-        default="View Classes",
         key="cls_active_tab",
         label_visibility="collapsed",
     )


### PR DESCRIPTION
## Summary

Three UI-facing fixes surfaced while testing the live app. None touch the ontology engine; all are in `orionbelt_ontology_builder/app.py`.

### 1. `AttributeError: 'OntologyManager' object has no attribute 'get_creatable_namespaces'`
`get_ontology_manager_class()` was decorated with `@st.cache_resource`, which pins the `OntologyManager` **class object** captured at first import for the life of the server process. Streamlit Community Cloud reruns the script on a git push without always restarting the process, so new instances were built from the **old** class definition and lacked methods added in newer code (e.g. `get_creatable_namespaces`, added in v1.16.0). This also aborted form rendering mid-body, which is why Streamlit additionally showed a spurious "Missing Submit Button" warning. Rebooting the app cleared the cache and masked it.

Fix: remove the decorator. The inner `import` is already cached by Python's module system, so re-resolving the class each call is cheap and always reflects the deployed code.

### 2. Clicking a section tab jumped to Dashboard (first time only)
The browser-localStorage autosave restore redirected navigation to Dashboard. That saved data arrives on an arbitrary later rerun, usually the first one the user triggers (for example clicking a tab), so the redirect hijacked that interaction and yanked the user off their page.

Fix: remove the redirect. Restore stays silent apart from the toast, and the user stays where they are. The synchronous disk-restore path (local/desktop launchers) is unaffected since it resolves before any interaction.

### 3. Streamlit warning about `cls_active_tab`
> The widget with key "cls_active_tab" was created with a default value but also had its value set via the Session State API.

The Classes section control passed both `default=` and a session-state value (graph "open editor" pre-sets `cls_active_tab`).

Fix: seed the key in session_state when unset and drop `default=`.

## Not included here (hosting action)
The live app's "Oh no" / segmentation fault is a separate, environment-only problem: Streamlit Community Cloud built the app on Python 3.14.6, where a Linux binary wheel segfaults during server startup. Verified locally that Python 3.14.6 imports and runs the app fine on macOS, so it is a Linux wheel issue, not our code. Resolution is to pin the Python version to 3.13 in the Streamlit Cloud dashboard settings. No repo change fixes it.

## Testing
- `pytest`: 424 passed
- `ruff@0.15.19` check + format: clean
- `uv run mypy orionbelt_ontology_builder/app.py`: success
- Ran the app headless on Python 3.14.6 locally: starts and serves without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)