### PR TITLE
chore: bump version to 1.16.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.16.2` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.16.3` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.16.2"
+APP_VERSION = "1.16.3"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.16.2"
+version = "1.16.3"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Bumps the version to 1.16.3, shipping the fixes merged in #109:

- Remove `@st.cache_resource` from the OntologyManager class getter so redeploys no longer serve a stale class (fixes the `get_creatable_namespaces` AttributeError and the spurious "Missing Submit Button").
- Stop the browser autosave restore from hijacking navigation to Dashboard on the first tab click.
- Silence the `cls_active_tab` default-plus-session-state widget warning.

Updated all three hardcoded references: `pyproject.toml`, `orionbelt_ontology_builder/app.py` (`APP_VERSION`), and the README pin example. Badges are dynamic (PyPI/Docker), so no badge edits needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)