### PR TITLE
chore: bump version to 1.16.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.16.3` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.16.4` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.16.3"
+APP_VERSION = "1.16.4"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.16.3"
+version = "1.16.4"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Bumps the version to 1.16.4, shipping issue #87 part B (merged in #112):

- Custom / arbitrary URI editing for all entity types (class, object/data property, individual, SKOS concept and scheme) via an "Advanced: set a custom URI" expander.
- Cross-ontology linking: an optional external-URI field on the Class/Property/Individual relation forms, so equivalentClass / equivalentProperty / sameAs can target an un-imported entity.
- An info-level `external_reference` validation notice listing links whose target is not defined in the ontology.
- SKOS concept/scheme addressing, keying, target selectors, disambiguation and add-dedup all key on URIs so custom-URI and duplicate-local-name cases resolve correctly.

Updated all three hardcoded references: `pyproject.toml`, `orionbelt_ontology_builder/app.py` (`APP_VERSION`), and the README pin example. Badges are dynamic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)