### PR TITLE
fix(bulk): surface rejected entries instead of failing silently (#114)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -876,6 +876,42 @@ def display_flash_message():
         st.session_state.flash_message = None
 
 
+def _bulk_result_message(result: dict, label: str) -> tuple[str, str]:
+    """Summarize a bulk-add result for a flash message, naming each entry that
+    failed and why, so a rejected row (e.g. an invalid name) is not a silent
+    failure (issue #114). ``label`` is the noun with its plural suffix, e.g.
+    "class(es)". Returns ``(message, type)`` for :func:`set_flash_message`.
+    """
+    parts = []
+    if result["created"]:
+        parts.append(f"Created {len(result['created'])} {label}")
+    if result["skipped"]:
+        parts.append(f"Skipped {len(result['skipped'])} existing")
+    errors = result["errors"]
+    if errors:
+        parts.append(f"{len(errors)} could not be created")
+    summary = ". ".join(parts) if parts else "Nothing to create"
+    if errors:
+        shown = errors[:10]
+        lines = "\n".join(
+            f"- **{e.get('name') or '(empty name)'}**: "
+            f"{e.get('error') or 'unknown error'}"
+            for e in shown
+        )
+        if len(errors) > len(shown):
+            lines += f"\n- ...and {len(errors) - len(shown)} more"
+        summary = f"{summary}:\n\n{lines}"
+    if errors and not result["created"]:
+        msg_type = "error"
+    elif errors:
+        msg_type = "warning"
+    elif result["created"]:
+        msg_type = "success"
+    else:
+        msg_type = "info"
+    return summary, msg_type
+
+
 def confirm_delete(resource_name: str, resource_type: str, key_suffix: str) -> bool:
     """Show delete impact and confirmation UI. Returns True when confirmed."""
     ont = st.session_state.ontology
@@ -2066,17 +2102,8 @@ def render_classes():
                     ):
                         result = ont.bulk_add_classes(entries)
                         save_checkpoint("Bulk add classes")
-                        parts = []
-                        if result["created"]:
-                            parts.append(f"Created {len(result['created'])} class(es)")
-                        if result["skipped"]:
-                            parts.append(f"Skipped {len(result['skipped'])} existing")
-                        if result["errors"]:
-                            parts.append(f"{len(result['errors'])} error(s)")
-                        show_message(
-                            ". ".join(parts),
-                            "success" if result["created"] else "warning",
-                        )
+                        _msg, _type = _bulk_result_message(result, "class(es)")
+                        set_flash_message(_msg, _type)
                         st.rerun()
 
         elif bulk_op == "Edit":
@@ -2885,19 +2912,8 @@ def render_properties():
                     ):
                         result = ont.bulk_add_properties(entries, property_type=ptype)
                         save_checkpoint("Bulk add properties")
-                        parts = []
-                        if result["created"]:
-                            parts.append(
-                                f"Created {len(result['created'])} propert(ies)"
-                            )
-                        if result["skipped"]:
-                            parts.append(f"Skipped {len(result['skipped'])} existing")
-                        if result["errors"]:
-                            parts.append(f"{len(result['errors'])} error(s)")
-                        show_message(
-                            ". ".join(parts),
-                            "success" if result["created"] else "warning",
-                        )
+                        _msg, _type = _bulk_result_message(result, "propert(ies)")
+                        set_flash_message(_msg, _type)
                         st.rerun()
 
         elif bulk_op == "Edit":
@@ -3318,19 +3334,8 @@ def render_individuals():
                     ):
                         result = ont.bulk_add_individuals(entries)
                         save_checkpoint("Bulk add individuals")
-                        parts = []
-                        if result["created"]:
-                            parts.append(
-                                f"Created {len(result['created'])} individual(s)"
-                            )
-                        if result["skipped"]:
-                            parts.append(f"Skipped {len(result['skipped'])} existing")
-                        if result["errors"]:
-                            parts.append(f"{len(result['errors'])} error(s)")
-                        show_message(
-                            ". ".join(parts),
-                            "success" if result["created"] else "warning",
-                        )
+                        _msg, _type = _bulk_result_message(result, "individual(s)")
+                        set_flash_message(_msg, _type)
                         st.rerun()
 
         elif bulk_op == "Edit":
@@ -4137,7 +4142,8 @@ def render_annotations():
                 msg = f"Applied {result['applied']} change(s)"
                 if result["errors"]:
                     msg += f", {len(result['errors'])} error(s)"
-                show_message(msg, "success" if not result["errors"] else "warning")
+                # Flash (not show_message) so the summary survives the rerun below.
+                set_flash_message(msg, "success" if not result["errors"] else "warning")
                 st.rerun()
             else:
                 show_message(
@@ -4723,9 +4729,6 @@ def render_skos_vocabulary():
 def render_import_export():
     """Render the import/export page."""
     st.header("Import / Export")
-
-    # Display any flash messages from previous actions
-    display_flash_message()
 
     ont = st.session_state.ontology
 
@@ -7369,6 +7372,11 @@ def main():
             st.session_state.pop("_back_to_viz", None)
             st.session_state.search_navigate_to = "Visualization"
             st.rerun()
+
+    # Show any flash message from a previous action (set_flash_message), for
+    # every page rather than only Import/Export, so bulk-add results and delete
+    # confirmations aren't lost after their rerun (issue #114).
+    display_flash_message()
 
     # Render selected page
     try:

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -353,6 +353,10 @@ class OntologyManager:
     # the app — spaces, '/', '#', ':' and stray punctuation — while still
     # allowing Unicode letters, digits, dots and hyphens (e.g. 'my-class.v2').
     _LOCAL_NAME_RE = re.compile(r"^\w[\w.\-]*$", re.UNICODE)
+    # A single character allowed anywhere in a local name (used to name the
+    # specific offending characters in an error, e.g. a ',' rather than only
+    # reporting the first-detected problem).
+    _LOCAL_NAME_CHAR_RE = re.compile(r"[\w.\-]", re.UNICODE)
 
     # Characters that make a full IRI unserializable in Turtle/N3 (mirrors
     # rdflib's own check); whitespace is handled separately via str.isspace().
@@ -378,17 +382,25 @@ class OntologyManager:
                     '< > " { } | \\ ^ `.'
                 )
             return None
-        if any(c.isspace() for c in name):
+        # Name the specific disallowed characters so a comma (or any other
+        # punctuation) is reported, not just the first problem found.
+        bad: List[str] = []
+        for c in name:
+            if not cls._LOCAL_NAME_CHAR_RE.match(c):
+                token = "spaces" if c.isspace() else f"'{c}'"
+                if token not in bad:
+                    bad.append(token)
+        if bad:
             return (
-                "Names cannot contain spaces. Put the readable name in the "
-                "Label field and use a name like 'MyClass' or 'my-class' here."
+                f"Names cannot contain {', '.join(bad)}. Names may contain only "
+                "letters, digits, '_', '-' and '.'. Put spaces and punctuation "
+                "in the Label field instead, and use a name like 'MyClass' or "
+                "'my-class' here."
             )
         if not cls._LOCAL_NAME_RE.match(name):
             return (
-                "Names may contain only letters, digits, '_', '-' and '.', and "
-                "cannot start with '-' or '.'. Characters like '/', '#', ':' or "
-                "spaces would produce an invalid URI. Put punctuation or spaces "
-                "in the Label instead."
+                "Names cannot start with '-' or '.'. Use a name like 'MyClass' "
+                "or 'my-class' here, and put spaces or punctuation in the Label."
             )
         return None
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -376,3 +376,92 @@ class TestBulkDeleteIndividuals:
         assert result["deleted"] == ["fido", "rex"]
         inds = [i["name"] for i in om_with_classes.get_individuals()]
         assert "fido" not in inds
+
+
+class TestBulkErrorDetail:
+    """Bulk add reports failed entries with a reason instead of failing
+    silently (issue #114)."""
+
+    def test_invalid_name_recorded_with_reason(self, om):
+        result = om.bulk_add_classes([{"name": "Dog, 1"}])
+        assert result["created"] == []
+        assert len(result["errors"]) == 1
+        err = result["errors"][0]
+        assert err["name"] == "Dog, 1"
+        assert err["error"]  # a non-empty human-readable reason
+
+    def test_issue_114_repro_parses_to_one_invalid_entry(self, om):
+        # The exact input from issue #114: the parser picks ';' (it splits to the
+        # expected 3 fields, comma splits to 4), yielding a single entry whose
+        # name contains a comma/space and is rejected -- now surfaced, not silent.
+        text = "Dog, 1; A very, special Dog; Animal, and friends"
+        entries = OntologyManager.parse_bulk_text(
+            text, default_columns=["name", "label", "parent"]
+        )
+        assert entries == [
+            {
+                "name": "Dog, 1",
+                "label": "A very, special Dog",
+                "parent": "Animal, and friends",
+            }
+        ]
+        result = om.bulk_add_classes(entries)
+        assert result["created"] == []
+        assert [e["name"] for e in result["errors"]] == ["Dog, 1"]
+        assert not om.get_classes()
+
+    def test_partial_success_records_only_the_bad_rows(self, om):
+        result = om.bulk_add_classes(
+            [{"name": "Dog"}, {"name": "bad name"}, {"name": "Cat"}]
+        )
+        assert set(result["created"]) == {"Dog", "Cat"}
+        assert [e["name"] for e in result["errors"]] == ["bad name"]
+
+
+class TestBulkResultMessage:
+    """The flash-message builder names failed entries and their reason."""
+
+    def test_message_lists_failures_with_reason(self):
+        from orionbelt_ontology_builder import app
+
+        result = {
+            "created": [],
+            "skipped": [],
+            "errors": [{"name": "Dog, 1", "error": "Names cannot contain spaces."}],
+        }
+        msg, mtype = app._bulk_result_message(result, "class(es)")
+        assert "Dog, 1" in msg
+        assert "Names cannot contain spaces." in msg
+        assert mtype == "error"  # nothing created, only errors
+
+    def test_message_partial_is_warning(self):
+        from orionbelt_ontology_builder import app
+
+        result = {
+            "created": ["Dog"],
+            "skipped": [],
+            "errors": [{"name": "bad name", "error": "invalid"}],
+        }
+        msg, mtype = app._bulk_result_message(result, "class(es)")
+        assert "Created 1 class(es)" in msg
+        assert "bad name" in msg
+        assert mtype == "warning"
+
+    def test_message_all_created_is_success(self):
+        from orionbelt_ontology_builder import app
+
+        result = {"created": ["Dog", "Cat"], "skipped": [], "errors": []}
+        msg, mtype = app._bulk_result_message(result, "class(es)")
+        assert mtype == "success"
+        assert "could not be created" not in msg
+
+    def test_message_truncates_long_error_lists(self):
+        from orionbelt_ontology_builder import app
+
+        result = {
+            "created": [],
+            "skipped": [],
+            "errors": [{"name": f"n{i}", "error": "bad"} for i in range(15)],
+        }
+        msg, _ = app._bulk_result_message(result, "class(es)")
+        assert "...and 5 more" in msg

--- a/tests/test_name_validation.py
+++ b/tests/test_name_validation.py
@@ -38,6 +38,20 @@ class TestInvalidNameReason:
     def test_invalid(self, name):
         assert OntologyManager.invalid_name_reason(name) is not None
 
+    def test_message_names_the_offending_characters(self):
+        # The reason names each disallowed character, not just the first problem
+        # (issue #114): "Dog, 1" has both a comma and a space.
+        assert "','" in OntologyManager.invalid_name_reason("Dog,1")
+        assert "'/'" in OntologyManager.invalid_name_reason("a/b")
+        msg = OntologyManager.invalid_name_reason("Dog, 1")
+        assert "','" in msg and "spaces" in msg
+
+    def test_leading_dash_message_is_specific(self):
+        # All characters are individually allowed, so the reason is the leading
+        # character rule rather than a bad-character list.
+        msg = OntologyManager.invalid_name_reason("-leading")
+        assert "start with" in msg
+
 
 class TestAddRejectsInvalid:
     def test_add_class_rejects_slash(self, om):


### PR DESCRIPTION
Fixes the silent failure reported in #114.

## Problem
Bulk-adding classes/properties/individuals reported only a bare "N error(s)" summary, and it was shown with `show_message()` immediately before `st.rerun()` — which wiped it. Compounding that, `display_flash_message()` was called only inside `render_import_export()`, so a flash set from any other page was never displayed at all. Net effect: a rejected row (like the issue's `Dog, 1`) looked like nothing happened.

The repro `Dog, 1; A very, special Dog; Animal, and friends` parses (correctly, by the semicolon delimiter) to a single entry named `Dog, 1`, which is an invalid class name — but the rejection was invisible.

## Fix
- New `_bulk_result_message()` names each failed entry and its reason, and the class/property/individual bulk-add flows now use `set_flash_message()` (which survives the rerun).
- `display_flash_message()` is called once in `main()` before the page renders, so flashes show on every page. This also fixes delete-confirmation messages that were previously only visible on Import/Export.

Commas were already rejected in names (like `/`), so this PR does not change validation or alter any name — it only makes the existing rejection visible. Per discussion on the issue, we keep the clear error (no silent auto-sanitizing of names, no tie-break change to the parser).

## Tests
- `_bulk_result_message` names failures, picks the right severity (error / warning / success), and truncates long lists.
- Engine: the exact #114 input parses to one invalid entry and `bulk_add_classes` records it as an error with a reason while creating nothing; partial batches record only the bad rows.
- `pytest` 463 passed, ruff + mypy clean.

Verified in the browser: the #114 input now shows a red banner naming `Dog, 1` and why it was rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)