### PR TITLE
fix(namespace): normalize custom prefix namespaces to end with a separator (#115)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1610,13 +1610,20 @@ def render_dashboard():
                 key="new_prefix_ns",
             )
         if st.button("Add Prefix", key="add_prefix_btn"):
-            if new_prefix and new_ns:
-                ont.add_prefix(new_prefix, new_ns)
-                save_checkpoint("Add prefix")
-                set_flash_message(f"Added prefix '{new_prefix}'", "success")
-                st.rerun()
-            else:
+            _pfx = (new_prefix or "").strip()
+            _ns = (new_ns or "").strip()
+            if not _pfx or not _ns:
                 show_message("Both prefix and namespace URI are required.", "warning")
+            elif any(c.isspace() for c in _ns):
+                show_message("Namespace URI cannot contain spaces.", "warning")
+            else:
+                bound = ont.add_prefix(_pfx, _ns)
+                save_checkpoint("Add prefix")
+                # A namespace URI needs a trailing '#' or '/' so entities created
+                # in it get a separator; note it when we add one (issue #115).
+                note = "" if bound == _ns else f" (normalized to {bound})"
+                set_flash_message(f"Added prefix '{_pfx}'{note}", "success")
+                st.rerun()
 
     # Show remove buttons for custom prefixes
     custom_pfx = [p for p in all_prefixes if p["source"] == "custom"]

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -195,10 +195,22 @@ class OntologyManager:
         prefixes.sort(key=lambda x: "" if x["prefix"] == "(default)" else x["prefix"])
         return prefixes
 
-    def add_prefix(self, prefix: str, namespace: str):
-        """Bind a custom prefix to a namespace URI in the graph."""
+    def add_prefix(self, prefix: str, namespace: str) -> str:
+        """Bind a custom prefix to a namespace URI in the graph.
+
+        The namespace is normalized to end with ``#`` or ``/`` (mirroring
+        :meth:`set_base_uri`) so entities created in it get a separator between
+        the namespace and the local name. Without it, a namespace like
+        ``http://example.org/ontology`` would concatenate with a name into
+        ``http://example.org/ontologyDog`` (issue #115). Returns the namespace
+        actually bound, so callers can surface the normalization.
+        """
+        namespace = namespace.strip()
+        if namespace and not namespace.endswith(("#", "/")):
+            namespace = namespace + "#"
         self.graph.bind(prefix, Namespace(namespace), override=True)
         self._user_added_prefixes[prefix] = namespace
+        return namespace
 
     def remove_prefix(self, prefix: str):
         """Remove a custom prefix binding. Standard prefixes cannot be removed."""

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -198,15 +198,20 @@ class OntologyManager:
     def add_prefix(self, prefix: str, namespace: str) -> str:
         """Bind a custom prefix to a namespace URI in the graph.
 
-        The namespace is normalized to end with ``#`` or ``/`` (mirroring
-        :meth:`set_base_uri`) so entities created in it get a separator between
-        the namespace and the local name. Without it, a namespace like
+        An ``http(s)`` namespace that lacks a trailing delimiter is normalized
+        to end with ``#`` so entities created in it get a separator between the
+        namespace and the local name. Without it, a namespace like
         ``http://example.org/ontology`` would concatenate with a name into
-        ``http://example.org/ontologyDog`` (issue #115). Returns the namespace
-        actually bound, so callers can surface the normalization.
+        ``http://example.org/ontologyDog`` (issue #115). Namespaces that already
+        end in a delimiter (``# / : ? = &``) and non-``http`` schemes such as
+        ``urn:example:`` are left untouched, since their separator is already
+        intentional. Returns the namespace actually bound, so callers can
+        surface the normalization.
         """
         namespace = namespace.strip()
-        if namespace and not namespace.endswith(("#", "/")):
+        if namespace.startswith(("http://", "https://")) and not namespace.endswith(
+            ("#", "/", ":", "?", "=", "&")
+        ):
             namespace = namespace + "#"
         self.graph.bind(prefix, Namespace(namespace), override=True)
         self._user_added_prefixes[prefix] = namespace

--- a/tests/test_prefixes.py
+++ b/tests/test_prefixes.py
@@ -94,3 +94,21 @@ class TestPrefixNamespaceNormalization:
         cls = {c["uri"]: c for c in om.get_classes()}
         assert cls["http://example.org/ontology#Dog"]["name"] == "Dog"
         assert "http://example.org/ontologyDog" not in cls
+
+    def test_urn_namespace_is_not_normalized(self, om):
+        # A URN already ends in its own separator (':'); appending '#' would
+        # mangle it into urn:example:#Dog (review on #117).
+        assert om.add_prefix("ex", "urn:example:") == "urn:example:"
+        uri = om.add_class("Dog", namespace="urn:example:")
+        assert str(uri) == "urn:example:Dog"
+
+    def test_non_http_scheme_left_as_is(self, om):
+        # Only http(s) namespaces are normalized; other schemes are untouched.
+        assert om.add_prefix("ex", "urn:example") == "urn:example"
+
+    def test_http_query_namespace_not_normalized(self, om):
+        # A trailing '=', '?' or '&' is an intentional separator.
+        assert (
+            om.add_prefix("q", "http://example.org/ns?term=")
+            == "http://example.org/ns?term="
+        )

--- a/tests/test_prefixes.py
+++ b/tests/test_prefixes.py
@@ -67,3 +67,30 @@ class TestGetAllPrefixes:
         default_idx = names.index("(default)") if "(default)" in names else -1
         if default_idx >= 0:
             assert default_idx == 0
+
+
+class TestPrefixNamespaceNormalization:
+    """A custom prefix namespace is normalized to end with '#' or '/', so
+    entities created in it get a separator (issue #115)."""
+
+    def test_namespace_without_separator_gets_hash(self, om):
+        bound = om.add_prefix("boat", "http://example.org/ontology")
+        assert bound == "http://example.org/ontology#"
+        ns = {p["prefix"]: p["namespace"] for p in om.get_all_prefixes()}
+        assert ns["boat"] == "http://example.org/ontology#"
+
+    def test_namespace_with_hash_is_unchanged(self, om):
+        assert om.add_prefix("ex", "http://example.org/ns#") == "http://example.org/ns#"
+
+    def test_namespace_with_slash_is_unchanged(self, om):
+        assert om.add_prefix("s", "http://schema.org/") == "http://schema.org/"
+
+    def test_class_in_normalized_namespace_is_not_mangled(self, om):
+        # The issue #115 repro: without normalization the class URI would be
+        # http://example.org/ontologyDog and its name "ontologyDog".
+        bound = om.add_prefix("boat", "http://example.org/ontology")
+        uri = om.add_class("Dog", namespace=bound)
+        assert str(uri) == "http://example.org/ontology#Dog"
+        cls = {c["uri"]: c for c in om.get_classes()}
+        assert cls["http://example.org/ontology#Dog"]["name"] == "Dog"
+        assert "http://example.org/ontologyDog" not in cls


### PR DESCRIPTION
Fixes the mangled-URI bug in #115.

## Problem
Binding a custom prefix to a namespace URI without a trailing `#` or `/` (e.g. `http://example.org/ontology`) produced mangled URIs when creating entities in it. `_uri()` concatenates `namespace + local_name`, so `Dog` became `http://example.org/ontologyDog` with the display name `ontologyDog`. The base URI is already normalized by `set_base_uri` (it appends `#` when missing), but custom prefixes were bound verbatim.

Repro (from the issue): Add Custom Prefix `boat` -> `http://example.org/ontology` (no `#`), then add class `Dog` in it -> IRI `http://example.org/ontologyDog`.

## Fix
- `add_prefix` normalizes the namespace the same way `set_base_uri` does (appends `#` when it lacks a trailing `#` or `/`) and returns the bound value. A namespace that already ends in `#` or `/` is left as-is, so a slash namespace stays a slash namespace.
- The "Add Custom Prefix" form rejects a namespace containing whitespace and notes when the value was normalized.
- `add_prefix` is only called from that one button, so imported ontologies are unaffected (their prefixes come straight from the file via rdflib).

## Not changed (triaged as expected, see issue reply)
- A prefix pointing at the same URI as the base is an alias and is de-duplicated in the namespace picker.
- The reported "server stopped" on a second prefix add could not be reproduced from the code; it looks like the separate platform flakiness rather than this path.

## Tests
- A namespace without a separator gets `#`; ones ending in `#` or `/` are unchanged; a class created in a normalized namespace is `http://example.org/ontology#Dog`, not the mangled `ontologyDog`.
- `pytest` 469 passed, ruff + mypy clean. Verified in the browser: the `boat` prefix normalizes to `http://example.org/ontology#`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)