### PR TITLE
chore: bump version to 1.16.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.16.4` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.16.5` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.16.4"
+APP_VERSION = "1.16.5"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.16.4"
+version = "1.16.5"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Bumps the version to 1.16.5, shipping the fixes merged since 1.16.4:

- **#116 (issue #114):** bulk-add now surfaces rejected entries with the reason instead of failing silently, flash messages display on every page, and the invalid-name reason names the specific disallowed characters (e.g. a comma).
- **#117 (issue #115):** custom-prefix namespaces are normalized to end with a separator for http(s) URIs that lack one, so entities are no longer mangled into `ontologyDog`; URN and query-style namespaces are left untouched.

Updated `pyproject.toml`, `orionbelt_ontology_builder/app.py` (`APP_VERSION`), and the README pin example. Badges are dynamic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)