### PR TITLE
fix(desktop): make copy buttons work in the embedded webview (#120)

### DIFF
--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -89,15 +89,19 @@ _CLIPBOARD_BRIDGE_JS = """
 (function () {
   if (window.__orionbeltClipboardBridge) return;
   window.__orionbeltClipboardBridge = true;
+  // Hand the text to the native writer and return its Promise<bool>, or null
+  // when the bridge is not available. The Python side reports whether the OS
+  // clipboard actually accepted the text, so callers must await it.
   function nativeCopy(text) {
     try {
       var api = window.pywebview && window.pywebview.api;
       if (api && api.orionbelt_copy_to_clipboard) {
-        api.orionbelt_copy_to_clipboard(text == null ? '' : String(text));
-        return true;
+        return Promise.resolve(
+          api.orionbelt_copy_to_clipboard(text == null ? '' : String(text))
+        );
       }
     } catch (e) {}
-    return false;
+    return null;
   }
   try {
     var clip = navigator.clipboard;
@@ -105,11 +109,19 @@ _CLIPBOARD_BRIDGE_JS = """
     var original = typeof clip.writeText === 'function'
       ? clip.writeText.bind(clip)
       : null;
-    clip.writeText = function (text) {
-      if (nativeCopy(text)) return Promise.resolve();
+    function fallback(text) {
       return original
         ? original(text)
         : Promise.reject(new Error('clipboard unavailable'));
+    }
+    clip.writeText = function (text) {
+      var pending = nativeCopy(text);
+      if (!pending) return fallback(text);
+      // Only resolve once the native write succeeds; on failure (e.g. no
+      // clipboard tool installed) fall back to the original API.
+      return pending.then(function (ok) {
+        return ok ? undefined : fallback(text);
+      });
     };
   } catch (e) {}
 })();

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -21,6 +21,7 @@ This reuses the same in-package Streamlit entry script as the console launcher
 
 import importlib.util
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -78,15 +79,95 @@ _TITLE_SYNC_JS = """
 """
 
 
-def _install_window_title_sync(app_name: str):
-    """Make the native window title follow the page title (issue #90).
+# Injected into the desktop webview: the embedded browser blocks
+# JavaScript-initiated clipboard writes, so Streamlit's built-in copy buttons
+# (e.g. the IRI in the Visualization details panel) silently do nothing (issue
+# #120, the same webview capability gap as the disabled downloads in #86).
+# Reroute navigator.clipboard.writeText through the native bridge exposed below;
+# the page keeps calling the standard API, so every copy button just works.
+_CLIPBOARD_BRIDGE_JS = """
+(function () {
+  if (window.__orionbeltClipboardBridge) return;
+  window.__orionbeltClipboardBridge = true;
+  function nativeCopy(text) {
+    try {
+      var api = window.pywebview && window.pywebview.api;
+      if (api && api.orionbelt_copy_to_clipboard) {
+        api.orionbelt_copy_to_clipboard(text == null ? '' : String(text));
+        return true;
+      }
+    } catch (e) {}
+    return false;
+  }
+  try {
+    var clip = navigator.clipboard;
+    if (!clip) return;
+    var original = typeof clip.writeText === 'function'
+      ? clip.writeText.bind(clip)
+      : null;
+    clip.writeText = function (text) {
+      if (nativeCopy(text)) return Promise.resolve();
+      return original
+        ? original(text)
+        : Promise.reject(new Error('clipboard unavailable'));
+    };
+  } catch (e) {}
+})();
+"""
 
-    Hooks ``webview.create_window`` so each window (a) exposes a title setter to
-    JS and (b) once loaded, runs :data:`_TITLE_SYNC_JS`, a MutationObserver that
-    pushes ``document.title`` back through that setter. Every step is defensive:
-    any failure leaves the static launch title in place rather than breaking the
-    desktop launch. Returns the original ``create_window`` for restoration, or
-    ``None`` when there is nothing to hook (e.g. a stubbed webview in tests).
+
+def _clipboard_commands() -> list[list[str]]:
+    """Return OS clipboard tools (stdin -> clipboard), tried in order.
+
+    macOS and Windows ship one; Linux depends on the session's clipboard helper
+    being installed, so Wayland and X11 tools are attempted in turn.
+    """
+    if sys.platform == "darwin":
+        return [["pbcopy"]]
+    if sys.platform == "win32":
+        return [["clip"]]
+    return [
+        ["wl-copy"],
+        ["xclip", "-selection", "clipboard"],
+        ["xsel", "--clipboard", "--input"],
+    ]
+
+
+def _copy_to_clipboard(text: str) -> bool:
+    """Write ``text`` to the OS clipboard from the desktop process (issue #120).
+
+    The embedded webview blocks JavaScript-initiated clipboard writes, so
+    Streamlit's built-in copy buttons do nothing there. :data:`_CLIPBOARD_BRIDGE_JS`
+    reroutes the page's ``navigator.clipboard.writeText`` to this, and because
+    the desktop app's Streamlit server runs on the user's own machine, writing
+    from Python lands on their real clipboard.
+
+    Best effort: returns ``True`` once a clipboard tool accepts the text, and
+    ``False`` when none is available (e.g. a Linux box without ``xclip`` /
+    ``wl-copy``) rather than raising.
+    """
+    data = text.encode("utf-8")
+    for command in _clipboard_commands():
+        try:
+            subprocess.run(command, input=data, check=True)
+            return True
+        except (OSError, subprocess.SubprocessError):
+            continue
+    return False
+
+
+def _install_window_bridges(app_name: str):
+    """Wire the native <-> page bridges each webview window needs.
+
+    Hooks ``webview.create_window`` so every window (a) exposes a title setter
+    and a clipboard writer to JS and (b) once loaded, injects the companion
+    scripts: :data:`_TITLE_SYNC_JS` (a MutationObserver mirroring
+    ``document.title`` onto the window, issue #90) and
+    :data:`_CLIPBOARD_BRIDGE_JS` (route the page's clipboard writes through the
+    native writer, issue #120). Every step is defensive: any failure leaves the
+    window working without that enhancement rather than breaking the desktop
+    launch. Returns the original ``create_window`` for restoration, or ``None``
+    when there is nothing to hook (e.g. a stubbed webview in tests).
     """
     import webview
 
@@ -106,16 +187,26 @@ def _install_window_title_sync(app_name: str):
                 pass
             return True
 
+        def orionbelt_copy_to_clipboard(text):
+            # Called from _CLIPBOARD_BRIDGE_JS when the page copies text. The
+            # desktop server runs on the user's own machine, so writing here
+            # reaches their real clipboard (issue #120).
+            try:
+                return _copy_to_clipboard("" if text is None else str(text))
+            except Exception:
+                return False
+
         try:
-            window.expose(orionbelt_set_window_title)
+            window.expose(orionbelt_set_window_title, orionbelt_copy_to_clipboard)
         except Exception:
             pass
 
         def _inject():
-            try:
-                window.evaluate_js(_TITLE_SYNC_JS)
-            except Exception:
-                pass
+            for script in (_TITLE_SYNC_JS, _CLIPBOARD_BRIDGE_JS):
+                try:
+                    window.evaluate_js(script)
+                except Exception:
+                    pass
 
         try:
             window.events.loaded += _inject
@@ -183,9 +274,9 @@ def run() -> None:
 
     entry = Path(__file__).parent / "streamlit_entry.py"
     webview.start = _start_with_persistent_storage
-    # Mirror the page title onto the native window so it shows the current
-    # ontology name like the browser tab (issue #90).
-    original_create_window = _install_window_title_sync(APP_NAME)
+    # Wire the native bridges: mirror the page title onto the window (issue #90)
+    # and route the page's clipboard writes to the OS clipboard (issue #120).
+    original_create_window = _install_window_bridges(APP_NAME)
     try:
         start_desktop_app(
             script_path=str(entry),

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -214,7 +214,7 @@ class _FakeWindow:
     def __init__(self):
         self.exposed = []
         self.title = None
-        self.evaluated = None
+        self.evaluated = []
         self.events = types.SimpleNamespace(loaded=_Event())
 
     def expose(self, *fns):
@@ -224,18 +224,18 @@ class _FakeWindow:
         self.title = title
 
     def evaluate_js(self, js):
-        self.evaluated = js
+        self.evaluated.append(js)
 
 
 def test_window_title_sync_wiring(monkeypatch):
-    """The title-sync hook exposes a setter and injects the observer, and the
+    """The bridge hook exposes a title setter and injects the observer, and the
     setter mirrors the page title onto the window (issue #90)."""
     window = _FakeWindow()
     fake_webview = types.ModuleType("webview")
     fake_webview.create_window = lambda *a, **k: window
     monkeypatch.setitem(sys.modules, "webview", fake_webview)
 
-    original = desktop._install_window_title_sync("AppName")
+    original = desktop._install_window_bridges("AppName")
     assert original is not None  # a real create_window was hooked
 
     # start_desktop_app would call create_window; simulate that.
@@ -258,14 +258,100 @@ def test_window_title_sync_wiring(monkeypatch):
     # On load, the MutationObserver script is injected.
     assert window.events.loaded, "no loaded handler registered"
     window.events.loaded[0]()
-    assert "MutationObserver" in window.evaluated
+    assert any("MutationObserver" in js for js in window.evaluated)
 
 
 def test_window_title_sync_noop_without_create_window(monkeypatch):
     """A stubbed webview lacking create_window must not raise (returns None)."""
     fake_webview = types.ModuleType("webview")  # no create_window attribute
     monkeypatch.setitem(sys.modules, "webview", fake_webview)
-    assert desktop._install_window_title_sync("AppName") is None
+    assert desktop._install_window_bridges("AppName") is None
+
+
+def test_window_bridges_wire_clipboard(monkeypatch):
+    """The bridge hook exposes a clipboard writer and injects the bridge script,
+    and the exposed writer delegates to the OS clipboard helper (issue #120)."""
+    window = _FakeWindow()
+    fake_webview = types.ModuleType("webview")
+    fake_webview.create_window = lambda *a, **k: window
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+
+    desktop._install_window_bridges("AppName")
+
+    import webview
+
+    webview.create_window("AppName", "http://localhost")
+
+    # The clipboard writer is exposed alongside the title setter, and routes
+    # text through _copy_to_clipboard.
+    copied = {}
+
+    def _fake_copy(text):
+        copied["text"] = text
+        return True
+
+    monkeypatch.setattr(desktop, "_copy_to_clipboard", _fake_copy)
+    writer = next(
+        fn for fn in window.exposed if fn.__name__ == "orionbelt_copy_to_clipboard"
+    )
+    assert writer("http://example.org/ontology#Dog") is True
+    assert copied["text"] == "http://example.org/ontology#Dog"
+    # None coalesces to an empty string rather than crashing.
+    assert writer(None) is True
+    assert copied["text"] == ""
+
+    # On load, the clipboard bridge script is injected.
+    window.events.loaded[0]()
+    assert any("__orionbeltClipboardBridge" in js for js in window.evaluated)
+
+
+def test_copy_to_clipboard_uses_platform_command(monkeypatch):
+    """Each platform writes stdin to its native clipboard tool (issue #120)."""
+    calls = {}
+
+    def _fake_run(command, input, check):  # noqa: A002 - mirror subprocess.run
+        calls["command"] = command
+        calls["input"] = input
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(desktop.subprocess, "run", _fake_run)
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert desktop._copy_to_clipboard("Dog") is True
+    assert calls["command"] == ["pbcopy"]
+    assert calls["input"] == b"Dog"
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert desktop._copy_to_clipboard("Dog") is True
+    assert calls["command"] == ["clip"]
+
+
+def test_copy_to_clipboard_falls_back_across_linux_tools(monkeypatch):
+    """On Linux, an unavailable tool is skipped for the next candidate."""
+    tried = []
+
+    def _fake_run(command, input, check):  # noqa: A002 - mirror subprocess.run
+        tried.append(command[0])
+        if command[0] == "wl-copy":
+            raise FileNotFoundError("wl-copy")
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(desktop.subprocess, "run", _fake_run)
+
+    assert desktop._copy_to_clipboard("Dog") is True
+    assert tried == ["wl-copy", "xclip"]
+
+
+def test_copy_to_clipboard_returns_false_when_unavailable(monkeypatch):
+    """With no working clipboard tool, it reports failure instead of raising."""
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    def _fake_run(command, input, check):  # noqa: A002 - mirror subprocess.run
+        raise FileNotFoundError(command[0])
+
+    monkeypatch.setattr(desktop.subprocess, "run", _fake_run)
+    assert desktop._copy_to_clipboard("Dog") is False
 
 
 def test_run_without_dependency_exits_cleanly(monkeypatch):


### PR DESCRIPTION
## Summary

The IRI copy button in the Visualization details panel (and every other Streamlit copy button) did nothing in the desktop app. The IRI is rendered with `st.code(entity["uri"])`, whose copy icon uses the browser Clipboard API, and the embedded webview blocks JavaScript-initiated clipboard writes. This is the same webview capability gap as the disabled downloads in #86, which the reporter anticipated ("a similar issue has already been fixed, so a similar patch may apply").

## Fix

Following the #86 native-bridge pattern in `desktop.py`:

- Expose a native `orionbelt_copy_to_clipboard` writer on each webview window.
- Inject JS that reroutes `navigator.clipboard.writeText` through that bridge, so the existing copy buttons work unchanged (no per-widget changes, fixes all of them at once).
- Write to the OS clipboard from Python using the platform tool (`pbcopy` / `clip` / `wl-copy` / `xclip` / `xsel`). Because the desktop app's Streamlit server runs on the user's own machine, this lands on their real clipboard. The write is best effort and returns False rather than raising when no tool is available.

The existing title-sync hook is generalized to `_install_window_bridges` since it now wires two bridges.

## Scope

Desktop only. The hosted web app is untouched (the bridge lives in the desktop launcher) and its copy buttons already work over HTTPS.

## Testing

- New unit tests: clipboard bridge wiring, platform command selection, Linux tool fallback, and the no-tool-available case.
- Verified the macOS path end to end (`pbcopy` -> `pbpaste` round-trip).
- Full suite: 476 passed. Ruff and mypy clean.

I could only exercise the macOS clipboard path locally, so a quick check on a Qt/Windows or Linux build before merge would be worthwhile.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
