### PR TITLE
fix(autosave): never let a disk-write failure crash the app (#121)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -625,11 +625,28 @@ def persist_autosave():
     if not st.session_state.get("_autosave_restored"):
         return
 
-    # Local/desktop runs persist to disk instead of browser localStorage.
-    if local_store.local_persist_enabled():
-        _persist_autosave_to_disk()
-    else:
-        _persist_autosave_to_localstorage()
+    # Autosave is best-effort and must never take down the app. It runs at the
+    # end of every rerun, outside main()'s error handling, and an important
+    # action (e.g. linking a file) forces an immediate flush — so an unexpected
+    # backend failure here would otherwise escape and stop the app on that very
+    # action (issue #121). The disk backend already handles the expected
+    # transient OSErrors; this catch-all is the safety net for anything else:
+    # log it (surfacing the cause in the in-app error log) and, on disk runs,
+    # pause further writes so it isn't retried every rerun until the user fixes
+    # the file and reloads.
+    try:
+        if local_store.local_persist_enabled():
+            _persist_autosave_to_disk()
+        else:
+            _persist_autosave_to_localstorage()
+    except Exception as e:
+        log_error(e, context="Autosave")
+        if local_store.local_persist_enabled():
+            _block_disk_persist(
+                "Autosave hit an unexpected error and has been paused so it "
+                "doesn't retry. Your work is still here — fix or re-link the "
+                "file, then reload."
+            )
 
 
 def _load_linked_file(target) -> bool:

--- a/tests/test_local_file_persist.py
+++ b/tests/test_local_file_persist.py
@@ -343,3 +343,47 @@ def test_localstorage_writes_when_dirty_and_settled(fake_st, monkeypatch):
     app._persist_autosave_to_localstorage()
     assert app.AUTOSAVE_KEY in ls.items  # written
     assert fake_st.session_state["_ls_saved_rev"] == 1
+
+
+# ---- autosave is best-effort and never crashes the app (issue #121) -------
+
+
+def test_persist_autosave_swallows_unexpected_disk_error(fake_st, monkeypatch):
+    """A non-OSError escaping the disk backend must not propagate; it is logged
+    and disk autosave is paused so it isn't retried (issue #121)."""
+    monkeypatch.setattr(local_store, "local_persist_enabled", lambda: True)
+    fake_st.session_state["_autosave_restored"] = True
+
+    def _boom():
+        raise ValueError("serialization blew up")
+
+    monkeypatch.setattr(app, "_persist_autosave_to_disk", _boom)
+
+    app.persist_autosave()  # must not raise
+
+    assert fake_st.session_state.get("_disk_persist_blocked") is True
+    assert fake_st.session_state.error_log  # the cause was logged
+
+
+def test_link_flush_with_bad_write_does_not_crash(fake_st, tmp_path, monkeypatch):
+    """Linking forces an immediate flush; a non-OSError on that write is caught
+    and pauses autosave rather than stopping the app (issue #121)."""
+    monkeypatch.setattr(local_store, "local_persist_enabled", lambda: True)
+    linked = tmp_path / "linked.ttl"
+    local_store.set_linked_path(str(linked))
+    om = _populated()
+    fake_st.session_state.ontology = om
+    fake_st.session_state["_autosave_restored"] = True
+    _set_state(fake_st, mc=1, recovery=None, linked=None, settled=True)
+    fake_st.session_state["_force_autosave_flush"] = True
+
+    def bad_save(self, path, format=None):
+        raise ValueError("rdflib serialize failed")
+
+    monkeypatch.setattr(type(om), "save_to_file", bad_save)
+
+    app.persist_autosave()  # must not raise
+
+    assert fake_st.session_state.get("_disk_persist_blocked") is True
+    assert fake_st.session_state["_linked_saved_rev"] is None  # never recorded
+    assert fake_st.session_state.error_log


### PR DESCRIPTION
## Context

Issue #121 reports the desktop server stopping every time an ontology is linked. I ran the exact repro (add a class while unlinked, Clear Ontology, then Link to a fresh file) against a local disk-backed build and could not reproduce a crash, so the trigger looks specific to the desktop build and/or the synced folder the reporter links into. I have asked them for the traceback / in-app error log to confirm the exact failure.

## The structural weakness this fixes

Regardless of the exact triggering exception, the code has a real robustness gap that matches the report precisely:

- **Link forces an immediate flush.** The Link button sets `_force_autosave_flush=True`, so the disk write happens on the very next rerun instead of being deferred by the debounce. That is why a latent write error would surface "every time the ontology is linked."
- **The disk write only catches `OSError`.** `_persist_autosave_to_disk` handles the expected transient `OSError`s (synced folder offline, etc.), but `save_to_file` re-raises anything else, so a non-`OSError` from `graph.serialize(...)` or `os.replace(...)` escapes.
- **`persist_autosave()` runs outside `main()`'s try/except** (`app.py`, called after the page-render guard). So an escaped exception is not handled by the app at all.

## Change

Wrap the backend dispatch in `persist_autosave` in a catch-all: log the cause to the in-app error log and, on disk runs, pause autosave via the existing `_block_disk_persist` path so it is not retried every rerun until the user fixes the file and reloads. Autosave is best-effort and must never take down the app.

Bonus: the real exception now lands in the in-app error log instead of stopping the server, so the reporter can tell us exactly what failed on their synced folder and we can confirm the root cause.

## Scope

This is defensive hardening plus diagnostics. It prevents the crash and captures the underlying error; it does not necessarily fix whatever disk/serialization failure is occurring on the reporter's machine, so it intentionally does not auto-close #121. Refs #121.

## Testing

- New tests: `persist_autosave` swallows an unexpected disk error (logs it, pauses autosave), and a forced link-time flush with a failing write does not crash and never records the linked revision.
- Full suite: 478 passed. Ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
