### PR TITLE
feat(search): disambiguate same-named results by namespace (#119)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -7317,7 +7317,14 @@ def main():
             for type_label, items in grouped.items():
                 st.sidebar.caption(type_label)
                 page = type_to_page.get(type_label, "Dashboard")
+                # Tag the namespace when the same local name appears under more
+                # than one URI in these results, so duplicates don't render as
+                # identical entries (e.g. `Dog` and `Dog (other)`). This is the
+                # same disambiguation the rest of the UI and the graph already
+                # use (issue #119).
+                collisions = _build_name_collision_set(items)
                 for r in items:
+                    disp_name = _disambiguated_name(r, collisions)
                     label_str = (
                         f" ({r['label']})"
                         if r["label"] and r["label"] != r["name"]
@@ -7328,7 +7335,7 @@ def main():
                     r_uri = r.get("uri", r["name"])
                     r_uid = _uid(r_uri)
                     if st.sidebar.button(
-                        f"{r['name']}{label_str}",
+                        f"{disp_name}{label_str}",
                         key=f"search_{type_label}_{r_uid}",
                         use_container_width=True,
                     ):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -81,3 +81,34 @@ def test_search_name_ranks_above_alt_label(populated_om):
     results = populated_om.search("Doggo")
     names = [r["name"] for r in results]
     assert names.index("Doggo") < names.index("Wolf")
+
+
+def test_search_disambiguates_same_name_across_namespaces(monkeypatch):
+    """Two entities sharing a local name in different namespaces get a
+    namespace tag in the sidebar search, matching the graph/UI (issue #119)."""
+    import types
+
+    from ontology_manager import OntologyManager
+    from orionbelt_ontology_builder import app
+
+    om = OntologyManager(base_uri="http://example.org/ontology#")
+    om.add_class("Dog")  # base namespace
+    other_ns = "http://example.org/other-ontology#"
+    om.add_prefix("other", other_ns)
+    om.add_class("Dog", namespace=other_ns)
+
+    results = [r for r in om.search("Dog") if r["type"] == "Class"]
+    assert len(results) == 2
+    assert {r["name"] for r in results} == {"Dog"}
+    assert len({r["uri"] for r in results}) == 2  # distinct URIs carried through
+
+    # The sidebar builds a per-group collision set and disambiguates via the
+    # shared helper; _prefix_for_uri reads the active ontology from session.
+    monkeypatch.setattr(
+        app, "st", types.SimpleNamespace(session_state={"ontology": om})
+    )
+    collisions = app._build_name_collision_set(results)
+    assert "Dog" in collisions
+    displayed = {app._disambiguated_name(r, collisions) for r in results}
+    assert len(displayed) == 2  # no two identical entries
+    assert "Dog (other)" in displayed


### PR DESCRIPTION
## Summary

When the same local name exists under more than one URI (e.g. `Dog` in the base ontology and `Dog` in a linked/second one), the sidebar `Search` listed both as an identical `Dog` button, with no way to tell them apart. The Visualization graph already disambiguates these as `Dog (other)`; this applies the same mechanism to Search, as requested in #119.

## Change

The search results already carry each result's full `uri` (the engine includes it precisely "so callers can distinguish duplicate local names from different namespaces"). The sidebar rendering just wasn't using it. Now, per type group, it builds a collision set and renders through the existing shared helpers:

- `_build_name_collision_set(items)` finds local names that appear under more than one URI.
- `_disambiguated_name(r, collisions)` appends the namespace prefix only for those (falling back to the raw namespace when no prefix is bound).

Unique names are unchanged; only genuine collisions gain the ` (prefix)` tag. This is the same code path used by the class/property/individual dropdowns and the graph, so behaviour is consistent across the app.

Before: `Dog`, `Dog`
After: `Dog`, `Dog (other)`

## Testing

- New test: two classes named `Dog` in different namespaces are returned distinctly by `search`, collide in the collision set, and disambiguate to `Dog` / `Dog (other)`.
- Full suite: 479 passed. Ruff and mypy clean.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
