### PR TITLE
chore: bump version to 1.16.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.16.5` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.16.6` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.16.5"
+APP_VERSION = "1.16.6"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.16.5"
+version = "1.16.6"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Patch release rolling up the fixes and enhancement merged since 1.16.5:

- fix(desktop): copy buttons work in the embedded webview (#122)
- fix(autosave): a disk-write failure can no longer crash the app (#123)
- feat(search): disambiguate same-named results by namespace (#124)

Bumps `pyproject.toml`, `APP_VERSION` in `app.py`, and the Docker pin example in the README. The tagged release (`v1.16.6`) will be cut once this lands on main, triggering the PyPI and Docker Hub publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
