### PR TITLE
ci: run the test suite on Python 3.14 alongside 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,19 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    strategy:
+      # Report every version's result, rather than cancelling siblings on the
+      # first failure, so a version-specific break is obvious.
+      fail-fast: false
+      matrix:
+        # 3.12 is what Streamlit Cloud runs; 3.14 is what the Docker image ships.
+        python: ["3.12", "3.14"]
+    name: check (py${{ matrix.python }})
+    # Bind every uv command in this job to the matrix interpreter. Without it uv
+    # is free to pick any interpreter satisfying requires-python, so a leg could
+    # silently test a version other than the one it claims to.
+    env:
+      UV_PYTHON: ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v7
 
@@ -18,10 +31,16 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.12
+        run: uv python install ${{ matrix.python }}
 
       - name: Install dependencies
         run: uv sync --extra dev
+
+      - name: Verify interpreter
+        run: |
+          actual=$(uv run python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+          echo "matrix=${{ matrix.python }} actual=$actual"
+          [ "$actual" = "${{ matrix.python }}" ] || { echo "::error::expected Python ${{ matrix.python }}, got $actual"; exit 1; }
 
       - name: Lint (ruff)
         run: uv run ruff check orionbelt_ontology_builder tests app.py ontology_manager.py templates.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,23 @@ jobs:
       # first failure, so a version-specific break is obvious.
       fail-fast: false
       matrix:
-        # 3.12 is what Streamlit Cloud runs; 3.14 is what the Docker image ships.
+        # 3.12 is what Streamlit Cloud runs; 3.14 is the base image the Docker
+        # image moves to in #128.
         python: ["3.12", "3.14"]
     name: check (py${{ matrix.python }})
-    # Bind every uv command in this job to the matrix interpreter. Without it uv
-    # is free to pick any interpreter satisfying requires-python, so a leg could
-    # silently test a version other than the one it claims to.
-    env:
-      UV_PYTHON: ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v7
 
+      # python-version sets UV_PYTHON, binding every uv command below to the
+      # matrix interpreter: uv is otherwise free to pick any python satisfying
+      # requires-python, so a leg could silently test a version other than the
+      # one it names. It also feeds setup-uv's cache key, which would otherwise
+      # be computed from the runner's system python and so collide across legs.
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          python-version: ${{ matrix.python }}
 
       - name: Set up Python
         run: uv python install ${{ matrix.python }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 ]
 dependencies = [


### PR DESCRIPTION
Runs the test suite on Python 3.14 as well as 3.12.

## Why

The Docker image ships Python 3.14 once #128 lands, but CI only ever ran the suite on 3.12, so the image would have shipped a runtime nothing tested. The smoke test added in #133 only proves the app starts and answers `/_stcore/health`; it would not catch a 3.14 behaviour change in the ontology engine.

## What changed

- **Matrix the `check` job over 3.12 and 3.14.** 3.12 is what Streamlit Cloud runs, 3.14 is what the image ships. `fail-fast: false` so a version-specific break is reported rather than cancelling its sibling.
- **`UV_PYTHON` binds each leg to its interpreter.** `uv python install X` alone does not guarantee `uv sync` uses X: uv is free to pick any interpreter satisfying `requires-python >=3.10`, so the 3.14 leg could silently have been a second 3.12 run. This is the failure mode where a check that never ran looks identical to one that passed.
- **A verify step asserts the interpreter matches the matrix leg**, for the same reason. A leg testing the wrong version would otherwise report green.
- **Claim 3.14 in the classifiers**, now that the suite covers it.

## Not changed

`desktop-extra` stays on 3.12. It guards Qt backend resolution (issue #68) rather than the test suite, and PySide6 only installs on Linux (`sys_platform != 'darwin'`), so its 3.14 behaviour cannot be verified from a macOS working copy. Worth a separate look if you want the desktop extra supported on 3.14.

## Verification

Ran the full CI equivalent locally on both legs against the current lock:

| leg | pytest | mypy | ruff check | ruff format |
| --- | --- | --- | --- | --- |
| 3.12 | 479 passed | clean | clean | 43 formatted |
| 3.14 | 479 passed | clean | clean | 43 formatted |

Also confirmed `UV_PYTHON=3.12` and `UV_PYTHON=3.14` each bind the interpreter they name, and actionlint is clean.

## Follow-up

`[tool.mypy] python_version` is still `3.12`, so type checking assumes 3.12 semantics on both legs. Left alone here to keep this focused, but worth deciding separately: `requires-python` allows 3.10, so 3.11+ only syntax would pass mypy today and break for a 3.10 user.

Relates to #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
