### PR TITLE
docs: correct the CI matrix comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,11 @@ jobs:
       # first failure, so a version-specific break is obvious.
       fail-fast: false
       matrix:
-        # 3.12 is what Streamlit Cloud runs; 3.14 is the base image the Docker
-        # image moves to in #128.
+        # 3.14 is the base image the Docker image ships (see Dockerfile). 3.12 is
+        # Streamlit Community Cloud's default and the oldest runtime we keep
+        # green. The hosted app's interpreter is picked in Community Cloud's
+        # Advanced settings at deploy time and is not recorded in this repo, so
+        # this floor is a deliberate choice rather than a reading of the deploy.
         python: ["3.12", "3.14"]
     name: check (py${{ matrix.python }})
     steps:


### PR DESCRIPTION
Corrects the CI matrix comment. Comment only, no matrix values change.

## What was wrong

Both halves of the comment stated something untrue:

- **"3.12 is what Streamlit Cloud runs"** was never verified. Community Cloud takes the interpreter from the Python version dropdown in Advanced settings at deploy time, [it cannot be changed after deployment](https://docs.streamlit.io/deploy/streamlit-community-cloud/manage-your-app/upgrade-python), and nothing in this repo records it. There is no `runtime.txt` or `.python-version`, and `.streamlit/config.toml` only carries theme and upload settings. So the hosted app's version is not knowable from the code.
- **"the base image the Docker image moves to in #128"** described a pending change. #128 has since merged, so `Dockerfile` ships `python:3.14-slim` today.

## What it says now

3.14 is what the image ships. 3.12 is Community Cloud's [documented default](https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/app-dependencies) and the oldest runtime we keep green, which is what that leg actually buys us, stated as a deliberate choice rather than as a reading of the deploy.

## Note

Community Cloud supports 3.10 through 3.14, so aligning the hosted app with the image is possible, but it requires deleting and redeploying the app. That is a separate decision, deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
