### PR TITLE
docs: document using OntologyManager as a Python library

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,48 @@ pipx run orionbelt-ontology-builder
 Any extra arguments are forwarded to Streamlit, e.g.
 `orionbelt-ontology-builder --server.port 8502`.
 
+### Use as a Python library
+
+The app is a thin wrapper over `OntologyManager`, the rdflib-backed engine. It
+needs no Streamlit runtime, so you can build ontologies from a script, a
+notebook, or a CI job:
+
+```python
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+ont = OntologyManager()
+ont.add_class("Question")
+
+# The same text format the Bulk Operations page accepts: name,label,parent
+entries = ont.parse_bulk_text(
+    "1,,Question\n1a,,1",
+    default_columns=["name", "label", "parent"],
+)
+result = ont.bulk_add_classes(entries)
+print(result["errors"])  # bulk methods report per entry, they do not raise
+
+ont.save_to_file("out.ttl")  # format inferred from the extension, written atomically
+```
+
+Three things that are easy to trip over:
+
+- Bulk methods return `{"created": [...], "errors": [...], "skipped": [...]}`
+  rather than raising, so a script that ignores `errors` will look like it
+  succeeded on input it silently rejected.
+- A parent referenced by a row but never given a row of its own is declared as a
+  bare `owl:Class`, so the `rdfs:subClassOf` target is a real node. Twenty rows
+  can legitimately produce twenty-one classes.
+- `parse_bulk_text` is a `@staticmethod`, so `OntologyManager.parse_bulk_text(...)`
+  works without an instance.
+
+The same applies to the rest of the app: classes, properties, individuals, class
+expressions, SKOS, reasoning and export are all `OntologyManager` methods. See
+[`orionbelt_ontology_builder/ontology_manager.py`](orionbelt_ontology_builder/ontology_manager.py)
+for the full surface.
+
+There is no REST/HTTP API, and the `orionbelt-ontology-builder` command only
+launches the app. In-process Python is the way to automate it.
+
 ### Run as a native desktop app
 
 Prefer a native window over a browser tab? Install the optional `desktop` extra


### PR DESCRIPTION
Adds a `### Use as a Python library` section to the README Quick Start.

Closes #136

## Why

Every entry under Quick Start (`Run as a command`, `Run as a native desktop app`, `Run with Docker`) is another way to launch the GUI, so the reasonable reading was that the GUI is the product and there is no way to script it. The engine has always been importable and needs no Streamlit runtime. #126 is someone hitting exactly that.

## What it covers

Placed after `### Run as a command`, since that is where a reader is already looking for non-browser entry points. Short by design, with the three things that are genuinely easy to trip over:

- **Bulk methods return `{created, errors, skipped}` and do not raise**, so a script ignoring `errors` looks like it succeeded on input it silently rejected.
- **A referenced parent with no row of its own is declared as a bare `owl:Class`** (#106), so 20 rows can legitimately produce 21 classes.
- **`parse_bulk_text` is a `@staticmethod`**, usable with no instance.

It also states plainly that there is no REST/HTTP API and that the console command only launches the app, so nobody has to infer that from silence, and it notes the bulk text format is the same one the Bulk Operations page accepts, via the same parser.

## Scope

Docs only, no engine change. Deliberately not an API reference: it points at `ontology_manager.py` for the full surface rather than duplicating it, so it cannot drift.

## Verification

Ran the snippet exactly as written in the README:

```
errors: []
snippet ran; out.ttl exists: True
result shape: ['created', 'errors', 'skipped']
classes: ['1', '1a', 'Question']
staticmethod call OK: [{'name': 'x', 'label': '', 'parent': 'y'}]
rows=20 created=21 classes=21
```

Every claim in the section is checked: the snippet runs, the result shape is as documented, the staticmethod call works without an instance, and the 20-rows-to-21-classes behaviour is real rather than asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
