### PR TITLE
fix: paginate View Classes so large ontologies don't crash the desktop app

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1037,18 +1037,21 @@ def _cb_toggle_view(prefix, uid):
     """Callback: open view panel, close edit. `uid` must be unique per resource."""
     st.session_state[f"view_{prefix}_{uid}"] = True
     st.session_state[f"edit_{prefix}_{uid}"] = False
+    st.session_state["_last_opened_entity"] = (prefix, uid)
 
 
 def _cb_toggle_edit(prefix, uid):
     """Callback: open edit panel, close view. `uid` must be unique per resource."""
     st.session_state[f"edit_{prefix}_{uid}"] = True
     st.session_state[f"view_{prefix}_{uid}"] = False
+    st.session_state["_last_opened_entity"] = (prefix, uid)
 
 
 def _cb_view_to_edit(prefix, uid):
     """Callback: switch from view to edit. `uid` must be unique per resource."""
     st.session_state[f"view_{prefix}_{uid}"] = False
     st.session_state[f"edit_{prefix}_{uid}"] = True
+    st.session_state["_last_opened_entity"] = (prefix, uid)
 
 
 def _cb_confirm_delete(key_suffix):
@@ -1777,15 +1780,38 @@ def render_classes():
                     _disambiguated_name(c, collisions), c.get("label")
                 ).lower(),
             )
-            _active_cls = next(
-                (
-                    c
-                    for c in sorted_classes
-                    if st.session_state.get(f"view_class_{_uid(c['uri'])}", False)
-                    or st.session_state.get(f"edit_class_{_uid(c['uri'])}", False)
-                ),
-                None,
+
+            def _is_active_cls(c):
+                _u = _uid(c["uri"])
+                return st.session_state.get(
+                    f"view_class_{_u}", False
+                ) or st.session_state.get(f"edit_class_{_u}", False)
+
+            # Prefer the most recently opened class, not just the first in sorted
+            # order. Otherwise a class left open (view/edit state still set) on an
+            # earlier page would win over one the user just clicked on a later
+            # page, and the single-active cleanup below would wipe the new click
+            # before it could render (issue #143 review).
+            _last_opened = st.session_state.get("_last_opened_entity")
+            _preferred_uid = (
+                _last_opened[1]
+                if isinstance(_last_opened, tuple) and _last_opened[0] == "class"
+                else None
             )
+            _active_cls = None
+            if _preferred_uid is not None:
+                _active_cls = next(
+                    (
+                        c
+                        for c in sorted_classes
+                        if _uid(c["uri"]) == _preferred_uid and _is_active_cls(c)
+                    ),
+                    None,
+                )
+            if _active_cls is None:
+                _active_cls = next(
+                    (c for c in sorted_classes if _is_active_cls(c)), None
+                )
             if _active_cls:
                 _active_uid = _uid(_active_cls["uri"])
                 for c in sorted_classes:

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1798,12 +1798,21 @@ def render_classes():
             # list stays available in the "All Classes" table below.
             _total = len(sorted_classes)
             if _total > CLASSES_PER_PAGE:
-                # Jump to the page holding the class being viewed/edited so its
-                # expanded card is visible no matter which page was last shown.
+                # Jump to the page holding a class only when it *becomes* the
+                # active (viewed/edited) card, not on every render — otherwise the
+                # auto-jump fights a manual page change and pins the user to that
+                # page for as long as the card stays open. Tracking the last
+                # jumped-to UID makes it a one-shot per open.
                 if _active_cls is not None:
-                    st.session_state["cls_view_page"] = (
-                        sorted_classes.index(_active_cls) // CLASSES_PER_PAGE + 1
-                    )
+                    _active_uid = _uid(_active_cls["uri"])
+                    if st.session_state.get("_cls_active_page_uid") != _active_uid:
+                        st.session_state["cls_view_page"] = (
+                            sorted_classes.index(_active_cls) // CLASSES_PER_PAGE + 1
+                        )
+                        st.session_state["_cls_active_page_uid"] = _active_uid
+                else:
+                    # No card open: forget the last jump so reopening one jumps again.
+                    st.session_state.pop("_cls_active_page_uid", None)
                 _num_pages, _page, _, _ = _page_bounds(
                     _total, st.session_state.get("cls_view_page", 1), CLASSES_PER_PAGE
                 )

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1716,6 +1716,27 @@ def render_dashboard():
                         st.write(f"{icon} **{issue['subject']}**: {issue['message']}")
 
 
+# Cap how many class cards the View Classes tab renders at once. Each card is an
+# expander plus several buttons (and a form when expanded), so an ontology with
+# hundreds of classes would otherwise emit thousands of widgets in one render —
+# enough to overwhelm the embedded desktop webview and take the app down (issue
+# #140). Paginating bounds the payload regardless of ontology size.
+CLASSES_PER_PAGE = 50
+
+
+def _page_bounds(total: int, page: int, page_size: int) -> tuple[int, int, int, int]:
+    """Resolve a 1-based ``page`` over ``total`` items into slice bounds.
+
+    Returns ``(num_pages, page, start, end)`` where ``page`` is clamped into
+    ``[1, num_pages]`` and ``start``/``end`` are 0-based slice indices. Pure, so
+    it is unit-tested directly.
+    """
+    num_pages = max(1, (total + page_size - 1) // page_size)
+    page = min(max(int(page), 1), num_pages)
+    start = (page - 1) * page_size
+    return num_pages, page, start, min(start + page_size, total)
+
+
 def render_classes():
     """Render the classes management page."""
     st.header("Classes")
@@ -1773,7 +1794,38 @@ def render_classes():
                         st.session_state.pop(f"view_class_{c_uid}", None)
                         st.session_state.pop(f"edit_class_{c_uid}", None)
 
-            for cls in sorted_classes:
+            # Only render one page of class cards at a time (issue #140). The full
+            # list stays available in the "All Classes" table below.
+            _total = len(sorted_classes)
+            if _total > CLASSES_PER_PAGE:
+                # Jump to the page holding the class being viewed/edited so its
+                # expanded card is visible no matter which page was last shown.
+                if _active_cls is not None:
+                    st.session_state["cls_view_page"] = (
+                        sorted_classes.index(_active_cls) // CLASSES_PER_PAGE + 1
+                    )
+                _num_pages, _page, _, _ = _page_bounds(
+                    _total, st.session_state.get("cls_view_page", 1), CLASSES_PER_PAGE
+                )
+                # Clamp back before the widget reads the key (e.g. a stale page
+                # left over after deletions) so number_input never sees an
+                # out-of-range value.
+                st.session_state["cls_view_page"] = _page
+                _page = st.number_input(
+                    "Class page",
+                    min_value=1,
+                    max_value=_num_pages,
+                    step=1,
+                    key="cls_view_page",
+                    help=f"{_total} classes; {CLASSES_PER_PAGE} shown per page.",
+                )
+                _, _, _start, _end = _page_bounds(_total, _page, CLASSES_PER_PAGE)
+                _page_classes = sorted_classes[_start:_end]
+                st.caption(f"Showing classes {_start + 1}–{_end} of {_total}.")
+            else:
+                _page_classes = sorted_classes
+
+            for cls in _page_classes:
                 cls_uid = _uid(cls["uri"])
                 disp_name = _disambiguated_name(cls, collisions)
                 display_name = format_label_name(disp_name, cls.get("label"))

--- a/tests/test_classes_page_ui.py
+++ b/tests/test_classes_page_ui.py
@@ -76,3 +76,66 @@ def test_opening_a_card_jumps_to_its_page_once():
 def test_no_card_open_leaves_the_chosen_page_alone():
     at = _run(open_idx=-1, set_page=3, set_tracker=False)
     assert _shown_range(at) == "Showing classes 101–120 of 120."
+
+
+def _script_multi():
+    import os
+
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        for i in range(120):
+            om.add_class(f"Class{i:03d}")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+        classes = om.get_classes()
+        for idx in os.environ["OPEN_IDXS"].split(","):
+            st.session_state[f"view_class_{app._uid(classes[int(idx)]['uri'])}"] = True
+        _lo = int(os.environ["LAST_OPENED_IDX"])
+        st.session_state["_last_opened_entity"] = (
+            "class",
+            app._uid(classes[_lo]["uri"]),
+        )
+        _tr = os.environ["TRACKER_IDX"]
+        if _tr:
+            st.session_state["_cls_active_page_uid"] = app._uid(
+                classes[int(_tr)]["uri"]
+            )
+        st.session_state["cls_view_page"] = int(os.environ["SET_PAGE"])
+
+    app.render_classes()
+
+
+def _class_uids(n=120):
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    om = OntologyManager()
+    for i in range(n):
+        om.add_class(f"Class{i:03d}")
+    return [app._uid(c["uri"]) for c in om.get_classes()]
+
+
+def test_clicking_a_class_on_a_later_page_wins_over_a_hidden_open_one():
+    # A class opened on page 1 is still flagged (hidden) while the user is on
+    # page 2 and clicks View on a class there. The just-clicked class must win:
+    # it stays open, the stale one is cleared, and the page follows the new card.
+    uids = _class_uids()
+    os.environ["OPEN_IDXS"] = "0,60"  # class 0 (page 1, hidden) + class 60 (page 2)
+    os.environ["LAST_OPENED_IDX"] = "60"
+    os.environ["TRACKER_IDX"] = "0"  # previously jumped to class 0
+    os.environ["SET_PAGE"] = "2"
+    at = AppTest.from_function(_script_multi)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+
+    assert _shown_range(at) == "Showing classes 51–100 of 120."
+    assert at.session_state[f"view_class_{uids[60]}"] is True
+    _stale = f"view_class_{uids[0]}"
+    assert _stale not in at.session_state or at.session_state[_stale] is False
+    assert at.session_state["_cls_active_page_uid"] == uids[60]

--- a/tests/test_classes_page_ui.py
+++ b/tests/test_classes_page_ui.py
@@ -1,0 +1,78 @@
+"""Regression tests for the View Classes page selector (issue #140 / PR #143).
+
+These render the real ``render_classes`` via Streamlit's ``AppTest`` so the
+session-state interplay between the auto-jump and the manual page selector is
+exercised end to end. Each case is a single run (no widget-interaction rerun),
+seeded through the environment because ``AppTest.from_function`` executes the
+script source in a fresh namespace without the test's closures.
+"""
+
+import os
+
+from streamlit.testing.v1 import AppTest
+
+
+def _script():
+    import os
+
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        for i in range(120):  # 3 pages at 50 per page
+            om.add_class(f"Class{i:03d}")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+        classes = om.get_classes()  # sorted by name, matching the render order
+        open_idx = int(os.environ["OPEN_IDX"])
+        if open_idx >= 0:
+            uid = app._uid(classes[open_idx]["uri"])
+            st.session_state[f"view_class_{uid}"] = True
+            if os.environ.get("SET_TRACKER") == "1":
+                st.session_state["_cls_active_page_uid"] = uid
+        if os.environ.get("SET_PAGE"):
+            st.session_state["cls_view_page"] = int(os.environ["SET_PAGE"])
+
+    app.render_classes()
+
+
+def _run(open_idx, set_page, set_tracker):
+    os.environ["OPEN_IDX"] = str(open_idx)
+    os.environ["SET_PAGE"] = str(set_page) if set_page is not None else ""
+    os.environ["SET_TRACKER"] = "1" if set_tracker else "0"
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    return at
+
+
+def _shown_range(at):
+    for c in at.caption:
+        if "of 120" in c.value:
+            return c.value
+    return None
+
+
+def test_manual_page_change_sticks_while_card_open():
+    # A card is open on page 1 and already jumped to (tracker set); the user then
+    # moves to page 2. The auto-jump must NOT drag them back to page 1.
+    at = _run(open_idx=0, set_page=2, set_tracker=True)
+    assert _shown_range(at) == "Showing classes 51–100 of 120."
+
+
+def test_opening_a_card_jumps_to_its_page_once():
+    # Same open card and page 2, but this is the first render after opening it
+    # (no tracker yet): the page should jump to the card's page (1).
+    at = _run(open_idx=0, set_page=2, set_tracker=False)
+    assert _shown_range(at) == "Showing classes 1–50 of 120."
+    # And the jump is recorded so it won't fire again on later renders.
+    assert at.session_state["_cls_active_page_uid"]
+
+
+def test_no_card_open_leaves_the_chosen_page_alone():
+    at = _run(open_idx=-1, set_page=3, set_tracker=False)
+    assert _shown_range(at) == "Showing classes 101–120 of 120."

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,33 @@
+"""Tests for View Classes pagination bounds (issue #140)."""
+
+from orionbelt_ontology_builder.app import _page_bounds
+
+
+def test_single_page_when_total_fits():
+    # Everything on one page; end is the item count, not the page size.
+    assert _page_bounds(30, 1, 50) == (1, 1, 0, 30)
+
+
+def test_empty_still_reports_one_page():
+    assert _page_bounds(0, 1, 50) == (1, 1, 0, 0)
+
+
+def test_multiple_pages_slice_bounds():
+    # 120 items, 50 per page -> 3 pages.
+    assert _page_bounds(120, 1, 50) == (3, 1, 0, 50)
+    assert _page_bounds(120, 2, 50) == (3, 2, 50, 100)
+    # Last page is short: only 20 items remain.
+    assert _page_bounds(120, 3, 50) == (3, 3, 100, 120)
+
+
+def test_page_clamped_into_range():
+    # A stale/too-high page (e.g. after deletions) clamps to the last page.
+    assert _page_bounds(120, 99, 50) == (3, 3, 100, 120)
+    # A too-low page clamps to the first.
+    assert _page_bounds(120, 0, 50) == (3, 1, 0, 50)
+    assert _page_bounds(120, -5, 50) == (3, 1, 0, 50)
+
+
+def test_exact_multiple_has_no_trailing_page():
+    # 100 items at 50 per page is exactly 2 pages, not 3.
+    assert _page_bounds(100, 2, 50) == (2, 2, 50, 100)


### PR DESCRIPTION
## Problem

Addresses #140. On the desktop app, navigating to **Classes** crashed for large ontologies, while the lighter path reached via the visualization panel's "Open full editor" stayed safe.

## Root cause

The **View Classes** tab (the default view for the Classes page) rendered, for **every class**, an `st.expander` plus three buttons and a conditional inline edit form. An ontology with hundreds of classes therefore emitted thousands of widgets in a single render. The desktop app runs Streamlit in a child process shown by an embedded pywebview browser, and that payload was large enough to take down the webview renderer, which reads as the app crashing.

This matches the reporter's own pinpointing:

- "Open full editor" for a class lands on the **Edit/Delete Class** tab, which renders one selectbox and one form (light) and stays safe.
- Navigating to **Classes** defaults to **View Classes**, which renders the full interactive tree for the whole class set (heavy) and crashes.

Autosave is an aggravating co-factor rather than the cause: the debounced `graph.serialize()` runs at the tail of that same heavy rerun, adding latency and memory pressure, which is why the crash correlated with "Autosaving..." but also happened at "Saved to disk."

## Fix

Cap the View Classes tab at `CLASSES_PER_PAGE` (50) cards with a page selector, bounding the render payload regardless of ontology size. The full list stays available in the "All Classes" table below (a single efficient dataframe). The pure slice math is extracted into `_page_bounds` and unit-tested.

The page selector jumps to whichever card is being viewed or edited **only when that card becomes active** (tracked via `_cls_active_page_uid`), not on every render. An earlier revision re-applied the jump every render, which overwrote a manual page change on the next rerun and pinned the user to the open card's page; the one-shot jump lets manual paging stick while a card stays open, and the tracker resets when no card is open so reopening jumps again. A stale page (for example after deletions) still clamps into range before the widget reads it.

## Verification

- `tests/test_pagination.py` covers `_page_bounds` (single page, empty, multi-page slices, clamping, exact multiples).
- `tests/test_classes_page_ui.py` renders the real `render_classes` via `AppTest`: a manual page change sticks while a card is open (fails against the pre-fix jump), opening a card jumps to its page once, and no card open leaves the chosen page alone.
- `AppTest` smoke run against a 230-class ontology: the page renders 50 cards instead of 230, page navigation and out-of-range clamping work with no exception, and a 10-class ontology shows no page control (unchanged behavior).
- Full suite: 487 passed. `ruff@0.15.19` format and check clean; `mypy` clean.

## Follow-up (tracked separately)

- #145: the sidebar can stay on "Autosaving..." when the write is really just pending until the next rerun (cosmetic status quirk).
- #146: apply the same pagination to the other per-item list views (Properties, Individuals, Relations, SKOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)