### PR TITLE
fix: make the pending-autosave caption honest instead of showing a stuck "Autosaving…"

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -711,7 +711,11 @@ def _render_disk_autosave_sidebar():
         if saved_rev == mc:
             st.sidebar.caption("✓ Saved to disk")
         elif saved_rev is not None:
-            st.sidebar.caption("• Autosaving…")
+            # The disk write is debounced and only runs on a rerun, so a pending
+            # write lands on the next edit/interaction rather than immediately. Say
+            # so honestly instead of "Autosaving…", which looked stuck when the
+            # session went idle even though the work is safe in memory (issue #145).
+            st.sidebar.caption("• Saved in memory; writing to disk shortly…")
 
     linked = local_store.get_linked_path()
     with st.sidebar.expander("Linked working file", expanded=linked is not None):


### PR DESCRIPTION
Closes #145.

## Problem

On the desktop app the sidebar could sit on "Autosaving…" indefinitely. The disk write is debounced (`AUTOSAVE_DEBOUNCE_SECONDS`) and only runs during a rerun, so a pending write lands on the next edit or interaction. If the session went idle no rerun occurred, and the caption looked stuck even though the work was safe in session state and would be written on the next interaction.

## Fix

Reword the pending-state caption from "Autosaving…" to "Saved in memory; writing to disk shortly…" so it reflects what is actually true: the data is safe and the disk write follows shortly. The "✓ Saved to disk" state is unchanged.

This is the low-risk option from the issue (honest caption). Streamlit cannot run code without a rerun, so proactively flushing while idle would need a timer-driven fragment doing background disk I/O on the autosave path; that machinery is not worth it for a cosmetic status, so it was deliberately not taken.

## Verification

- Full suite: 488 passed. `ruff@0.15.19` format and check clean; `mypy` clean.
- Grepped the repo: no other reference to the old "Autosaving…" string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)