### PR TITLE
fix: paginate the other per-item list views (Properties, Individuals, Relations, SKOS)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1723,12 +1723,13 @@ def render_dashboard():
                         st.write(f"{icon} **{issue['subject']}**: {issue['message']}")
 
 
-# Cap how many class cards the View Classes tab renders at once. Each card is an
-# expander plus several buttons (and a form when expanded), so an ontology with
-# hundreds of classes would otherwise emit thousands of widgets in one render —
-# enough to overwhelm the embedded desktop webview and take the app down (issue
-# #140). Paginating bounds the payload regardless of ontology size.
-CLASSES_PER_PAGE = 50
+# Cap how many item cards a "view" list renders at once. Each card is an expander
+# plus several buttons (and a form when expanded), so an ontology with hundreds of
+# classes / properties / individuals / concepts would otherwise emit thousands of
+# widgets in one render — enough to overwhelm the embedded desktop webview and take
+# the app down (issue #140). Paginating bounds the payload regardless of size, and
+# every per-item list view shares this cap (issue #146).
+LIST_PAGE_SIZE = 50
 
 
 def _page_bounds(total: int, page: int, page_size: int) -> tuple[int, int, int, int]:
@@ -1742,6 +1743,110 @@ def _page_bounds(total: int, page: int, page_size: int) -> tuple[int, int, int, 
     page = min(max(int(page), 1), num_pages)
     start = (page - 1) * page_size
     return num_pages, page, start, min(start + page_size, total)
+
+
+def _paginate_rows(items: list, page_key: str, noun: str) -> list:
+    """Paginate a flat list of rows (no open/active state) at LIST_PAGE_SIZE.
+
+    Renders a page selector and a range caption when there is more than one
+    page, and returns the slice of ``items`` to render. ``page_key`` is the
+    session-state key backing the selector (unique per list). Used for the
+    Relations lists, which are plain rows rather than expandable cards.
+    """
+    total = len(items)
+    if total <= LIST_PAGE_SIZE:
+        return items
+    num_pages, page, _, _ = _page_bounds(
+        total, st.session_state.get(page_key, 1), LIST_PAGE_SIZE
+    )
+    st.session_state[page_key] = page  # clamp before the widget reads the key
+    page = st.number_input(
+        "Page",
+        min_value=1,
+        max_value=num_pages,
+        step=1,
+        key=page_key,
+        help=f"{total} {noun}; {LIST_PAGE_SIZE} shown per page.",
+    )
+    _, _, start, end = _page_bounds(total, page, LIST_PAGE_SIZE)
+    st.caption(f"Showing {noun} {start + 1}–{end} of {total}.")
+    return items[start:end]
+
+
+def _resolve_list_view(items, kind, key_of, page_key, noun):
+    """Shared logic for a per-item "view" list (classes, properties, ...).
+
+    Given the already sorted/filtered display list, this:
+
+      * picks the active (open) item, preferring the most recently opened one
+        over the first in list order, so a fresh click wins over a card left
+        open on another page (issue #143 review);
+      * enforces single-active by clearing every other item's view/edit flags;
+      * paginates at LIST_PAGE_SIZE with a page selector, jumping to the active
+        item's page once when it becomes active — not every render, so a manual
+        page change sticks while a card stays open (issues #140 / #146).
+
+    ``kind`` is the session-state flag segment (``view_{kind}_{key}`` /
+    ``edit_{kind}_{key}``) and also the ``_last_opened_entity`` tag set by the
+    open callbacks. ``key_of`` maps an item to its unique key string.
+
+    Returns ``(page_items, active_item)``.
+    """
+
+    def _is_active(it):
+        _k = key_of(it)
+        return st.session_state.get(f"view_{kind}_{_k}", False) or st.session_state.get(
+            f"edit_{kind}_{_k}", False
+        )
+
+    last = st.session_state.get("_last_opened_entity")
+    preferred = last[1] if isinstance(last, tuple) and last[0] == kind else None
+    active = None
+    if preferred is not None:
+        active = next(
+            (it for it in items if key_of(it) == preferred and _is_active(it)),
+            None,
+        )
+    if active is None:
+        active = next((it for it in items if _is_active(it)), None)
+
+    if active is not None:
+        _akey = key_of(active)
+        for it in items:
+            _k = key_of(it)
+            if _k != _akey:
+                st.session_state.pop(f"view_{kind}_{_k}", None)
+                st.session_state.pop(f"edit_{kind}_{_k}", None)
+
+    total = len(items)
+    if total <= LIST_PAGE_SIZE:
+        return items, active
+
+    jump_key = f"{page_key}__active_key"
+    if active is not None:
+        _akey = key_of(active)
+        if st.session_state.get(jump_key) != _akey:
+            st.session_state[page_key] = items.index(active) // LIST_PAGE_SIZE + 1
+            st.session_state[jump_key] = _akey
+    else:
+        # No card open: forget the last jump so reopening one jumps again.
+        st.session_state.pop(jump_key, None)
+
+    num_pages, page, _, _ = _page_bounds(
+        total, st.session_state.get(page_key, 1), LIST_PAGE_SIZE
+    )
+    st.session_state[page_key] = page  # clamp before the widget reads the key
+    page = st.number_input(
+        "Page",
+        min_value=1,
+        max_value=num_pages,
+        step=1,
+        key=page_key,
+        help=f"{total} {noun}; {LIST_PAGE_SIZE} shown per page.",
+    )
+    _, _, start, end = _page_bounds(total, page, LIST_PAGE_SIZE)
+    st.caption(f"Showing {noun} {start + 1}–{end} of {total}.")
+    return items[start:end], active
 
 
 def render_classes():
@@ -1785,84 +1890,15 @@ def render_classes():
                 ).lower(),
             )
 
-            def _is_active_cls(c):
-                _u = _uid(c["uri"])
-                return st.session_state.get(
-                    f"view_class_{_u}", False
-                ) or st.session_state.get(f"edit_class_{_u}", False)
-
-            # Prefer the most recently opened class, not just the first in sorted
-            # order. Otherwise a class left open (view/edit state still set) on an
-            # earlier page would win over one the user just clicked on a later
-            # page, and the single-active cleanup below would wipe the new click
-            # before it could render (issue #143 review).
-            _last_opened = st.session_state.get("_last_opened_entity")
-            _preferred_uid = (
-                _last_opened[1]
-                if isinstance(_last_opened, tuple) and _last_opened[0] == "class"
-                else None
+            # Single-active selection + pagination (issues #140 / #143 / #146).
+            # The full list stays available in the "All Classes" table below.
+            _page_classes, _ = _resolve_list_view(
+                sorted_classes,
+                "class",
+                lambda c: _uid(c["uri"]),
+                "cls_view_page",
+                "classes",
             )
-            _active_cls = None
-            if _preferred_uid is not None:
-                _active_cls = next(
-                    (
-                        c
-                        for c in sorted_classes
-                        if _uid(c["uri"]) == _preferred_uid and _is_active_cls(c)
-                    ),
-                    None,
-                )
-            if _active_cls is None:
-                _active_cls = next(
-                    (c for c in sorted_classes if _is_active_cls(c)), None
-                )
-            if _active_cls:
-                _active_uid = _uid(_active_cls["uri"])
-                for c in sorted_classes:
-                    c_uid = _uid(c["uri"])
-                    if c_uid != _active_uid:
-                        st.session_state.pop(f"view_class_{c_uid}", None)
-                        st.session_state.pop(f"edit_class_{c_uid}", None)
-
-            # Only render one page of class cards at a time (issue #140). The full
-            # list stays available in the "All Classes" table below.
-            _total = len(sorted_classes)
-            if _total > CLASSES_PER_PAGE:
-                # Jump to the page holding a class only when it *becomes* the
-                # active (viewed/edited) card, not on every render — otherwise the
-                # auto-jump fights a manual page change and pins the user to that
-                # page for as long as the card stays open. Tracking the last
-                # jumped-to UID makes it a one-shot per open.
-                if _active_cls is not None:
-                    _active_uid = _uid(_active_cls["uri"])
-                    if st.session_state.get("_cls_active_page_uid") != _active_uid:
-                        st.session_state["cls_view_page"] = (
-                            sorted_classes.index(_active_cls) // CLASSES_PER_PAGE + 1
-                        )
-                        st.session_state["_cls_active_page_uid"] = _active_uid
-                else:
-                    # No card open: forget the last jump so reopening one jumps again.
-                    st.session_state.pop("_cls_active_page_uid", None)
-                _num_pages, _page, _, _ = _page_bounds(
-                    _total, st.session_state.get("cls_view_page", 1), CLASSES_PER_PAGE
-                )
-                # Clamp back before the widget reads the key (e.g. a stale page
-                # left over after deletions) so number_input never sees an
-                # out-of-range value.
-                st.session_state["cls_view_page"] = _page
-                _page = st.number_input(
-                    "Class page",
-                    min_value=1,
-                    max_value=_num_pages,
-                    step=1,
-                    key="cls_view_page",
-                    help=f"{_total} classes; {CLASSES_PER_PAGE} shown per page.",
-                )
-                _, _, _start, _end = _page_bounds(_total, _page, CLASSES_PER_PAGE)
-                _page_classes = sorted_classes[_start:_end]
-                st.caption(f"Showing classes {_start + 1}–{_end} of {_total}.")
-            else:
-                _page_classes = sorted_classes
 
             for cls in _page_classes:
                 cls_uid = _uid(cls["uri"])
@@ -2369,22 +2405,13 @@ def render_properties():
             )
 
             op_collisions = _build_name_collision_set(object_props)
-            _active_op = next(
-                (
-                    p
-                    for p in filtered_obj_props
-                    if st.session_state.get(f"view_objprop_{_uid(p['uri'])}", False)
-                    or st.session_state.get(f"edit_objprop_{_uid(p['uri'])}", False)
-                ),
-                None,
+            filtered_obj_props, _ = _resolve_list_view(
+                filtered_obj_props,
+                "objprop",
+                lambda p: _uid(p["uri"]),
+                "objprop_view_page",
+                "properties",
             )
-            if _active_op:
-                _active_op_uid = _uid(_active_op["uri"])
-                for p in filtered_obj_props:
-                    p_uid = _uid(p["uri"])
-                    if p_uid != _active_op_uid:
-                        st.session_state.pop(f"view_objprop_{p_uid}", None)
-                        st.session_state.pop(f"edit_objprop_{p_uid}", None)
 
             for prop in filtered_obj_props:
                 prop_uid = _uid(prop["uri"])
@@ -2589,22 +2616,13 @@ def render_properties():
             datatypes = list(get_ontology_manager_class().XSD_DATATYPES.keys())
 
             dp_collisions = _build_name_collision_set(data_props)
-            _active_dp = next(
-                (
-                    p
-                    for p in filtered_data_props
-                    if st.session_state.get(f"view_dataprop_{_uid(p['uri'])}", False)
-                    or st.session_state.get(f"edit_dataprop_{_uid(p['uri'])}", False)
-                ),
-                None,
+            filtered_data_props, _ = _resolve_list_view(
+                filtered_data_props,
+                "dataprop",
+                lambda p: _uid(p["uri"]),
+                "dataprop_view_page",
+                "properties",
             )
-            if _active_dp:
-                _active_dp_uid = _uid(_active_dp["uri"])
-                for p in filtered_data_props:
-                    p_uid = _uid(p["uri"])
-                    if p_uid != _active_dp_uid:
-                        st.session_state.pop(f"view_dataprop_{p_uid}", None)
-                        st.session_state.pop(f"edit_dataprop_{p_uid}", None)
 
             for prop in filtered_data_props:
                 prop_uid = _uid(prop["uri"])
@@ -3130,24 +3148,17 @@ def render_individuals():
             # Use URI hash for unique widget keys (name may not be unique across namespaces)
             ind_collisions = _build_name_collision_set(individuals)
 
-            _active_ind = next(
-                (
-                    i
-                    for i in individuals
-                    if st.session_state.get(f"view_ind_{_uid(i['uri'])}", False)
-                    or st.session_state.get(f"edit_ind_{_uid(i['uri'])}", False)
-                ),
-                None,
+            # Master `individuals` list is reused elsewhere in this page, so keep
+            # it intact and iterate only the current page here.
+            _page_inds, _ = _resolve_list_view(
+                individuals,
+                "ind",
+                lambda i: _uid(i["uri"]),
+                "ind_view_page",
+                "individuals",
             )
-            if _active_ind:
-                _active_ind_uid = _uid(_active_ind["uri"])
-                for i in individuals:
-                    i_uid = _uid(i["uri"])
-                    if i_uid != _active_ind_uid:
-                        st.session_state.pop(f"view_ind_{i_uid}", None)
-                        st.session_state.pop(f"edit_ind_{i_uid}", None)
 
-            for ind in individuals:
+            for ind in _page_inds:
                 classes_str = (
                     ", ".join(ind["classes"]) if ind["classes"] else "No class"
                 )
@@ -3675,7 +3686,9 @@ def render_relations():
         class_relations = ont.get_class_relations()
         if class_relations:
             st.write("**Class Relations:**")
-            for rel in class_relations:
+            for rel in _paginate_rows(
+                class_relations, "rel_class_page", "class relations"
+            ):
                 subj_uri = rel.get("subject_uri", rel["subject"])
                 obj_uri = rel.get("object_uri", rel["object"])
                 rel_uid = _uid(f"{subj_uri}|{rel['relation']}|{obj_uri}")
@@ -3701,7 +3714,9 @@ def render_relations():
         prop_relations = ont.get_property_relations()
         if prop_relations:
             st.write("**Property Relations:**")
-            for rel in prop_relations:
+            for rel in _paginate_rows(
+                prop_relations, "rel_prop_page", "property relations"
+            ):
                 col1, col2, col3, col4 = st.columns([3, 2, 3, 1])
                 with col1:
                     st.write(f"🔗 {rel['subject']}")
@@ -3727,7 +3742,9 @@ def render_relations():
         ind_relations = ont.get_individual_relations()
         if ind_relations:
             st.write("**Individual Relations:**")
-            for rel in ind_relations:
+            for rel in _paginate_rows(
+                ind_relations, "rel_ind_page", "individual relations"
+            ):
                 col1, col2, col3, col4 = st.columns([3, 2, 3, 1])
                 with col1:
                     st.write(f"👤 {rel['subject']}")
@@ -4461,26 +4478,14 @@ def render_skos_vocabulary():
                 else ont.get_concepts(scheme=scheme_lookup.get(filter_scheme))
             )
 
-            # Collapse other concepts when one is active
             def _concept_key(c):
                 return str(abs(hash(c["uri"])))[:8]
 
-            _active_concept = next(
-                (
-                    c
-                    for c in filtered
-                    if st.session_state.get(f"view_skos_{_concept_key(c)}", False)
-                    or st.session_state.get(f"edit_skos_{_concept_key(c)}", False)
-                ),
-                None,
+            # Single-active selection + pagination, keyed by the concept's URI
+            # hash (local names may collide across schemes).
+            filtered, _ = _resolve_list_view(
+                filtered, "skos", _concept_key, "skos_view_page", "concepts"
             )
-            if _active_concept:
-                _active_ck = _concept_key(_active_concept)
-                for c in filtered:
-                    ck = _concept_key(c)
-                    if ck != _active_ck:
-                        st.session_state.pop(f"view_skos_{ck}", None)
-                        st.session_state.pop(f"edit_skos_{ck}", None)
 
             for concept in filtered:
                 pref = concept["prefLabel"] or concept["name"]

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1058,6 +1058,22 @@ def _cb_view_to_edit(prefix, uid):
     st.session_state["_last_opened_entity"] = (prefix, uid)
 
 
+def _mark_view_flag_open(view_flag: str) -> None:
+    """Open a card by its raw ``view_{kind}_{key}`` flag from a navigation path.
+
+    Search, graph-click, and "Open full editor" navigation set the view flag
+    directly rather than through the View/Edit callbacks, so they must also record
+    the entity as the most recently opened. Otherwise, if another card is already
+    open, the list view's single-active resolver prefers that stale card and
+    clears the freshly requested one (issue #146 review). The flag's ``kind``
+    segment never contains an underscore, so a 3-way split recovers (kind, key).
+    """
+    st.session_state[view_flag] = True
+    parts = view_flag.split("_", 2)
+    if len(parts) == 3 and parts[0] == "view":
+        st.session_state["_last_opened_entity"] = (parts[1], parts[2])
+
+
 def _cb_confirm_delete(key_suffix):
     """Callback: trigger delete confirmation."""
     st.session_state[f"confirm_delete_{key_suffix}"] = True
@@ -7054,8 +7070,7 @@ def render_visualization():
                             st.session_state["cls_active_tab"] = "Edit/Delete Class"
                             st.session_state["edit_class_select"] = _disp
                             st.rerun()
-                vk = _view_key_map[_ntype](_ename)
-                st.session_state[vk] = True
+                _mark_view_flag_open(_view_key_map[_ntype](_ename))
                 if _ntype == "SKOS Concept":
                     st.session_state["_skos_navigate_to_concept"] = True
                 st.rerun()
@@ -7330,7 +7345,7 @@ def main():
             st.session_state.search_navigate_to = _nav_page
             _vk = _view_key_map.get(_gv_type)
             if _vk:
-                st.session_state[_vk] = True
+                _mark_view_flag_open(_vk)
             if _gv_type == "SKOS Concept":
                 st.session_state["_skos_navigate_to_concept"] = True
         st.query_params.clear()
@@ -7448,7 +7463,7 @@ def main():
                         }
                         view_key = view_key_map.get(type_label)
                         if view_key:
-                            st.session_state[view_key] = True
+                            _mark_view_flag_open(view_key)
                         st.rerun()
         else:
             st.sidebar.caption("No results found.")

--- a/tests/test_classes_page_ui.py
+++ b/tests/test_classes_page_ui.py
@@ -33,7 +33,7 @@ def _script():
             uid = app._uid(classes[open_idx]["uri"])
             st.session_state[f"view_class_{uid}"] = True
             if os.environ.get("SET_TRACKER") == "1":
-                st.session_state["_cls_active_page_uid"] = uid
+                st.session_state["cls_view_page__active_key"] = uid
         if os.environ.get("SET_PAGE"):
             st.session_state["cls_view_page"] = int(os.environ["SET_PAGE"])
 
@@ -70,7 +70,7 @@ def test_opening_a_card_jumps_to_its_page_once():
     at = _run(open_idx=0, set_page=2, set_tracker=False)
     assert _shown_range(at) == "Showing classes 1–50 of 120."
     # And the jump is recorded so it won't fire again on later renders.
-    assert at.session_state["_cls_active_page_uid"]
+    assert at.session_state["cls_view_page__active_key"]
 
 
 def test_no_card_open_leaves_the_chosen_page_alone():
@@ -103,7 +103,7 @@ def _script_multi():
         )
         _tr = os.environ["TRACKER_IDX"]
         if _tr:
-            st.session_state["_cls_active_page_uid"] = app._uid(
+            st.session_state["cls_view_page__active_key"] = app._uid(
                 classes[int(_tr)]["uri"]
             )
         st.session_state["cls_view_page"] = int(os.environ["SET_PAGE"])
@@ -138,4 +138,4 @@ def test_clicking_a_class_on_a_later_page_wins_over_a_hidden_open_one():
     assert at.session_state[f"view_class_{uids[60]}"] is True
     _stale = f"view_class_{uids[0]}"
     assert _stale not in at.session_state or at.session_state[_stale] is False
-    assert at.session_state["_cls_active_page_uid"] == uids[60]
+    assert at.session_state["cls_view_page__active_key"] == uids[60]

--- a/tests/test_list_pagination_ui.py
+++ b/tests/test_list_pagination_ui.py
@@ -1,0 +1,88 @@
+"""Pagination coverage for the other per-item list views (issue #146).
+
+Classes are covered in test_classes_page_ui.py; these exercise the same shared
+helpers on the Individuals view (an expander list via _resolve_list_view) and the
+Relations view (plain rows via _paginate_rows). Each case is a single AppTest run
+seeded through the environment, since AppTest.from_function runs the script source
+in a fresh namespace.
+"""
+
+import os
+
+from streamlit.testing.v1 import AppTest
+
+
+def _ind_script():
+    import os
+
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Thing")
+        for i in range(120):  # 3 pages at 50 per page
+            om.add_individual(f"Ind{i:03d}", class_name="Thing")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        _p = os.environ.get("IND_PAGE")
+        if _p:
+            st.session_state["ind_view_page"] = int(_p)
+
+    app.render_individuals()
+
+
+def _rel_script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Thing")
+        om.add_individual("Hub", class_name="Thing")
+        for i in range(120):
+            om.add_individual(f"Ind{i:03d}", class_name="Thing")
+            om.add_individual_relation("Hub", "differentFrom", f"Ind{i:03d}")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    app.render_relations()
+
+
+def _shown(at, needle):
+    return next((c.value for c in at.caption if needle in c.value), None)
+
+
+def test_individuals_view_paginates():
+    os.environ.pop("IND_PAGE", None)
+    at = AppTest.from_function(_ind_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    assert _shown(at, "of 120") == "Showing individuals 1–50 of 120."
+    # Count the individual cards (each also nests a "Show Usages" expander).
+    cards = [e for e in at.expander if "👤" in e.label]
+    assert len(cards) == 50  # bounded, not 120
+
+
+def test_individuals_view_last_page_is_short_and_clamps():
+    os.environ["IND_PAGE"] = "99"  # out of range -> clamps to the last page
+    at = AppTest.from_function(_ind_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    assert _shown(at, "of 120") == "Showing individuals 101–120 of 120."
+    cards = [e for e in at.expander if "👤" in e.label]
+    assert len(cards) == 20
+
+
+def test_relations_view_paginates_rows():
+    at = AppTest.from_function(_rel_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    assert _shown(at, "of 120") == "Showing individual relations 1–50 of 120."
+    # Each relation row renders one delete button; the page bounds them to 50.
+    del_buttons = [b for b in at.button if b.key and b.key.startswith("del_irel_")]
+    assert len(del_buttons) == 50

--- a/tests/test_nav_mark_open.py
+++ b/tests/test_nav_mark_open.py
@@ -1,0 +1,31 @@
+"""Navigation-open marker records the last-opened entity (issue #146 review).
+
+Search, graph-click, and "Open full editor" navigation open a card by its raw
+view flag; they must also record _last_opened_entity so the list view's
+single-active resolver prefers the freshly requested card over one left open
+elsewhere.
+"""
+
+from orionbelt_ontology_builder import app
+
+
+def test_marks_flag_and_last_opened(monkeypatch):
+    fake: dict = {}
+    monkeypatch.setattr(app.st, "session_state", fake)
+
+    app._mark_view_flag_open("view_ind_abc123")
+    assert fake["view_ind_abc123"] is True
+    assert fake["_last_opened_entity"] == ("ind", "abc123")
+
+
+def test_skos_hash_key_and_underscored_uid_preserved(monkeypatch):
+    fake: dict = {}
+    monkeypatch.setattr(app.st, "session_state", fake)
+
+    app._mark_view_flag_open("view_skos_9f8e7d6c")
+    assert fake["_last_opened_entity"] == ("skos", "9f8e7d6c")
+
+    # A key that itself contains underscores stays intact (only kind is split off).
+    app._mark_view_flag_open("view_objprop_a_b_c")
+    assert fake["view_objprop_a_b_c"] is True
+    assert fake["_last_opened_entity"] == ("objprop", "a_b_c")


### PR DESCRIPTION
Closes #146.

## Background

#143 fixed the desktop crash on **View Classes** (a large ontology rendered thousands of widgets at once and took down the embedded webview) by paginating the class cards. The other list views share the exact same pattern and the same risk. This applies the fix everywhere.

## Changes

Two shared helpers replace the per-page copies:

- `_resolve_list_view(items, kind, key_of, page_key, noun)` — the card-list logic from #143/#146-review in one place: single-active selection with the last-opened preference, single-active cleanup, and pagination with a one-shot page jump. Used by **classes, object properties, data properties, individuals, and SKOS concepts**.
- `_paginate_rows(items, page_key, noun)` — pagination for plain row lists with no open/active state. Used by the three **Relations** lists (class, property, individual relations).

`render_classes` is refactored onto `_resolve_list_view`, so every card view now shares one implementation (and the existing `test_classes_page_ui.py` coverage validates the extracted helper). `CLASSES_PER_PAGE` is renamed to `LIST_PAGE_SIZE` since it is now shared.

Each paginated list keeps its full contents available in the accompanying table (where one exists) and shows a page selector plus a range caption only when it exceeds one page (50 items).

## Verification

- New `tests/test_list_pagination_ui.py`: renders the real `render_individuals` and `render_relations` via `AppTest` against 120-item datasets and asserts the page is bounded (50 cards / 50 delete buttons), the range caption is correct, and an out-of-range page clamps to the short last page.
- `test_classes_page_ui.py` / `test_pagination.py` still pass against the refactored helper (jump-tracker key renamed accordingly).
- Full suite: 491 passed. `ruff@0.15.19` format and check clean; `mypy` clean.

## Notes

- Object and data properties keep their existing domain-filter caption; the pagination caption is additional.
- The underlying single-active flag model is unchanged here; simplifying it to one active-entity value is tracked separately in #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)