### PR TITLE
chore: bump version to 1.16.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.16.6` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.16.7` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -14,7 +14,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.16.6"
+APP_VERSION = "1.16.7"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.16.6"
+version = "1.16.7"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.16.6"
+version = "1.16.7"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Release 1.16.7.

Includes since 1.16.6:
- fix(desktop): paginate View Classes so large ontologies don't crash the app (#143)
- fix(autosave): make the pending-save caption honest instead of a stuck "Autosaving..." (#149)
- fix(desktop): paginate the other list views: properties, individuals, relations, SKOS (#150, closes #146)

Version bumped in `pyproject.toml`, `orionbelt_ontology_builder/app.py` (`APP_VERSION`), `README.md`, and the `uv.lock` package entry. Grepped the repo: no `1.16.6` references remain. `uv lock --check` passes; full suite 493 passed; `ruff@0.15.19` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)