### PR TITLE
refactor: model the open list card as a single active-entity value

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1037,41 +1037,77 @@ def _disambiguated_name(item: dict, collisions: set) -> str:
     return name
 
 
+# Which card is open on a per-item list page is a single source of truth:
+# ``active_{kind}`` holds ``(key, mode)`` where ``mode`` is ``"view"`` or
+# ``"edit"`` (absent means nothing is open). One value per kind means opening a
+# card overwrites any previously open one, so single-active is inherent — no
+# per-item boolean flags to scan or clean up. ``kind`` is the page's flag
+# segment: ``class``, ``objprop``, ``dataprop``, ``ind``, ``skos``, ``scheme``.
+
+
 def _cb_toggle_view(prefix, uid):
-    """Callback: open view panel, close edit. `uid` must be unique per resource."""
-    st.session_state[f"view_{prefix}_{uid}"] = True
-    st.session_state[f"edit_{prefix}_{uid}"] = False
-    st.session_state["_last_opened_entity"] = (prefix, uid)
+    """Callback: open `uid`'s view panel. `uid` must be unique per resource."""
+    st.session_state[f"active_{prefix}"] = (uid, "view")
 
 
 def _cb_toggle_edit(prefix, uid):
-    """Callback: open edit panel, close view. `uid` must be unique per resource."""
-    st.session_state[f"edit_{prefix}_{uid}"] = True
-    st.session_state[f"view_{prefix}_{uid}"] = False
-    st.session_state["_last_opened_entity"] = (prefix, uid)
+    """Callback: open `uid`'s edit panel. `uid` must be unique per resource."""
+    st.session_state[f"active_{prefix}"] = (uid, "edit")
 
 
 def _cb_view_to_edit(prefix, uid):
-    """Callback: switch from view to edit. `uid` must be unique per resource."""
-    st.session_state[f"view_{prefix}_{uid}"] = False
-    st.session_state[f"edit_{prefix}_{uid}"] = True
-    st.session_state["_last_opened_entity"] = (prefix, uid)
+    """Callback: switch `uid`'s open card from view to edit."""
+    st.session_state[f"active_{prefix}"] = (uid, "edit")
 
 
-def _mark_view_flag_open(view_flag: str) -> None:
-    """Open a card by its raw ``view_{kind}_{key}`` flag from a navigation path.
-
-    Search, graph-click, and "Open full editor" navigation set the view flag
-    directly rather than through the View/Edit callbacks, so they must also record
-    the entity as the most recently opened. Otherwise, if another card is already
-    open, the list view's single-active resolver prefers that stale card and
-    clears the freshly requested one (issue #146 review). The flag's ``kind``
-    segment never contains an underscore, so a 3-way split recovers (kind, key).
+def _open_entity(kind: str, key: str, mode: str = "view") -> None:
+    """Open a card from a navigation path (search, graph-click, "Open full
+    editor"). These open a card directly rather than through the View/Edit
+    button callbacks. Because there is a single ``active_{kind}`` value, the
+    freshly requested card always wins — no card left open elsewhere can shadow
+    it (issue #146 review).
     """
-    st.session_state[view_flag] = True
-    parts = view_flag.split("_", 2)
-    if len(parts) == 3 and parts[0] == "view":
-        st.session_state["_last_opened_entity"] = (parts[1], parts[2])
+    st.session_state[f"active_{kind}"] = (key, mode)
+
+
+def _get_active(kind: str):
+    """Return ``(key, mode)`` for the open card of ``kind``, or ``None``."""
+    value = st.session_state.get(f"active_{kind}")
+    if isinstance(value, tuple) and len(value) == 2 and value[1] in ("view", "edit"):
+        return value
+    return None
+
+
+def _is_open(kind: str, key: str, mode: str | None = None) -> bool:
+    """True if ``key`` is the open card for ``kind`` (in ``mode`` if given)."""
+    active = _get_active(kind)
+    if active is None or active[0] != key:
+        return False
+    return mode is None or active[1] == mode
+
+
+# Maps a graph/search/editor entity's display type to its active-card kind.
+_NAV_KIND_BY_TYPE = {
+    "Class": "class",
+    "Object Property": "objprop",
+    "Data Property": "dataprop",
+    "Individual": "ind",
+    "SKOS Concept": "skos",
+}
+
+
+def _nav_open_entity(display_type: str, uid: str, uri: str | None = None) -> None:
+    """Open the card for a navigation target (graph-click, search, "Open full
+    editor") named by its display type. SKOS concepts key by URI hash — local
+    names collide across schemes — so pass ``uri`` for them; every other kind
+    keys by ``uid`` (already URI-derived at the call sites). No-op for unknown
+    types.
+    """
+    kind = _NAV_KIND_BY_TYPE.get(display_type)
+    if not kind:
+        return
+    key = str(abs(hash(uri if uri is not None else uid)))[:8] if kind == "skos" else uid
+    _open_entity(kind, key)
 
 
 def _cb_confirm_delete(key_suffix):
@@ -1794,45 +1830,26 @@ def _resolve_list_view(items, kind, key_of, page_key, noun):
 
     Given the already sorted/filtered display list, this:
 
-      * picks the active (open) item, preferring the most recently opened one
-        over the first in list order, so a fresh click wins over a card left
-        open on another page (issue #143 review);
-      * enforces single-active by clearing every other item's view/edit flags;
+      * reads the open item directly from the single ``active_{kind}`` value —
+        no scan over per-item flags, no cleanup loop, since only one card can be
+        open per kind by construction (issue #147);
       * paginates at LIST_PAGE_SIZE with a page selector, jumping to the active
         item's page once when it becomes active — not every render, so a manual
-        page change sticks while a card stays open (issues #140 / #146).
+        page change sticks while a card stays open (issues #140 / #143 / #146).
 
-    ``kind`` is the session-state flag segment (``view_{kind}_{key}`` /
-    ``edit_{kind}_{key}``) and also the ``_last_opened_entity`` tag set by the
-    open callbacks. ``key_of`` maps an item to its unique key string.
+    ``kind`` is the active-value segment (``active_{kind}`` holds
+    ``(key, mode)``) and ``key_of`` maps an item to its unique key string. An
+    open item that is not in ``items`` (e.g. filtered out by search) simply
+    reads as "nothing open" this render, leaving the value intact so the card
+    reappears when the filter clears.
 
     Returns ``(page_items, active_item)``.
     """
 
-    def _is_active(it):
-        _k = key_of(it)
-        return st.session_state.get(f"view_{kind}_{_k}", False) or st.session_state.get(
-            f"edit_{kind}_{_k}", False
-        )
-
-    last = st.session_state.get("_last_opened_entity")
-    preferred = last[1] if isinstance(last, tuple) and last[0] == kind else None
+    active_state = _get_active(kind)
     active = None
-    if preferred is not None:
-        active = next(
-            (it for it in items if key_of(it) == preferred and _is_active(it)),
-            None,
-        )
-    if active is None:
-        active = next((it for it in items if _is_active(it)), None)
-
-    if active is not None:
-        _akey = key_of(active)
-        for it in items:
-            _k = key_of(it)
-            if _k != _akey:
-                st.session_state.pop(f"view_{kind}_{_k}", None)
-                st.session_state.pop(f"edit_{kind}_{_k}", None)
+    if active_state is not None:
+        active = next((it for it in items if key_of(it) == active_state[0]), None)
 
     total = len(items)
     if total <= LIST_PAGE_SIZE:
@@ -1985,9 +2002,7 @@ def render_classes():
                 cls_uid = _uid(cls["uri"])
                 disp_name = _disambiguated_name(cls, collisions)
                 display_name = format_label_name(disp_name, cls.get("label"))
-                _cls_expanded = st.session_state.get(
-                    f"view_class_{cls_uid}", False
-                ) or st.session_state.get(f"edit_class_{cls_uid}", False)
+                _cls_expanded = _is_open("class", cls_uid)
                 with st.expander(f"📦 **{display_name}**", expanded=_cls_expanded):
                     st.write(
                         f"**URI:** `{cls['uri']}`"
@@ -2022,7 +2037,7 @@ def render_classes():
                         )
 
                     # View details
-                    if st.session_state.get(f"view_class_{cls_uid}", False):
+                    if _is_open("class", cls_uid, "view"):
                         st.divider()
                         st.write(f"**Name:** {cls['name']}")
                         st.write(f"**Label:** {cls['label'] or '—'}")
@@ -2046,7 +2061,7 @@ def render_classes():
                         st.rerun()
 
                     # Inline edit form
-                    if st.session_state.get(f"edit_class_{cls_uid}", False):
+                    if _is_open("class", cls_uid, "edit"):
                         st.divider()
                         with st.form(f"edit_class_form_{cls_uid}"):
                             new_name = st.text_input(
@@ -2116,7 +2131,7 @@ def render_classes():
                                     else None,
                                 )
                                 save_checkpoint("Update class")
-                                st.session_state[f"edit_class_{cls_uid}"] = False
+                                st.session_state.pop("active_class", None)
                                 show_message("Class updated!", "success")
                                 st.rerun()
 
@@ -2497,9 +2512,7 @@ def render_properties():
             for prop in filtered_obj_props:
                 prop_uid = _uid(prop["uri"])
                 disp_name = _disambiguated_name(prop, op_collisions)
-                _op_expanded = st.session_state.get(
-                    f"view_objprop_{prop_uid}", False
-                ) or st.session_state.get(f"edit_objprop_{prop_uid}", False)
+                _op_expanded = _is_open("objprop", prop_uid)
                 with st.expander(
                     f"🔗 **{disp_name}** ({prop['domain'] or '?'} → {prop['range'] or '?'})",
                     expanded=_op_expanded,
@@ -2537,7 +2550,7 @@ def render_properties():
                         )
 
                     # View details
-                    if st.session_state.get(f"view_objprop_{prop_uid}", False):
+                    if _is_open("objprop", prop_uid, "view"):
                         st.divider()
                         st.write(f"**Name:** {prop['name']}")
                         st.write(f"**Label:** {prop['label'] or '—'}")
@@ -2562,7 +2575,7 @@ def render_properties():
                         st.rerun()
 
                     # Inline edit form
-                    if st.session_state.get(f"edit_objprop_{prop_uid}", False):
+                    if _is_open("objprop", prop_uid, "edit"):
                         st.divider()
                         with st.form(f"edit_objprop_form_{prop_uid}"):
                             new_name = st.text_input(
@@ -2666,7 +2679,7 @@ def render_properties():
                                     new_range=new_rng_uri,
                                 )
                                 save_checkpoint("Update property")
-                                st.session_state[f"edit_objprop_{prop_uid}"] = False
+                                st.session_state.pop("active_objprop", None)
                                 show_message("Property updated!", "success")
                                 st.rerun()
 
@@ -2708,9 +2721,7 @@ def render_properties():
             for prop in filtered_data_props:
                 prop_uid = _uid(prop["uri"])
                 disp_name = _disambiguated_name(prop, dp_collisions)
-                _dp_expanded = st.session_state.get(
-                    f"view_dataprop_{prop_uid}", False
-                ) or st.session_state.get(f"edit_dataprop_{prop_uid}", False)
+                _dp_expanded = _is_open("dataprop", prop_uid)
                 with st.expander(
                     f"📝 **{disp_name}** ({prop['domain'] or '?'} → {prop['range']})",
                     expanded=_dp_expanded,
@@ -2748,7 +2759,7 @@ def render_properties():
                         )
 
                     # View details
-                    if st.session_state.get(f"view_dataprop_{prop_uid}", False):
+                    if _is_open("dataprop", prop_uid, "view"):
                         st.divider()
                         st.write(f"**Name:** {prop['name']}")
                         st.write(f"**Label:** {prop['label'] or '—'}")
@@ -2772,7 +2783,7 @@ def render_properties():
                         st.rerun()
 
                     # Inline edit form
-                    if st.session_state.get(f"edit_dataprop_{prop_uid}", False):
+                    if _is_open("dataprop", prop_uid, "edit"):
                         st.divider()
                         with st.form(f"edit_dataprop_form_{prop_uid}"):
                             new_name = st.text_input(
@@ -2872,7 +2883,7 @@ def render_properties():
                                     new_range=new_range,
                                 )
                                 save_checkpoint("Update property")
-                                st.session_state[f"edit_dataprop_{prop_uid}"] = False
+                                st.session_state.pop("active_dataprop", None)
                                 show_message("Property updated!", "success")
                                 st.rerun()
 
@@ -3245,9 +3256,7 @@ def render_individuals():
                 )
                 _ik = _uid(ind["uri"])
                 disp_ind_name = _disambiguated_name(ind, ind_collisions)
-                _ind_expanded = st.session_state.get(
-                    f"view_ind_{_ik}", False
-                ) or st.session_state.get(f"edit_ind_{_ik}", False)
+                _ind_expanded = _is_open("ind", _ik)
                 with st.expander(
                     f"👤 **{disp_ind_name}** ({classes_str})", expanded=_ind_expanded
                 ):
@@ -3284,7 +3293,7 @@ def render_individuals():
                         )
 
                     # View details
-                    if st.session_state.get(f"view_ind_{_ik}", False):
+                    if _is_open("ind", _ik, "view"):
                         st.divider()
                         st.write(f"**Name:** {ind['name']}")
                         st.write(f"**Label:** {ind['label'] or '—'}")
@@ -3328,7 +3337,7 @@ def render_individuals():
                             st.caption("No usages found.")
 
                     # Inline edit form
-                    if st.session_state.get(f"edit_ind_{_ik}", False):
+                    if _is_open("ind", _ik, "edit"):
                         st.divider()
                         with st.form(f"edit_ind_form_{_ik}"):
                             new_name = st.text_input(
@@ -3415,7 +3424,7 @@ def render_individuals():
                                     else None,
                                 )
                                 save_checkpoint("Update individual")
-                                st.session_state[f"edit_ind_{_ik}"] = False
+                                st.session_state.pop("active_ind", None)
                                 show_message("Individual updated!", "success")
                                 st.rerun()
 
@@ -4440,9 +4449,7 @@ def render_skos_vocabulary():
                 # another, which would collide Streamlit widget keys and make
                 # local-name-based actions ambiguous (issue #87 part B).
                 _sk = str(abs(hash(scheme["uri"])))[:8]
-                _scheme_expanded = st.session_state.get(
-                    f"view_scheme_{_sk}", False
-                ) or st.session_state.get(f"edit_scheme_{_sk}", False)
+                _scheme_expanded = _is_open("scheme", _sk)
                 with st.expander(
                     f"📚 **{display_name}** ({scheme['concept_count']} concepts)",
                     expanded=_scheme_expanded,
@@ -4479,7 +4486,7 @@ def render_skos_vocabulary():
                             args=(f"scheme_{_sk}",),
                         )
 
-                    if st.session_state.get(f"view_scheme_{_sk}", False):
+                    if _is_open("scheme", _sk, "view"):
                         st.divider()
                         st.write(f"**Name:** {scheme['name']}")
                         st.write(f"**Label:** {scheme['label'] or '—'}")
@@ -4494,7 +4501,7 @@ def render_skos_vocabulary():
                         )
                         st.rerun()
 
-                    if st.session_state.get(f"edit_scheme_{_sk}", False):
+                    if _is_open("scheme", _sk, "edit"):
                         st.divider()
                         with st.form(f"edit_scheme_form_{_sk}"):
                             new_name = st.text_input(
@@ -4548,9 +4555,8 @@ def render_skos_vocabulary():
                                         new_comment=new_comment,
                                     )
                                     save_checkpoint("Update concept scheme")
-                                    st.session_state[f"edit_scheme_{_sk}"] = False
                                     _new_sk = str(abs(hash(target)))[:8]
-                                    st.session_state[f"view_scheme_{_new_sk}"] = True
+                                    _open_entity("scheme", _new_sk)
                                     show_message(
                                         f"Scheme '{scheme['name']}' updated!", "success"
                                     )
@@ -4619,12 +4625,8 @@ def render_skos_vocabulary():
 
                 # Use URI hash for unique widget keys (local name may not be unique)
                 _ck = str(abs(hash(concept["uri"])))[:8]
-                _sk = f"view_skos_{_ck}"
-                _ek = f"edit_skos_{_ck}"
 
-                _skos_expanded = st.session_state.get(
-                    _sk, False
-                ) or st.session_state.get(_ek, False)
+                _skos_expanded = _is_open("skos", _ck)
                 with st.expander(
                     f"🏷️ **{display_name}**{badge_str}", expanded=_skos_expanded
                 ):
@@ -4661,7 +4663,7 @@ def render_skos_vocabulary():
                         )
 
                     # View details
-                    if st.session_state.get(_sk, False):
+                    if _is_open("skos", _ck, "view"):
                         st.divider()
                         st.write(f"**Name:** {concept['name']}")
                         st.write(f"**prefLabel:** {concept['prefLabel'] or '—'}")
@@ -4725,7 +4727,7 @@ def render_skos_vocabulary():
                         st.rerun()
 
                     # Inline edit form
-                    if st.session_state.get(_ek, False):
+                    if _is_open("skos", _ck, "edit"):
                         st.divider()
                         with st.form(f"edit_concept_form_{_ck}"):
                             new_name = st.text_input(
@@ -4860,12 +4862,10 @@ def render_skos_vocabulary():
                                         _update_kwargs["new_broader"] = broader_val
                                     ont.update_concept(target, **_update_kwargs)
                                     save_checkpoint("Update concept")
-                                    st.session_state[_ek] = False
-                                    if renamed:
-                                        _new_ck = str(abs(hash(target)))[:8]
-                                        st.session_state[f"view_skos_{_new_ck}"] = True
-                                    else:
-                                        st.session_state[_sk] = True
+                                    _new_ck = (
+                                        str(abs(hash(target)))[:8] if renamed else _ck
+                                    )
+                                    _open_entity("skos", _new_ck)
                                     show_message(
                                         f"Concept '{target}' updated!", "success"
                                     )
@@ -7137,14 +7137,6 @@ def render_visualization():
                 "Individual": "Individuals",
                 "SKOS Concept": "SKOS Vocabulary",
             }
-            _view_key_map = {
-                "Class": lambda n: f"view_class_{n}",
-                "Object Property": lambda n: f"view_objprop_{n}",
-                "Data Property": lambda n: f"view_dataprop_{n}",
-                "Individual": lambda n: f"view_ind_{n}",
-                "SKOS Concept": lambda n: f"view_skos_{str(abs(hash(n)))[:8]}",
-            }
-
             # The selection was already captured (from the component's current
             # value) before the component call above, so just read it here.
             _sel = st.session_state.get("_viz_last_selection")
@@ -7172,7 +7164,7 @@ def render_visualization():
                             st.session_state["cls_active_tab"] = "Edit/Delete Class"
                             st.session_state["edit_class_select"] = _disp
                             st.rerun()
-                _mark_view_flag_open(_view_key_map[_ntype](_ename))
+                _nav_open_entity(_ntype, _ename)
                 if _ntype == "SKOS Concept":
                     st.session_state["_skos_navigate_to_concept"] = True
                 st.rerun()
@@ -7435,19 +7427,10 @@ def main():
             "Individual": "Individuals",
             "SKOS Concept": "SKOS Vocabulary",
         }
-        _view_key_map = {
-            "Class": f"view_class_{_gv_name}",
-            "Object Property": f"view_objprop_{_gv_name}",
-            "Data Property": f"view_dataprop_{_gv_name}",
-            "Individual": f"view_ind_{_gv_name}",
-            "SKOS Concept": f"view_skos_{str(abs(hash(_gv_name)))[:8]}",
-        }
         _nav_page = _type_to_page.get(_gv_type)
         if _nav_page:
             st.session_state.search_navigate_to = _nav_page
-            _vk = _view_key_map.get(_gv_type)
-            if _vk:
-                _mark_view_flag_open(_vk)
+            _nav_open_entity(_gv_type, _gv_name)
             if _gv_type == "SKOS Concept":
                 st.session_state["_skos_navigate_to_concept"] = True
         st.query_params.clear()
@@ -7556,16 +7539,7 @@ def main():
                         # Open the view pane keyed by URI hash so we navigate
                         # to the *exact* resource, not whichever shares the
                         # same local name.
-                        view_key_map = {
-                            "Class": f"view_class_{r_uid}",
-                            "Object Property": f"view_objprop_{r_uid}",
-                            "Data Property": f"view_dataprop_{r_uid}",
-                            "Individual": f"view_ind_{r_uid}",
-                            "SKOS Concept": f"view_skos_{str(abs(hash(r_uri)))[:8]}",
-                        }
-                        view_key = view_key_map.get(type_label)
-                        if view_key:
-                            _mark_view_flag_open(view_key)
+                        _nav_open_entity(type_label, r_uid, r_uri)
                         st.rerun()
         else:
             st.sidebar.caption("No results found.")

--- a/tests/test_classes_page_ui.py
+++ b/tests/test_classes_page_ui.py
@@ -5,6 +5,10 @@ session-state interplay between the auto-jump and the manual page selector is
 exercised end to end. Each case is a single run (no widget-interaction rerun),
 seeded through the environment because ``AppTest.from_function`` executes the
 script source in a fresh namespace without the test's closures.
+
+Since issue #147 the open card is a single ``active_class`` value holding
+``(uid, mode)`` rather than a per-item ``view_class_``/``edit_class_`` flag pair,
+so the seeds set that value directly.
 """
 
 import os
@@ -31,7 +35,7 @@ def _script():
         open_idx = int(os.environ["OPEN_IDX"])
         if open_idx >= 0:
             uid = app._uid(classes[open_idx]["uri"])
-            st.session_state[f"view_class_{uid}"] = True
+            st.session_state["active_class"] = (uid, "view")
             if os.environ.get("SET_TRACKER") == "1":
                 st.session_state["cls_view_page__active_key"] = uid
         if os.environ.get("SET_PAGE"):
@@ -78,7 +82,7 @@ def test_no_card_open_leaves_the_chosen_page_alone():
     assert _shown_range(at) == "Showing classes 101–120 of 120."
 
 
-def _script_multi():
+def _script_active():
     import os
 
     import streamlit as st
@@ -94,13 +98,12 @@ def _script_multi():
         st.session_state["_autosave_restored"] = True
 
         classes = om.get_classes()
-        for idx in os.environ["OPEN_IDXS"].split(","):
-            st.session_state[f"view_class_{app._uid(classes[int(idx)]['uri'])}"] = True
-        _lo = int(os.environ["LAST_OPENED_IDX"])
-        st.session_state["_last_opened_entity"] = (
-            "class",
-            app._uid(classes[_lo]["uri"]),
-        )
+        # The single active card is the source of truth: in the old per-flag
+        # model two view_class_ flags could be set at once and a sorted-order
+        # scan (plus a _last_opened_entity shim) picked the winner. Now the one
+        # value cannot be shadowed by a card left open elsewhere.
+        active_uid = app._uid(classes[int(os.environ["ACTIVE_IDX"])]["uri"])
+        st.session_state["active_class"] = (active_uid, "view")
         _tr = os.environ["TRACKER_IDX"]
         if _tr:
             st.session_state["cls_view_page__active_key"] = app._uid(
@@ -121,21 +124,18 @@ def _class_uids(n=120):
     return [app._uid(c["uri"]) for c in om.get_classes()]
 
 
-def test_clicking_a_class_on_a_later_page_wins_over_a_hidden_open_one():
-    # A class opened on page 1 is still flagged (hidden) while the user is on
-    # page 2 and clicks View on a class there. The just-clicked class must win:
-    # it stays open, the stale one is cleared, and the page follows the new card.
+def test_active_card_pulls_the_page_to_it_over_a_stale_tracker():
+    # The active card is class 60 (page 2) while the user sits on page 1 and the
+    # jump tracker still points at a page-1 card. The render must follow the
+    # active card to its page and refresh the tracker to match.
     uids = _class_uids()
-    os.environ["OPEN_IDXS"] = "0,60"  # class 0 (page 1, hidden) + class 60 (page 2)
-    os.environ["LAST_OPENED_IDX"] = "60"
-    os.environ["TRACKER_IDX"] = "0"  # previously jumped to class 0
-    os.environ["SET_PAGE"] = "2"
-    at = AppTest.from_function(_script_multi)
+    os.environ["ACTIVE_IDX"] = "60"  # open card lives on page 2
+    os.environ["TRACKER_IDX"] = "0"  # tracker still points at a page-1 card
+    os.environ["SET_PAGE"] = "1"
+    at = AppTest.from_function(_script_active)
     at.run(timeout=120)
     assert not at.exception, at.exception
 
     assert _shown_range(at) == "Showing classes 51–100 of 120."
-    assert at.session_state[f"view_class_{uids[60]}"] is True
-    _stale = f"view_class_{uids[0]}"
-    assert _stale not in at.session_state or at.session_state[_stale] is False
+    assert at.session_state["active_class"] == (uids[60], "view")
     assert at.session_state["cls_view_page__active_key"] == uids[60]

--- a/tests/test_nav_mark_open.py
+++ b/tests/test_nav_mark_open.py
@@ -1,31 +1,74 @@
-"""Navigation-open marker records the last-opened entity (issue #146 review).
+"""Navigation-open helpers set the single active-card value (issue #147).
 
-Search, graph-click, and "Open full editor" navigation open a card by its raw
-view flag; they must also record _last_opened_entity so the list view's
-single-active resolver prefers the freshly requested card over one left open
-elsewhere.
+Search, graph-click, and "Open full editor" navigation open a card directly
+rather than through the View/Edit button callbacks. Since issue #147 that means
+writing the one ``active_{kind}`` value, so the freshly requested card always
+wins over one left open elsewhere (no per-item flag to shadow it).
 """
 
 from orionbelt_ontology_builder import app
 
 
-def test_marks_flag_and_last_opened(monkeypatch):
+def test_open_entity_sets_active_value(monkeypatch):
     fake: dict = {}
     monkeypatch.setattr(app.st, "session_state", fake)
 
-    app._mark_view_flag_open("view_ind_abc123")
-    assert fake["view_ind_abc123"] is True
-    assert fake["_last_opened_entity"] == ("ind", "abc123")
+    app._open_entity("ind", "abc123")
+    assert fake["active_ind"] == ("abc123", "view")
+    assert app._get_active("ind") == ("abc123", "view")
+    assert app._is_open("ind", "abc123")
+    assert app._is_open("ind", "abc123", "view")
+    assert not app._is_open("ind", "abc123", "edit")
+    assert not app._is_open("ind", "other")
 
 
-def test_skos_hash_key_and_underscored_uid_preserved(monkeypatch):
+def test_open_entity_overwrites_any_prior_open_card(monkeypatch):
+    fake: dict = {"active_ind": ("stale", "edit")}
+    monkeypatch.setattr(app.st, "session_state", fake)
+
+    app._open_entity("ind", "fresh")
+    # One value, so the fresh request fully replaces the stale one.
+    assert fake["active_ind"] == ("fresh", "view")
+    assert app._get_active("ind") == ("fresh", "view")
+
+
+def test_nav_open_entity_maps_display_type_to_kind(monkeypatch):
     fake: dict = {}
     monkeypatch.setattr(app.st, "session_state", fake)
 
-    app._mark_view_flag_open("view_skos_9f8e7d6c")
-    assert fake["_last_opened_entity"] == ("skos", "9f8e7d6c")
+    app._nav_open_entity("Individual", "abc123")
+    assert fake["active_ind"] == ("abc123", "view")
 
-    # A key that itself contains underscores stays intact (only kind is split off).
-    app._mark_view_flag_open("view_objprop_a_b_c")
-    assert fake["view_objprop_a_b_c"] is True
-    assert fake["_last_opened_entity"] == ("objprop", "a_b_c")
+    # A uid that itself contains underscores stays intact.
+    app._nav_open_entity("Object Property", "a_b_c")
+    assert fake["active_objprop"] == ("a_b_c", "view")
+
+
+def test_nav_open_entity_skos_keys_by_uri_hash(monkeypatch):
+    fake: dict = {}
+    monkeypatch.setattr(app.st, "session_state", fake)
+
+    uri = "http://example.org/concepts/Dog"
+    expected = str(abs(hash(uri)))[:8]
+    app._nav_open_entity("SKOS Concept", "unused_uid", uri)
+    assert fake["active_skos"] == (expected, "view")
+
+
+def test_nav_open_entity_ignores_unknown_type(monkeypatch):
+    fake: dict = {}
+    monkeypatch.setattr(app.st, "session_state", fake)
+
+    app._nav_open_entity("Restriction", "abc123")
+    assert fake == {}
+
+
+def test_get_active_rejects_malformed_values(monkeypatch):
+    fake: dict = {"active_class": "not-a-tuple"}
+    monkeypatch.setattr(app.st, "session_state", fake)
+    assert app._get_active("class") is None
+
+    fake["active_class"] = ("uid", "bogus-mode")
+    assert app._get_active("class") is None
+
+    fake["active_class"] = ("uid", "edit")
+    assert app._get_active("class") == ("uid", "edit")


### PR DESCRIPTION
## Summary

Follow-up to #140 / #143 / #146. Replaces the per-item `view_<kind>_` / `edit_<kind>_` boolean session-state flags with a single `active_<kind>` value holding `(key, mode)`, where `mode` is `view` or `edit` (absent means nothing is open). Because there is one value per kind, "which card is open" becomes a single source of truth: opening a card overwrites any previously open one, so single-active is inherent rather than reconstructed.

Closes #147.

## What this removes

From `_resolve_list_view`:

- the sorted-order scan that reconstructed the active card,
- the cleanup loop that cleared every other item's flags,
- the `_last_opened_entity` preference shim added in the #143 / #146 reviews.

The pagination auto-jump (jump to the active card's page once, so a manual page change sticks while a card stays open) is preserved unchanged.

## Scope

All five per-item lists move to the new model:

- Classes
- Properties (object and data)
- Individuals
- SKOS Concepts
- SKOS Concept Schemes

The Schemes subsection previously never routed through `_resolve_list_view` and had no single-active enforcement (multiple scheme cards could be open at once). It now shares the same `active_scheme` value, so only one scheme card is open at a time. That is the one intentional behavior change, made deliberately to bring Schemes into the unified model as the issue invites.

The three external open paths each carried a duplicated five-entry `view_key_map`:

- the visualization panel's "Open full editor",
- graph-view query-param navigation,
- sidebar search navigation.

These collapse into one module-level `_NAV_KIND_BY_TYPE` map plus a shared `_nav_open_entity` helper, which preserves each site's exact key derivation (SKOS keys by URI hash; other kinds by their URI-derived uid).

## New helpers

`_open_entity`, `_get_active`, `_is_open`, `_nav_open_entity` replace `_mark_view_flag_open`. Net result is fewer lines in `app.py` despite the added helpers.

## Tests

- `test_classes_page_ui` and `test_nav_mark_open` rewritten against the new model.
- Added coverage for malformed `active_` values and the single-active overwrite guarantee.
- Full suite (510 tests) passes; `ruff` (pinned 0.15.22) format and lint clean; `mypy` reports no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)