### PR TITLE
feat: add extra parents to existing classes in bulk add

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -912,7 +912,10 @@ def _bulk_result_message(result: dict, label: str) -> tuple[str, str]:
         parts.append(f"Skipped {len(result['skipped'])} existing")
     errors = result["errors"]
     if errors:
-        parts.append(f"{len(errors)} could not be created")
+        # "row(s) failed" rather than "could not be created": a bulk class run
+        # can now fail while *updating* an existing class (e.g. adding an
+        # invalid parent), not only while creating one (issue #157 review).
+        parts.append(f"{len(errors)} row{'s' if len(errors) != 1 else ''} failed")
     summary = ". ".join(parts) if parts else "Nothing to create"
     if errors:
         shown = errors[:10]

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -906,6 +906,8 @@ def _bulk_result_message(result: dict, label: str) -> tuple[str, str]:
     parts = []
     if result["created"]:
         parts.append(f"Created {len(result['created'])} {label}")
+    if result.get("updated"):
+        parts.append(f"Updated {len(result['updated'])} existing")
     if result["skipped"]:
         parts.append(f"Skipped {len(result['skipped'])} existing")
     errors = result["errors"]
@@ -922,11 +924,12 @@ def _bulk_result_message(result: dict, label: str) -> tuple[str, str]:
         if len(errors) > len(shown):
             lines += f"\n- ...and {len(errors) - len(shown)} more"
         summary = f"{summary}:\n\n{lines}"
-    if errors and not result["created"]:
+    succeeded = result["created"] or result.get("updated")
+    if errors and not succeeded:
         msg_type = "error"
     elif errors:
         msg_type = "warning"
-    elif result["created"]:
+    elif succeeded:
         msg_type = "success"
     else:
         msg_type = "info"

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -909,9 +909,23 @@ class OntologyManager:
         full URI: a parent that another row actually creates (with its own
         label/comment) is left alone, but one whose explicit row is missing,
         skipped, or errors is still declared so no dangling parent remains.
-        Returns {created: [], errors: [], skipped: []}.
+
+        A row whose class already exists is not dropped outright: if it names a
+        parent the class does not yet have, that parent is added as an extra
+        ``rdfs:subClassOf`` (multiple inheritance) and the row is reported under
+        ``updated`` (issue #157). Two rows with the same name and different
+        parents therefore give the class both parents. An existing row with no
+        new parent to add stays in ``skipped``; label/comment on an existing
+        class are left untouched.
+
+        Returns {created: [], updated: [], errors: [], skipped: []}.
         """
-        result: Dict[str, Any] = {"created": [], "errors": [], "skipped": []}
+        result: Dict[str, Any] = {
+            "created": [],
+            "updated": [],
+            "errors": [],
+            "skipped": [],
+        }
         existing = {c["uri"] for c in self.get_classes()}
         referenced_parents: set[str] = set()
 
@@ -924,7 +938,25 @@ class OntologyManager:
             parent = entry.get("parent", "").strip() or None
             uri = str(self._uri(name, namespace))
             if uri in existing:
-                result["skipped"].append(name)
+                # Existing class: add a newly named parent as an extra
+                # subClassOf rather than silently dropping the whole row (#157).
+                # A row with no new parent to contribute is still a plain skip.
+                if not parent:
+                    result["skipped"].append(name)
+                    continue
+                try:
+                    self._require_valid_name(parent)
+                except Exception as e:
+                    result["errors"].append({"name": name, "error": str(e)})
+                    continue
+                class_ref = self._uri(name, namespace)
+                parent_ref = self._uri(parent)
+                if (class_ref, RDFS.subClassOf, parent_ref) in self.graph:
+                    result["skipped"].append(name)
+                else:
+                    self.graph.add((class_ref, RDFS.subClassOf, parent_ref))
+                    result["updated"].append(name)
+                    referenced_parents.add(str(parent_ref))
                 continue
             try:
                 self.add_class(

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -275,6 +275,73 @@ class TestBulkAddClasses:
         assert result["skipped"] == ["Dog"]
         assert result["created"] == []
 
+    def test_second_row_adds_extra_parent(self, om):
+        # Issue #157: two rows for the same class naming different parents give
+        # the class both parents instead of dropping the second row.
+        result = om.bulk_add_classes(
+            [
+                {"name": "TVCurrent", "parent": "Current"},
+                {"name": "TVCurrent", "parent": "TVQuantity"},
+            ]
+        )
+        # TVCurrent is created once (row 1) and updated once (row 2's parent);
+        # both referenced parents are backfilled as classes (issue #106).
+        assert result["created"].count("TVCurrent") == 1
+        assert result["updated"] == ["TVCurrent"]
+        assert {"Current", "TVQuantity"} <= set(result["created"])
+        parents = next(c for c in om.get_classes() if c["name"] == "TVCurrent")[
+            "parents"
+        ]
+        assert "Current" in parents
+        assert "TVQuantity" in parents
+
+    def test_existing_class_gains_new_parent(self, om_with_classes):
+        # Person already exists; a row giving it a parent adds the link and is
+        # reported as updated (not created, not silently skipped).
+        result = om_with_classes.bulk_add_classes(
+            [{"name": "Person", "parent": "Animal"}]
+        )
+        assert result["created"] == []
+        assert result["updated"] == ["Person"]
+        assert result["skipped"] == []
+        person = next(c for c in om_with_classes.get_classes() if c["name"] == "Person")
+        assert "Animal" in person["parents"]
+
+    def test_existing_parent_link_is_skipped_not_duplicated(self, om_with_classes):
+        om_with_classes.update_class("Person", new_parent="Animal")
+        result = om_with_classes.bulk_add_classes(
+            [{"name": "Person", "parent": "Animal"}]
+        )
+        assert result["updated"] == []
+        assert result["skipped"] == ["Person"]
+        person = next(c for c in om_with_classes.get_classes() if c["name"] == "Person")
+        assert person["parents"].count("Animal") == 1
+
+    def test_existing_class_without_parent_still_skipped(self, om_with_classes):
+        result = om_with_classes.bulk_add_classes([{"name": "Person"}])
+        assert result["created"] == []
+        assert result["updated"] == []
+        assert result["skipped"] == ["Person"]
+
+    def test_added_parent_to_existing_class_is_backfilled(self, om_with_classes):
+        # The new parent isn't a class yet, so it's declared as a bare owl:Class
+        # just like on the create path (issue #106).
+        result = om_with_classes.bulk_add_classes(
+            [{"name": "Person", "parent": "Organism"}]
+        )
+        assert result["updated"] == ["Person"]
+        assert "Organism" in result["created"]
+        assert "Organism" in {c["name"] for c in om_with_classes.get_classes()}
+        assert om_with_classes.graph.serialize(format="turtle")
+
+    def test_invalid_parent_on_existing_class_is_an_error(self, om_with_classes):
+        result = om_with_classes.bulk_add_classes(
+            [{"name": "Person", "parent": "Bad Parent"}]
+        )
+        assert result["updated"] == []
+        assert result["skipped"] == []
+        assert [e["name"] for e in result["errors"]] == ["Person"]
+
 
 class TestBulkAddProperties:
     def test_add_object_properties(self, om_with_classes):
@@ -465,3 +532,22 @@ class TestBulkResultMessage:
         }
         msg, _ = app._bulk_result_message(result, "class(es)")
         assert "...and 5 more" in msg
+
+    def test_message_counts_updated(self):
+        from orionbelt_ontology_builder import app
+
+        result = {"created": ["Dog"], "updated": ["Cat"], "skipped": [], "errors": []}
+        msg, mtype = app._bulk_result_message(result, "class(es)")
+        assert "Created 1 class(es)" in msg
+        assert "Updated 1 existing" in msg
+        assert mtype == "success"
+
+    def test_message_only_updated_is_success(self):
+        # A run that only added parents to existing classes still succeeded.
+        from orionbelt_ontology_builder import app
+
+        result = {"created": [], "updated": ["Cat"], "skipped": [], "errors": []}
+        msg, mtype = app._bulk_result_message(result, "class(es)")
+        assert "Updated 1 existing" in msg
+        assert "Nothing to create" not in msg
+        assert mtype == "success"

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -551,3 +551,33 @@ class TestBulkResultMessage:
         assert "Updated 1 existing" in msg
         assert "Nothing to create" not in msg
         assert mtype == "success"
+
+    def test_message_failure_wording_is_path_neutral(self):
+        # A failure can come from the update path (e.g. adding an invalid parent
+        # to an existing class), so the summary must not claim "could not be
+        # created" (issue #157 review).
+        from orionbelt_ontology_builder import app
+
+        result = {
+            "created": [],
+            "updated": [],
+            "skipped": [],
+            "errors": [{"name": "Person", "error": "invalid parent"}],
+        }
+        msg, mtype = app._bulk_result_message(result, "class(es)")
+        assert "1 row failed" in msg
+        assert "could not be created" not in msg
+        assert mtype == "error"
+
+    def test_message_pluralizes_failed_rows(self):
+        from orionbelt_ontology_builder import app
+
+        result = {
+            "created": ["Dog"],
+            "updated": [],
+            "skipped": [],
+            "errors": [{"name": "a", "error": "x"}, {"name": "b", "error": "y"}],
+        }
+        msg, mtype = app._bulk_result_message(result, "class(es)")
+        assert "2 rows failed" in msg
+        assert mtype == "warning"


### PR DESCRIPTION
## Summary

Fixes #157. Bulk "Add Classes" previously skipped any row whose class already existed, even when the row named a parent the class did not yet have. Pasting two rows with the same name and different parents silently dropped the second `subClassOf` and reported the confusing "Skipped 1 existing".

Now, for an existing class, `bulk_add_classes` adds a newly named parent as an extra `rdfs:subClassOf` (multiple inheritance) and reports the row under a new `updated` key instead of skipping it.

Closes #157.

## Behavior

Pasting the issue's example:

```
Puppy,,Dog
Puppy,,Animal
```

- **Before:** "Created 1 class(es). Skipped 1 existing" — Puppy has only `Dog` as a parent.
- **After:** "Created 1 class(es). Updated 1 existing" — Puppy has both `Dog` and `Animal` as parents.

## Details

- **Idempotent:** a parent link already present stays a plain skip (no duplicate triple).
- **Validated:** an invalid parent name on an existing-class row is reported as an error, not silently applied.
- **Backfill:** a parent that is not yet a class is declared as a bare `owl:Class`, matching the create path (issue #106).
- **Non-destructive:** label and comment on an existing class are left untouched; only the parent link is added.
- `_bulk_result_message` gains an "Updated N existing" line and counts updates as success, so a run that only added parents no longer reads as "Nothing to create".

## Tests

`tests/test_bulk.py` adds 6 engine cases (two-rows-same-name, adding a parent to a pre-existing class, idempotent re-run, no-parent skip, parent backfill, invalid parent) and 2 message-builder cases.

Full suite (518) passes; ruff format and lint clean; mypy clean.

## Verification

Confirmed live via Playwright: pasted the two-row example in Classes -> Bulk Operations, saw "Created 1 class(es). Updated 1 existing", and Puppy's View pane shows "Parent Class: Dog, Animal".

🤖 Generated with [Claude Code](https://claude.com/claude-code)