### PR TITLE
feat: find and centre on an entity in the graph, with viz fixes

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6244,14 +6244,15 @@ def render_visualization():
         _find_id: str | None = None
         focus_seed_ids: list = []
         focus_depth = 0
-        _find_col, _filter_col = st.columns([1, 1])
+        _find_col, _filter_col = st.columns([1, 3])
         with _find_col:
             if focus_targets:
                 _find_choice = st.selectbox(
-                    "🔍 Find entity in graph",
+                    "Find entity in graph",
                     options=sorted(focus_targets),
                     index=None,
-                    placeholder="Find and centre on an entity…",
+                    placeholder="🔍 Find and centre on an entity…",
+                    label_visibility="collapsed",
                     key="viz_find_entity",
                     on_change=_viz_find_changed,
                     help="Jump to and highlight an entity so it's easy to spot "

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6053,6 +6053,14 @@ def render_visualization():
                 sel = st.session_state.get("_viz_cfg_selected_classes") or []
                 st.session_state["_viz_cfg_focus_seeds"] = [f"Class: {c}" for c in sel]
 
+        def _viz_find_changed():
+            """Bump a sequence so the graph re-centres on the picked entity only
+            when the Find selection changes — not on every rerun or drag, which
+            would keep yanking the camera back (issue #144)."""
+            st.session_state["_viz_find_seq"] = (
+                st.session_state.get("_viz_find_seq", 0) + 1
+            )
+
         _cols = (
             st.columns([1, 1, 1, 1, 1, 1, 1, 1])
             if _has_skos
@@ -6226,6 +6234,23 @@ def render_visualization():
         if show_skos and _has_skos:
             for concept in ont.get_concepts():
                 focus_targets[f"Concept: {concept['name']}"] = f"skos_{concept['name']}"
+
+        # Find & centre on a specific entity (issue #144). Independent of focus
+        # mode: picking an entity here selects and camera-centres it in the graph
+        # via vis-network focus(), so it's easy to locate in a large graph. The
+        # options reuse the focus_targets label -> node-id map built above.
+        _find_id: str | None = None
+        if focus_targets:
+            _find_choice = st.selectbox(
+                "🔍 Find entity in graph",
+                options=["—"] + sorted(focus_targets),
+                key="viz_find_entity",
+                on_change=_viz_find_changed,
+                help="Jump to and highlight an entity so it's easy to spot in a "
+                "large graph. Lists the entity types enabled above.",
+            )
+            if _find_choice and _find_choice != "—":
+                _find_id = focus_targets.get(_find_choice)
 
         focus_seed_ids: list = []
         focus_depth = 0
@@ -7082,6 +7107,10 @@ def render_visualization():
                     autofit=fit,
                     theme=_gv_theme,
                     selected_node=(_prev_sel.get("nodeId") if _prev_has_sel else None),
+                    # Find & centre target + a change-seq, so the component
+                    # re-centres only on a fresh pick (issue #144).
+                    focus_node=_find_id,
+                    focus_seq=st.session_state.get("_viz_find_seq", 0),
                     # On desktop the webview can't download; the component sends
                     # the PNG back for us to save instead (#86).
                     web_download=not local_store.local_persist_enabled(),

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6238,23 +6238,28 @@ def render_visualization():
         # Find & centre on a specific entity (issue #144). Independent of focus
         # mode: picking an entity here selects and camera-centres it in the graph
         # via vis-network focus(), so it's easy to locate in a large graph. The
-        # options reuse the focus_targets label -> node-id map built above.
+        # options reuse the focus_targets label -> node-id map built above. It
+        # sits beside the Filter Classes expander so it doesn't cost the graph a
+        # whole row; the empty state is a placeholder (clearable), not a "—" row.
         _find_id: str | None = None
-        if focus_targets:
-            _find_choice = st.selectbox(
-                "🔍 Find entity in graph",
-                options=["—"] + sorted(focus_targets),
-                key="viz_find_entity",
-                on_change=_viz_find_changed,
-                help="Jump to and highlight an entity so it's easy to spot in a "
-                "large graph. Lists the entity types enabled above.",
-            )
-            if _find_choice and _find_choice != "—":
-                _find_id = focus_targets.get(_find_choice)
-
         focus_seed_ids: list = []
         focus_depth = 0
-        with st.expander("Filter Classes", expanded=False):
+        _find_col, _filter_col = st.columns([1, 1])
+        with _find_col:
+            if focus_targets:
+                _find_choice = st.selectbox(
+                    "🔍 Find entity in graph",
+                    options=sorted(focus_targets),
+                    index=None,
+                    placeholder="Find and centre on an entity…",
+                    key="viz_find_entity",
+                    on_change=_viz_find_changed,
+                    help="Jump to and highlight an entity so it's easy to spot "
+                    "in a large graph. Lists the entity types enabled above.",
+                )
+                if _find_choice:
+                    _find_id = focus_targets.get(_find_choice)
+        with _filter_col.expander("Filter Classes", expanded=False):
             focus_mode = st.checkbox(
                 "Focus on one node",
                 key="viz_focus_mode",

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6328,11 +6328,25 @@ def render_visualization():
                 selected_classes = st.multiselect(
                     "Select classes to display",
                     options=all_class_names,
-                    help="Choose which classes to show in the graph",
+                    help="Choose which classes to show in the graph. Empty shows "
+                    "no classes; use 'Select all' to bring them back.",
                     key="viz_selected_classes",
                     on_change=_viz_sync,
                     args=("_viz_cfg_selected_classes", "viz_selected_classes"),
                 )
+                # An empty (or narrowed) filter hides classes and there is no
+                # native way back — offer a one-click restore (issue B3). Only
+                # shown when something is actually hidden.
+                if all_class_names and set(selected_classes) != all_class_set:
+                    if st.button(
+                        "Select all classes",
+                        key="viz_select_all_classes",
+                        help="Show every class in the graph again.",
+                    ):
+                        st.session_state["_viz_cfg_selected_classes"] = list(
+                            all_class_names
+                        )
+                        st.rerun()
 
         # Store graph settings in session state for caching
         selected_classes_key = (

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6185,7 +6185,13 @@ def render_visualization():
                 args=("_viz_cfg_highlight_issues", "viz_highlight_issues"),
             )
         with col5:
-            render_graph = st.button("Render", type="primary", use_container_width=True)
+            render_graph = st.button(
+                "Render",
+                type="primary",
+                use_container_width=True,
+                help="Redraw the graph and re-run the layout. Also re-centres on "
+                "the current Find selection.",
+            )
 
         validation_subjects = set()
         if highlight_issues:
@@ -6399,6 +6405,13 @@ def render_visualization():
         # Bump sequence on Render click to force component re-init (re-runs layout)
         if render_graph:
             st.session_state.viz_render_seq += 1
+            # Render also re-centres on the current Find selection, so a user who
+            # panned away can recentre on it without clearing and re-picking
+            # (PR #144 review P3 — reuses the existing button, no new control).
+            if _find_id:
+                st.session_state["_viz_find_seq"] = (
+                    st.session_state.get("_viz_find_seq", 0) + 1
+                )
 
         # Rebuild graph data when settings change or on first visit
         needs_rebuild = (

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6260,6 +6260,38 @@ def render_visualization():
                 )
                 if _find_choice:
                     _find_id = focus_targets.get(_find_choice)
+                    # The target may currently be hidden — by the class display
+                    # filter, or pruned away in focus mode — in which case its
+                    # node isn't in the graph and the JS focus() would silently
+                    # no-op (PR #144 review P2). On a fresh pick, reveal it:
+                    # restore a filtered-out class and, in focus mode, add it as
+                    # a seed so the prune keeps it. Guarded by the find seq so
+                    # this runs once per pick.
+                    _cur_seq = st.session_state.get("_viz_find_seq", 0)
+                    if st.session_state.get("_viz_find_revealed_seq") != _cur_seq:
+                        st.session_state["_viz_find_revealed_seq"] = _cur_seq
+                        _kind, _, _name = _find_choice.partition(": ")
+                        _reveal_rerun = False
+                        if _kind == "Class":
+                            _sel = list(
+                                st.session_state.get("_viz_cfg_selected_classes") or []
+                            )
+                            if _name in all_class_set and _name not in _sel:
+                                st.session_state["_viz_cfg_selected_classes"] = _sel + [
+                                    _name
+                                ]
+                                _reveal_rerun = True
+                        if st.session_state.get("_viz_cfg_focus_mode"):
+                            _seeds = list(
+                                st.session_state.get("_viz_cfg_focus_seeds") or []
+                            )
+                            if _find_choice not in _seeds:
+                                st.session_state["_viz_cfg_focus_seeds"] = _seeds + [
+                                    _find_choice
+                                ]
+                                _reveal_rerun = True
+                        if _reveal_rerun:
+                            st.rerun()
         with _filter_col.expander("Filter Classes", expanded=False):
             focus_mode = st.checkbox(
                 "Focus on one node",

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -88,11 +88,26 @@ function applyTheme(theme) {
     }
 }
 
-window.addEventListener('resize', function() {
+function autofitApply() {
     if (!autofitOn || !network) return;
     var h = autofitHeight();
     if (h) { applyHeight(h); network.redraw(); }
-});
+}
+window.addEventListener('resize', autofitApply);
+// The fit-to-window height depends on this iframe's position, which shifts when
+// controls above it change (e.g. the "Filter Classes" expander opening or
+// closing) — layout changes that don't fire a 'resize' event. Poll for a
+// position change and re-fit, so the graph grows back after such a shift
+// instead of staying stuck at a height computed for the old position (bug B2).
+var _lastFitTop = null;
+setInterval(function() {
+    if (!autofitOn || !network) return;
+    var t;
+    try {
+        t = window.frameElement ? Math.round(window.frameElement.getBoundingClientRect().top) : 0;
+    } catch (e) { return; }
+    if (t !== _lastFitTop) { _lastFitTop = t; autofitApply(); }
+}, 400);
 
 function downloadGraph() {
     if (!network) return;

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -40,6 +40,23 @@ function sendToStreamlit(type, data) {
     window.parent.postMessage(Object.assign({isStreamlitMessage: true, type: type}, data || {}), "*");
 }
 
+// Report a Find-selected node to Streamlit, matching the selectNode payload, so
+// the details/status panel reflects the found node. selectNodes() alone does not
+// fire selectNode, so a Find focus would otherwise leave the panel out of sync
+// with the highlighted node (PR #144 review P2).
+function sendFindSelection(id) {
+    try {
+        var ds = network && network.body && network.body.data && network.body.data.nodes;
+        var nd = ds && ds.get(id);
+        if (nd) {
+            sendToStreamlit("streamlit:setComponentValue", {
+                value: {nodeId: id, ntype: nd.ntype || null, ename: nd.ename || null,
+                        label: nd.label, title: nd.title || '', selected: true}
+            });
+        }
+    } catch (e) {}
+}
+
 var visLoaded = false;
 var pendingArgs = null;
 var network = null;
@@ -152,6 +169,7 @@ function renderGraph(args) {
             if (_spin) {
                 try { network.selectNodes([_spin]); } catch (e) {}
                 try { network.focus(_spin, {scale: 1.1, animation: {duration: 700, easingFunction: 'easeInOutQuad'}}); } catch (e) {}
+                sendFindSelection(_spin);
             }
             try {
                 sessionStorage.setItem('viz_find', JSON.stringify(
@@ -268,6 +286,7 @@ function renderGraph(args) {
         try { network.moveTo({scale: savedView.scale, position: savedView.position}); } catch (e) {}
     }
     if (_pin) {
+        var _findFresh = !_find.centred;
         try { network.selectNodes([_pin]); } catch (e) {}
         try {
             network.focus(_pin, {
@@ -275,6 +294,7 @@ function renderGraph(args) {
                 animation: _find.centred ? false : {duration: 700, easingFunction: 'easeInOutQuad'}
             });
         } catch (e) {}
+        if (_findFresh) sendFindSelection(_pin);
         _find.centred = true;
     }
     try { sessionStorage.setItem('viz_find', JSON.stringify(_find)); } catch (e) {}

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -125,6 +125,24 @@ function renderGraph(args) {
         applyTheme(args.theme);
         var hh = autofitOn ? autofitHeight() : (args.height || 600);
         if (hh) applyHeight(hh);
+        // A fresh "Find entity" pick is a same-data re-render (only focus_seq
+        // changed), so centre on the new node here without rebuilding the whole
+        // network (issue #144). Anything that isn't a new pick leaves the
+        // viewport and selection exactly as the user left them.
+        var _sf = {};
+        try { _sf = JSON.parse(sessionStorage.getItem('viz_find') || '{}') || {}; } catch (e) {}
+        if (_sf.seq !== args.focus_seq) {
+            var _sds = network.body && network.body.data && network.body.data.nodes;
+            var _spin = (args.focus_node && _sds && _sds.get(args.focus_node)) ? args.focus_node : null;
+            if (_spin) {
+                try { network.selectNodes([_spin]); } catch (e) {}
+                try { network.focus(_spin, {scale: 1.1, animation: {duration: 700, easingFunction: 'easeInOutQuad'}}); } catch (e) {}
+            }
+            try {
+                sessionStorage.setItem('viz_find', JSON.stringify(
+                    {seq: args.focus_seq, released: false, centred: !!_spin}));
+            } catch (e) {}
+        }
         return;
     }
     lastSeq = args.seq;
@@ -212,9 +230,50 @@ function renderGraph(args) {
     if (args.selected_node !== null && args.selected_node !== undefined) {
         try { network.selectNodes([args.selected_node]); } catch (e) {}
     }
-    if (usedSaved && savedView) {
+    // --- Find & centre (issue #144) ---------------------------------------
+    // Python sends focus_node (the entity picked in "Find entity", present on
+    // every render while it stays picked) and focus_seq (bumps only on a fresh
+    // pick). The component iframe can re-mount between renders and renderGraph
+    // rebuilds the whole network each render, so window state isn't reliable —
+    // we keep the find state in sessionStorage like the viewport cache above.
+    // While a pick is active we "pin" the camera on the node and keep it
+    // selected across rebuilds instead of restoring the (now stale) saved
+    // viewport; the pin is released the moment the user clicks or drags, so we
+    // never fight them, and a fresh pick (new seq) re-arms it.
+    var _find = {};
+    try { _find = JSON.parse(sessionStorage.getItem('viz_find') || '{}') || {}; } catch (e) {}
+    if (_find.seq !== args.focus_seq) {
+        _find = {seq: args.focus_seq, released: false, centred: false};
+    }
+    var _pin = (!_find.released && args.focus_node && nodes.get(args.focus_node))
+        ? args.focus_node : null;
+    // Hold the camera on the pinned node across this rebuild instead of
+    // restoring the (now stale) saved viewport; otherwise use the saved view.
+    if (usedSaved && savedView && !_pin) {
         try { network.moveTo({scale: savedView.scale, position: savedView.position}); } catch (e) {}
     }
+    if (_pin) {
+        try { network.selectNodes([_pin]); } catch (e) {}
+        try {
+            network.focus(_pin, {
+                scale: 1.1,
+                animation: _find.centred ? false : {duration: 700, easingFunction: 'easeInOutQuad'}
+            });
+        } catch (e) {}
+        _find.centred = true;
+    }
+    try { sessionStorage.setItem('viz_find', JSON.stringify(_find)); } catch (e) {}
+    // Release the pin the moment the user takes control (click or drag), so we
+    // never fight their navigation; a fresh Find pick (new seq) re-arms it.
+    function _releaseFindPin() {
+        try {
+            var f = JSON.parse(sessionStorage.getItem('viz_find') || '{}') || {};
+            f.released = true;
+            sessionStorage.setItem('viz_find', JSON.stringify(f));
+        } catch (e) {}
+    }
+    network.on('dragStart', _releaseFindPin);
+    network.on('click', _releaseFindPin);
     // Cache the layout AND viewport so re-mounts restore both instantly. Save
     // after the settle animation has frozen (not on stabilizationIterationsDone,
     // which fires ~500ms before the freeze while nodes still move), and after any


### PR DESCRIPTION
## Summary

Adds a "Find entity" control to the Visualization page so a specific entity can be located in a large graph, and fixes two related Visualization rough edges found while testing it.

Closes #144.

## Find entity (#144)

A compact, type-to-filter selectbox above the Interactive Graph. Picking an entity highlights the node and camera-centres on it via vis-network `focus()`. It lists the entity types currently enabled (classes, individuals, SKOS concepts), reusing the same label to node-id map the focus feature uses. Typing narrows the list, so it scales to large ontologies.

Robustness details:
- The component receives `focus_node` and a `focus_seq` that bumps only on a fresh pick, so it centres on a pick rather than on every rerun.
- The graph iframe can re-mount between renders and `renderGraph` rebuilds the network each render, so the find state lives in `sessionStorage` (like the viewport cache): a "pin" holds the camera and selection across rebuilds and is released the moment the user clicks or drags, so it never fights their navigation.
- Centring is applied on both the full-rebuild path and the same-data re-render path (a fresh pick only changes `focus_seq`, which would otherwise hit the early return). No auto-centre on load.

UI, after review feedback: the label is hidden with the magnifying glass in the placeholder, the empty state is a clearable placeholder (not a "-" row), and the control shares a row with the Filter Classes expander at 1/4 : 3/4 width so it does not cost the graph a vertical row.

## Fixes found while testing

**Fit-to-window never restored (B2).** The graph height recomputed only on rerun or window resize, never when the Filter Classes expander opened or closed. Opening it pushed the iframe down; a later rerun sized the graph for that lower position and collapsing never restored it, leaving the graph stuck small. The component now polls its own top position and re-fits whenever the surrounding layout shifts, so the graph grows back on collapse.

**No way back from an empty class filter (B3).** Emptying "Select classes to display" hides every class, and the empty state is intentional (so Clear-all works), but there was no way to restore. Added a "Select all classes" button that appears only while classes are hidden. This is also the recovery path for the reported "unchecking Focus on one node removes classes" confusion: focus mode shows classes even when the filter is empty, so disabling it revealed an already-empty filter.

## Verification

- 520 tests pass; ruff and mypy clean (the vis-network JS is not covered by pytest, so the graph behavior was driven through a real browser).
- Verified live with Playwright: picking an entity selects and centres it; re-picking re-centres; clearing releases the pin; the expander toggle re-fits the graph height both ways; and "Select all classes" restores the hidden classes.

## Files

- `orionbelt_ontology_builder/app.py` - the finder control, its component args, and the Select-all button.
- `orionbelt_ontology_builder/lib/graph_viewer/index.html` - the find/centre focus logic and the autofit re-fit poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)