### PR TITLE
feat: persist visualization display settings across sessions

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -706,15 +706,30 @@ def _apply_viz_settings(data, defaults) -> None:
             st.session_state[f"_viz_cfg_{k}"] = max(lo, min(hi, v))
 
 
+def _viz_settings_payload() -> str:
+    """Serialize the persisted viz settings for change detection and storage."""
+    data = {
+        k: st.session_state[f"_viz_cfg_{k}"]
+        for k in _VIZ_PERSIST_KEYS
+        if f"_viz_cfg_{k}" in st.session_state
+    }
+    return json.dumps(data, sort_keys=True)
+
+
 def _restore_viz_settings(defaults) -> None:
     """Restore persisted viz display settings once per session (issue #142).
 
-    Mirrors the ontology-autosave restore: on the cloud the localStorage value
-    arrives on a later rerun, so this keeps retrying until either our value
-    arrives or the storage component has delivered its items (nothing saved).
-    On desktop the config file is read synchronously.
+    On the cloud the localStorage value arrives on a *later* rerun, and the
+    storage component's first render hands back an empty default — so this only
+    resolves once a real value is read (disk and no-storage cases resolve
+    immediately). Until then it retries. It also stops, without overriding, once
+    the user has started changing settings this session, so a late-arriving
+    saved set never clobbers what they are doing now (PR #142 review P1).
     """
     if st.session_state.get("_viz_settings_restored"):
+        return
+    if st.session_state.get("_viz_settings_dirty"):
+        st.session_state["_viz_settings_restored"] = True
         return
     if local_store.local_persist_enabled():
         _apply_viz_settings(local_store.load_config().get("viz_settings"), defaults)
@@ -724,10 +739,6 @@ def _restore_viz_settings(defaults) -> None:
     if ls is None:
         st.session_state["_viz_settings_restored"] = True
         return
-    _stored_key = getattr(ls, "storedKey", None)
-    delivered = isinstance(_stored_key, str) and isinstance(
-        st.session_state.get(_stored_key), dict
-    )
     saved = ls.getItem(VIZ_SETTINGS_KEY)
     if isinstance(saved, dict):
         saved = saved.get(VIZ_SETTINGS_KEY) or next(
@@ -739,32 +750,28 @@ def _restore_viz_settings(defaults) -> None:
         except (ValueError, TypeError):
             pass
         st.session_state["_viz_settings_restored"] = True
-    elif delivered:
-        # The component handed back its items and ours isn't among them: nothing
-        # was ever saved, so stop retrying and let the defaults stand.
-        st.session_state["_viz_settings_restored"] = True
+    # else: the real value hasn't arrived (or nothing was ever saved). Retry on
+    # a later rerun; a brand-new user's first change lifts the save gate via the
+    # dirty flag, so nothing is written until there is a real change to save.
 
 
 def _persist_viz_settings() -> None:
-    """Save the current viz display settings when they change (issue #142).
+    """Save the current viz display settings after the user changes one (#142).
 
-    Waits until restore has resolved so the starting defaults don't overwrite a
-    saved set before it is read back. No-ops when nothing changed.
+    Gated on an explicit change (the dirty flag set by the settings callbacks),
+    not merely on the page rendering: otherwise a cloud reload could write the
+    starting defaults back over a saved set before localStorage had answered
+    (PR #142 review P1). No-ops when nothing changed since the last write.
     """
-    if not st.session_state.get("_viz_settings_restored"):
+    if not st.session_state.get("_viz_settings_dirty"):
         return
-    data = {
-        k: st.session_state[f"_viz_cfg_{k}"]
-        for k in _VIZ_PERSIST_KEYS
-        if f"_viz_cfg_{k}" in st.session_state
-    }
-    payload = json.dumps(data, sort_keys=True)
+    payload = _viz_settings_payload()
     if payload == st.session_state.get("_viz_settings_saved_json"):
         return
     if local_store.local_persist_enabled():
         try:
             cfg = local_store.load_config()
-            cfg["viz_settings"] = data
+            cfg["viz_settings"] = json.loads(payload)
             local_store.save_config(cfg)
         except OSError as e:
             log_error(e, context="Viz settings save")
@@ -6175,6 +6182,10 @@ def render_visualization():
         def _viz_sync(cfg_key, wid_key):
             """Callback to persist widget value when changed."""
             st.session_state[cfg_key] = st.session_state[wid_key]
+            # A change to a persisted setting lifts the cross-session save gate
+            # (issue #142); changes to per-ontology filters do not.
+            if cfg_key.removeprefix("_viz_cfg_") in _VIZ_PERSIST_KEYS:
+                st.session_state["_viz_settings_dirty"] = True
 
         def _viz_focus_toggle():
             """Persist the focus toggle and, when it turns on, seed the focus
@@ -6183,6 +6194,7 @@ def render_visualization():
             or several). An empty selection falls back to the first node."""
             on = st.session_state["viz_focus_mode"]
             st.session_state["_viz_cfg_focus_mode"] = on
+            st.session_state["_viz_settings_dirty"] = True
             if on:
                 sel = st.session_state.get("_viz_cfg_selected_classes") or []
                 st.session_state["_viz_cfg_focus_seeds"] = [f"Class: {c}" for c in sel]
@@ -7300,6 +7312,7 @@ def render_visualization():
                         type="primary" if _prev_has_sel else "secondary",
                     ):
                         st.session_state["_viz_cfg_details_panel"] = True
+                        st.session_state["_viz_settings_dirty"] = True
                         st.rerun()
 
             with _col_graph:
@@ -7416,6 +7429,7 @@ def render_visualization():
                     with _h2:
                         if st.button("›", key="viz_hide_panel", help="Hide panel"):
                             st.session_state["_viz_cfg_details_panel"] = False
+                            st.session_state["_viz_settings_dirty"] = True
                             st.rerun()
                     if not has_selection:
                         st.caption(

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -4,6 +4,7 @@ and managing OWL ontologies.
 """
 
 import hashlib
+import json
 import logging
 import streamlit as st
 import time
@@ -28,6 +29,38 @@ GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/iss
 AUTOSAVE_KEY = "orionbelt_ontology_builder_autosave"
 # localStorage is ~5 MB per origin; stay well under to leave headroom.
 AUTOSAVE_MAX_BYTES = 4_000_000
+
+# Visualization display preferences persisted across sessions (issue #142), so a
+# user's Fit-to-window / entity-type / spacing etc. choices survive a reload.
+# Stored in the same backends as the ontology autosave (browser localStorage on
+# the cloud, config.json on desktop). Only ontology-INDEPENDENT settings are
+# persisted; the class filter and focus seeds reference entity names and are
+# left to their own per-ontology reset logic.
+VIZ_SETTINGS_KEY = "orionbelt_viz_settings"
+_VIZ_PERSIST_KEYS = (
+    "show_classes",
+    "show_obj_props",
+    "show_data_props",
+    "show_annotations",
+    "show_individuals",
+    "show_skos",
+    "show_ind_edges",
+    "show_triples",
+    "graph_height",
+    "node_spacing",
+    "fit",
+    "highlight_issues",
+    "details_panel",
+    "focus_mode",
+    "focus_depth",
+)
+# Clamp restored integer settings so a stale/tampered value can't crash a slider
+# whose value must lie within its min/max.
+_VIZ_INT_RANGES = {
+    "graph_height": (300, 1200),
+    "node_spacing": (50, 300),
+    "focus_depth": (1, 5),
+}
 # Disk autosave (local/desktop) is gated on the mutation counter and debounced:
 # the graph is only serialized when it actually changed and edits have settled,
 # so normal UI reruns do no work even for large ontologies. Important actions
@@ -647,6 +680,104 @@ def persist_autosave():
                 "doesn't retry. Your work is still here — fix or re-link the "
                 "file, then reload."
             )
+
+
+def _apply_viz_settings(data, defaults) -> None:
+    """Copy persisted viz settings into the ``_viz_cfg_*`` session keys.
+
+    ``defaults`` is the ``_viz_cfg`` dict, used both to enumerate the settings
+    and to validate types: a saved value is only applied when it matches the
+    default's type (bools stay bools, ints stay ints), and ints are clamped to
+    their widget range so a stale/tampered value can't crash a slider.
+    """
+    if not isinstance(data, dict):
+        return
+    for k, default in defaults.items():
+        if k not in _VIZ_PERSIST_KEYS or k not in data:
+            continue
+        v = data[k]
+        if isinstance(default, bool):
+            if isinstance(v, bool):
+                st.session_state[f"_viz_cfg_{k}"] = v
+        elif (
+            isinstance(default, int) and isinstance(v, int) and not isinstance(v, bool)
+        ):
+            lo, hi = _VIZ_INT_RANGES.get(k, (v, v))
+            st.session_state[f"_viz_cfg_{k}"] = max(lo, min(hi, v))
+
+
+def _restore_viz_settings(defaults) -> None:
+    """Restore persisted viz display settings once per session (issue #142).
+
+    Mirrors the ontology-autosave restore: on the cloud the localStorage value
+    arrives on a later rerun, so this keeps retrying until either our value
+    arrives or the storage component has delivered its items (nothing saved).
+    On desktop the config file is read synchronously.
+    """
+    if st.session_state.get("_viz_settings_restored"):
+        return
+    if local_store.local_persist_enabled():
+        _apply_viz_settings(local_store.load_config().get("viz_settings"), defaults)
+        st.session_state["_viz_settings_restored"] = True
+        return
+    ls = _get_local_storage()
+    if ls is None:
+        st.session_state["_viz_settings_restored"] = True
+        return
+    _stored_key = getattr(ls, "storedKey", None)
+    delivered = isinstance(_stored_key, str) and isinstance(
+        st.session_state.get(_stored_key), dict
+    )
+    saved = ls.getItem(VIZ_SETTINGS_KEY)
+    if isinstance(saved, dict):
+        saved = saved.get(VIZ_SETTINGS_KEY) or next(
+            (v for v in saved.values() if isinstance(v, str)), None
+        )
+    if isinstance(saved, str) and saved.strip():
+        try:
+            _apply_viz_settings(json.loads(saved), defaults)
+        except (ValueError, TypeError):
+            pass
+        st.session_state["_viz_settings_restored"] = True
+    elif delivered:
+        # The component handed back its items and ours isn't among them: nothing
+        # was ever saved, so stop retrying and let the defaults stand.
+        st.session_state["_viz_settings_restored"] = True
+
+
+def _persist_viz_settings() -> None:
+    """Save the current viz display settings when they change (issue #142).
+
+    Waits until restore has resolved so the starting defaults don't overwrite a
+    saved set before it is read back. No-ops when nothing changed.
+    """
+    if not st.session_state.get("_viz_settings_restored"):
+        return
+    data = {
+        k: st.session_state[f"_viz_cfg_{k}"]
+        for k in _VIZ_PERSIST_KEYS
+        if f"_viz_cfg_{k}" in st.session_state
+    }
+    payload = json.dumps(data, sort_keys=True)
+    if payload == st.session_state.get("_viz_settings_saved_json"):
+        return
+    if local_store.local_persist_enabled():
+        try:
+            cfg = local_store.load_config()
+            cfg["viz_settings"] = data
+            local_store.save_config(cfg)
+        except OSError as e:
+            log_error(e, context="Viz settings save")
+            return
+    else:
+        ls = _get_local_storage()
+        if ls is None:
+            return
+        h = _content_hash(payload)
+        ls.setItem(
+            VIZ_SETTINGS_KEY, payload, key=f"orionbelt_viz_settings_set_{h[:12]}"
+        )
+    st.session_state["_viz_settings_saved_json"] = payload
 
 
 def _load_linked_file(target) -> bool:
@@ -6030,6 +6161,9 @@ def render_visualization():
             "focus_mode": False,
             "focus_depth": 1,
         }
+        # Bring back settings saved in a previous session before applying
+        # defaults, so a returning user opens with their own preferences (#142).
+        _restore_viz_settings(_viz_cfg)
         for _k, _v in _viz_cfg.items():
             cfg_key = f"_viz_cfg_{_k}"
             wid_key = f"viz_{_k}"
@@ -6385,6 +6519,11 @@ def render_visualization():
                             all_class_names
                         )
                         st.rerun()
+
+        # Persist the display preferences (entity toggles, spacing, fit, ...) so
+        # they survive a reload (#142). Runs after every control has synced its
+        # value; no-ops when nothing changed.
+        _persist_viz_settings()
 
         # Store graph settings in session state for caching
         selected_classes_key = (

--- a/tests/test_viz_settings.py
+++ b/tests/test_viz_settings.py
@@ -9,6 +9,7 @@ from orionbelt_ontology_builder import app
 DEFAULTS = {
     "show_classes": True,
     "show_obj_props": True,
+    "show_skos": True,
     "graph_height": 670,
     "node_spacing": 150,
     "fit": True,
@@ -16,6 +17,20 @@ DEFAULTS = {
     "focus_depth": 1,
     "selected_classes": [],  # not in _VIZ_PERSIST_KEYS
 }
+
+
+class _FakeLS:
+    """Minimal stand-in for the streamlit_local_storage handle."""
+
+    def __init__(self, value=None):
+        self._value = value
+        self.saved = None
+
+    def getItem(self, _key):
+        return self._value
+
+    def setItem(self, _key, value, key=None):  # noqa: A002 - mirrors the real API
+        self.saved = value
 
 
 def test_apply_validates_types_and_clamps_ints(monkeypatch):
@@ -54,9 +69,9 @@ def test_disk_persist_and_restore_roundtrip(monkeypatch, tmp_path):
     monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
     monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
 
-    # Save from one "session".
+    # Save from one "session" — a user change lifts the gate.
     save_state: dict = {
-        "_viz_settings_restored": True,
+        "_viz_settings_dirty": True,
         "_viz_cfg_show_classes": False,
         "_viz_cfg_graph_height": 800,
         "_viz_cfg_fit": False,
@@ -76,9 +91,9 @@ def test_disk_persist_and_restore_roundtrip(monkeypatch, tmp_path):
     assert restore_state["_viz_cfg_fit"] is False
 
 
-def test_persist_waits_for_restore(monkeypatch, tmp_path):
-    # Before restore resolves, saving is skipped so starting defaults can't
-    # clobber a previously saved set.
+def test_persist_requires_a_user_change(monkeypatch, tmp_path):
+    # Merely rendering the page (no change) must not write anything, so a cloud
+    # reload can't overwrite saved settings with the starting defaults (P1).
     cfg_file = tmp_path / "config.json"
     monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
     monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
@@ -91,9 +106,62 @@ def test_persist_noops_when_unchanged(monkeypatch, tmp_path):
     cfg_file = tmp_path / "config.json"
     monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
     monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
-    state: dict = {"_viz_settings_restored": True, "_viz_cfg_fit": True}
+    state: dict = {"_viz_settings_dirty": True, "_viz_cfg_fit": True}
     monkeypatch.setattr(app.st, "session_state", state)
     app._persist_viz_settings()
     first = cfg_file.stat().st_mtime_ns
     app._persist_viz_settings()  # nothing changed
     assert cfg_file.stat().st_mtime_ns == first  # not rewritten
+
+
+def test_browser_restore_retries_until_real_value(monkeypatch):
+    # The localStorage value hasn't arrived yet (getItem returns None). Restore
+    # must NOT resolve (it retries next rerun) — otherwise a later save would
+    # write defaults over the real saved set before it is read (P1).
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
+    monkeypatch.setattr(app, "_get_local_storage", lambda: _FakeLS(None))
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app._restore_viz_settings(DEFAULTS)
+    assert "_viz_settings_restored" not in state
+    # And with no user change, nothing is persisted regardless.
+    app._persist_viz_settings()
+    assert "_viz_settings_saved_json" not in state
+
+
+def test_browser_restore_applies_real_value(monkeypatch):
+    val = json.dumps({"show_skos": False, "graph_height": 900})
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
+    monkeypatch.setattr(app, "_get_local_storage", lambda: _FakeLS(val))
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app._restore_viz_settings(DEFAULTS)
+    assert state["_viz_settings_restored"] is True
+    assert state["_viz_cfg_show_skos"] is False
+    assert state["_viz_cfg_graph_height"] == 900
+
+
+def test_browser_dirty_change_is_saved(monkeypatch):
+    # A brand-new user (nothing saved) still persists once they change a setting.
+    ls = _FakeLS(None)
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
+    monkeypatch.setattr(app, "_get_local_storage", lambda: ls)
+    state: dict = {"_viz_settings_dirty": True, "_viz_cfg_show_skos": False}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app._persist_viz_settings()
+    assert ls.saved is not None
+    assert json.loads(ls.saved)["show_skos"] is False
+
+
+def test_restore_defers_to_in_progress_changes(monkeypatch):
+    # If the user already changed a setting this session, a late restore must not
+    # override it.
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
+    monkeypatch.setattr(
+        app, "_get_local_storage", lambda: _FakeLS(json.dumps({"show_skos": True}))
+    )
+    state: dict = {"_viz_settings_dirty": True, "_viz_cfg_show_skos": False}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app._restore_viz_settings(DEFAULTS)
+    assert state["_viz_settings_restored"] is True
+    assert state["_viz_cfg_show_skos"] is False  # user's change kept

--- a/tests/test_viz_settings.py
+++ b/tests/test_viz_settings.py
@@ -1,0 +1,99 @@
+"""Persistence of Visualization display settings across sessions (issue #142)."""
+
+import json
+
+from orionbelt_ontology_builder import app
+
+# A representative slice of the _viz_cfg defaults, incl. a non-persisted key
+# (selected_classes) that must be ignored.
+DEFAULTS = {
+    "show_classes": True,
+    "show_obj_props": True,
+    "graph_height": 670,
+    "node_spacing": 150,
+    "fit": True,
+    "focus_mode": False,
+    "focus_depth": 1,
+    "selected_classes": [],  # not in _VIZ_PERSIST_KEYS
+}
+
+
+def test_apply_validates_types_and_clamps_ints(monkeypatch):
+    fake: dict = {}
+    monkeypatch.setattr(app.st, "session_state", fake)
+    app._apply_viz_settings(
+        {
+            "show_classes": False,  # bool -> applied
+            "graph_height": 99999,  # clamped to 1200
+            "node_spacing": 10,  # clamped to 50
+            "focus_depth": 3,  # in range
+            "fit": "yes",  # wrong type -> ignored
+            "selected_classes": ["X"],  # not persisted -> ignored
+            "bogus": 1,  # not a known setting -> ignored
+        },
+        DEFAULTS,
+    )
+    assert fake["_viz_cfg_show_classes"] is False
+    assert fake["_viz_cfg_graph_height"] == 1200
+    assert fake["_viz_cfg_node_spacing"] == 50
+    assert fake["_viz_cfg_focus_depth"] == 3
+    assert "_viz_cfg_fit" not in fake  # wrong type left at default
+    assert "_viz_cfg_selected_classes" not in fake
+    assert "_viz_cfg_bogus" not in fake
+
+
+def test_apply_ignores_non_dict(monkeypatch):
+    fake: dict = {}
+    monkeypatch.setattr(app.st, "session_state", fake)
+    app._apply_viz_settings(None, DEFAULTS)
+    assert fake == {}
+
+
+def test_disk_persist_and_restore_roundtrip(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
+    monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
+
+    # Save from one "session".
+    save_state: dict = {
+        "_viz_settings_restored": True,
+        "_viz_cfg_show_classes": False,
+        "_viz_cfg_graph_height": 800,
+        "_viz_cfg_fit": False,
+    }
+    monkeypatch.setattr(app.st, "session_state", save_state)
+    app._persist_viz_settings()
+    stored = json.loads(cfg_file.read_text())["viz_settings"]
+    assert stored == {"show_classes": False, "graph_height": 800, "fit": False}
+
+    # Restore into a fresh "session".
+    restore_state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", restore_state)
+    app._restore_viz_settings(DEFAULTS)
+    assert restore_state["_viz_settings_restored"] is True
+    assert restore_state["_viz_cfg_show_classes"] is False
+    assert restore_state["_viz_cfg_graph_height"] == 800
+    assert restore_state["_viz_cfg_fit"] is False
+
+
+def test_persist_waits_for_restore(monkeypatch, tmp_path):
+    # Before restore resolves, saving is skipped so starting defaults can't
+    # clobber a previously saved set.
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
+    monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
+    monkeypatch.setattr(app.st, "session_state", {"_viz_cfg_show_classes": True})
+    app._persist_viz_settings()
+    assert not cfg_file.exists()
+
+
+def test_persist_noops_when_unchanged(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
+    monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
+    state: dict = {"_viz_settings_restored": True, "_viz_cfg_fit": True}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app._persist_viz_settings()
+    first = cfg_file.stat().st_mtime_ns
+    app._persist_viz_settings()  # nothing changed
+    assert cfg_file.stat().st_mtime_ns == first  # not rewritten


### PR DESCRIPTION
## Summary

Visualization display preferences lived only in in-session state, so every reload reset the entity-type toggles, node spacing, Fit-to-window, focus mode, and so on. They are now saved and restored across sessions, so a returning user opens the graph with the setup they left.

Closes #142.

## What is persisted

Only ontology-independent display settings: the entity-type checkboxes (Classes / Obj Props / Data Props / Annotations / Individuals / SKOS / Ind. Edges / Triples), graph height, node spacing, Fit to window, Highlight Issues, details-panel state, focus mode, and focus depth.

The class filter and focus seeds are deliberately not persisted: they reference entity names, so they would go stale against a different ontology. They keep their existing per-ontology reset behavior.

## How

Uses the same backends as the ontology autosave, so there is no new storage mechanism to reason about:
- Cloud: a `orionbelt_viz_settings` key in browser localStorage (via the existing `_get_local_storage()` handle).
- Desktop/local: a `viz_settings` entry in `config.json` (via `local_store.load_config`/`save_config`).

Restore runs once per session, before the defaults are applied, so a returning user's values become the initial state. On the cloud the localStorage value arrives on a later rerun, so restore retries until either the value arrives or the storage component reports it has delivered its items (nothing saved) — mirroring the ontology-restore flow. Saving waits until restore has resolved so the starting defaults can't overwrite a saved set before it is read back, no-ops when nothing changed, and clamps restored integers to their slider ranges so a stale or tampered value can't crash a widget.

## Tests

`tests/test_viz_settings.py` covers type validation, integer clamping, the disk save/restore round-trip, the wait-for-restore guard, and the unchanged no-op. 525 tests pass; ruff and mypy clean.

Verified live with Playwright: toggled SKOS off and Individuals on, reloaded into a fresh session, and both were restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)