### PR TITLE
feat: stable, deterministic graph layout on expand

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6553,7 +6553,11 @@ def render_visualization():
         if "viz_render_seq" not in st.session_state:
             st.session_state.viz_render_seq = 0
 
-        # Bump sequence on Render click to force component re-init (re-runs layout)
+        # Bump the layout generation only when a fresh re-layout is actually
+        # wanted: an explicit Render click, or a node-spacing change (which
+        # alters the physics and should spread the graph out rather than freeze
+        # the old spread). Every other rebuild reuses cached positions so the
+        # graph stays put (issue #141).
         if render_graph:
             st.session_state.viz_render_seq += 1
             # Render also re-centres on the current Find selection, so a user who
@@ -6563,6 +6567,12 @@ def render_visualization():
                 st.session_state["_viz_find_seq"] = (
                     st.session_state.get("_viz_find_seq", 0) + 1
                 )
+        if (
+            "_viz_last_node_spacing" in st.session_state
+            and st.session_state["_viz_last_node_spacing"] != node_spacing
+        ):
+            st.session_state.viz_render_seq += 1
+        st.session_state["_viz_last_node_spacing"] = node_spacing
 
         # Rebuild graph data when settings change or on first visit
         needs_rebuild = (
@@ -7232,8 +7242,12 @@ def render_visualization():
                     "edges": edges_json,
                     "options": options_json,
                 }
-                # Bump seq so the iframe component re-initialises with the new data
-                st.session_state.viz_render_seq += 1
+                # NB: don't bump viz_render_seq here. The component re-renders on
+                # its own whenever nodes/edges change, and seq is the layout-cache
+                # generation: bumping it on every rebuild invalidated the cache so
+                # a node-set change (e.g. a focus expand) always re-ran physics
+                # from scratch instead of freezing the existing nodes (issue #141,
+                # PR review). seq is now bumped only for a real re-layout below.
                 status.empty()
 
             except Exception as e:

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6541,7 +6541,7 @@ def render_visualization():
         selected_classes_key = (
             "_".join(sorted(selected_classes)) if selected_classes else "none"
         )
-        _graph_ver = 15  # Bump to invalidate cached graph data after code changes
+        _graph_ver = 16  # Bump to invalidate cached graph data after code changes
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.
@@ -6600,6 +6600,12 @@ def render_visualization():
 
             net = _GraphBuilder()
             net.options = {
+                # Pin the layout's initial-placement RNG so a given graph always
+                # stabilizes to the same arrangement instead of a fresh random
+                # one each time it is rebuilt (issue #141). Combined with the
+                # cached positions, this keeps the picture consistent across
+                # renders, Render clicks, and fresh sessions.
+                "layout": {"randomSeed": 191021},
                 "physics": {
                     "enabled": True,
                     "barnesHut": {

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -229,26 +229,40 @@ function renderGraph(args) {
         return h;
     }
     var nodeHash = _hash(nodeArr.map(function(n) { return n.id; }).sort().join('|'));
-    var savedPos = null, savedView = null;
-    try {
-        var _raw = JSON.parse(sessionStorage.getItem('viz_pos') || 'null');
-        if (_raw && _raw.seq === args.seq && _raw.hash === nodeHash) {
-            savedPos = _raw.pos;
-            savedView = _raw.view || null;  // {scale, position}
-        }
-    } catch (e) {}
+    var savedPos = null, savedView = null, pinnedIds = [];
+    var _raw = null;
+    try { _raw = JSON.parse(sessionStorage.getItem('viz_pos') || 'null'); } catch (e) {}
 
     var usedSaved = false;
-    if (savedPos) {
-        // Render at saved positions with physics off — no stabilization, no flicker.
+    if (_raw && _raw.seq === args.seq && _raw.hash === nodeHash && _raw.pos) {
+        // Exact same graph: restore every position with physics off — no
+        // stabilization, no flicker.
+        savedPos = _raw.pos;
+        savedView = _raw.view || null;  // {scale, position}
         nodeArr.forEach(function(n) {
             if (savedPos[n.id]) { n.x = savedPos[n.id].x; n.y = savedPos[n.id].y; }
         });
         options.physics.enabled = false;
         usedSaved = true;
+    } else if (_raw && _raw.seq === args.seq && _raw.pos) {
+        // Same render generation but a changed node set — e.g. a Ctrl/Cmd-click
+        // expand revealed new nodes. Freeze the nodes we already placed exactly
+        // where they are and let physics settle only the new ones around them,
+        // so the graph doesn't jump (issue #141). Existing nodes are pinned for
+        // the stabilization pass, then released so they stay draggable.
+        savedView = _raw.view || null;  // hold the camera steady too
+        nodeArr.forEach(function(n) {
+            if (_raw.pos[n.id]) {
+                n.x = _raw.pos[n.id].x; n.y = _raw.pos[n.id].y;
+                n.fixed = { x: true, y: true };
+                pinnedIds.push(n.id);
+            }
+        });
+        var iters2 = Math.min(Math.max(nCount * 3, 150), 500);
+        options.physics.stabilization = { enabled: true, iterations: Math.max(iters2 - 40, 80), updateInterval: 50 };
     } else {
-        // Batch-stabilize most of the layout, then freeze. Scale iterations with
-        // node count for a quality vs speed balance.
+        // Fresh layout (Render, or nothing cached): deterministic thanks to the
+        // pinned randomSeed set in Python (issue #141).
         var iters = Math.min(Math.max(nCount * 3, 150), 500);
         var batchIters = Math.max(iters - 40, 80);
         options.physics.stabilization = { enabled: true, iterations: batchIters, updateInterval: 50 };
@@ -282,7 +296,7 @@ function renderGraph(args) {
         ? args.focus_node : null;
     // Hold the camera on the pinned node across this rebuild instead of
     // restoring the (now stale) saved viewport; otherwise use the saved view.
-    if (usedSaved && savedView && !_pin) {
+    if (savedView && !_pin) {
         try { network.moveTo({scale: savedView.scale, position: savedView.position}); } catch (e) {}
     }
     if (_pin) {
@@ -332,6 +346,15 @@ function renderGraph(args) {
         network.once('stabilizationIterationsDone', function() {
             setTimeout(function() {
                 network.setOptions({ physics: { enabled: false } });
+                // Release the frozen-existing pins now that physics is off (so
+                // they won't move), keeping those nodes draggable (issue #141).
+                if (pinnedIds.length) {
+                    try {
+                        nodes.update(pinnedIds.map(function(id) {
+                            return { id: id, fixed: false };
+                        }));
+                    } catch (e) {}
+                }
                 savePositions();
             }, 500);
         });


### PR DESCRIPTION
## Summary

Rolling out an ontology by hopping node to node (Ctrl/Cmd-click to expand) made the graph re-run physics from scratch and jump around. Two changes fix that.

Closes #141.

## 1. Deterministic layout (pinned random seed)

vis-network seeds initial node placement randomly, so every from-scratch stabilization produced a different arrangement. Pinning `layout.randomSeed` makes a given graph always stabilize to the same layout.

Verified: two "Render" clicks (each a full from-scratch layout) now produce byte-for-byte identical node positions (max delta 0); before, each reshuffled the whole graph.

## 2. Freeze existing, sprout new

When a rebuild in the same render generation changes the node set (e.g. an expand reveals new nodes), the nodes already placed are pinned at their cached positions and only the new nodes are settled by physics around them. The pins are released after stabilization so nodes stay draggable, and the camera is held steady so the view doesn't jump either. A "Render" click (new render seq) still does a full, now-deterministic, fresh layout.

Verified: removing a node type and re-adding it left every existing node at delta 0 while the removed nodes sprouted back in as new ones.

Both build on the existing sessionStorage position cache (which already avoids re-layout when the visible set is unchanged).

## Notes

The behavior is in the vendored vis-network component JS (`lib/graph_viewer/index.html`), which pytest does not cover, so it was validated through a real browser with Playwright. The one Python change is the `layout.randomSeed` option plus a graph-cache version bump. 529 tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)