### PR TITLE
fix: keep brand colour on sliders and multiselects when the theme resets

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -160,6 +160,22 @@ _BRAND_CSS = f"""
     .stTabs [data-baseweb="tab-highlight"] {{
         background-color: {_BRAND} !important;
     }}
+    /* Slider thumb + its floating value label */
+    [data-testid="stSlider"] [role="slider"] {{
+        background-color: {_BRAND} !important;
+    }}
+    [data-testid="stSliderThumbValue"] {{
+        color: {_BRAND} !important;
+    }}
+    /* (The filled-track bar keeps its Streamlit colour: its fill % lives in an
+       inline gradient we can't recolour without losing the fill indicator.) */
+    /* Multiselect selected chips and their focus outline */
+    [data-testid="stMultiSelect"] [data-baseweb="tag"] {{
+        background-color: {_BRAND} !important;
+    }}
+    [data-testid="stMultiSelect"] [data-baseweb="select"] > div:focus-within {{
+        border-color: {_BRAND} !important;
+    }}
 </style>
 """
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -197,6 +197,15 @@ _DARK_CSS = f"""
     .stTabs [data-baseweb="tab-highlight"] {{
         background-color: {_DARK_ACCENT} !important;
     }}
+    /* Text/indicator accents from _BRAND_CSS that are too dark on a dark
+       backdrop: the slider value label and the multiselect focus outline.
+       (The filled thumb and chips stay navy, like the checkboxes/buttons.) */
+    [data-testid="stSliderThumbValue"] {{
+        color: {_DARK_ACCENT} !important;
+    }}
+    [data-testid="stMultiSelect"] [data-baseweb="select"] > div:focus-within {{
+        border-color: {_DARK_ACCENT} !important;
+    }}
 </style>
 """
 

--- a/tests/test_brand_theme.py
+++ b/tests/test_brand_theme.py
@@ -28,3 +28,17 @@ def test_brand_css_forces_the_brand_colour_on_every_accent_widget():
     ]
     missing = [h for h in required_hooks if h not in css]
     assert not missing, f"_BRAND_CSS no longer styles: {missing}"
+
+
+def test_dark_css_relightens_text_and_indicator_accents():
+    # Navy is too dark for text/indicator accents on a dark backdrop, so the
+    # dark-mode CSS must re-colour those to the lighter accent. The slider value
+    # label and the multiselect focus outline are text/line accents and must be
+    # covered (filled shapes like the thumb and chips stay navy).
+    dark = app._DARK_CSS
+    assert app._DARK_ACCENT in dark
+    for hook in [
+        'data-testid="stSliderThumbValue"',
+        'data-testid="stMultiSelect"',
+    ]:
+        assert hook in dark, f"_DARK_CSS missing a dark override for {hook}"

--- a/tests/test_brand_theme.py
+++ b/tests/test_brand_theme.py
@@ -1,0 +1,30 @@
+"""Guard the brand-colour fallback CSS.
+
+Streamlit's built-in theme presets (the Appearance / theme picker, and Streamlit
+Cloud's default) drop the configured brand primaryColor and fall back to the
+default red. The app re-forces the brand navy onto the accent widgets with CSS
+(``_BRAND_CSS``). If a widget is dropped from that CSS, it silently reverts to
+red in the reset case, which is hard to catch by eye — this test fails loudly
+instead.
+"""
+
+from orionbelt_ontology_builder import app
+
+
+def test_brand_css_forces_the_brand_colour_on_every_accent_widget():
+    css = app._BRAND_CSS
+    assert app._BRAND in css  # the navy is actually referenced
+
+    # Each accent widget Streamlit would otherwise render in default red.
+    required_hooks = [
+        'data-testid="stBaseButton-primary"',  # primary buttons
+        'data-testid="stCheckbox"',  # checked checkbox
+        'data-testid="stRadio"',  # selected radio
+        'data-testid="stSlider"',  # slider thumb
+        'data-testid="stSliderThumbValue"',  # slider value label
+        'data-testid="stMultiSelect"',  # multiselect chips + focus border
+        'data-baseweb="tag"',  # the selected chips themselves
+        ".stTabs",  # selected tab
+    ]
+    missing = [h for h in required_hooks if h not in css]
+    assert not missing, f"_BRAND_CSS no longer styles: {missing}"


### PR DESCRIPTION
## Summary

Sliders and multiselect chips were showing Streamlit's default red instead of the brand navy.

**Cause (not a 1.17.0 regression):** Streamlit's built-in theme presets (the Appearance picker, and Streamlit Cloud's default appearance) replace the whole theme and drop the configured `primaryColor`, falling back to red. The app already re-forces the brand navy onto buttons, checkboxes, radios, and tabs via `_BRAND_CSS`, but **sliders and multiselects were never in that CSS**, so they reverted to red once the theme was reset. This gap has existed since the fallback was added; it just became obvious on the slider-heavy Visualization page.

## Fix

Extend `_BRAND_CSS` to also force the brand colour onto:
- the slider thumb (`[role="slider"]`)
- the slider value label (`stSliderThumbValue`)
- the multiselect chips (`[data-baseweb="tag"]`)
- the multiselect focus outline

The filled-track bar is intentionally left as Streamlit renders it: its fill percentage lives in an inline gradient that cannot be recoloured without losing the fill indicator. The thumb (the prominent handle) carries the brand colour.

## Regression guard

Adds `tests/test_brand_theme.py`, which asserts `_BRAND_CSS` styles every accent widget (buttons, checkboxes, radios, tabs, slider, slider value, multiselect chips). It fails loudly if any is dropped, since a missing widget silently reverts to red only in the theme-reset case and is easy to miss by eye.

## Verification

Live: with the config `primaryColor` temporarily removed to simulate the theme reset, the slider thumb, value label, and multiselect chips all render brand navy (`rgb(13,43,122)`) instead of red. 530 tests pass; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)