### PR TITLE
fix: neutralise the slider filled-track colour so no red shows

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -167,8 +167,13 @@ _BRAND_CSS = f"""
     [data-testid="stSliderThumbValue"] {{
         color: {_BRAND} !important;
     }}
-    /* (The filled-track bar keeps its Streamlit colour: its fill % lives in an
-       inline gradient we can't recolour without losing the fill indicator.) */
+    /* Slider track: the filled portion's colour (red on a reset theme) is baked
+       into a per-value class we can't recolour selectively, so neutralise the
+       whole bar to Streamlit's unfilled tint — no red shows, and the navy thumb
+       marks the position. Targets the track (the thumb's direct parent). */
+    [data-testid="stSlider"] [data-baseweb="slider"] div:has(> [role="slider"]) {{
+        background: rgba(151, 166, 195, 0.25) !important;
+    }}
     /* Multiselect selected chips and their focus outline */
     [data-testid="stMultiSelect"] [data-baseweb="tag"] {{
         background-color: {_BRAND} !important;


### PR DESCRIPTION
## Summary

Follow-up to #167. After that fix the slider thumb, value label, and multiselect chips render brand navy, but the slider's **filled-track bar** still showed red once Streamlit's theme preset reset `primaryColor`.

The filled portion's colour is baked into a Streamlit per-value class (the fill percentage changes as the slider is dragged), and there is no CSS hook or variable for just the filled colour, so it cannot be recoloured selectively via static CSS. Instead, the whole track is now rendered in Streamlit's neutral unfilled tint via a rule targeting the track element (the thumb's direct parent). No red shows in any theme state, and the navy thumb marks the position.

The slider now looks the same whether or not the theme preset has reset the primary colour. Trade-off: the filled-portion bar is replaced by a uniform neutral track. The thumb still indicates the value.

## Verification

Live, with the config `primaryColor` removed to simulate the theme reset: the slider has no red anywhere (`anyRedInSlider: false`), the track is the neutral tint, and the thumb/value stay navy. 531 tests pass; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)