### PR TITLE
feat: list data properties in the Find-entity picker too

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6413,6 +6413,11 @@ def render_visualization():
         if show_individuals:
             for ind in individuals:
                 focus_targets[f"Individual: {ind['name']}"] = f"ind_{_uid(ind['uri'])}"
+        if show_data_props:
+            for prop in data_props:
+                focus_targets[f"Data Property: {prop['name']}"] = (
+                    f"dprop_{_uid(prop['uri'])}"
+                )
         if show_skos and _has_skos:
             for concept in ont.get_concepts():
                 focus_targets[f"Concept: {concept['name']}"] = f"skos_{concept['name']}"


### PR DESCRIPTION
## Summary

The "Find entity" picker in the Visualization graph already listed classes, individuals, and SKOS concepts (each when its type checkbox is enabled), but not data properties, even though they are rendered as graph nodes. Now, with "Data Props" enabled, data properties appear as `Data Property: <name>` and can be found and centred on, keyed by the same `dprop_<uid>` node id the graph builder assigns.

Object properties remain excluded on purpose: they render as edges, not nodes, so there is no single node to centre on.

## Verification

Live: added a data property, enabled Data Props, and it appeared in the picker; selecting it selected and centred its node (`dprop_...`, scale 1.1). 531 tests pass; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)