### PR TITLE
chore: bump version to 1.17.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.17.1` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.17.2` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -15,7 +15,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.17.1"
+APP_VERSION = "1.17.2"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.17.1"
+version = "1.17.2"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.17.1"
+version = "1.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Patch release, bumping `pyproject.toml`, `app.py` APP_VERSION, the README pin hint, and `uv.lock` from 1.17.1 to 1.17.2.

Contents since 1.17.1:

- fix: neutralise the slider filled-track colour so no red shows when Streamlit's theme preset resets the primary colour (#169)
- feat: list data properties in the Find-entity picker too (#173)

🤖 Generated with [Claude Code](https://claude.com/claude-code)