### PR TITLE
feat: fullscreen toggle for the interactive graph

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -83,7 +83,7 @@ var lastEdges = null;
 var currentTheme = {bg: '#ffffff', panel: 'rgba(255,255,255,0.92)', text: '#333333'};
 var currentHeight = 600;  // last non-fullscreen graph height, restored on exit
 var fsRestoreView = null;  // viewport captured just before a fullscreen toggle
-var FS_ZOOM_OUT = 0.65;    // entering fullscreen zooms out ~35% around the centre
+var FS_ZOOM_OUT = 0.70;    // entering fullscreen zooms out ~30% around the centre
 var fsGen = 0;             // fullscreen transition counter, to void stale callbacks
 var fsResizeHandler = null; // active 'resize' listener from the current transition
 var fsDetachTimer = null;   // timer that detaches fsResizeHandler
@@ -195,7 +195,7 @@ function toggleFullscreen() {
 }
 
 // Resize the graph to fill the screen on enter and back to the toolbar-driven
-// height on exit, and swap the icon/hint. On enter the graph zooms out ~35%
+// height on exit, and swap the icon/hint. On enter the graph zooms out ~30%
 // around the same centre so fullscreen reveals more context without shrinking a
 // large graph to an unreadable whole-graph fit; on exit the pre-fullscreen
 // viewport is restored, so a round-trip leaves the user's zoom/pan untouched

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -24,12 +24,27 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 }
 #download-btn:hover { opacity: 1; }
 #download-btn svg { width: 18px; height: 18px; fill: #555; }
+#fullscreen-btn {
+    position: absolute; top: 8px; right: 48px; z-index: 10;
+    width: 32px; height: 32px; border: none; border-radius: 6px;
+    background: rgba(255,255,255,0.92); cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    opacity: 0.7; transition: opacity 0.2s;
+}
+#fullscreen-btn:hover { opacity: 1; }
+#fullscreen-btn svg { width: 18px; height: 18px; fill: #555; }
+/* In fullscreen the container fills the screen; keep the themed background so
+   the graph doesn't fall back to the browser's default black backdrop. */
+#container:fullscreen { width: 100vw; height: 100vh; }
 </style>
 </head>
 <body>
 <div id="container" style="position: relative;">
     <div id="graph"></div>
     <div id="legend"></div>
+    <button id="fullscreen-btn" title="Fullscreen" style="display:none;" onclick="toggleFullscreen()">
+        <svg viewBox="0 0 24 24"><path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/></svg>
+    </button>
     <button id="download-btn" title="Download as PNG" style="display:none;" onclick="downloadGraph()">
         <svg viewBox="0 0 24 24"><path d="M5 20h14v-2H5v2zm7-18L5.33 9h3.84v6h3.66V9h3.84L12 2z" transform="rotate(180 12 12)"/></svg>
     </button>
@@ -65,6 +80,8 @@ var webDownload = true;  // browser download works on the web; on desktop we sav
 var lastSeq = null;
 var lastNodes = null;
 var lastEdges = null;
+var currentTheme = {bg: '#ffffff', panel: 'rgba(255,255,255,0.92)', text: '#333333'};
+var currentHeight = 600;  // last non-fullscreen graph height, restored on exit
 
 // When "Fit to window" is on, fill the available window height instead of using
 // the fixed Graph Height. Reads the parent window's height and this iframe's
@@ -90,13 +107,21 @@ function applyHeight(h) {
 // encode type, not theme, so only the background, overlays and edge labels change.
 function applyTheme(theme) {
     theme = theme || {bg: '#ffffff', panel: 'rgba(255,255,255,0.92)', text: '#333333'};
+    currentTheme = theme;
     document.documentElement.style.background = theme.bg;
     document.body.style.background = theme.bg;
+    document.getElementById('container').style.background = theme.bg;
     var dlBtn = document.getElementById('download-btn');
     if (dlBtn) {
         dlBtn.style.background = theme.panel;
         var dlSvg = dlBtn.querySelector('svg');
         if (dlSvg) dlSvg.style.fill = theme.text;
+    }
+    var fsBtn = document.getElementById('fullscreen-btn');
+    if (fsBtn) {
+        fsBtn.style.background = theme.panel;
+        var fsSvg = fsBtn.querySelector('svg');
+        if (fsSvg) fsSvg.style.fill = theme.text;
     }
     var legendEl = document.getElementById('legend');
     if (legendEl) { legendEl.style.background = theme.panel; legendEl.style.color = theme.text; }
@@ -106,7 +131,7 @@ function applyTheme(theme) {
 }
 
 function autofitApply() {
-    if (!autofitOn || !network) return;
+    if (!autofitOn || !network || document.fullscreenElement) return;
     var h = autofitHeight();
     if (h) { applyHeight(h); network.redraw(); }
 }
@@ -141,6 +166,52 @@ function downloadGraph() {
     }
 }
 
+// Enter/exit fullscreen for just the graph. The whole vis-network canvas lives
+// in this iframe, so fullscreening the container makes the graph fill the
+// physical screen — no sidebar, no toolbar, no black borders (issue #177).
+function toggleFullscreen() {
+    var c = document.getElementById('container');
+    if (!document.fullscreenElement) {
+        (c.requestFullscreen || c.webkitRequestFullscreen || function () {}).call(c);
+    } else {
+        (document.exitFullscreen || document.webkitExitFullscreen || function () {}).call(document);
+    }
+}
+
+// Resize the graph to fill the screen on enter, and restore the toolbar-driven
+// height on exit. Swap the icon and hint between enter/exit.
+function onFullscreenChange() {
+    var el = document.getElementById('graph');
+    var fsBtn = document.getElementById('fullscreen-btn');
+    if (document.fullscreenElement) {
+        el.style.height = window.innerHeight + 'px';
+        if (fsBtn) {
+            fsBtn.title = 'Exit fullscreen';
+            fsBtn.querySelector('svg').innerHTML =
+                '<path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/>';
+        }
+    } else {
+        if (fsBtn) {
+            fsBtn.title = 'Fullscreen';
+            fsBtn.querySelector('svg').innerHTML =
+                '<path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>';
+        }
+        var h = autofitOn ? (autofitHeight() || currentHeight) : currentHeight;
+        el.style.height = h + 'px';
+        sendToStreamlit("streamlit:setFrameHeight", {height: h});
+    }
+    if (network) { network.redraw(); network.fit(); }
+}
+document.addEventListener('fullscreenchange', onFullscreenChange);
+document.addEventListener('webkitfullscreenchange', onFullscreenChange);
+// Fullscreen from inside an iframe needs the frame to permit it. Streamlit's
+// component iframe is same-origin, so grant it defensively (belt and braces on
+// top of Streamlit's own allowFullScreen).
+try {
+    var _fe = window.frameElement;
+    if (_fe) { _fe.allowFullscreen = true; _fe.setAttribute('allow', 'fullscreen'); }
+} catch (e) {}
+
 function renderGraph(args) {
     if (!visLoaded) { pendingArgs = args; return; }
     autofitOn = !!args.autofit;
@@ -156,7 +227,7 @@ function renderGraph(args) {
     if (network && args.seq === lastSeq && args.nodes === lastNodes && args.edges === lastEdges) {
         applyTheme(args.theme);
         var hh = autofitOn ? autofitHeight() : (args.height || 600);
-        if (hh) applyHeight(hh);
+        if (hh) { currentHeight = hh; if (!document.fullscreenElement) applyHeight(hh); }
         // A fresh "Find entity" pick is a same-data re-render (only focus_seq
         // changed), so centre on the new node here without rebuilding the whole
         // network (issue #144). Anything that isn't a new pick leaves the
@@ -188,14 +259,28 @@ function renderGraph(args) {
         if (af) height = af;
     }
     var el = document.getElementById('graph');
-    el.style.height = height + 'px';
-    sendToStreamlit("streamlit:setFrameHeight", {height: height});
+    // In fullscreen the graph fills the screen; don't clobber that with the
+    // toolbar height. Remember the requested height so exiting fullscreen can
+    // restore it.
+    currentHeight = height;
+    if (!document.fullscreenElement) {
+        el.style.height = height + 'px';
+        sendToStreamlit("streamlit:setFrameHeight", {height: height});
+    }
 
     // Theme the canvas + overlays to match the app, so the graph isn't a white
     // box in dark mode (issue #62). Defaults keep the original light look.
     var theme = args.theme || {bg: '#ffffff', panel: 'rgba(255,255,255,0.92)', text: '#333333'};
+    currentTheme = theme;
     document.documentElement.style.background = theme.bg;
     document.body.style.background = theme.bg;
+    document.getElementById('container').style.background = theme.bg;
+    var fsBtn2 = document.getElementById('fullscreen-btn');
+    if (fsBtn2) {
+        fsBtn2.style.background = theme.panel;
+        var fsSvg2 = fsBtn2.querySelector('svg');
+        if (fsSvg2) fsSvg2.style.fill = theme.text;
+    }
     var dlBtn = document.getElementById('download-btn');
     dlBtn.style.background = theme.panel;
     var dlSvg = dlBtn.querySelector('svg');
@@ -270,6 +355,7 @@ function renderGraph(args) {
     var nodes = new vis.DataSet(nodeArr);
     network = new vis.Network(el, {nodes: nodes, edges: edges}, options);
     document.getElementById('download-btn').style.display = 'flex';
+    document.getElementById('fullscreen-btn').style.display = 'flex';
     // Restore selection + viewport after a genuine re-mount (e.g. the panel
     // toggled), so the node stays highlighted and the zoom/pan don't reset —
     // making the rebuild invisible. selectNodes() does not fire selectNode, so

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -83,6 +83,7 @@ var lastEdges = null;
 var currentTheme = {bg: '#ffffff', panel: 'rgba(255,255,255,0.92)', text: '#333333'};
 var currentHeight = 600;  // last non-fullscreen graph height, restored on exit
 var fsRestoreView = null;  // viewport captured just before a fullscreen toggle
+var FS_ZOOM_OUT = 0.65;    // entering fullscreen zooms out ~35% around the centre
 
 // When "Fit to window" is on, fill the available window height instead of using
 // the fixed Graph Height. Reads the parent window's height and this iframe's
@@ -191,24 +192,22 @@ function toggleFullscreen() {
 }
 
 // Resize the graph to fill the screen on enter and back to the toolbar-driven
-// height on exit, and swap the icon/hint. On enter the graph is fit to the
-// larger canvas so it actually uses the space; on exit the pre-fullscreen
+// height on exit, and swap the icon/hint. On enter the graph zooms out ~35%
+// around the same centre so fullscreen reveals more context without shrinking a
+// large graph to an unreadable whole-graph fit; on exit the pre-fullscreen
 // viewport is restored, so a round-trip leaves the user's zoom/pan untouched
 // (review P2). vis rescales the view on each of the several 'resize' events it
-// fires while the canvas changes size, and a fit()/moveTo() *inside* that emit
-// is overwritten by vis — so we re-apply after each resize via a deferred call
+// fires while the canvas changes size, and a moveTo() *inside* that emit is
+// overwritten by vis — so we re-apply after each resize via a deferred call
 // (which sticks) and detach after a window so we never fight the user later.
 function onFullscreenChange() {
     var el = document.getElementById('graph');
     var fsBtn = document.getElementById('fullscreen-btn');
     var entering = isFullscreen();
     function applyView() {
-        if (!network) return;
-        if (entering) {
-            try { network.fit({animation: false}); } catch (e) {}
-        } else if (fsRestoreView) {
-            try { network.moveTo({scale: fsRestoreView.scale, position: fsRestoreView.position}); } catch (e) {}
-        }
+        if (!network || !fsRestoreView) return;
+        var scale = entering ? fsRestoreView.scale * FS_ZOOM_OUT : fsRestoreView.scale;
+        try { network.moveTo({scale: scale, position: fsRestoreView.position}); } catch (e) {}
     }
     if (entering) {
         el.style.height = window.innerHeight + 'px';

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -16,7 +16,7 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 #legend .line.dashed { border-top: 2px dashed; height: 0; }
 #legend .line.solid { border-top: 2px solid; height: 0; }
 #download-btn {
-    position: absolute; top: 8px; right: 8px; z-index: 10;
+    position: absolute; top: 8px; right: 48px; z-index: 10;
     width: 32px; height: 32px; border: none; border-radius: 6px;
     background: rgba(255,255,255,0.92); cursor: pointer;
     display: flex; align-items: center; justify-content: center;
@@ -25,7 +25,7 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 #download-btn:hover { opacity: 1; }
 #download-btn svg { width: 18px; height: 18px; fill: #555; }
 #fullscreen-btn {
-    position: absolute; top: 8px; right: 48px; z-index: 10;
+    position: absolute; top: 8px; right: 8px; z-index: 10;
     width: 32px; height: 32px; border: none; border-radius: 6px;
     background: rgba(255,255,255,0.92); cursor: pointer;
     display: flex; align-items: center; justify-content: center;
@@ -82,6 +82,7 @@ var lastNodes = null;
 var lastEdges = null;
 var currentTheme = {bg: '#ffffff', panel: 'rgba(255,255,255,0.92)', text: '#333333'};
 var currentHeight = 600;  // last non-fullscreen graph height, restored on exit
+var fsRestoreView = null;  // viewport captured just before a fullscreen toggle
 
 // When "Fit to window" is on, fill the available window height instead of using
 // the fixed Graph Height. Reads the parent window's height and this iframe's
@@ -131,7 +132,7 @@ function applyTheme(theme) {
 }
 
 function autofitApply() {
-    if (!autofitOn || !network || document.fullscreenElement) return;
+    if (!autofitOn || !network || isFullscreen()) return;
     var h = autofitHeight();
     if (h) { applyHeight(h); network.redraw(); }
 }
@@ -166,24 +167,50 @@ function downloadGraph() {
     }
 }
 
+// True when the document is fullscreen, checking the prefixed property too so a
+// WebKit implementation isn't misread as "not fullscreen" (review P3).
+function isFullscreen() {
+    return !!(document.fullscreenElement || document.webkitFullscreenElement);
+}
+
 // Enter/exit fullscreen for just the graph. The whole vis-network canvas lives
 // in this iframe, so fullscreening the container makes the graph fill the
 // physical screen — no sidebar, no toolbar, no black borders (issue #177).
+// Before entering, remember the current viewport so exiting can put it back.
 function toggleFullscreen() {
     var c = document.getElementById('container');
-    if (!document.fullscreenElement) {
+    if (!isFullscreen()) {
+        if (network) {
+            try { fsRestoreView = {scale: network.getScale(), position: network.getViewPosition()}; }
+            catch (e) { fsRestoreView = null; }
+        }
         (c.requestFullscreen || c.webkitRequestFullscreen || function () {}).call(c);
     } else {
         (document.exitFullscreen || document.webkitExitFullscreen || function () {}).call(document);
     }
 }
 
-// Resize the graph to fill the screen on enter, and restore the toolbar-driven
-// height on exit. Swap the icon and hint between enter/exit.
+// Resize the graph to fill the screen on enter and back to the toolbar-driven
+// height on exit, and swap the icon/hint. On enter the graph is fit to the
+// larger canvas so it actually uses the space; on exit the pre-fullscreen
+// viewport is restored, so a round-trip leaves the user's zoom/pan untouched
+// (review P2). vis rescales the view on each of the several 'resize' events it
+// fires while the canvas changes size, and a fit()/moveTo() *inside* that emit
+// is overwritten by vis — so we re-apply after each resize via a deferred call
+// (which sticks) and detach after a window so we never fight the user later.
 function onFullscreenChange() {
     var el = document.getElementById('graph');
     var fsBtn = document.getElementById('fullscreen-btn');
-    if (document.fullscreenElement) {
+    var entering = isFullscreen();
+    function applyView() {
+        if (!network) return;
+        if (entering) {
+            try { network.fit({animation: false}); } catch (e) {}
+        } else if (fsRestoreView) {
+            try { network.moveTo({scale: fsRestoreView.scale, position: fsRestoreView.position}); } catch (e) {}
+        }
+    }
+    if (entering) {
         el.style.height = window.innerHeight + 'px';
         if (fsBtn) {
             fsBtn.title = 'Exit fullscreen';
@@ -200,7 +227,15 @@ function onFullscreenChange() {
         el.style.height = h + 'px';
         sendToStreamlit("streamlit:setFrameHeight", {height: h});
     }
-    if (network) { network.redraw(); network.fit(); }
+    if (network) {
+        network.redraw();
+        applyView();  // handles the case where no 'resize' fires at all
+        var onResize = function () { setTimeout(applyView, 0); };
+        try {
+            network.on('resize', onResize);
+            setTimeout(function () { try { network.off('resize', onResize); } catch (e) {} }, 1000);
+        } catch (e) {}
+    }
 }
 document.addEventListener('fullscreenchange', onFullscreenChange);
 document.addEventListener('webkitfullscreenchange', onFullscreenChange);
@@ -227,7 +262,7 @@ function renderGraph(args) {
     if (network && args.seq === lastSeq && args.nodes === lastNodes && args.edges === lastEdges) {
         applyTheme(args.theme);
         var hh = autofitOn ? autofitHeight() : (args.height || 600);
-        if (hh) { currentHeight = hh; if (!document.fullscreenElement) applyHeight(hh); }
+        if (hh) { currentHeight = hh; if (!isFullscreen()) applyHeight(hh); }
         // A fresh "Find entity" pick is a same-data re-render (only focus_seq
         // changed), so centre on the new node here without rebuilding the whole
         // network (issue #144). Anything that isn't a new pick leaves the
@@ -263,7 +298,7 @@ function renderGraph(args) {
     // toolbar height. Remember the requested height so exiting fullscreen can
     // restore it.
     currentHeight = height;
-    if (!document.fullscreenElement) {
+    if (!isFullscreen()) {
         el.style.height = height + 'px';
         sendToStreamlit("streamlit:setFrameHeight", {height: height});
     }

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -84,6 +84,9 @@ var currentTheme = {bg: '#ffffff', panel: 'rgba(255,255,255,0.92)', text: '#3333
 var currentHeight = 600;  // last non-fullscreen graph height, restored on exit
 var fsRestoreView = null;  // viewport captured just before a fullscreen toggle
 var FS_ZOOM_OUT = 0.65;    // entering fullscreen zooms out ~35% around the centre
+var fsGen = 0;             // fullscreen transition counter, to void stale callbacks
+var fsResizeHandler = null; // active 'resize' listener from the current transition
+var fsDetachTimer = null;   // timer that detaches fsResizeHandler
 
 // When "Fit to window" is on, fill the available window height instead of using
 // the fixed Graph Height. Reads the parent window's height and this iframe's
@@ -204,8 +207,12 @@ function onFullscreenChange() {
     var el = document.getElementById('graph');
     var fsBtn = document.getElementById('fullscreen-btn');
     var entering = isFullscreen();
+    // Each transition gets a generation id; a deferred callback only acts if it
+    // still matches, so a superseded transition (e.g. a quick enter/exit) can't
+    // apply its zoom after a newer one has run (review P3).
+    var gen = ++fsGen;
     function applyView() {
-        if (!network || !fsRestoreView) return;
+        if (!network || !fsRestoreView || gen !== fsGen) return;
         var scale = entering ? fsRestoreView.scale * FS_ZOOM_OUT : fsRestoreView.scale;
         try { network.moveTo({scale: scale, position: fsRestoreView.position}); } catch (e) {}
     }
@@ -227,12 +234,21 @@ function onFullscreenChange() {
         sendToStreamlit("streamlit:setFrameHeight", {height: h});
     }
     if (network) {
+        // Tear down the previous transition's listener/timer before redraw(),
+        // which synchronously emits 'resize' — otherwise a stale "entering"
+        // listener from a just-superseded transition would schedule its
+        // zoom-out and undo this one (review P3).
+        if (fsResizeHandler) { try { network.off('resize', fsResizeHandler); } catch (e) {} fsResizeHandler = null; }
+        if (fsDetachTimer) { clearTimeout(fsDetachTimer); fsDetachTimer = null; }
         network.redraw();
         applyView();  // handles the case where no 'resize' fires at all
-        var onResize = function () { setTimeout(applyView, 0); };
+        fsResizeHandler = function () { setTimeout(applyView, 0); };
         try {
-            network.on('resize', onResize);
-            setTimeout(function () { try { network.off('resize', onResize); } catch (e) {} }, 1000);
+            network.on('resize', fsResizeHandler);
+            fsDetachTimer = setTimeout(function () {
+                if (fsResizeHandler) { try { network.off('resize', fsResizeHandler); } catch (e) {} fsResizeHandler = null; }
+                fsDetachTimer = null;
+            }, 1000);
         } catch (e) {}
     }
 }


### PR DESCRIPTION
## What

Adds a Fullscreen button to the interactive graph on the Visualization page. It fullscreens just the vis-network canvas via the browser Fullscreen API, so the graph fills the entire screen with no sidebar, no toolbar, and none of the black borders shown in the issue.

The button sits inside the graph, next to the existing Download and panel-toggle controls. This keeps the change entirely within the graph component and avoids redesigning the Streamlit toolbar widgets, which was the concern raised in the issue.

## Behavior

- Enter: the graph resizes to the full window height; icon and hint swap to "Exit fullscreen".
- Exit: the previous toolbar-driven height (fixed or Fit-to-window) is restored; icon swaps back.
- Fit-to-window auto-resize and same-data reruns (e.g. clicking a node) are guarded so they do not shrink the graph while fullscreen is active.
- The themed background carries into fullscreen so it does not fall back to the browser's default black backdrop.
- The same-origin component iframe is granted allowfullscreen defensively, on top of Streamlit's own allowFullScreen.

## Scope

Fullscreen button only. Zoom and pan stay on the mouse; the legend and download overlay remain available in fullscreen. The rest of the toolbar (filters, sliders, Find) is intentionally not shown in fullscreen.

## Testing

Verified live with a loaded template: button renders and is visible, document.fullscreenEnabled is true, requesting fullscreen succeeds, graph height goes from the fixed height to the full window height and back on exit, icon and title swap correctly both ways, and there are zero console errors. Change is pure frontend HTML/JS in the graph component, so it does not touch the Python test surface.

Addresses #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
