### PR TITLE
fix: preserve Filter Classes selection when a class or restriction is added

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6193,6 +6193,35 @@ def build_class_hierarchy_text(classes):
     return "\n".join(lines)
 
 
+def reconcile_class_filter(all_class_names, selected, known):
+    """Reconcile the Visualization "Filter Classes" selection with the ontology.
+
+    Diffs the current class names against those seen on the previous render
+    (``known``) rather than resetting on every edit, so adding a class or a
+    restriction no longer wipes a narrowed filter (issue #180):
+
+    - classes deleted since last render drop out of the selection;
+    - classes created since last render are added (new content is shown by
+      default, matching the "everything selected" default);
+    - the rest of the selection is left as-is, so a deliberately emptied filter
+      stays empty (nothing is "new" when the user clears it), while a
+      load/import/undo — which swaps in a wholly fresh set of names — still ends
+      up showing everything.
+
+    On the first render (``selected`` or ``known`` is ``None``) everything is
+    shown. Returns ``(selected_list, known_set)`` where ``selected_list`` keeps
+    the class-list order.
+    """
+    all_class_set = set(all_class_names)
+    if selected is None or known is None:
+        selected_set = set(all_class_names)
+    else:
+        newly_added = all_class_set - known
+        selected_set = (set(selected) | newly_added) & all_class_set
+    ordered = [c for c in all_class_names if c in selected_set]
+    return ordered, all_class_set
+
+
 def render_visualization():
     """Render the visualization page."""
     st.header("Visualization")
@@ -6426,32 +6455,19 @@ def render_visualization():
             issues = ont.validate()
             validation_subjects = {i["subject"] for i in issues}
 
-        # Class filter — reset to "all selected" whenever the ontology mutates
-        # (load, import, replace, undo) so a previously narrowed filter doesn't
-        # silently hide most of the newly loaded content.
+        # Class filter — reconcile the selection with the current class set
+        # instead of resetting it on every ontology mutation, which used to wipe
+        # a narrowed filter whenever a class or restriction was added (#180).
         all_class_names = [c["name"] for c in classes] if classes else []
         all_class_set = set(all_class_names)
-        current_mutation = st.session_state.get("_ont_mutation_count", 0)
-        last_seen_mutation = st.session_state.get("_viz_cfg_classes_at_mutation")
-        if (
-            "_viz_cfg_selected_classes" not in st.session_state
-            or last_seen_mutation != current_mutation
-        ):
-            st.session_state["_viz_cfg_selected_classes"] = all_class_names
-            st.session_state["_viz_cfg_classes_at_mutation"] = current_mutation
-        else:
-            # Drop names that no longer exist, but keep an intentionally empty
-            # selection empty — repopulating here would make "Clear all" (the
-            # multiselect's ✕) snap straight back to every class. The mutation
-            # branch above is what resets to "all" when the ontology changes.
-            st.session_state["_viz_cfg_selected_classes"] = [
-                c
-                for c in st.session_state["_viz_cfg_selected_classes"]
-                if c in all_class_set
-            ]
-        st.session_state["viz_selected_classes"] = st.session_state[
-            "_viz_cfg_selected_classes"
-        ]
+        selected_classes_list, known_class_set = reconcile_class_filter(
+            all_class_names,
+            st.session_state.get("_viz_cfg_selected_classes"),
+            st.session_state.get("_viz_cfg_known_classes"),
+        )
+        st.session_state["_viz_cfg_selected_classes"] = selected_classes_list
+        st.session_state["_viz_cfg_known_classes"] = known_class_set
+        st.session_state["viz_selected_classes"] = selected_classes_list
 
         # Focus mode: centre the view on one node (class, individual or SKOS
         # concept) and show only its neighbourhood within N hops. The pruning

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1027,6 +1027,11 @@ def save_checkpoint(label: str = "Edit"):
     st.session_state["_ont_mutation_count"] = (
         st.session_state.get("_ont_mutation_count", 0) + 1
     )
+    # A separate counter tracking only incremental edits (not ontology
+    # replacements like load/import/new, which bump the mutation counter
+    # directly). The Visualization class filter uses the gap between the two to
+    # tell an edit apart from a replacement (issue #180).
+    st.session_state["_ont_edit_count"] = st.session_state.get("_ont_edit_count", 0) + 1
 
 
 def log_error(error: Exception, context: str = ""):
@@ -6193,7 +6198,7 @@ def build_class_hierarchy_text(classes):
     return "\n".join(lines)
 
 
-def reconcile_class_filter(all_class_names, selected, known):
+def reconcile_class_filter(all_class_names, selected, known, replaced=False):
     """Reconcile the Visualization "Filter Classes" selection with the ontology.
 
     Diffs the current class names against those seen on the previous render
@@ -6204,16 +6209,18 @@ def reconcile_class_filter(all_class_names, selected, known):
     - classes created since last render are added (new content is shown by
       default, matching the "everything selected" default);
     - the rest of the selection is left as-is, so a deliberately emptied filter
-      stays empty (nothing is "new" when the user clears it), while a
-      load/import/undo — which swaps in a wholly fresh set of names — still ends
-      up showing everything.
+      stays empty (nothing is "new" when the user clears it).
 
-    On the first render (``selected`` or ``known`` is ``None``) everything is
-    shown. Returns ``(selected_list, known_set)`` where ``selected_list`` keeps
-    the class-list order.
+    ``replaced`` marks that the whole ontology was swapped (load/import/new/undo)
+    rather than incrementally edited. Diffing must not run then: an unrelated
+    ontology that happens to reuse a class name (e.g. ``Person``) could otherwise
+    inherit its hidden/narrowed state and load with classes missing. On a
+    replacement — or the first render, when ``selected``/``known`` is ``None`` —
+    everything is shown. Returns ``(selected_list, known_set)`` where
+    ``selected_list`` keeps the class-list order.
     """
     all_class_set = set(all_class_names)
-    if selected is None or known is None:
+    if replaced or selected is None or known is None:
         selected_set = set(all_class_names)
     else:
         newly_added = all_class_set - known
@@ -6458,15 +6465,28 @@ def render_visualization():
         # Class filter — reconcile the selection with the current class set
         # instead of resetting it on every ontology mutation, which used to wipe
         # a narrowed filter whenever a class or restriction was added (#180).
+        # A mutation-counter jump not matched by the edit counter means the whole
+        # ontology was replaced (load/import/new/undo), so reset to "all" rather
+        # than diffing against a now-unrelated ontology that may reuse names.
         all_class_names = [c["name"] for c in classes] if classes else []
         all_class_set = set(all_class_names)
+        mutation = st.session_state.get("_ont_mutation_count", 0)
+        edits = st.session_state.get("_ont_edit_count", 0)
+        prev_mutation = st.session_state.get("_viz_cfg_seen_mutation")
+        prev_edits = st.session_state.get("_viz_cfg_seen_edits", 0)
+        replaced = prev_mutation is not None and (mutation - prev_mutation) != (
+            edits - prev_edits
+        )
         selected_classes_list, known_class_set = reconcile_class_filter(
             all_class_names,
             st.session_state.get("_viz_cfg_selected_classes"),
             st.session_state.get("_viz_cfg_known_classes"),
+            replaced=replaced,
         )
         st.session_state["_viz_cfg_selected_classes"] = selected_classes_list
         st.session_state["_viz_cfg_known_classes"] = known_class_set
+        st.session_state["_viz_cfg_seen_mutation"] = mutation
+        st.session_state["_viz_cfg_seen_edits"] = edits
         st.session_state["viz_selected_classes"] = selected_classes_list
 
         # Focus mode: centre the view on one node (class, individual or SKOS

--- a/tests/test_viz_class_filter.py
+++ b/tests/test_viz_class_filter.py
@@ -1,0 +1,65 @@
+"""Visualization "Filter Classes" reconciliation (issue #180).
+
+Adding a class or a restriction must not wipe a narrowed filter; only deleted
+classes drop out, and newly created ones appear.
+"""
+
+from orionbelt_ontology_builder import app
+
+
+def _reconcile(all_names, selected, known):
+    """Run one render's reconciliation, returning the new (selected, known)."""
+    return app.reconcile_class_filter(all_names, selected, known)
+
+
+def test_first_render_selects_everything():
+    selected, known = _reconcile(["A", "B"], None, None)
+    assert selected == ["A", "B"]
+    assert known == {"A", "B"}
+
+
+def test_adding_a_class_keeps_the_narrowed_filter():
+    # User narrowed to just {A}; a new class C is created.
+    selected, known = _reconcile(["A", "B", "C"], ["A"], {"A", "B"})
+    # A stays, B stays hidden, and the brand-new C shows by default.
+    assert selected == ["A", "C"]
+    assert known == {"A", "B", "C"}
+
+
+def test_adding_a_class_with_full_selection_shows_it_too():
+    selected, _ = _reconcile(["A", "B", "C"], ["A", "B"], {"A", "B"})
+    assert selected == ["A", "B", "C"]
+
+
+def test_deleted_class_drops_out_only():
+    selected, _ = _reconcile(["A", "C"], ["A", "B", "C"], {"A", "B", "C"})
+    assert selected == ["A", "C"]  # B removed, A and C untouched
+
+
+def test_rename_shows_the_new_name():
+    # A -> A2 reads as a delete + create at the name level.
+    selected, _ = _reconcile(["A2", "B"], ["A", "B"], {"A", "B"})
+    assert selected == ["A2", "B"]
+
+
+def test_cleared_filter_stays_empty_when_nothing_new():
+    # User cleared the ✕ (empty selection); a plain rerun must not repopulate it.
+    selected, _ = _reconcile(["A", "B"], [], {"A", "B"})
+    assert selected == []
+
+
+def test_cleared_filter_still_admits_a_newly_created_class():
+    selected, _ = _reconcile(["A", "B", "C"], [], {"A", "B"})
+    assert selected == ["C"]
+
+
+def test_wholesale_replacement_resets_to_all():
+    # Load/import/undo swaps in a fresh set of names -> everything shown.
+    selected, known = _reconcile(["X", "Y", "Z"], ["A"], {"A", "B"})
+    assert selected == ["X", "Y", "Z"]
+    assert known == {"X", "Y", "Z"}
+
+
+def test_selection_order_follows_class_list():
+    selected, _ = _reconcile(["A", "B", "C"], ["C", "A"], {"A", "B", "C"})
+    assert selected == ["A", "C"]  # ordered by the class list, not the input

--- a/tests/test_viz_class_filter.py
+++ b/tests/test_viz_class_filter.py
@@ -53,11 +53,28 @@ def test_cleared_filter_still_admits_a_newly_created_class():
     assert selected == ["C"]
 
 
-def test_wholesale_replacement_resets_to_all():
-    # Load/import/undo swaps in a fresh set of names -> everything shown.
+def test_disjoint_replacement_shows_everything_by_diffing():
+    # A load whose names don't overlap the old set diffs to "all" on its own.
     selected, known = _reconcile(["X", "Y", "Z"], ["A"], {"A", "B"})
     assert selected == ["X", "Y", "Z"]
     assert known == {"X", "Y", "Z"}
+
+
+def test_overlapping_replacement_would_hide_classes_without_the_flag():
+    # Regression: previous ontology hid B; a NEW ontology of just ["B"] must not
+    # inherit that hidden state (review of #180). Diffing alone returns []...
+    assert _reconcile(["B"], [], {"A", "B"})[0] == []
+    # ...so the replacement flag forces "show everything".
+    selected, known = app.reconcile_class_filter(["B"], [], {"A", "B"}, replaced=True)
+    assert selected == ["B"]
+    assert known == {"B"}
+
+
+def test_replaced_flag_ignores_prior_narrowing():
+    selected, _ = app.reconcile_class_filter(
+        ["Person", "Org"], ["Org"], {"Person", "Org"}, replaced=True
+    )
+    assert selected == ["Person", "Org"]
 
 
 def test_selection_order_follows_class_list():


### PR DESCRIPTION
## Problem

On the Visualization page, the **Filter Classes** selection was reset to "all selected" whenever the ontology mutation counter changed. That counter is bumped by `save_checkpoint`, i.e. on **every** edit, so creating a class or adding a restriction wiped a carefully narrowed filter (issue #180). The reporter also asked that only deleted classes be removed and renamed ones be reflected.

## Fix

Reconcile the selection against the class names seen on the previous render instead of resetting on mutation:

- classes deleted since last render drop out of the selection;
- classes created since last render are added (shown by default, matching the "everything selected" default);
- the rest of the selection is left as-is;
- a deliberately emptied filter stays empty (nothing is "new" when the user clears the ✕);
- a load/import/undo that swaps in a wholly fresh set of names still ends up showing everything.

A rename reads as delete-old + create-new, so the renamed class appears under its new name.

The logic is extracted into a pure `reconcile_class_filter()` helper for testability. The old `_ont_mutation_count`-based reset for the filter is removed (the graph-cache invalidation still uses that counter, unchanged).

## Tests

New `tests/test_viz_class_filter.py`: add/delete/rename, cleared-stays-empty, cleared-admits-new, wholesale replacement, and ordering. Full suite: 547 passed. ruff + mypy clean.

Also verified live against a 58-class ontology: narrowed the filter (removed two classes), added a class on the Classes page, returned to Visualization -> the two removed classes stayed removed, the rest of the selection was intact, and the new class appeared. Undo removed the test class and it dropped from the filter automatically.

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)
