### PR TITLE
fix: fullscreen graph on desktop and in the browser

### DIFF
--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -213,10 +213,15 @@ def _install_window_bridges(app_name: str):
         def orionbelt_toggle_fullscreen():
             # The embedded webview doesn't support the HTML Fullscreen API, so the
             # graph's Fullscreen button routes here to toggle the native window
-            # instead (issue #177). Returns the resulting state, or None on error.
+            # instead (issue #177). Returns True once the toggle is away, or None
+            # if it couldn't be requested — deliberately not the resulting
+            # fullscreen state: pywebview keeps that on its platform window, and
+            # some backends (Qt) only flip it once the GUI thread catches up, so
+            # anything read here could be a lie. The page tracks its own overlay
+            # state and is told about native exits by _on_window_restored below.
             try:
                 window.toggle_fullscreen()
-                return bool(getattr(window, "fullscreen", False))
+                return True
             except Exception:
                 return None
 
@@ -231,11 +236,11 @@ def _install_window_bridges(app_name: str):
 
         def _clear_native_fullscreen_flag():
             # pywebview decides which way toggle_fullscreen() goes purely from a
-            # flag it flips itself, so a fullscreen exit it didn't initiate (Esc)
-            # leaves that flag stale and the next toggle fails to re-enter. There
-            # is no public setter, hence reaching for the platform window; every
-            # step is optional so an unknown backend simply keeps today's
-            # behaviour.
+            # flag it keeps on the platform window, so a fullscreen exit it didn't
+            # initiate (Esc) leaves that flag stale and the next toggle fails to
+            # re-enter. There is no public setter, hence reaching for the platform
+            # window; every step is optional so an unknown backend simply keeps
+            # today's behaviour.
             try:
                 view = window.gui.BrowserView.instances.get(window.uid)
             except Exception:

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -176,10 +176,12 @@ def _install_window_bridges(app_name: str):
     scripts: :data:`_TITLE_SYNC_JS` (a MutationObserver mirroring
     ``document.title`` onto the window, issue #90) and
     :data:`_CLIPBOARD_BRIDGE_JS` (route the page's clipboard writes through the
-    native writer, issue #120). Every step is defensive: any failure leaves the
-    window working without that enhancement rather than breaking the desktop
-    launch. Returns the original ``create_window`` for restoration, or ``None``
-    when there is nothing to hook (e.g. a stubbed webview in tests).
+    native writer, issue #120). It also mirrors native fullscreen exits back to
+    the page so the graph's fullscreen overlay can't outlive them (issue #177
+    follow-up). Every step is defensive: any failure leaves the window working
+    without that enhancement rather than breaking the desktop launch. Returns the
+    original ``create_window`` for restoration, or ``None`` when there is nothing
+    to hook (e.g. a stubbed webview in tests).
     """
     import webview
 
@@ -224,6 +226,44 @@ def _install_window_bridges(app_name: str):
                 orionbelt_copy_to_clipboard,
                 orionbelt_toggle_fullscreen,
             )
+        except Exception:
+            pass
+
+        def _clear_native_fullscreen_flag():
+            # pywebview decides which way toggle_fullscreen() goes purely from a
+            # flag it flips itself, so a fullscreen exit it didn't initiate (Esc)
+            # leaves that flag stale and the next toggle fails to re-enter. There
+            # is no public setter, hence reaching for the platform window; every
+            # step is optional so an unknown backend simply keeps today's
+            # behaviour.
+            try:
+                view = window.gui.BrowserView.instances.get(window.uid)
+            except Exception:
+                return
+            if view is not None and getattr(view, "is_fullscreen", False):
+                try:
+                    view.is_fullscreen = False
+                except Exception:
+                    pass
+
+        def _on_window_restored():
+            # macOS fires the window's "restored" event when it leaves fullscreen
+            # (Esc, the green button, the Window menu). The webview reports no
+            # fullscreenchange to the page, so the graph's desktop fullscreen
+            # overlay would stay stretched over the shrunken window and keep
+            # covering the whole app (issue #177 follow-up). Tell the page to drop
+            # it. The event runs on its own thread, so evaluate_js can't deadlock.
+            _clear_native_fullscreen_flag()
+            try:
+                window.evaluate_js(
+                    "window.__orionbeltNativeFullscreenExit &&"
+                    " window.__orionbeltNativeFullscreenExit()"
+                )
+            except Exception:
+                pass
+
+        try:
+            window.events.restored += _on_window_restored
         except Exception:
             pass
 

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -208,8 +208,22 @@ def _install_window_bridges(app_name: str):
             except Exception:
                 return False
 
+        def orionbelt_toggle_fullscreen():
+            # The embedded webview doesn't support the HTML Fullscreen API, so the
+            # graph's Fullscreen button routes here to toggle the native window
+            # instead (issue #177). Returns the resulting state, or None on error.
+            try:
+                window.toggle_fullscreen()
+                return bool(getattr(window, "fullscreen", False))
+            except Exception:
+                return None
+
         try:
-            window.expose(orionbelt_set_window_title, orionbelt_copy_to_clipboard)
+            window.expose(
+                orionbelt_set_window_title,
+                orionbelt_copy_to_clipboard,
+                orionbelt_toggle_fullscreen,
+            )
         except Exception:
             pass
 

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -229,6 +229,19 @@ function afterReflow(fn) {
     }
 }
 
+// Name of the hook the native host (desktop.py) calls when its window leaves
+// fullscreen without going through our button — Esc, the macOS green button, the
+// Window menu. The webview surfaces no fullscreenchange for the native window,
+// so without this the overlay stays pinned at 100vw/100vh while the window
+// shrinks back, leaving the graph covering the whole app (issue #177 follow-up).
+// It lives
+// on the top window because that is the frame Python's evaluate_js runs in.
+var TOP_FS_EXIT_HOOK = '__orionbeltNativeFullscreenExit';
+
+function setNativeFsExitHook(fn) {
+    try { if (window.top) window.top[TOP_FS_EXIT_HOOK] = fn; } catch (e) {}
+}
+
 function enterPseudoFullscreen() {
     var fe = window.frameElement;
     if (!fe) return false;
@@ -245,6 +258,9 @@ function enterPseudoFullscreen() {
     fe.style.zIndex = '2147483647';
     fe.style.background = currentTheme.bg;
     desktopFsOn = true;
+    // The native window can leave fullscreen on its own; drop the overlay then
+    // (without toggling the window back, it has already left).
+    setNativeFsExitHook(function () { if (desktopFsOn) exitPseudoFullscreen(); });
     setFullscreenIcon(true);
     afterReflow(function () { if (desktopFsOn) scheduleFullscreenView(true); });
     return true;
@@ -254,6 +270,7 @@ function exitPseudoFullscreen() {
     var fe = window.frameElement;
     if (fe) fe.setAttribute('style', pseudoFsPrevStyle || '');
     desktopFsOn = false;
+    setNativeFsExitHook(null);
     setFullscreenIcon(false);
     scheduleFullscreenView(false);
 }

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -136,7 +136,7 @@ function applyTheme(theme) {
 }
 
 function autofitApply() {
-    if (!autofitOn || !network || isFullscreen()) return;
+    if (!autofitOn || !network || isFullscreen() || desktopFsOn) return;
     var h = autofitHeight();
     if (h) { applyHeight(h); network.redraw(); }
 }
@@ -201,37 +201,96 @@ function desktopFullscreenToggle() {
     return null;
 }
 
-// Offer the button when either the HTML API works (web) or the native desktop
-// toggle is available; hide it only where neither exists.
+// Offer the button when either the HTML API works (web) or we can build the
+// desktop overlay (a same-origin frame plus the native pywebview toggle); hide
+// it only where neither path exists.
 function fullscreenSupported() {
-    return htmlFullscreenSupported() || !!desktopFullscreenToggle();
+    return htmlFullscreenSupported() ||
+        (!!desktopFullscreenToggle() && !!window.frameElement);
 }
 
-var desktopFsOn = false;  // tracked native-window state (no fullscreenchange fires)
+var desktopFsOn = false;   // tracked pseudo-fullscreen state (no fullscreenchange)
+var pseudoFsPrevStyle = null;  // saved inline style of this iframe in the parent
 
-// Toggle the native desktop window's fullscreen via the pywebview bridge, and
-// swap the icon ourselves since no fullscreenchange event fires for it. Returns
-// true if a bridge was found and invoked.
+// Desktop graph-only fullscreen. The webview has no HTML Fullscreen API and the
+// native-window toggle alone fullscreens the whole app (sidebar + toolbar), not
+// the graph (issue #177 follow-up). So promote this same-origin iframe to a
+// fixed, full-viewport overlay — it covers the sidebar and toolbar, leaving just
+// the graph — and also toggle the native window so it fills the monitor.
+function enterPseudoFullscreen() {
+    var fe = window.frameElement;
+    if (!fe) return false;
+    if (network) {
+        try { fsRestoreView = {scale: network.getScale(), position: network.getViewPosition()}; }
+        catch (e) { fsRestoreView = null; }
+    }
+    pseudoFsPrevStyle = fe.getAttribute('style') || '';
+    fe.style.position = 'fixed';
+    fe.style.top = '0';
+    fe.style.left = '0';
+    fe.style.width = '100vw';
+    fe.style.height = '100vh';
+    fe.style.zIndex = '2147483647';
+    fe.style.background = currentTheme.bg;
+    desktopFsOn = true;
+    var el = document.getElementById('graph');
+    el.style.height = window.innerHeight + 'px';
+    if (network) {
+        network.redraw();
+        if (fsRestoreView) {
+            try { network.moveTo({scale: fsRestoreView.scale * FS_ZOOM_OUT, position: fsRestoreView.position}); }
+            catch (e) {}
+        }
+    }
+    setFullscreenIcon(true);
+    return true;
+}
+
+function exitPseudoFullscreen() {
+    var fe = window.frameElement;
+    if (fe) fe.setAttribute('style', pseudoFsPrevStyle || '');
+    desktopFsOn = false;
+    var el = document.getElementById('graph');
+    var h = autofitOn ? (autofitHeight() || currentHeight) : currentHeight;
+    el.style.height = h + 'px';
+    sendToStreamlit("streamlit:setFrameHeight", {height: h});
+    if (network) {
+        network.redraw();
+        if (fsRestoreView) {
+            try { network.moveTo({scale: fsRestoreView.scale, position: fsRestoreView.position}); }
+            catch (e) {}
+        }
+    }
+    setFullscreenIcon(false);
+}
+
+// Toggle desktop fullscreen: the overlay (graph-only) plus, when available, the
+// native window (fills the monitor). Returns true if it handled the toggle.
 function tryDesktopFullscreen() {
+    if (!window.frameElement) return false;  // can't build the overlay
     var nativeToggle = desktopFullscreenToggle();
-    if (!nativeToggle) return false;
-    try {
-        var r = nativeToggle();
-        desktopFsOn = !desktopFsOn;
-        setFullscreenIcon(desktopFsOn);
-        if (r && r.catch) r.catch(function () {});
-    } catch (e) {}
+    var callNative = function () {
+        if (!nativeToggle) return;
+        try { var r = nativeToggle(); if (r && r.catch) r.catch(function () {}); } catch (e) {}
+    };
+    if (!desktopFsOn) {
+        callNative();
+        enterPseudoFullscreen();
+    } else {
+        exitPseudoFullscreen();
+        callNative();
+    }
     return true;
 }
 
 // Enter/exit fullscreen for just the graph. The whole vis-network canvas lives
 // in this iframe, so fullscreening the container makes the graph fill the
-// physical screen — no sidebar, no toolbar, no black borders (issue #177). In
-// the desktop app the HTML API is unavailable, so we toggle the native window
-// instead (the whole window; with "Fit to window" on, the graph fills it) — used
-// both when the API is reported unsupported and if a requestFullscreen attempt
-// throws/rejects anyway. Before entering, remember the viewport so exiting
-// restores it.
+// physical screen — no sidebar, no toolbar, no black borders (issue #177). On
+// the web the HTML Fullscreen API does this; in the desktop app it's
+// unavailable, so tryDesktopFullscreen() builds an equivalent graph-only overlay
+// (used both when the API is reported unsupported and if a requestFullscreen
+// attempt throws/rejects anyway). Before entering, remember the viewport so
+// exiting restores it.
 function toggleFullscreen() {
     var c = document.getElementById('container');
     if (htmlFullscreenSupported()) {
@@ -343,7 +402,7 @@ function renderGraph(args) {
     if (network && args.seq === lastSeq && args.nodes === lastNodes && args.edges === lastEdges) {
         applyTheme(args.theme);
         var hh = autofitOn ? autofitHeight() : (args.height || 600);
-        if (hh) { currentHeight = hh; if (!isFullscreen()) applyHeight(hh); }
+        if (hh) { currentHeight = hh; if (!isFullscreen() && !desktopFsOn) applyHeight(hh); }
         // A fresh "Find entity" pick is a same-data re-render (only focus_seq
         // changed), so centre on the new node here without rebuilding the whole
         // network (issue #144). Anything that isn't a new pick leaves the
@@ -379,7 +438,7 @@ function renderGraph(args) {
     // toolbar height. Remember the requested height so exiting fullscreen can
     // restore it.
     currentHeight = height;
-    if (!isFullscreen()) {
+    if (!isFullscreen() && !desktopFsOn) {
         el.style.height = height + 'px';
         sendToStreamlit("streamlit:setFrameHeight", {height: height});
     }

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -33,9 +33,13 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 }
 #fullscreen-btn:hover { opacity: 1; }
 #fullscreen-btn svg { width: 18px; height: 18px; fill: #555; }
-/* In fullscreen the container fills the screen; keep the themed background so
-   the graph doesn't fall back to the browser's default black backdrop. */
-#container:fullscreen { width: 100vw; height: 100vh; }
+/* In fullscreen the container fills the screen, so the graph doesn't fall back
+   to the browser's default black backdrop. Percentages, not vw/vh: this document
+   is a Streamlit component iframe, where vw/vh resolve against the *iframe's*
+   viewport, so a browser window smaller than the screen left the container that
+   size with black bands around it (issue #177 follow-up). 100% resolves against
+   the fullscreen box the UA gives us, which is the screen. */
+#container:fullscreen { width: 100%; height: 100%; }
 </style>
 </head>
 <body>
@@ -136,7 +140,12 @@ function applyTheme(theme) {
 }
 
 function autofitApply() {
-    if (!autofitOn || !network || isFullscreen() || desktopFsOn) return;
+    if (!network) return;
+    // In fullscreen the graph fills the screen instead of the toolbar height, and
+    // that target can change after the transition (a moved window, another
+    // monitor), so re-fit rather than bailing out.
+    if (isFullscreen() || desktopFsOn) { fitFullscreenGraph(); return; }
+    if (!autofitOn) return;
     var h = autofitHeight();
     if (h) { applyHeight(h); network.redraw(); }
 }
@@ -263,6 +272,7 @@ function enterPseudoFullscreen() {
     setNativeFsExitHook(function () { if (desktopFsOn) exitPseudoFullscreen(); });
     setFullscreenIcon(true);
     afterReflow(function () { if (desktopFsOn) scheduleFullscreenView(true); });
+    watchFullscreenBox();
     return true;
 }
 
@@ -271,6 +281,7 @@ function exitPseudoFullscreen() {
     if (fe) fe.setAttribute('style', pseudoFsPrevStyle || '');
     desktopFsOn = false;
     setNativeFsExitHook(null);
+    unwatchFullscreenBox();
     setFullscreenIcon(false);
     scheduleFullscreenView(false);
 }
@@ -340,15 +351,53 @@ function setFullscreenIcon(on) {
         : '<path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>';
 }
 
-// Resize the graph to fill the screen on enter and back to the toolbar-driven
-// height on exit, and swap the icon/hint. On enter the graph zooms out ~30%
-// around the same centre so fullscreen reveals more context without shrinking a
-// large graph to an unreadable whole-graph fit; on exit the pre-fullscreen
-// viewport is restored, so a round-trip leaves the user's zoom/pan untouched
-// (review P2). vis rescales the view on each of the several 'resize' events it
-// fires while the canvas changes size, and a moveTo() *inside* that emit is
-// overwritten by vis — so we re-apply after each resize via a deferred call
-// (which sticks) and detach after a window so we never fight the user later.
+// Height the graph canvas needs to fill the screen while fullscreen. This
+// document is a Streamlit component iframe, so window.innerHeight stays the
+// *iframe's* height even while the container is fullscreen: reading it here left
+// the canvas at the pre-fullscreen height, cutting the graph off whenever the
+// browser window was smaller than the screen (issue #177 follow-up). Measure the
+// fullscreen box itself instead. The desktop overlay has no fullscreen element
+// and falls back to the iframe height — which is the full window by then, hence
+// the afterReflow() before its call.
+function fullscreenHeight() {
+    var c = document.getElementById('container');
+    var fsEl = document.fullscreenElement || document.webkitFullscreenElement;
+    if (c && fsEl === c && c.clientHeight) return c.clientHeight;
+    return window.innerHeight;
+}
+
+// Keep the canvas matched to the fullscreen box. Redraws only on a real change,
+// so the observer below cannot feed itself.
+function fitFullscreenGraph() {
+    var el = document.getElementById('graph');
+    if (!el) return;
+    var h = fullscreenHeight();
+    if (!h || parseInt(el.style.height, 10) === h) return;
+    el.style.height = h + 'px';
+    if (network) network.redraw();
+}
+
+// The fullscreen box isn't always at its final size when fullscreenchange fires
+// (the transition animates, and inside an iframe no window 'resize' need follow),
+// so watch it while fullscreen lasts and re-fit as it settles.
+var fsBoxObserver = null;
+
+function watchFullscreenBox() {
+    if (fsBoxObserver || !window.ResizeObserver) return;
+    var c = document.getElementById('container');
+    if (!c) return;
+    fsBoxObserver = new ResizeObserver(function () {
+        if (isFullscreen() || desktopFsOn) fitFullscreenGraph();
+    });
+    try { fsBoxObserver.observe(c); } catch (e) { fsBoxObserver = null; }
+}
+
+function unwatchFullscreenBox() {
+    if (!fsBoxObserver) return;
+    try { fsBoxObserver.disconnect(); } catch (e) {}
+    fsBoxObserver = null;
+}
+
 // Size the graph to the fullscreen viewport (on enter) or back to the
 // toolbar-driven height (on exit), then hold the viewport steady. vis rescales
 // the view on each of the several 'resize' events it fires while the canvas
@@ -357,8 +406,8 @@ function setFullscreenIcon(on) {
 // a window so we never fight the user later. On enter the graph zooms out ~30%
 // around the same centre; on exit the pre-fullscreen viewport is restored, so a
 // round-trip leaves the user's zoom/pan untouched (review P2). Used by both the
-// web HTML path and the desktop overlay. Reads window.innerHeight when called,
-// so the overlay must call it *after* the iframe has reflowed to full size.
+// web HTML path and the desktop overlay. Measures the fullscreen box when called,
+// so callers must call it *after* the box has reflowed to its full size.
 function scheduleFullscreenView(entering) {
     var el = document.getElementById('graph');
     // Each transition gets a generation id; a deferred callback only acts if it
@@ -371,7 +420,7 @@ function scheduleFullscreenView(entering) {
         try { network.moveTo({scale: scale, position: fsRestoreView.position}); } catch (e) {}
     }
     if (entering) {
-        el.style.height = window.innerHeight + 'px';
+        el.style.height = fullscreenHeight() + 'px';
     } else {
         var h = autofitOn ? (autofitHeight() || currentHeight) : currentHeight;
         el.style.height = h + 'px';
@@ -401,6 +450,14 @@ function onFullscreenChange() {
     var entering = isFullscreen();
     setFullscreenIcon(entering);
     scheduleFullscreenView(entering);
+    if (entering) {
+        // The fullscreen box is often still the old size at this point, so
+        // re-measure once the browser has reflowed and keep watching it settle.
+        afterReflow(function () { if (isFullscreen()) scheduleFullscreenView(true); });
+        watchFullscreenBox();
+    } else {
+        unwatchFullscreenBox();
+    }
 }
 document.addEventListener('fullscreenchange', onFullscreenChange);
 document.addEventListener('webkitfullscreenchange', onFullscreenChange);

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -217,6 +217,18 @@ var pseudoFsPrevStyle = null;  // saved inline style of this iframe in the paren
 // the graph (issue #177 follow-up). So promote this same-origin iframe to a
 // fixed, full-viewport overlay — it covers the sidebar and toolbar, leaving just
 // the graph — and also toggle the native window so it fills the monitor.
+// Run fn after the browser has reflowed (two frames), falling back to a timer,
+// so window.innerHeight reflects the iframe's new full-viewport size. Reading it
+// synchronously after the style change returns the stale pre-overlay height,
+// which left the graph filling only part of the screen.
+function afterReflow(fn) {
+    if (window.requestAnimationFrame) {
+        requestAnimationFrame(function () { requestAnimationFrame(fn); });
+    } else {
+        setTimeout(fn, 60);
+    }
+}
+
 function enterPseudoFullscreen() {
     var fe = window.frameElement;
     if (!fe) return false;
@@ -233,16 +245,8 @@ function enterPseudoFullscreen() {
     fe.style.zIndex = '2147483647';
     fe.style.background = currentTheme.bg;
     desktopFsOn = true;
-    var el = document.getElementById('graph');
-    el.style.height = window.innerHeight + 'px';
-    if (network) {
-        network.redraw();
-        if (fsRestoreView) {
-            try { network.moveTo({scale: fsRestoreView.scale * FS_ZOOM_OUT, position: fsRestoreView.position}); }
-            catch (e) {}
-        }
-    }
     setFullscreenIcon(true);
+    afterReflow(function () { if (desktopFsOn) scheduleFullscreenView(true); });
     return true;
 }
 
@@ -250,18 +254,8 @@ function exitPseudoFullscreen() {
     var fe = window.frameElement;
     if (fe) fe.setAttribute('style', pseudoFsPrevStyle || '');
     desktopFsOn = false;
-    var el = document.getElementById('graph');
-    var h = autofitOn ? (autofitHeight() || currentHeight) : currentHeight;
-    el.style.height = h + 'px';
-    sendToStreamlit("streamlit:setFrameHeight", {height: h});
-    if (network) {
-        network.redraw();
-        if (fsRestoreView) {
-            try { network.moveTo({scale: fsRestoreView.scale, position: fsRestoreView.position}); }
-            catch (e) {}
-        }
-    }
     setFullscreenIcon(false);
+    scheduleFullscreenView(false);
 }
 
 // Toggle desktop fullscreen: the overlay (graph-only) plus, when available, the
@@ -338,9 +332,18 @@ function setFullscreenIcon(on) {
 // fires while the canvas changes size, and a moveTo() *inside* that emit is
 // overwritten by vis — so we re-apply after each resize via a deferred call
 // (which sticks) and detach after a window so we never fight the user later.
-function onFullscreenChange() {
+// Size the graph to the fullscreen viewport (on enter) or back to the
+// toolbar-driven height (on exit), then hold the viewport steady. vis rescales
+// the view on each of the several 'resize' events it fires while the canvas
+// changes size, and a moveTo() *inside* that emit is overwritten by vis — so we
+// re-apply after each resize via a deferred call (which sticks) and detach after
+// a window so we never fight the user later. On enter the graph zooms out ~30%
+// around the same centre; on exit the pre-fullscreen viewport is restored, so a
+// round-trip leaves the user's zoom/pan untouched (review P2). Used by both the
+// web HTML path and the desktop overlay. Reads window.innerHeight when called,
+// so the overlay must call it *after* the iframe has reflowed to full size.
+function scheduleFullscreenView(entering) {
     var el = document.getElementById('graph');
-    var entering = isFullscreen();
     // Each transition gets a generation id; a deferred callback only acts if it
     // still matches, so a superseded transition (e.g. a quick enter/exit) can't
     // apply its zoom after a newer one has run (review P3).
@@ -350,7 +353,6 @@ function onFullscreenChange() {
         var scale = entering ? fsRestoreView.scale * FS_ZOOM_OUT : fsRestoreView.scale;
         try { network.moveTo({scale: scale, position: fsRestoreView.position}); } catch (e) {}
     }
-    setFullscreenIcon(entering);
     if (entering) {
         el.style.height = window.innerHeight + 'px';
     } else {
@@ -376,6 +378,12 @@ function onFullscreenChange() {
             }, 1000);
         } catch (e) {}
     }
+}
+
+function onFullscreenChange() {
+    var entering = isFullscreen();
+    setFullscreenIcon(entering);
+    scheduleFullscreenView(entering);
 }
 document.addEventListener('fullscreenchange', onFullscreenChange);
 document.addEventListener('webkitfullscreenchange', onFullscreenChange);

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -177,21 +177,97 @@ function isFullscreen() {
     return !!(document.fullscreenElement || document.webkitFullscreenElement);
 }
 
+// Whether the HTML Fullscreen API is actually available here. The desktop
+// pywebview doesn't support it — requestFullscreen throws "Fullscreen is not
+// supported" (#177) — in which case we fall back to toggling the native window.
+function htmlFullscreenSupported() {
+    try {
+        var c = document.getElementById('container');
+        return !!(document.fullscreenEnabled || document.webkitFullscreenEnabled) &&
+            !!(c && (c.requestFullscreen || c.webkitRequestFullscreen));
+    } catch (e) {
+        return false;
+    }
+}
+
+// The native desktop window's fullscreen toggle, exposed by the pywebview host
+// (desktop.py). Reached via window.top since the graph is in a same-origin
+// iframe; returns null on the web (cross-origin access throws, or no pywebview).
+function desktopFullscreenToggle() {
+    try {
+        var api = window.top && window.top.pywebview && window.top.pywebview.api;
+        if (api && api.orionbelt_toggle_fullscreen) return api.orionbelt_toggle_fullscreen;
+    } catch (e) {}
+    return null;
+}
+
+// Offer the button when either the HTML API works (web) or the native desktop
+// toggle is available; hide it only where neither exists.
+function fullscreenSupported() {
+    return htmlFullscreenSupported() || !!desktopFullscreenToggle();
+}
+
+var desktopFsOn = false;  // tracked native-window state (no fullscreenchange fires)
+
+// Toggle the native desktop window's fullscreen via the pywebview bridge, and
+// swap the icon ourselves since no fullscreenchange event fires for it. Returns
+// true if a bridge was found and invoked.
+function tryDesktopFullscreen() {
+    var nativeToggle = desktopFullscreenToggle();
+    if (!nativeToggle) return false;
+    try {
+        var r = nativeToggle();
+        desktopFsOn = !desktopFsOn;
+        setFullscreenIcon(desktopFsOn);
+        if (r && r.catch) r.catch(function () {});
+    } catch (e) {}
+    return true;
+}
+
 // Enter/exit fullscreen for just the graph. The whole vis-network canvas lives
 // in this iframe, so fullscreening the container makes the graph fill the
-// physical screen — no sidebar, no toolbar, no black borders (issue #177).
-// Before entering, remember the current viewport so exiting can put it back.
+// physical screen — no sidebar, no toolbar, no black borders (issue #177). In
+// the desktop app the HTML API is unavailable, so we toggle the native window
+// instead (the whole window; with "Fit to window" on, the graph fills it) — used
+// both when the API is reported unsupported and if a requestFullscreen attempt
+// throws/rejects anyway. Before entering, remember the viewport so exiting
+// restores it.
 function toggleFullscreen() {
     var c = document.getElementById('container');
-    if (!isFullscreen()) {
-        if (network) {
-            try { fsRestoreView = {scale: network.getScale(), position: network.getViewPosition()}; }
-            catch (e) { fsRestoreView = null; }
+    if (htmlFullscreenSupported()) {
+        try {
+            if (!isFullscreen()) {
+                if (network) {
+                    try {
+                        fsRestoreView = {scale: network.getScale(), position: network.getViewPosition()};
+                    } catch (e) { fsRestoreView = null; }
+                }
+                var req = c.requestFullscreen || c.webkitRequestFullscreen;
+                var p = req && req.call(c);
+                // If the request rejects (e.g. a webview that claims support but
+                // refuses), fall back to the native toggle instead of no-op.
+                if (p && p.catch) p.catch(function () { tryDesktopFullscreen(); });
+            } else {
+                var exit = document.exitFullscreen || document.webkitExitFullscreen;
+                var pe = exit && exit.call(document);
+                if (pe && pe.catch) pe.catch(function () {});
+            }
+            return;
+        } catch (e) {
+            // Synchronous failure: fall through to the native toggle.
         }
-        (c.requestFullscreen || c.webkitRequestFullscreen || function () {}).call(c);
-    } else {
-        (document.exitFullscreen || document.webkitExitFullscreen || function () {}).call(document);
     }
+    tryDesktopFullscreen();
+}
+
+// Swap the button glyph/hint between the "enter" and "exit" states.
+function setFullscreenIcon(on) {
+    var fsBtn = document.getElementById('fullscreen-btn');
+    if (!fsBtn) return;
+    fsBtn.title = on ? 'Exit fullscreen' : 'Fullscreen';
+    fsBtn.querySelector('svg').innerHTML = on
+        ? '<path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/>'
+        : '<path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>';
 }
 
 // Resize the graph to fill the screen on enter and back to the toolbar-driven
@@ -205,7 +281,6 @@ function toggleFullscreen() {
 // (which sticks) and detach after a window so we never fight the user later.
 function onFullscreenChange() {
     var el = document.getElementById('graph');
-    var fsBtn = document.getElementById('fullscreen-btn');
     var entering = isFullscreen();
     // Each transition gets a generation id; a deferred callback only acts if it
     // still matches, so a superseded transition (e.g. a quick enter/exit) can't
@@ -216,19 +291,10 @@ function onFullscreenChange() {
         var scale = entering ? fsRestoreView.scale * FS_ZOOM_OUT : fsRestoreView.scale;
         try { network.moveTo({scale: scale, position: fsRestoreView.position}); } catch (e) {}
     }
+    setFullscreenIcon(entering);
     if (entering) {
         el.style.height = window.innerHeight + 'px';
-        if (fsBtn) {
-            fsBtn.title = 'Exit fullscreen';
-            fsBtn.querySelector('svg').innerHTML =
-                '<path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/>';
-        }
     } else {
-        if (fsBtn) {
-            fsBtn.title = 'Fullscreen';
-            fsBtn.querySelector('svg').innerHTML =
-                '<path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>';
-        }
         var h = autofitOn ? (autofitHeight() || currentHeight) : currentHeight;
         el.style.height = h + 'px';
         sendToStreamlit("streamlit:setFrameHeight", {height: h});
@@ -405,7 +471,10 @@ function renderGraph(args) {
     var nodes = new vis.DataSet(nodeArr);
     network = new vis.Network(el, {nodes: nodes, edges: edges}, options);
     document.getElementById('download-btn').style.display = 'flex';
-    document.getElementById('fullscreen-btn').style.display = 'flex';
+    // Only offer fullscreen where the API works — hidden in the desktop webview.
+    if (fullscreenSupported()) {
+        document.getElementById('fullscreen-btn').style.display = 'flex';
+    }
     // Restore selection + viewport after a genuine re-mount (e.g. the panel
     // toggled), so the node stays highlighted and the zoom/pan don't reset —
     // making the rebuild invisible. selectNodes() does not fire selectNode, so

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -216,7 +216,9 @@ class _FakeWindow:
         self.title = None
         self.evaluated = []
         self.fullscreen = False
-        self.events = types.SimpleNamespace(loaded=_Event())
+        self.uid = "master"
+        self.gui = None
+        self.events = types.SimpleNamespace(loaded=_Event(), restored=_Event())
 
     def expose(self, *fns):
         self.exposed.extend(fns)
@@ -331,6 +333,50 @@ def test_window_bridges_wire_fullscreen_toggle(monkeypatch):
     assert window.fullscreen is True
     assert toggler() is False
     assert window.fullscreen is False
+
+
+def test_native_fullscreen_exit_notifies_page(monkeypatch):
+    """Leaving fullscreen outside our button (Esc) must reach the page and reset
+    pywebview's tracked flag, or the graph overlay keeps covering the shrunken
+    window (issue #177 follow-up)."""
+    window = _FakeWindow()
+    view = types.SimpleNamespace(is_fullscreen=True)
+    window.gui = types.SimpleNamespace(
+        BrowserView=types.SimpleNamespace(instances={window.uid: view})
+    )
+    fake_webview = types.ModuleType("webview")
+    fake_webview.create_window = lambda *a, **k: window
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+
+    desktop._install_window_bridges("AppName")
+
+    import webview
+
+    webview.create_window("AppName", "http://localhost")
+
+    assert window.events.restored, "no restored handler registered"
+    window.events.restored[0]()
+
+    assert any("__orionbeltNativeFullscreenExit" in js for js in window.evaluated)
+    # The stale flag is cleared so the next Fullscreen click enters again.
+    assert view.is_fullscreen is False
+
+
+def test_native_fullscreen_exit_survives_unknown_backend(monkeypatch):
+    """A backend without the internals we poke at must still notify the page."""
+    window = _FakeWindow()  # gui is None: no BrowserView to reach
+    fake_webview = types.ModuleType("webview")
+    fake_webview.create_window = lambda *a, **k: window
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+
+    desktop._install_window_bridges("AppName")
+
+    import webview
+
+    webview.create_window("AppName", "http://localhost")
+    window.events.restored[0]()
+
+    assert any("__orionbeltNativeFullscreenExit" in js for js in window.evaluated)
 
 
 def test_copy_to_clipboard_uses_platform_command(monkeypatch):

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -215,9 +215,12 @@ class _FakeWindow:
         self.exposed = []
         self.title = None
         self.evaluated = []
-        self.fullscreen = False
         self.uid = "master"
         self.gui = None
+        # Real pywebview keeps the fullscreen state on the platform window, not
+        # here, so the fake tracks toggles rather than exposing a state field the
+        # bridge could read (a stub that did would overstate the API).
+        self.toggle_fullscreen_calls = 0
         self.events = types.SimpleNamespace(loaded=_Event(), restored=_Event())
 
     def expose(self, *fns):
@@ -227,7 +230,7 @@ class _FakeWindow:
         self.title = title
 
     def toggle_fullscreen(self):
-        self.fullscreen = not self.fullscreen
+        self.toggle_fullscreen_calls += 1
 
     def evaluate_js(self, js):
         self.evaluated.append(js)
@@ -328,11 +331,20 @@ def test_window_bridges_wire_fullscreen_toggle(monkeypatch):
     toggler = next(
         fn for fn in window.exposed if fn.__name__ == "orionbelt_toggle_fullscreen"
     )
-    assert window.fullscreen is False
-    assert toggler() is True  # returns the new state
-    assert window.fullscreen is True
-    assert toggler() is False
-    assert window.fullscreen is False
+    # Each call reaches the native window and reports only that it got there:
+    # pywebview holds the resulting state on its platform window, and Qt flips it
+    # asynchronously, so the bridge deliberately doesn't claim to know it.
+    assert toggler() is True
+    assert window.toggle_fullscreen_calls == 1
+    assert toggler() is True
+    assert window.toggle_fullscreen_calls == 2
+
+    # A backend that can't toggle reports failure rather than raising into JS.
+    def _boom():
+        raise RuntimeError("no fullscreen here")
+
+    window.toggle_fullscreen = _boom
+    assert toggler() is None
 
 
 def test_native_fullscreen_exit_notifies_page(monkeypatch):

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -215,6 +215,7 @@ class _FakeWindow:
         self.exposed = []
         self.title = None
         self.evaluated = []
+        self.fullscreen = False
         self.events = types.SimpleNamespace(loaded=_Event())
 
     def expose(self, *fns):
@@ -222,6 +223,9 @@ class _FakeWindow:
 
     def set_title(self, title):
         self.title = title
+
+    def toggle_fullscreen(self):
+        self.fullscreen = not self.fullscreen
 
     def evaluate_js(self, js):
         self.evaluated.append(js)
@@ -303,6 +307,30 @@ def test_window_bridges_wire_clipboard(monkeypatch):
     # On load, the clipboard bridge script is injected.
     window.events.loaded[0]()
     assert any("__orionbeltClipboardBridge" in js for js in window.evaluated)
+
+
+def test_window_bridges_wire_fullscreen_toggle(monkeypatch):
+    """The bridge exposes a native fullscreen toggle for the graph button to call
+    when the webview lacks the HTML Fullscreen API (issue #177)."""
+    window = _FakeWindow()
+    fake_webview = types.ModuleType("webview")
+    fake_webview.create_window = lambda *a, **k: window
+    monkeypatch.setitem(sys.modules, "webview", fake_webview)
+
+    desktop._install_window_bridges("AppName")
+
+    import webview
+
+    webview.create_window("AppName", "http://localhost")
+
+    toggler = next(
+        fn for fn in window.exposed if fn.__name__ == "orionbelt_toggle_fullscreen"
+    )
+    assert window.fullscreen is False
+    assert toggler() is True  # returns the new state
+    assert window.fullscreen is True
+    assert toggler() is False
+    assert window.fullscreen is False
 
 
 def test_copy_to_clipboard_uses_platform_command(monkeypatch):


### PR DESCRIPTION
## Problem

Follow-up to #177 (reported [here](https://github.com/ralforion/orionbelt-ontology-builder/issues/177#issuecomment-5072518573)). Started as one desktop bug and grew into every way the graph's Fullscreen button was broken:

1. **Desktop:** the button raised `Uncaught (in promise) TypeError: Fullscreen is not supported`. The embedded pywebview has no HTML Fullscreen API.
2. **Desktop:** the native-window fallback fullscreened the *whole app* (sidebar, toolbar), not the graph, and the graph did not fill the screen.
3. **Desktop:** leaving fullscreen with `Esc` restored the window size but left the graph covering the whole window. Only the exit icon worked.
4. **Browser (Chrome):** entering fullscreen from a window smaller than the screen left the graph canvas at its old height, so the graph was cut off with background below it, and the container itself was letterboxed.

## Fix

**Desktop host** (`desktop.py`)

- Expose `orionbelt_toggle_fullscreen`, toggling the native pywebview window.
- Mirror native fullscreen exits back to the page: hook the window's `restored` event (macOS fires it on `windowDidExitFullScreen`, so `Esc`, the green button and the Window menu are all covered) and call a hook the page registers. The event runs on its own thread, so `evaluate_js` there cannot deadlock the UI thread.
- Clear pywebview's internal `is_fullscreen` flag on such an exit. `toggle_fullscreen()` picks its direction from that flag alone, so a stale flag would break re-entering fullscreen afterwards. Guarded so an unrecognised backend keeps current behaviour.

**Graph component** (`lib/graph_viewer/index.html`)

- Prefer the HTML Fullscreen API (web); where it is unavailable, or a `requestFullscreen()` attempt throws or rejects anyway, promote this same-origin iframe to a fixed full-viewport overlay so only the graph shows, and toggle the native window alongside it.
- Native fullscreen fires no `fullscreenchange`, so the icon and hint are swapped explicitly through a shared `setFullscreenIcon()` helper (also used by the web path, de-duplicating the SVG).
- Tear the overlay down, without toggling the window back, when the host reports the window already left fullscreen.
- Size the fullscreen container in percentages rather than `vw/vh`, and measure the canvas from the fullscreen box rather than `window.innerHeight`. This document is a Streamlit component iframe, where both metrics are iframe-relative and engine-dependent: Chrome resizes a plain iframe's viewport in step with the fullscreen element but not Streamlit's nested one, which is what cut the graph off.
- Keep the canvas matched to that box with a `ResizeObserver` while fullscreen lasts, covering engines where the box settles after `fullscreenchange` and a window moved to another monitor.

### Behaviour

- **Web:** fullscreens just the graph, filling the screen whatever the window size, 30% zoom-out around the centre, exact view restored on exit.
- **Desktop:** same, via the overlay plus the native window. `Esc` and the exit icon now behave identically.

## Tests

- Three desktop tests: the native toggle is exposed and flips window state; a native fullscreen exit notifies the page and clears the stale flag; an unrecognised backend still notifies.
- Full suite: 552 passed; ruff and mypy clean.
- Web path verified live (zoom round-trip, icon swap, no console errors) and the fullscreen canvas measured against the fullscreen box in a Playwright Chromium.
- Desktop path and the Chrome fullscreen fix confirmed by hand on a real desktop build and in Chrome.

Note: a standalone iframe harness does *not* reproduce the Chrome sizing bug, since Chrome resizes a plain iframe's viewport in step with the fullscreen element. Verify fullscreen changes in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
