### PR TITLE
chore: bump version to 1.17.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.17.2` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.17.3` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -15,7 +15,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.17.2"
+APP_VERSION = "1.17.3"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.17.2"
+version = "1.17.3"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.17.2"
+version = "1.17.3"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## What

Bump the version to 1.17.3.

Changed in the four places the version appears: `pyproject.toml`, `APP_VERSION` in `orionbelt_ontology_builder/app.py`, the Docker pin example in `README.md`, and `uv.lock` (relocked). The README badges read the version from PyPI, so they need no change.

## Since v1.17.2

- #184 fullscreen graph fixes for desktop and the browser
- #183 preserve Filter Classes selection when a class or restriction is added
- #182 Class Hierarchy (Text) recursion error on subClassOf cycles
- #181 fullscreen toggle for the interactive graph
- #175 run the Docker build/description jobs only when relevant files change

## Tests

552 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
