### PR TITLE
feat: create custom annotation types from the Annotation Type picker

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -4256,6 +4256,21 @@ def render_relations():
                         st.rerun()
 
 
+def resolve_annotation_predicate_choice(ont, choice, lookup) -> tuple:
+    """Map the "Annotation Type" picker's value to a ``(predicate, error)`` pair.
+
+    A listed type comes back through ``lookup`` as its URI and always resolves.
+    Anything else was typed into the picker to create a new annotation type
+    (issue #161), so it is validated first: an unbound prefix or an unusable name
+    is reported rather than minted into a broken URI. ``error`` is None when the
+    predicate is usable.
+    """
+    if choice in lookup:
+        return lookup[choice], None
+    text = (choice or "").strip()
+    return text, ont.invalid_annotation_predicate_reason(text)
+
+
 def render_annotations():
     """Render the annotations management page."""
     st.header("Annotations")
@@ -4483,8 +4498,20 @@ def render_annotations():
                 ]
                 selected = st.selectbox("Select Resource", options=resource_options)
 
+                # Typing a type that isn't listed creates it, so an ID with no
+                # standard predicate (a Wikidata item, an internal ticket) gets
+                # its own annotation type instead of going into Comment
+                # (issue #161).
                 predicate_display = st.selectbox(
-                    "Annotation Type", options=predicate_options
+                    "Annotation Type",
+                    options=predicate_options,
+                    accept_new_options=True,
+                    help=(
+                        "Pick a type, or type your own to create it: a name like "
+                        "`wikidataId`, a bound prefix like `wdt:P31`, or a full "
+                        "URI. A new name of your own is declared as an "
+                        "annotation property in the ontology."
+                    ),
                 )
 
                 value = st.text_area("Value")
@@ -4495,15 +4522,19 @@ def render_annotations():
 
                 submitted = st.form_submit_button("Add Annotation")
                 if submitted:
+                    predicate_uri, predicate_reason = (
+                        resolve_annotation_predicate_choice(
+                            ont, predicate_display, predicate_lookup
+                        )
+                    )
                     if not value:
                         show_message("Value is required!", "error")
+                    elif predicate_reason:
+                        show_message(predicate_reason, "error")
                     else:
                         # Find the resource by matching the option string
                         idx = resource_options.index(selected)
                         resource_name = all_resources[idx]["name"]
-                        predicate_uri = predicate_lookup.get(
-                            predicate_display, predicate_display
-                        )
                         ont.add_annotation(
                             resource_name,
                             predicate_uri,

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -4271,6 +4271,175 @@ def resolve_annotation_predicate_choice(ont, choice, lookup) -> tuple:
     return text, ont.invalid_annotation_predicate_reason(text)
 
 
+def annotation_option_for_predicate(ont, predicate_lookup, predicate_uri):
+    """Return the "Annotation Type" option that stands for ``predicate_uri``.
+
+    Options are matched on the URI they resolve to, so one predicate written as
+    a bare name, a CURIE or a full URI all find the same option (issue #161).
+    Returns None when no option covers it.
+    """
+    for display, predicate in predicate_lookup.items():
+        if ont.resolve_annotation_predicate(predicate) == predicate_uri:
+            return display
+    return None
+
+
+def render_add_annotation(ont, all_resources):
+    """Render the "Add Annotation" tab.
+
+    Split out of :func:`render_annotations` so the form can be driven
+    directly in tests: the page's tab picker is a ``segmented_control``, and
+    Streamlit's AppTest mis-serializes a single-select one, so any
+    interaction after switching tabs fails before reaching the form.
+    """
+    st.subheader("Add Annotation")
+
+    if not all_resources:
+        st.warning("Please create at least one resource first.")
+    else:
+        # Get predicates used in the ontology
+        used_predicates = ont.get_used_annotation_predicates()
+
+        # Build predicate options: standard ones + used from ontology
+        standard_predicates = [
+            {"local_name": "label", "uri": "label", "prefix": "rdfs"},
+            {"local_name": "comment", "uri": "comment", "prefix": "rdfs"},
+            {"local_name": "seeAlso", "uri": "seeAlso", "prefix": "rdfs"},
+            {"local_name": "isDefinedBy", "uri": "isDefinedBy", "prefix": "rdfs"},
+            {"local_name": "prefLabel", "uri": "prefLabel", "prefix": "skos"},
+            {"local_name": "altLabel", "uri": "altLabel", "prefix": "skos"},
+            {"local_name": "definition", "uri": "definition", "prefix": "skos"},
+            {"local_name": "example", "uri": "example", "prefix": "skos"},
+            {"local_name": "note", "uri": "note", "prefix": "skos"},
+            {"local_name": "title", "uri": "title", "prefix": "dcterms"},
+            {
+                "local_name": "description",
+                "uri": "description",
+                "prefix": "dcterms",
+            },
+            {"local_name": "creator", "uri": "creator", "prefix": "dcterms"},
+            {
+                "local_name": "contributor",
+                "uri": "contributor",
+                "prefix": "dcterms",
+            },
+            {"local_name": "date", "uri": "date", "prefix": "dcterms"},
+            {"local_name": "deprecated", "uri": "deprecated", "prefix": "owl"},
+        ]
+
+        # Combine and deduplicate (used predicates take priority as they have full URIs)
+        predicate_options = []
+        predicate_lookup = {}  # display -> uri
+
+        # Add used predicates first (from ontology)
+        seen_names = set()
+        for p in used_predicates:
+            display = (
+                f"{p['prefix']}:{p['local_name']}" if p["prefix"] else p["local_name"]
+            )
+            if display not in seen_names:
+                predicate_options.append(display)
+                predicate_lookup[display] = p["uri"]
+                seen_names.add(display)
+                seen_names.add(p["local_name"])  # Also mark local name as seen
+
+        # Add standard predicates that aren't already included
+        for p in standard_predicates:
+            display = f"{p['prefix']}:{p['local_name']}"
+            if p["local_name"] not in seen_names and display not in seen_names:
+                predicate_options.append(display)
+                predicate_lookup[display] = p["uri"]  # Use short name for standard ones
+
+        # Sort options
+        predicate_options.sort(key=lambda x: x.lower())
+
+        # Clear the value/language of the annotation just saved, on the run
+        # after it was added: a widget's state can't be changed once it has
+        # been instantiated, so the add flags it here instead. The type and
+        # the resource are left alone, so the same type can be applied to one
+        # resource after another without re-picking it.
+        if st.session_state.pop("_ann_clear_value", False):
+            st.session_state["ann_value"] = ""
+            st.session_state["ann_lang"] = ""
+
+        # Re-select the type just used. The picker holds whatever was typed
+        # ("wikidataId"), but once the annotation exists the options carry that
+        # predicate's canonical display ("ex:wikidataId") instead, and a value
+        # that is not among the options cannot be held: the widget would snap
+        # back to the first entry, and the stale typed value could reappear in a
+        # different case.
+        _ann_pending = st.session_state.pop("_ann_select_predicate", None)
+        if _ann_pending:
+            _ann_option = annotation_option_for_predicate(
+                ont, predicate_lookup, _ann_pending
+            )
+            if _ann_option:
+                st.session_state["ann_predicate"] = _ann_option
+
+        with st.form("add_annotation_form"):
+            # Use display format with label
+            resource_options = [f"{r['display']} [{r['type']}]" for r in all_resources]
+            selected = st.selectbox(
+                "Select Resource", options=resource_options, key="ann_resource"
+            )
+
+            # Typing a type that isn't listed creates it, so an ID with no
+            # standard predicate (a Wikidata item, an internal ticket) gets
+            # its own annotation type instead of going into Comment
+            # (issue #161). The explicit key matters: an unkeyed selectbox is
+            # identified by its arguments, so adding an annotation — which
+            # puts its type into the used-predicate options — would change
+            # the widget's identity and snap the selection back to the first
+            # entry.
+            predicate_display = st.selectbox(
+                "Annotation Type",
+                options=predicate_options,
+                accept_new_options=True,
+                key="ann_predicate",
+                help=(
+                    "Pick a type, or type your own to create it: a name like "
+                    "`wikidataId`, a bound prefix like `wdt:P31`, or a full "
+                    "URI. A new name of your own is declared as an "
+                    "annotation property in the ontology."
+                ),
+            )
+
+            value = st.text_area("Value", key="ann_value")
+
+            language = st.text_input(
+                "Language Tag (optional)",
+                placeholder="en, de, fr...",
+                key="ann_lang",
+            )
+
+            submitted = st.form_submit_button("Add Annotation")
+            if submitted:
+                predicate_uri, predicate_reason = resolve_annotation_predicate_choice(
+                    ont, predicate_display, predicate_lookup
+                )
+                if not value:
+                    show_message("Value is required!", "error")
+                elif predicate_reason:
+                    show_message(predicate_reason, "error")
+                else:
+                    # Find the resource by matching the option string
+                    idx = resource_options.index(selected)
+                    resource_name = all_resources[idx]["name"]
+                    ont.add_annotation(
+                        resource_name,
+                        predicate_uri,
+                        value,
+                        lang=language if language else None,
+                    )
+                    st.session_state["_ann_clear_value"] = True
+                    st.session_state["_ann_select_predicate"] = (
+                        ont.resolve_annotation_predicate(predicate_uri)
+                    )
+                    save_checkpoint("Add annotation")
+                    show_message("Annotation added!", "success")
+                    st.rerun()
+
+
 def render_annotations():
     """Render the annotations management page."""
     st.header("Annotations")
@@ -4426,124 +4595,7 @@ def render_annotations():
                                     st.rerun()
 
     if _ann_tab == "Add Annotation":
-        st.subheader("Add Annotation")
-
-        if not all_resources:
-            st.warning("Please create at least one resource first.")
-        else:
-            # Get predicates used in the ontology
-            used_predicates = ont.get_used_annotation_predicates()
-
-            # Build predicate options: standard ones + used from ontology
-            standard_predicates = [
-                {"local_name": "label", "uri": "label", "prefix": "rdfs"},
-                {"local_name": "comment", "uri": "comment", "prefix": "rdfs"},
-                {"local_name": "seeAlso", "uri": "seeAlso", "prefix": "rdfs"},
-                {"local_name": "isDefinedBy", "uri": "isDefinedBy", "prefix": "rdfs"},
-                {"local_name": "prefLabel", "uri": "prefLabel", "prefix": "skos"},
-                {"local_name": "altLabel", "uri": "altLabel", "prefix": "skos"},
-                {"local_name": "definition", "uri": "definition", "prefix": "skos"},
-                {"local_name": "example", "uri": "example", "prefix": "skos"},
-                {"local_name": "note", "uri": "note", "prefix": "skos"},
-                {"local_name": "title", "uri": "title", "prefix": "dcterms"},
-                {
-                    "local_name": "description",
-                    "uri": "description",
-                    "prefix": "dcterms",
-                },
-                {"local_name": "creator", "uri": "creator", "prefix": "dcterms"},
-                {
-                    "local_name": "contributor",
-                    "uri": "contributor",
-                    "prefix": "dcterms",
-                },
-                {"local_name": "date", "uri": "date", "prefix": "dcterms"},
-                {"local_name": "deprecated", "uri": "deprecated", "prefix": "owl"},
-            ]
-
-            # Combine and deduplicate (used predicates take priority as they have full URIs)
-            predicate_options = []
-            predicate_lookup = {}  # display -> uri
-
-            # Add used predicates first (from ontology)
-            seen_names = set()
-            for p in used_predicates:
-                display = (
-                    f"{p['prefix']}:{p['local_name']}"
-                    if p["prefix"]
-                    else p["local_name"]
-                )
-                if display not in seen_names:
-                    predicate_options.append(display)
-                    predicate_lookup[display] = p["uri"]
-                    seen_names.add(display)
-                    seen_names.add(p["local_name"])  # Also mark local name as seen
-
-            # Add standard predicates that aren't already included
-            for p in standard_predicates:
-                display = f"{p['prefix']}:{p['local_name']}"
-                if p["local_name"] not in seen_names and display not in seen_names:
-                    predicate_options.append(display)
-                    predicate_lookup[display] = p[
-                        "uri"
-                    ]  # Use short name for standard ones
-
-            # Sort options
-            predicate_options.sort(key=lambda x: x.lower())
-
-            with st.form("add_annotation_form"):
-                # Use display format with label
-                resource_options = [
-                    f"{r['display']} [{r['type']}]" for r in all_resources
-                ]
-                selected = st.selectbox("Select Resource", options=resource_options)
-
-                # Typing a type that isn't listed creates it, so an ID with no
-                # standard predicate (a Wikidata item, an internal ticket) gets
-                # its own annotation type instead of going into Comment
-                # (issue #161).
-                predicate_display = st.selectbox(
-                    "Annotation Type",
-                    options=predicate_options,
-                    accept_new_options=True,
-                    help=(
-                        "Pick a type, or type your own to create it: a name like "
-                        "`wikidataId`, a bound prefix like `wdt:P31`, or a full "
-                        "URI. A new name of your own is declared as an "
-                        "annotation property in the ontology."
-                    ),
-                )
-
-                value = st.text_area("Value")
-
-                language = st.text_input(
-                    "Language Tag (optional)", placeholder="en, de, fr..."
-                )
-
-                submitted = st.form_submit_button("Add Annotation")
-                if submitted:
-                    predicate_uri, predicate_reason = (
-                        resolve_annotation_predicate_choice(
-                            ont, predicate_display, predicate_lookup
-                        )
-                    )
-                    if not value:
-                        show_message("Value is required!", "error")
-                    elif predicate_reason:
-                        show_message(predicate_reason, "error")
-                    else:
-                        # Find the resource by matching the option string
-                        idx = resource_options.index(selected)
-                        resource_name = all_resources[idx]["name"]
-                        ont.add_annotation(
-                            resource_name,
-                            predicate_uri,
-                            value,
-                            lang=language if language else None,
-                        )
-                        save_checkpoint("Add annotation")
-                        show_message("Annotation added!", "success")
-                        st.rerun()
+        render_add_annotation(ont, all_resources)
 
     if _ann_tab == "Bulk Edit":
         st.subheader("Bulk Edit Annotations")

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -1923,6 +1923,12 @@ class OntologyManager:
             )
         return None
 
+    def _require_valid_annotation_predicate(self, predicate: str) -> None:
+        """Raise ``ValueError`` if ``predicate`` is unusable as an annotation type."""
+        reason = self.invalid_annotation_predicate_reason(predicate)
+        if reason:
+            raise ValueError(reason)
+
     def add_annotation(
         self, subject: str, predicate: str, value: str, lang: Optional[str] = None
     ):
@@ -1936,12 +1942,20 @@ class OntologyManager:
         anything under a bound external prefix) are left alone, as is a URI that
         already has a type here.
 
+        Raises ``ValueError`` if the predicate is unusable — an unbound prefix
+        above all, which would otherwise be minted as a base-namespace URI
+        containing a colon. The check lives here so every caller is covered, not
+        only the Annotations page: bulk edits reach this too, and report the
+        reason per row. ``delete_annotation`` deliberately stays unchecked, so an
+        oddly named predicate already in the graph can still be removed.
+
         Args:
             subject: The resource name to annotate
             predicate: Either a full URI, a common name (label, comment, etc.), or a local name
             value: The annotation value
             lang: Optional language tag
         """
+        self._require_valid_annotation_predicate(predicate)
         subj_uri = self._uri(subject)
         pred_uri = self._resolve_predicate_uri(predicate)
 

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -1863,6 +1863,15 @@ class OntologyManager:
                     return URIRef(str(ns) + local)
         return self._uri(predicate)
 
+    def resolve_annotation_predicate(self, predicate: str) -> str:
+        """Return the URI an annotation type resolves to, as a string.
+
+        Public form of :meth:`_resolve_predicate_uri`, so callers can recognise
+        the same predicate however it was written: a known name, a new local
+        name, a ``prefix:local`` CURIE, or a full URI (issue #161).
+        """
+        return str(self._resolve_predicate_uri(predicate))
+
     def invalid_annotation_predicate_reason(self, predicate: str) -> Optional[str]:
         """Return a human-readable reason ``predicate`` can't be used as an
         annotation type, or ``None`` if it can.

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -1863,10 +1863,69 @@ class OntologyManager:
                     return URIRef(str(ns) + local)
         return self._uri(predicate)
 
+    def invalid_annotation_predicate_reason(self, predicate: str) -> Optional[str]:
+        """Return a human-readable reason ``predicate`` can't be used as an
+        annotation type, or ``None`` if it can.
+
+        Companion to :meth:`invalid_name_reason` for the forms
+        :meth:`_resolve_predicate_uri` accepts: a full ``http(s)`` URI, a known
+        name (``comment``, ``prefLabel``, ...), a ``prefix:local`` CURIE whose
+        prefix is bound here, and a new local name minted in the base namespace.
+        An unbound prefix is named explicitly, because resolution would
+        otherwise fall through and mint a nonsense base-namespace URI containing
+        a colon (issue #161).
+        """
+        if predicate is None or not predicate.strip():
+            return "Annotation type cannot be empty."
+        predicate = predicate.strip()
+        if predicate.startswith("http://") or predicate.startswith("https://"):
+            if any(c.isspace() or c in self._INVALID_URI_CHARS for c in predicate):
+                return (
+                    "A full URI cannot contain spaces or any of the characters "
+                    '< > " { } | \\ ^ `.'
+                )
+            return None
+        if predicate in self._ANNOTATION_PREDICATES:
+            return None
+        if ":" in predicate:
+            prefix, _, local = predicate.partition(":")
+            bound = {p for p, _ns in self.graph.namespaces()}
+            known = ("" in bound) if prefix == "(default)" else (prefix in bound)
+            if not known:
+                return (
+                    f"Prefix '{prefix}' is not bound in this ontology. Add it "
+                    "under Namespaces first, or paste the full URI instead."
+                )
+            if not local:
+                return (
+                    f"'{predicate}' is missing a name after the prefix, for "
+                    "example 'wdt:P31'."
+                )
+            if not self._LOCAL_NAME_RE.match(local):
+                return (
+                    f"'{local}' is not a valid name after the prefix. Use "
+                    "letters, digits, '_', '-' and '.', for example 'wdt:P31'."
+                )
+            return None
+        if not self._LOCAL_NAME_RE.match(predicate):
+            return (
+                f"'{predicate}' is not a valid annotation type. Use a name like "
+                "'wikidataId', a bound prefix like 'wdt:P31', or a full URI."
+            )
+        return None
+
     def add_annotation(
         self, subject: str, predicate: str, value: str, lang: Optional[str] = None
     ):
         """Add an annotation to any resource.
+
+        A predicate that resolves into this ontology's own namespace is a
+        custom annotation type the user just invented (issue #161), so it is
+        declared as an ``owl:AnnotationProperty``. That keeps the ontology
+        well-formed OWL, so other tools list the annotation instead of seeing an
+        undeclared predicate. Vocabulary predicates (``rdfs:label``, ``skos:*``,
+        anything under a bound external prefix) are left alone, as is a URI that
+        already has a type here.
 
         Args:
             subject: The resource name to annotate
@@ -1876,6 +1935,17 @@ class OntologyManager:
         """
         subj_uri = self._uri(subject)
         pred_uri = self._resolve_predicate_uri(predicate)
+
+        if (
+            str(pred_uri).startswith(str(self.namespace))
+            and (
+                pred_uri,
+                RDF.type,
+                None,
+            )
+            not in self.graph
+        ):
+            self.graph.add((pred_uri, RDF.type, OWL.AnnotationProperty))
 
         if lang:
             literal = Literal(value, lang=lang)

--- a/tests/test_annotations_add_ui.py
+++ b/tests/test_annotations_add_ui.py
@@ -1,0 +1,96 @@
+"""Adding an annotation keeps the chosen type and clears the value.
+
+A successful add puts the new type into the used-predicate options. The picker
+was unkeyed, so that changed the widget's identity and snapped the selection back
+to the first entry, while the value box kept the text just saved (issue #161
+follow-up).
+
+Note when extending these: AppTest serializes a selectbox as the *index* of the
+selection, so a changed options list moves the selection on its own here in a way
+a browser never does. Assertions about which option survives an options change
+therefore belong on ``annotation_option_for_predicate`` (see
+``test_annotations_custom.py``), not on an AppTest run.
+"""
+
+from streamlit.testing.v1 import AppTest
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Animal")
+        om.add_class("Plant")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    resources = [
+        {
+            "name": c["name"],
+            "label": c.get("label"),
+            "type": "Class",
+            "display": c["name"],
+        }
+        for c in ont.get_classes()
+    ]
+    app.render_add_annotation(ont, resources)
+
+
+def _add_annotation(at, predicate, value):
+    at.selectbox(key="ann_predicate").set_value(predicate)
+    at.text_area(key="ann_value").set_value(value)
+    at.button[0].click().run(timeout=120)
+
+
+def test_add_keeps_type_and_clears_value():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+
+    _add_annotation(at, "skos:example", "an example")
+    assert not at.exception, at.exception
+
+    ont = at.session_state["ontology"]
+    anns = ont.get_annotations("Animal")
+    assert any(a["value"] == "an example" for a in anns), anns
+
+    # The type stays put even though the options list just gained skos:example,
+    # and the value box is empty so a second submit can't duplicate the entry.
+    assert at.session_state["ann_predicate"] == "skos:example"
+    assert at.session_state["ann_value"] == ""
+
+
+def test_pending_predicate_is_applied_to_the_picker():
+    """The add flags the type it used; the next run selects that option."""
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+
+    ont = at.session_state["ontology"]
+    ont.add_annotation("Plant", "skos:example", "an example")
+    at.session_state["_ann_select_predicate"] = ont.resolve_annotation_predicate(
+        "http://www.w3.org/2004/02/skos/core#example"
+    )
+    at.run(timeout=120)
+
+    assert not at.exception, at.exception
+    assert at.session_state["ann_predicate"] == "skos:example"
+    # The flag is consumed, so a later rerun doesn't keep forcing the selection.
+    assert "_ann_select_predicate" not in at.session_state
+
+
+def test_missing_value_reports_error_and_adds_nothing():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+
+    at.selectbox(key="ann_predicate").set_value("skos:example")
+    at.button[0].click().run(timeout=120)
+
+    assert not at.exception, at.exception
+    ont = at.session_state["ontology"]
+    assert not ont.get_annotations("Animal")

--- a/tests/test_annotations_custom.py
+++ b/tests/test_annotations_custom.py
@@ -1,0 +1,150 @@
+"""Custom annotation types: a predicate the user invents is usable and declared,
+and an unusable one is reported rather than minted into a broken URI (issue #161).
+"""
+
+from rdflib import OWL, RDF, URIRef
+
+from orionbelt_ontology_builder.app import resolve_annotation_predicate_choice
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+
+def test_custom_predicate_is_stored_and_readable(populated_om):
+    populated_om.add_annotation("Person", "wikidataId", "Q5")
+    anns = populated_om.get_annotations("Person")
+    assert any(a["predicate"] == "wikidataId" and a["value"] == "Q5" for a in anns), (
+        anns
+    )
+
+
+def test_custom_predicate_is_declared_as_annotation_property(populated_om):
+    """Without a declaration other tools see an undeclared predicate."""
+    populated_om.add_annotation("Person", "wikidataId", "Q5")
+    pred = URIRef("http://test.org/ont#wikidataId")
+    assert (pred, RDF.type, OWL.AnnotationProperty) in populated_om.graph
+
+
+def test_standard_predicate_is_not_declared_locally(populated_om):
+    """rdfs:comment and friends are declared by their own vocabulary."""
+    populated_om.add_annotation("Person", "comment", "A human being")
+    from rdflib import RDFS
+
+    assert (RDFS.comment, RDF.type, None) not in populated_om.graph
+
+
+def test_external_prefix_predicate_is_not_declared_locally(populated_om):
+    """A bound external vocabulary keeps its own declaration, not ours."""
+    populated_om.add_prefix("wdt", "http://www.wikidata.org/prop/direct/")
+    populated_om.add_annotation("Person", "wdt:P31", "Q5")
+    pred = URIRef("http://www.wikidata.org/prop/direct/P31")
+    anns = populated_om.get_annotations("Person")
+    assert any(a["value"] == "Q5" for a in anns), anns
+    assert (pred, RDF.type, None) not in populated_om.graph
+
+
+def test_existing_entity_type_is_not_overwritten(populated_om):
+    """A name that is already a class must not gain a second type."""
+    populated_om.add_annotation("Person", "Organization", "not really an annotation")
+    pred = URIRef("http://test.org/ont#Organization")
+    types = set(populated_om.graph.objects(pred, RDF.type))
+    assert types == {OWL.Class}, types
+
+
+def test_custom_predicate_roundtrips_through_delete(populated_om):
+    populated_om.add_annotation("Person", "wikidataId", "Q5")
+    populated_om.delete_annotation("Person", "wikidataId", "Q5")
+    anns = populated_om.get_annotations("Person")
+    assert not any(a["predicate"] == "wikidataId" for a in anns), anns
+
+
+def test_custom_predicate_becomes_a_listed_option(populated_om):
+    """After first use it shows up alongside the standard predicates."""
+    populated_om.add_annotation("Person", "wikidataId", "Q5")
+    used = populated_om.get_used_annotation_predicates()
+    assert any(p["local_name"] == "wikidataId" for p in used), used
+
+
+def test_custom_predicate_survives_export(populated_om):
+    populated_om.add_annotation("Person", "wikidataId", "Q5")
+    ttl = populated_om.export_to_string("turtle")
+    reloaded = OntologyManager(base_uri="http://test.org/ont#")
+    reloaded.load_from_string(ttl, "turtle")
+    anns = reloaded.get_annotations("Person")
+    assert any(a["value"] == "Q5" for a in anns), anns
+
+
+# --- validation -------------------------------------------------------------
+
+
+def test_valid_predicate_forms_are_accepted(populated_om):
+    populated_om.add_prefix("wdt", "http://www.wikidata.org/prop/direct/")
+    for predicate in (
+        "wikidataId",
+        "my-note.v2",
+        "comment",
+        "wdt:P31",
+        "http://example.org/vocab#ticket",
+    ):
+        assert populated_om.invalid_annotation_predicate_reason(predicate) is None, (
+            predicate
+        )
+
+
+def test_unbound_prefix_is_reported_by_name(populated_om):
+    reason = populated_om.invalid_annotation_predicate_reason("wdt:P31")
+    assert reason and "wdt" in reason and "Namespaces" in reason
+
+
+def test_empty_predicate_is_reported(populated_om):
+    assert populated_om.invalid_annotation_predicate_reason("") is not None
+    assert populated_om.invalid_annotation_predicate_reason("   ") is not None
+    assert populated_om.invalid_annotation_predicate_reason(None) is not None
+
+
+def test_bad_name_is_reported(populated_om):
+    reason = populated_om.invalid_annotation_predicate_reason("wikidata id")
+    assert reason and "wikidata id" in reason
+
+
+def test_prefix_without_local_name_is_reported(populated_om):
+    populated_om.add_prefix("wdt", "http://www.wikidata.org/prop/direct/")
+    reason = populated_om.invalid_annotation_predicate_reason("wdt:")
+    assert reason and "after the prefix" in reason
+
+
+def test_uri_with_unserializable_characters_is_reported(populated_om):
+    reason = populated_om.invalid_annotation_predicate_reason(
+        "http://example.org/a b#x"
+    )
+    assert reason and "spaces" in reason
+
+
+# --- the picker's wiring ----------------------------------------------------
+
+
+def test_listed_choice_resolves_to_its_uri(populated_om):
+    lookup = {"rdfs:comment": "comment"}
+    predicate, error = resolve_annotation_predicate_choice(
+        populated_om, "rdfs:comment", lookup
+    )
+    assert (predicate, error) == ("comment", None)
+
+
+def test_typed_choice_is_validated(populated_om):
+    predicate, error = resolve_annotation_predicate_choice(
+        populated_om, "  wikidataId  ", {}
+    )
+    assert predicate == "wikidataId"
+    assert error is None
+
+
+def test_typed_choice_with_unbound_prefix_reports_error(populated_om):
+    predicate, error = resolve_annotation_predicate_choice(
+        populated_om, "wdt:P31", {"rdfs:comment": "comment"}
+    )
+    assert predicate == "wdt:P31"
+    assert error and "wdt" in error
+
+
+def test_empty_choice_reports_error(populated_om):
+    _predicate, error = resolve_annotation_predicate_choice(populated_om, None, {})
+    assert error is not None

--- a/tests/test_annotations_custom.py
+++ b/tests/test_annotations_custom.py
@@ -4,7 +4,10 @@ and an unusable one is reported rather than minted into a broken URI (issue #161
 
 from rdflib import OWL, RDF, URIRef
 
-from orionbelt_ontology_builder.app import resolve_annotation_predicate_choice
+from orionbelt_ontology_builder.app import (
+    annotation_option_for_predicate,
+    resolve_annotation_predicate_choice,
+)
 from orionbelt_ontology_builder.ontology_manager import OntologyManager
 
 
@@ -148,3 +151,43 @@ def test_typed_choice_with_unbound_prefix_reports_error(populated_om):
 def test_empty_choice_reports_error(populated_om):
     _predicate, error = resolve_annotation_predicate_choice(populated_om, None, {})
     assert error is not None
+
+
+# --- re-selecting the type just used ----------------------------------------
+#
+# After an add, the picker's value is the raw text that was typed while the
+# rebuilt options carry the predicate's canonical display, so the just-used type
+# has to be found again by the URI it resolves to.
+
+
+def test_typed_name_finds_its_canonical_option(populated_om):
+    populated_om.add_annotation("Person", "wikidataId", "Q5")
+    lookup = {
+        "rdfs:comment": "comment",
+        "test:wikidataId": "http://test.org/ont#wikidataId",
+    }
+    uri = populated_om.resolve_annotation_predicate("wikidataId")
+    assert annotation_option_for_predicate(populated_om, lookup, uri) == (
+        "test:wikidataId"
+    )
+
+
+def test_full_uri_and_short_name_find_the_same_option(populated_om):
+    lookup = {"skos:example": "example", "rdfs:comment": "comment"}
+    uri = populated_om.resolve_annotation_predicate(
+        "http://www.w3.org/2004/02/skos/core#example"
+    )
+    assert annotation_option_for_predicate(populated_om, lookup, uri) == "skos:example"
+
+
+def test_curie_finds_its_option(populated_om):
+    populated_om.add_prefix("wdt", "http://www.wikidata.org/prop/direct/")
+    lookup = {"wdt:P31": "http://www.wikidata.org/prop/direct/P31"}
+    uri = populated_om.resolve_annotation_predicate("wdt:P31")
+    assert annotation_option_for_predicate(populated_om, lookup, uri) == "wdt:P31"
+
+
+def test_unlisted_predicate_finds_no_option(populated_om):
+    lookup = {"rdfs:comment": "comment"}
+    uri = populated_om.resolve_annotation_predicate("wikidataId")
+    assert annotation_option_for_predicate(populated_om, lookup, uri) is None

--- a/tests/test_annotations_custom.py
+++ b/tests/test_annotations_custom.py
@@ -153,6 +153,60 @@ def test_empty_choice_reports_error(populated_om):
     assert error is not None
 
 
+# --- the guard covers every caller, not just the picker ---------------------
+
+
+def test_add_annotation_rejects_an_unbound_prefix(populated_om):
+    import pytest
+
+    with pytest.raises(ValueError, match="wdt"):
+        populated_om.add_annotation("Person", "wdt:P31", "Q5")
+    assert not any(a["value"] == "Q5" for a in populated_om.get_annotations("Person"))
+
+
+def test_bulk_add_reports_an_unbound_prefix_instead_of_minting_a_uri(populated_om):
+    """The Bulk Edit tab reaches add_annotation directly, so it must be guarded
+    too: an unbound CURIE used to be stored as <base#wdt:P31>."""
+    result = populated_om.bulk_update_annotations(
+        [{"resource": "Person", "predicate": "wdt:P31", "value": "Q5"}]
+    )
+    assert result["applied"] == 0
+    assert result["errors"] and "wdt" in result["errors"][0]["error"]
+    assert not any(
+        "wdt:P31" in str(p) for p in populated_om.graph.predicates(None, None)
+    )
+
+
+def test_bulk_add_still_creates_a_valid_custom_type(populated_om):
+    result = populated_om.bulk_update_annotations(
+        [{"resource": "Person", "predicate": "wikidataId", "value": "Q5"}]
+    )
+    assert result == {"applied": 1, "errors": []}
+    pred = URIRef("http://test.org/ont#wikidataId")
+    assert (pred, RDF.type, OWL.AnnotationProperty) in populated_om.graph
+
+
+def test_bulk_delete_can_still_remove_an_oddly_named_predicate(populated_om):
+    """Data minted before the guard has to stay removable."""
+    from rdflib import Literal
+
+    bad = URIRef("http://test.org/ont#wdt:P31")
+    populated_om.graph.add((URIRef("http://test.org/ont#Person"), bad, Literal("Q5")))
+
+    result = populated_om.bulk_update_annotations(
+        [
+            {
+                "resource": "Person",
+                "predicate": "http://test.org/ont#wdt:P31",
+                "value": "Q5",
+                "action": "delete",
+            }
+        ]
+    )
+    assert result["applied"] == 1, result
+    assert (URIRef("http://test.org/ont#Person"), bad, None) not in populated_om.graph
+
+
 # --- re-selecting the type just used ----------------------------------------
 #
 # After an add, the picker's value is the raw text that was typed while the


### PR DESCRIPTION
## Problem

Issue #161: the **Annotation Type** picker offered only the predicates already used in the ontology plus a fixed standard list (rdfs, skos, dcterms, owl:deprecated). An ID with no standard predicate, a Wikidata item or an internal ticket number, had nowhere to go but `Comment`.

The engine was never the limitation: `_resolve_predicate_uri` already accepted a full URI, a `prefix:local` CURIE bound in the graph, or a local name. Only the closed picker was in the way.

## Fix

**Picker** (`app.py`): the selectbox takes `accept_new_options=True`, so typing a type that isn't listed creates it. Help text spells out the three accepted forms. After first use the new type appears as a listed option on its own, because `get_used_annotation_predicates()` picks it up.

**Declaration** (`ontology_manager.py`): a predicate that resolves into the ontology's own namespace is a type the user just invented, so `add_annotation` declares it as an `owl:AnnotationProperty`. Without that, other tools see an undeclared predicate rather than an annotation. Left alone: vocabulary predicates (`rdfs:label`, `skos:*`, anything under a bound external prefix), which their own vocabulary declares, and any URI that already has a type here, so an existing class cannot pick up a second one.

**Validation** (`ontology_manager.py`): new `invalid_annotation_predicate_reason()`, a companion to the existing `invalid_name_reason()`. It names an unbound prefix explicitly, because resolution would otherwise fall through and mint a base-namespace URI containing a colon. It also catches an empty type, a missing name after the prefix, bad characters, and an unserializable URI.

### Second commit: the picker reset after adding

Submitting reset the type back to the first entry while the Value box kept the text just saved, so applying one type to several resources meant re-picking it every time, and a stray second submit would duplicate the value.

The picker was unkeyed, so it was identified by its arguments, and adding an annotation puts its type into the options. Keying it is not enough on its own: the picker holds the text that was typed (`wikidataId`) while the rebuilt options carry that predicate's canonical display (`ex:wikidataId`), and a value outside the options cannot be held either. The add now records the URI it used and the next run re-selects the option that resolves to it, matched on the URI so a bare name, a CURIE and a full URI all find the same option. Value and Language are cleared on that same run; the resource is left alone.

This also removes a case glitch: a stale typed value carried across runs could reappear lowercased (`ex:wikidataid`). Streamlit preserves the case of a new option and so does the engine, both checked in isolation; the culprit was the picker carrying a typed value rather than a real option.

## Tests

25 tests across `tests/test_annotations_custom.py` and `tests/test_annotations_add_ui.py`: storage and readback, the declaration and each case that must not be declared, delete roundtrip, export and reimport, promotion to a listed option, every validation branch, the picker's submit wiring, and option matching by resolved URI. Full suite 577 passed; ruff and mypy clean.

Two notes for reviewers:

- `render_add_annotation()` is split out of `render_annotations()` because AppTest mis-serializes a single-select `segmented_control`, so any interaction after switching tabs fails before reaching the form.
- AppTest serializes a selectbox as the *index* of the selection, so a changed options list moves the selection there in a way a browser never does. Assertions about which option survives an options change live on `annotation_option_for_predicate`, not on an AppTest run. A first attempt at that assertion passed with the fix removed, which is what turned this up.

Verified live in the running app:

- typing `wikidataId` offers "Add: wikidataId"; after submitting, `Animal` shows `ex:wikidataId  Q729`
- the Source tab shows `ex:CatalogNumber a owl:AnnotationProperty .` once, alongside the annotation triples
- adding `CatalogNumber` to `Animal`, then switching the resource to `Cat` and submitting again, keeps the type selected and the value box empty
- typing `wdt:P31` with no `wdt` prefix bound reports "Prefix 'wdt' is not bound in this ontology. Add it under Namespaces first, or paste the full URI instead." and adds nothing

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
