### PR TITLE
feat: find a relation or restriction by pasting the whole triple

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -2061,19 +2061,67 @@ def _resolve_list_view(items, kind, key_of, page_key, noun):
     return items[start:end], active
 
 
-def _filter_relations(relations: list, query: str) -> list:
-    """Case-insensitive substring filter over a relation row's subject, relation,
-    and object local names. An empty query returns the list unchanged (issue #148).
+# Stands for "anything" in a slot of a pasted triple, so two of the three parts
+# can be pinned: "* disjointWith inductor".
+_SEARCH_ANY = {"*", "?", "_", "-"}
+
+
+def parse_search_query(query: str) -> tuple:
+    """Split a search box's text into ``(slots, terms)``.
+
+    ``slots`` is a three-item tuple when the text reads like a pasted triple —
+    ``capacitor disjointWith inductor`` — so each word can be matched against its
+    own column, with ``*`` standing for anything (issue #170). It is None
+    otherwise, and then ``terms`` are the words that must each appear somewhere
+    in the row. Local names never contain whitespace (the name validation
+    rejects it), so splitting on whitespace is unambiguous.
     """
-    q = (query or "").strip().lower()
-    if not q:
+    words = (query or "").strip().lower().split()
+    if not words:
+        return None, []
+    if len(words) == 3:
+        slots = tuple(None if w in _SEARCH_ANY else w for w in words)
+        return slots, []
+    return None, words
+
+
+def _matches_slots(slots: tuple, fields: tuple) -> bool:
+    """Whether each non-wildcard slot is a substring of its field.
+
+    A field may be a tuple of alternatives, in which case any of them can carry
+    the match (a restriction's middle column is its property *or* its type).
+    """
+    for slot, field in zip(slots, fields):
+        if slot is None:
+            continue
+        candidates = field if isinstance(field, tuple) else (field,)
+        if not any(slot in (c or "").lower() for c in candidates):
+            return False
+    return True
+
+
+def _filter_relations(relations: list, query: str) -> list:
+    """Filter relation rows by subject, relation and object local names.
+
+    A pasted triple matches column by column, so ``capacitor disjointWith
+    inductor`` finds exactly that relation (issue #170). Anything else is
+    matched as separate words that must each appear in the row, which keeps the
+    single-word search from issue #148 working. An empty query returns the list
+    unchanged.
+    """
+    slots, terms = parse_search_query(query)
+    if slots is None and not terms:
         return relations
+
+    def _fields(r):
+        return (r["subject"], r["relation"], r["object"])
+
+    if slots:
+        return [r for r in relations if _matches_slots(slots, _fields(r))]
     return [
         r
         for r in relations
-        if q in r["subject"].lower()
-        or q in r["relation"].lower()
-        or q in r["object"].lower()
+        if all(any(t in f.lower() for f in _fields(r)) for t in terms)
     ]
 
 
@@ -2091,9 +2139,16 @@ def _sort_relations(relations: list) -> list:
 
 def _filter_restrictions(restrictions: list, query: str) -> list:
     """Case-insensitive substring filter over a restriction's property, type,
-    value, qualified class, and the classes it applies to (issue #148)."""
-    q = (query or "").strip().lower()
-    if not q:
+    value, qualified class, and the classes it applies to (issue #148).
+
+    A restriction is not a triple, but it reads like one: the class it applies to,
+    the property, and the value. So a pasted ``Bicycle hasPart Wheel`` matches
+    those three columns (issue #170). The middle word also matches the
+    restriction type and the last one the qualified class, so ``Bicycle
+    someValuesFrom Wheel`` finds it too.
+    """
+    slots, terms = parse_search_query(query)
+    if slots is None and not terms:
         return restrictions
 
     def _haystack(r):
@@ -2109,7 +2164,17 @@ def _filter_restrictions(restrictions: list, query: str) -> list:
         ]
         return " ".join(parts).lower()
 
-    return [r for r in restrictions if q in _haystack(r)]
+    def _fields(r):
+        val = r.get("value")
+        return (
+            " ".join(str(c) for c in (r.get("applied_to") or [])),
+            (r.get("property") or "", r.get("type") or ""),
+            ("" if val is None else str(val), r.get("on_class") or ""),
+        )
+
+    if slots:
+        return [r for r in restrictions if _matches_slots(slots, _fields(r))]
+    return [r for r in restrictions if all(t in _haystack(r) for t in terms)]
 
 
 def _sort_restrictions(restrictions: list) -> list:
@@ -3830,7 +3895,12 @@ def render_restrictions():
             _rest_query = st.text_input(
                 "Search restrictions",
                 key="rest_search",
-                placeholder="Filter by property, type, value, or class",
+                placeholder="Bicycle hasPart Wheel",
+                help=(
+                    "Paste class, property and value to find just that "
+                    "restriction, or type any words to match a property, type, "
+                    "value or class. Use `*` for a part you don't want to pin."
+                ),
             )
             _rest_sort = st.checkbox("Sort alphabetically", key="rest_sort")
             _view_restrictions = _filter_restrictions(restrictions, _rest_query)
@@ -3971,7 +4041,12 @@ def render_relations():
         _rel_query = st.text_input(
             "Search relations",
             key="rel_search",
-            placeholder="Filter by subject, relation, or object",
+            placeholder="capacitor disjointWith inductor",
+            help=(
+                "Paste a whole relation to find just that one, or type any words "
+                "to match a subject, relation or object. Use `*` for a part you "
+                "don't want to pin: `* disjointWith inductor`."
+            ),
         )
         _rel_sort = st.checkbox("Sort alphabetically", key="rel_sort")
 

--- a/tests/test_triple_search.py
+++ b/tests/test_triple_search.py
@@ -1,0 +1,159 @@
+"""Pasting a whole triple into the search box narrows to that one row (issue #170).
+
+The single-word search from issue #148 keeps working; see
+``test_relations_restrictions_search.py`` for those cases.
+"""
+
+from orionbelt_ontology_builder.app import (
+    _filter_relations,
+    _filter_restrictions,
+    parse_search_query,
+)
+
+RELS = [
+    {"subject": "capacitor", "relation": "disjointWith", "object": "inductor"},
+    {"subject": "capacitor", "relation": "disjointWith", "object": "resistor"},
+    {"subject": "capacitor", "relation": "subClassOf", "object": "component"},
+    {"subject": "inductor", "relation": "disjointWith", "object": "capacitor"},
+]
+
+RESTS = [
+    {
+        "property": "hasPart",
+        "type": "someValuesFrom",
+        "value": "Wheel",
+        "on_class": "",
+        "applied_to": ["Bicycle"],
+    },
+    {
+        "property": "hasPart",
+        "type": "someValuesFrom",
+        "value": "Engine",
+        "on_class": "",
+        "applied_to": ["Car"],
+    },
+    {
+        "property": "owns",
+        "type": "allValuesFrom",
+        "value": "House",
+        "on_class": "Truck",
+        "applied_to": ["Driver"],
+    },
+]
+
+
+# --- parsing ----------------------------------------------------------------
+
+
+def test_three_words_parse_as_slots():
+    slots, terms = parse_search_query("capacitor disjointWith inductor")
+    assert slots == ("capacitor", "disjointwith", "inductor")
+    assert terms == []
+
+
+def test_wildcards_leave_a_slot_open():
+    slots, _terms = parse_search_query("* disjointWith inductor")
+    assert slots == (None, "disjointwith", "inductor")
+    assert parse_search_query("capacitor - -")[0] == ("capacitor", None, None)
+
+
+def test_other_word_counts_parse_as_terms():
+    assert parse_search_query("capacitor") == (None, ["capacitor"])
+    assert parse_search_query("capacitor inductor") == (None, ["capacitor", "inductor"])
+    assert parse_search_query("a b c d") == (None, ["a", "b", "c", "d"])
+
+
+def test_empty_query_parses_to_nothing():
+    assert parse_search_query("") == (None, [])
+    assert parse_search_query("   ") == (None, [])
+    assert parse_search_query(None) == (None, [])
+
+
+def test_extra_whitespace_is_ignored():
+    slots, _ = parse_search_query("  capacitor   disjointWith\tinductor  ")
+    assert slots == ("capacitor", "disjointwith", "inductor")
+
+
+# --- relations --------------------------------------------------------------
+
+
+def test_pasted_triple_isolates_one_relation():
+    got = _filter_relations(RELS, "capacitor disjointWith inductor")
+    assert len(got) == 1
+    assert got[0]["object"] == "inductor"
+
+
+def test_direction_matters():
+    """capacitor->inductor and inductor->capacitor are different rows."""
+    got = _filter_relations(RELS, "inductor disjointWith capacitor")
+    assert len(got) == 1 and got[0]["subject"] == "inductor"
+
+
+def test_triple_matching_is_case_insensitive_and_partial():
+    got = _filter_relations(RELS, "CAPACITOR disjoint induct")
+    assert len(got) == 1 and got[0]["object"] == "inductor"
+
+
+def test_wildcard_slot_matches_any_value():
+    got = _filter_relations(RELS, "* disjointWith capacitor")
+    assert [r["subject"] for r in got] == ["inductor"]
+    got = _filter_relations(RELS, "capacitor disjointWith *")
+    assert {r["object"] for r in got} == {"inductor", "resistor"}
+
+
+def test_two_words_require_both_somewhere():
+    """Not a triple, so both words just have to appear in the row."""
+    got = _filter_relations(RELS, "capacitor resistor")
+    assert len(got) == 1 and got[0]["object"] == "resistor"
+
+
+def test_single_word_still_matches_any_column():
+    got = _filter_relations(RELS, "component")
+    assert len(got) == 1 and got[0]["relation"] == "subClassOf"
+
+
+def test_triple_with_no_match_returns_nothing():
+    assert _filter_relations(RELS, "capacitor disjointWith transistor") == []
+
+
+# --- restrictions -----------------------------------------------------------
+
+
+def test_pasted_restriction_isolates_one_row():
+    got = _filter_restrictions(RESTS, "Bicycle hasPart Wheel")
+    assert len(got) == 1 and got[0]["value"] == "Wheel"
+
+
+def test_restriction_middle_slot_also_matches_the_type():
+    got = _filter_restrictions(RESTS, "Bicycle someValuesFrom Wheel")
+    assert len(got) == 1 and got[0]["applied_to"] == ["Bicycle"]
+
+
+def test_restriction_last_slot_also_matches_the_qualified_class():
+    got = _filter_restrictions(RESTS, "Driver owns Truck")
+    assert len(got) == 1 and got[0]["on_class"] == "Truck"
+
+
+def test_restriction_wildcard_narrows_by_property_alone():
+    got = _filter_restrictions(RESTS, "* hasPart *")
+    assert {r["value"] for r in got} == {"Wheel", "Engine"}
+
+
+def test_restriction_single_word_still_matches_any_field():
+    assert len(_filter_restrictions(RESTS, "wheel")) == 1
+    assert len(_filter_restrictions(RESTS, "hasPart")) == 2
+
+
+def test_restriction_triple_tolerates_none_fields():
+    """Unmapped restrictions (e.g. owl:hasSelf) carry None fields."""
+    rows = [
+        {
+            "property": "hasSelf",
+            "type": None,
+            "value": None,
+            "on_class": None,
+            "applied_to": None,
+        }
+    ]
+    assert _filter_restrictions(rows, "Bicycle hasPart Wheel") == []
+    assert _filter_restrictions(rows, "* hasSelf *") == rows


### PR DESCRIPTION
## Problem

Issue #170: there is no way to search for one specific relation. The box added in #148 matches a single term against any column, so hunting `capacitor disjointWith inductor` means typing `capacitor` and reading through every relation that touches it, spread across the paginated Class / Property / Individual sections.

## Fix

The same box now recognises a pasted triple, so no new widgets appear and nothing has to be learned before it helps.

| Query | Result |
| --- | --- |
| `capacitor disjointWith inductor` | exactly that relation |
| `inductor disjointWith capacitor` | the other direction, a distinct row |
| `* disjointWith inductor` | anything disjoint with inductor |
| `capacitor disjointWith *` | all of capacitor's disjointness |
| `capacitor` | unchanged: matches any column |
| `capacitor resistor` | rows containing both words (previously: no match) |

Three words match column by column; `*` (also `?`, `_`, `-`) leaves a slot unpinned. Any other word count is matched as separate terms that must each appear somewhere in the row, which keeps the #148 behaviour and quietly improves the multi-word case. Matching stays case-insensitive and partial, so `CAPACITOR disjoint induct` still lands.

Splitting on whitespace is unambiguous here because local names cannot contain it: `invalid_name_reason()` rejects spaces.

**Restrictions** are not triples but read like one, so the slots map to the class it applies to, the property, and the value. The middle word also matches the restriction type and the last one the qualified class, so both `Bicycle hasPart Wheel` and `Bicycle someValuesFrom Wheel` find the same row.

## Scope

This makes a specific triple findable. It does not make it editable: the Relations and Restrictions pages are still view and delete only, so the payoff today is verifying that a relation exists and deleting a specific one without scrolling. Per-item editors are #152, which is the natural follow-up and would turn this into find-then-fix.

## Tests

18 new tests in `tests/test_triple_search.py`: parsing (slots, wildcards, word counts, whitespace), relation matching including direction and partial/case-insensitive terms, the two-word fallback, restriction slot mapping onto class/type/qualified class, and `None` fields on restrictions the manager does not map (e.g. `owl:hasSelf`). The #148 tests are untouched and still pass. Full suite 599 passed; ruff and mypy clean.

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)
