### PR TITLE
feat: edit relations and restrictions in place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,10 @@ jobs:
       - name: Format check (ruff)
         run: uv run ruff format --check orionbelt_ontology_builder tests app.py ontology_manager.py templates.py
 
+      # Same scope as ruff above: checking the package alone let a type error in
+      # tests/ sit unnoticed, since nothing ever looked at it.
       - name: Type check (mypy)
-        run: uv run mypy orionbelt_ontology_builder
+        run: uv run mypy orionbelt_ontology_builder tests app.py ontology_manager.py templates.py
 
       - name: Test (pytest)
         run: uv run pytest

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -4520,14 +4520,24 @@ def render_relation_rows(ont, rows, spec):
         if not _is_open(spec["kind"], rel_uid, "edit"):
             continue
 
+        # A relation may point at an entity this list doesn't hold — the add
+        # forms accept an external URI. Offer it as its own option, or the
+        # editor would silently rewrite it to the first local entity when the
+        # user only meant to change the relation type (review P2).
+        row_options, row_lookup = list(options), dict(lookup)
+        for endpoint in (subj_uri, obj_uri):
+            if endpoint not in row_lookup.values():
+                row_options.append(endpoint)
+                row_lookup[endpoint] = endpoint
+
         with st.form(f"edit_form_{spec['kind']}_{rel_uid}"):
             # Slots are pre-set to the row's own values, so an edit that touches
             # one part leaves the rest exactly as asserted.
-            subj_default = _uri_option_index(options, lookup, subj_uri)
-            obj_default = _uri_option_index(options, lookup, obj_uri)
+            subj_default = _uri_option_index(row_options, row_lookup, subj_uri)
+            obj_default = _uri_option_index(row_options, row_lookup, obj_uri)
             types = list(spec["relation_types"])
             new_subject = st.selectbox(
-                "Subject", options, index=subj_default, key=f"es_{rel_uid}"
+                "Subject", row_options, index=subj_default, key=f"es_{rel_uid}"
             )
             new_type = st.selectbox(
                 "Relation",
@@ -4536,7 +4546,7 @@ def render_relation_rows(ont, rows, spec):
                 key=f"et_{rel_uid}",
             )
             new_object = st.selectbox(
-                "Object", options, index=obj_default, key=f"eo_{rel_uid}"
+                "Object", row_options, index=obj_default, key=f"eo_{rel_uid}"
             )
             save_col, cancel_col = st.columns(2)
             with save_col:
@@ -4550,7 +4560,7 @@ def render_relation_rows(ont, rows, spec):
             if saved:
                 changed = spec["update"](
                     (subj_uri, rel["relation"], obj_uri),
-                    (lookup[new_subject], new_type, lookup[new_object]),
+                    (row_lookup[new_subject], new_type, row_lookup[new_object]),
                 )
                 if changed:
                     save_checkpoint(f"Edit {spec['label']}")

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1249,6 +1249,11 @@ def _open_entity(kind: str, key: str, mode: str = "view") -> None:
     st.session_state[f"active_{kind}"] = (key, mode)
 
 
+def _close_entity(kind: str) -> None:
+    """Close whatever card of ``kind`` is open (Cancel, or a finished save)."""
+    st.session_state.pop(f"active_{kind}", None)
+
+
 def _get_active(kind: str):
     """Return ``(key, mode)`` for the open card of ``kind``, or ``None``."""
     value = st.session_state.get(f"active_{kind}")
@@ -3864,6 +3869,172 @@ def render_individuals():
                         st.rerun()
 
 
+def render_restriction_row(ont, rest, row_key, class_names, property_names):
+    """Render one restriction as a row, with edit and delete (issue #152).
+
+    Mirrors the Relations lists: class, property, type and value across the row,
+    so a page of restrictions can be scanned at a glance. The editor opens
+    underneath the row it belongs to.
+    """
+    value_text = "—" if rest["value"] is None else str(rest["value"])
+    if rest["on_class"]:
+        value_text = f"{value_text} (on {rest['on_class']})"
+
+    col_cls, col_prop, col_type, col_val, col_edit, col_del = st.columns(
+        [3, 2, 2, 3, 0.7, 0.7]
+    )
+    with col_cls:
+        st.write(f"📦 {', '.join(rest['applied_to']) or '—'}")
+    with col_prop:
+        st.write(f"🔗 {rest['property']}")
+    with col_type:
+        st.write(f"🔒 {rest['type'] or '—'}")
+    with col_val:
+        st.write(value_text)
+
+    # An orphaned restriction (applied to nothing) has no class to edit or
+    # delete against, so it is shown but not actionable.
+    if not rest["applied_to"]:
+        return
+
+    with col_edit:
+        st.button(
+            "✏️",
+            key=f"edit_rest_{row_key}",
+            help="Edit this restriction",
+            on_click=_cb_toggle_edit,
+            args=("rest", row_key),
+        )
+    with col_del:
+        if st.button("🗑️", key=f"del_rest_{row_key}", help="Delete this restriction"):
+            # Use full URIs so restrictions on external/imported properties or
+            # classes delete correctly, and the value (with the qualified class)
+            # so a sibling on the same property and type is not deleted instead
+            # of this row (issue #152).
+            applied_uri = rest.get("applied_to_uris") or rest["applied_to"]
+            removed = ont.delete_restriction(
+                applied_uri[0],
+                rest.get("property_uri") or rest["property"],
+                rest["type"],
+                value=rest.get("value_uri") or rest.get("value"),
+                on_class=rest.get("on_class_uri") or rest.get("on_class"),
+            )
+            if removed:
+                save_checkpoint("Delete restriction")
+                show_message("Restriction deleted!", "success")
+                st.rerun()
+            else:
+                show_message("Could not delete this restriction.", "error")
+
+    render_restriction_editor(ont, rest, row_key, class_names, property_names)
+
+
+def render_restriction_editor(ont, rest, row_key, class_names, property_names):
+    """Edit one restriction in place, inside its expander (issue #152).
+
+    The row is identified by its whole spec, so a class carrying several
+    restrictions on the same property and type edits the one on screen rather
+    than whichever the graph yields first. Keyed by the row's position in the
+    rendered list, which is what the delete button already does: two identical
+    restrictions would otherwise share a key.
+    """
+    kind = "rest"
+    if not _is_open(kind, row_key, "edit"):
+        return
+
+    types = list(ont.RESTRICTION_TYPES)
+    applied = rest["applied_to"][0]
+    with st.form(f"edit_rest_form_{row_key}"):
+        new_class = st.selectbox(
+            "Applies to Class",
+            class_names,
+            index=class_names.index(applied) if applied in class_names else 0,
+            key=f"er_cls_{row_key}",
+        )
+        new_property = st.selectbox(
+            "Property",
+            property_names,
+            index=(
+                property_names.index(rest["property"])
+                if rest["property"] in property_names
+                else 0
+            ),
+            key=f"er_prop_{row_key}",
+        )
+        new_type = st.selectbox(
+            "Restriction Type",
+            types,
+            index=types.index(rest["type"]) if rest["type"] in types else 0,
+            key=f"er_type_{row_key}",
+        )
+        # One text box for every value kind: a cardinality is a number, the
+        # others name a class or carry a literal, and the engine rejects a
+        # cardinality that isn't a whole number.
+        new_value = st.text_input(
+            "Value",
+            value="" if rest["value"] is None else str(rest["value"]),
+            key=f"er_val_{row_key}",
+            help="A class name for someValuesFrom/allValuesFrom, a number for a "
+            "cardinality, or a literal for hasValue.",
+        )
+        new_on_class = None
+        if "Qualified" in new_type:
+            on_class_options = class_names or [""]
+            new_on_class = st.selectbox(
+                "Qualified on Class",
+                on_class_options,
+                index=(
+                    on_class_options.index(rest["on_class"])
+                    if rest["on_class"] in on_class_options
+                    else 0
+                ),
+                key=f"er_onclass_{row_key}",
+            )
+
+        save_col, cancel_col = st.columns(2)
+        with save_col:
+            saved = st.form_submit_button("💾 Save", use_container_width=True)
+        with cancel_col:
+            cancelled = st.form_submit_button("Cancel", use_container_width=True)
+
+        if cancelled:
+            _close_entity(kind)
+            st.rerun()
+        if saved:
+            applied_uris = rest.get("applied_to_uris") or rest["applied_to"]
+            try:
+                changed = ont.update_restriction(
+                    {
+                        "class_name": applied_uris[0],
+                        "property_name": rest.get("property_uri") or rest["property"],
+                        "restriction_type": rest["type"],
+                        "value": rest.get("value_uri") or rest.get("value"),
+                        "on_class": rest.get("on_class_uri") or rest.get("on_class"),
+                    },
+                    {
+                        "class_name": new_class,
+                        "property_name": new_property,
+                        "restriction_type": new_type,
+                        "value": new_value,
+                        "on_class": new_on_class,
+                    },
+                )
+            except ValueError as exc:
+                show_message(str(exc), "error")
+                return
+            if changed:
+                save_checkpoint("Edit restriction")
+                _close_entity(kind)
+                set_flash_message("Restriction updated!", "success")
+                st.rerun()
+            else:
+                show_message(
+                    "This restriction is no longer in the ontology, so it "
+                    "wasn't changed.",
+                    "error",
+                )
+
+
 def render_restrictions():
     """Render the restrictions management page."""
     st.header("Restrictions")
@@ -3908,44 +4079,19 @@ def render_restrictions():
                 _view_restrictions = _sort_restrictions(_view_restrictions)
             if not _view_restrictions:
                 st.caption("No restrictions match your search.")
-            # Key delete buttons by the row's position in the rendered list, which
-            # is unique per render. (list.index would collide when two identical
-            # restrictions exist, since it returns the first match for both.)
-            for _row_i, rest in enumerate(_view_restrictions):
-                with st.expander(f"🔒 {rest['type']} on {rest['property']}"):
-                    st.write(f"**Property:** {rest['property']}")
-                    st.write(f"**Restriction Type:** {rest['type']}")
-                    st.write(f"**Value:** {rest['value']}")
-                    if rest["on_class"]:
-                        st.write(f"**Qualified on Class:** {rest['on_class']}")
-                    st.write(f"**Applied to Classes:** {', '.join(rest['applied_to'])}")
-
-                    if rest["applied_to"]:
-                        if st.button("Delete", key=f"del_rest_{_row_i}"):
-                            # Use full URIs so restrictions on external/imported
-                            # properties or classes delete correctly.
-                            applied_uri = (
-                                rest.get("applied_to_uris") or rest["applied_to"]
-                            )
-                            # Pass the value (and qualified class) as well, or a
-                            # sibling restriction on the same property and type
-                            # is deleted instead of this row (issue #152).
-                            removed = ont.delete_restriction(
-                                applied_uri[0],
-                                rest.get("property_uri") or rest["property"],
-                                rest["type"],
-                                value=rest.get("value_uri") or rest.get("value"),
-                                on_class=rest.get("on_class_uri")
-                                or rest.get("on_class"),
-                            )
-                            if removed:
-                                save_checkpoint("Delete restriction")
-                                show_message("Restriction deleted!", "success")
-                                st.rerun()
-                            else:
-                                show_message(
-                                    "Could not delete this restriction.", "error"
-                                )
+            # Rows rather than one expander each: a long list reads as a table
+            # of class / property / type / value instead of a wall of collapsed
+            # boxes, and it paginates like the Relations lists do.
+            _rest_page = st.session_state.get("rest_page", 1)
+            for _row_i, rest in enumerate(
+                _paginate_rows(_view_restrictions, "rest_page", "restrictions")
+            ):
+                # Key by page and position: unique per render, and stable while
+                # the page is. (Keying by the restriction itself would collide
+                # when a class carries two identical ones.)
+                render_restriction_row(
+                    ont, rest, f"{_rest_page}_{_row_i}", class_names, all_props
+                )
 
     if _rest_tab == "Add Restriction":
         st.subheader("Add Restriction")
@@ -4067,25 +4213,19 @@ def render_relations():
             st.write("**Class Relations:**")
             if not class_relations:
                 st.caption("No class relations match your search.")
-            for rel in _paginate_rows(
-                class_relations, "rel_class_page", "class relations"
-            ):
-                subj_uri = rel.get("subject_uri", rel["subject"])
-                obj_uri = rel.get("object_uri", rel["object"])
-                rel_uid = _uid(f"{subj_uri}|{rel['relation']}|{obj_uri}")
-                col1, col2, col3, col4 = st.columns([3, 2, 3, 1])
-                with col1:
-                    st.write(f"📦 {rel['subject']}")
-                with col2:
-                    st.write(f"➡️ {rel['relation']}")
-                with col3:
-                    st.write(f"📦 {rel['object']}")
-                with col4:
-                    if st.button("🗑️", key=f"del_crel_{rel_uid}"):
-                        ont.remove_class_relation(subj_uri, rel["relation"], obj_uri)
-                        save_checkpoint("Delete class relation")
-                        show_message("Relation deleted!", "success")
-                        st.rerun()
+            render_relation_rows(
+                ont,
+                _paginate_rows(class_relations, "rel_class_page", "class relations"),
+                {
+                    "icon": "📦",
+                    "kind": "crel",
+                    "label": "class relation",
+                    "entities": classes,
+                    "relation_types": ont.CLASS_RELATIONS,
+                    "remove": ont.remove_class_relation,
+                    "update": ont.update_class_relation,
+                },
+            )
         else:
             st.info("No class relations defined.")
 
@@ -4098,25 +4238,19 @@ def render_relations():
             st.write("**Property Relations:**")
             if not prop_relations:
                 st.caption("No property relations match your search.")
-            for rel in _paginate_rows(
-                prop_relations, "rel_prop_page", "property relations"
-            ):
-                col1, col2, col3, col4 = st.columns([3, 2, 3, 1])
-                with col1:
-                    st.write(f"🔗 {rel['subject']}")
-                with col2:
-                    st.write(f"➡️ {rel['relation']}")
-                with col3:
-                    st.write(f"🔗 {rel['object']}")
-                with col4:
-                    subj_uri = rel.get("subject_uri", rel["subject"])
-                    obj_uri = rel.get("object_uri", rel["object"])
-                    rel_uid = _uid(f"{subj_uri}|{rel['relation']}|{obj_uri}")
-                    if st.button("🗑️", key=f"del_prel_{rel_uid}"):
-                        ont.remove_property_relation(subj_uri, rel["relation"], obj_uri)
-                        save_checkpoint("Delete property relation")
-                        show_message("Relation deleted!", "success")
-                        st.rerun()
+            render_relation_rows(
+                ont,
+                _paginate_rows(prop_relations, "rel_prop_page", "property relations"),
+                {
+                    "icon": "🔗",
+                    "kind": "prel",
+                    "label": "property relation",
+                    "entities": object_props + data_props,
+                    "relation_types": ont.PROPERTY_RELATIONS,
+                    "remove": ont.remove_property_relation,
+                    "update": ont.update_property_relation,
+                },
+            )
         else:
             st.info("No property relations defined.")
 
@@ -4129,27 +4263,19 @@ def render_relations():
             st.write("**Individual Relations:**")
             if not ind_relations:
                 st.caption("No individual relations match your search.")
-            for rel in _paginate_rows(
-                ind_relations, "rel_ind_page", "individual relations"
-            ):
-                col1, col2, col3, col4 = st.columns([3, 2, 3, 1])
-                with col1:
-                    st.write(f"👤 {rel['subject']}")
-                with col2:
-                    st.write(f"➡️ {rel['relation']}")
-                with col3:
-                    st.write(f"👤 {rel['object']}")
-                with col4:
-                    subj_uri = rel.get("subject_uri", rel["subject"])
-                    obj_uri = rel.get("object_uri", rel["object"])
-                    rel_uid = _uid(f"{subj_uri}|{rel['relation']}|{obj_uri}")
-                    if st.button("🗑️", key=f"del_irel_{rel_uid}"):
-                        ont.remove_individual_relation(
-                            subj_uri, rel["relation"], obj_uri
-                        )
-                        save_checkpoint("Delete individual relation")
-                        show_message("Relation deleted!", "success")
-                        st.rerun()
+            render_relation_rows(
+                ont,
+                _paginate_rows(ind_relations, "rel_ind_page", "individual relations"),
+                {
+                    "icon": "👤",
+                    "kind": "irel",
+                    "label": "individual relation",
+                    "entities": individuals,
+                    "relation_types": ont.INDIVIDUAL_RELATIONS,
+                    "remove": ont.remove_individual_relation,
+                    "update": ont.update_individual_relation,
+                },
+            )
         else:
             st.info("No individual relations defined.")
 
@@ -4350,6 +4476,105 @@ def resolve_annotation_predicate_choice(ont, choice, lookup) -> tuple:
         return lookup[choice], None
     text = (choice or "").strip()
     return text, ont.invalid_annotation_predicate_reason(text)
+
+
+def render_relation_rows(ont, rows, spec):
+    """Render one relation section: a row each, with edit and delete.
+
+    ``spec`` carries what differs between the class, property and individual
+    lists: the icon, the entities that can fill a slot, the relation types, the
+    active-card kind and the engine calls. Editing rewrites the triple in place
+    rather than asking the user to delete and re-add it (issue #152).
+    """
+    options, lookup = build_uri_options(spec["entities"])
+    for rel in rows:
+        subj_uri = rel.get("subject_uri", rel["subject"])
+        obj_uri = rel.get("object_uri", rel["object"])
+        rel_uid = _uid(f"{subj_uri}|{rel['relation']}|{obj_uri}")
+        icon = spec["icon"]
+
+        col1, col2, col3, col_edit, col_del = st.columns([3, 2, 3, 0.7, 0.7])
+        with col1:
+            st.write(f"{icon} {rel['subject']}")
+        with col2:
+            st.write(f"➡️ {rel['relation']}")
+        with col3:
+            st.write(f"{icon} {rel['object']}")
+        with col_edit:
+            st.button(
+                "✏️",
+                key=f"edit_{spec['kind']}_{rel_uid}",
+                help="Edit this relation",
+                on_click=_cb_toggle_edit,
+                args=(spec["kind"], rel_uid),
+            )
+        with col_del:
+            if st.button(
+                "🗑️", key=f"del_{spec['kind']}_{rel_uid}", help="Delete this relation"
+            ):
+                spec["remove"](subj_uri, rel["relation"], obj_uri)
+                save_checkpoint(f"Delete {spec['label']}")
+                show_message("Relation deleted!", "success")
+                st.rerun()
+
+        if not _is_open(spec["kind"], rel_uid, "edit"):
+            continue
+
+        with st.form(f"edit_form_{spec['kind']}_{rel_uid}"):
+            # Slots are pre-set to the row's own values, so an edit that touches
+            # one part leaves the rest exactly as asserted.
+            subj_default = _uri_option_index(options, lookup, subj_uri)
+            obj_default = _uri_option_index(options, lookup, obj_uri)
+            types = list(spec["relation_types"])
+            new_subject = st.selectbox(
+                "Subject", options, index=subj_default, key=f"es_{rel_uid}"
+            )
+            new_type = st.selectbox(
+                "Relation",
+                types,
+                index=types.index(rel["relation"]) if rel["relation"] in types else 0,
+                key=f"et_{rel_uid}",
+            )
+            new_object = st.selectbox(
+                "Object", options, index=obj_default, key=f"eo_{rel_uid}"
+            )
+            save_col, cancel_col = st.columns(2)
+            with save_col:
+                saved = st.form_submit_button("💾 Save", use_container_width=True)
+            with cancel_col:
+                cancelled = st.form_submit_button("Cancel", use_container_width=True)
+
+            if cancelled:
+                _close_entity(spec["kind"])
+                st.rerun()
+            if saved:
+                changed = spec["update"](
+                    (subj_uri, rel["relation"], obj_uri),
+                    (lookup[new_subject], new_type, lookup[new_object]),
+                )
+                if changed:
+                    save_checkpoint(f"Edit {spec['label']}")
+                    _close_entity(spec["kind"])
+                    set_flash_message("Relation updated!", "success")
+                    st.rerun()
+                else:
+                    # The row was deleted or edited elsewhere since this list
+                    # was drawn; re-adding it under the new values would
+                    # resurrect a relation the user already removed.
+                    show_message(
+                        "This relation is no longer in the ontology, so it "
+                        "wasn't changed. Close the editor to refresh the list.",
+                        "error",
+                    )
+
+
+def _uri_option_index(options: list, lookup: dict, uri: str) -> int:
+    """Index of the option standing for ``uri``, or 0 when it isn't listed
+    (an external URI with no entity of its own)."""
+    for i, option in enumerate(options):
+        if lookup.get(option) == uri:
+            return i
+    return 0
 
 
 def annotation_option_for_predicate(ont, predicate_lookup, predicate_uri):

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -3869,7 +3869,22 @@ def render_individuals():
                         st.rerun()
 
 
-def render_restriction_row(ont, rest, row_key, class_names, property_names):
+def _slot_options(entities: list, current_uri) -> tuple:
+    """Build ``(options, lookup)`` for an editor slot, keeping ``current_uri``.
+
+    Selecting by local name would resolve into the base namespace and rewrite an
+    imported entity (``other:Foo`` saved back as ``:Foo``), so options map to
+    full URIs and the row's own value is offered as itself when nothing local
+    holds it (review P2).
+    """
+    options, lookup = build_uri_options(entities)
+    if current_uri and current_uri not in lookup.values():
+        options = options + [str(current_uri)]
+        lookup = {**lookup, str(current_uri): str(current_uri)}
+    return options, lookup
+
+
+def render_restriction_row(ont, rest, row_key, classes, properties):
     """Render one restriction as a row, with edit and delete (issue #152).
 
     Mirrors the Relations lists: class, property, type and value across the row,
@@ -3926,10 +3941,10 @@ def render_restriction_row(ont, rest, row_key, class_names, property_names):
             else:
                 show_message("Could not delete this restriction.", "error")
 
-    render_restriction_editor(ont, rest, row_key, class_names, property_names)
+    render_restriction_editor(ont, rest, row_key, classes, properties)
 
 
-def render_restriction_editor(ont, rest, row_key, class_names, property_names):
+def render_restriction_editor(ont, rest, row_key, classes, properties):
     """Edit one restriction in place, inside its expander (issue #152).
 
     The row is identified by its whole spec, so a class carrying several
@@ -3943,21 +3958,34 @@ def render_restriction_editor(ont, rest, row_key, class_names, property_names):
         return
 
     types = list(ont.RESTRICTION_TYPES)
-    applied = rest["applied_to"][0]
+    applied_uris = rest.get("applied_to_uris") or rest["applied_to"]
+    cls_options, cls_lookup = _slot_options(classes, applied_uris[0])
+    prop_options, prop_lookup = _slot_options(
+        properties, rest.get("property_uri") or rest["property"]
+    )
+    on_options, on_lookup = _slot_options(classes, rest.get("on_class_uri"))
+
+    # The value stays free text: it can be a class, a cardinality or a literal,
+    # and a form cannot swap the widget when the type picker changes. An
+    # imported class is pre-filled as its full URI, so saving round-trips it
+    # instead of resolving the local name into the base namespace (review P2).
+    value_default = "" if rest["value"] is None else str(rest["value"])
+    _value_uri = rest.get("value_uri")
+    if _value_uri and not str(_value_uri).startswith(str(ont.namespace)):
+        value_default = str(_value_uri)
+
     with st.form(f"edit_rest_form_{row_key}"):
         new_class = st.selectbox(
             "Applies to Class",
-            class_names,
-            index=class_names.index(applied) if applied in class_names else 0,
+            cls_options,
+            index=_uri_option_index(cls_options, cls_lookup, applied_uris[0]),
             key=f"er_cls_{row_key}",
         )
         new_property = st.selectbox(
             "Property",
-            property_names,
-            index=(
-                property_names.index(rest["property"])
-                if rest["property"] in property_names
-                else 0
+            prop_options,
+            index=_uri_option_index(
+                prop_options, prop_lookup, rest.get("property_uri") or rest["property"]
             ),
             key=f"er_prop_{row_key}",
         )
@@ -3967,25 +3995,21 @@ def render_restriction_editor(ont, rest, row_key, class_names, property_names):
             index=types.index(rest["type"]) if rest["type"] in types else 0,
             key=f"er_type_{row_key}",
         )
-        # One text box for every value kind: a cardinality is a number, the
-        # others name a class or carry a literal, and the engine rejects a
-        # cardinality that isn't a whole number.
         new_value = st.text_input(
             "Value",
-            value="" if rest["value"] is None else str(rest["value"]),
+            value=value_default,
             key=f"er_val_{row_key}",
             help="A class name for someValuesFrom/allValuesFrom, a number for a "
-            "cardinality, or a literal for hasValue.",
+            "cardinality, or a literal for hasValue. A full URI is kept as it is.",
         )
         new_on_class = None
         if "Qualified" in new_type:
-            on_class_options = class_names or [""]
             new_on_class = st.selectbox(
                 "Qualified on Class",
-                on_class_options,
+                on_options,
                 index=(
-                    on_class_options.index(rest["on_class"])
-                    if rest["on_class"] in on_class_options
+                    _uri_option_index(on_options, on_lookup, rest["on_class_uri"])
+                    if rest.get("on_class_uri")
                     else 0
                 ),
                 key=f"er_onclass_{row_key}",
@@ -4001,7 +4025,6 @@ def render_restriction_editor(ont, rest, row_key, class_names, property_names):
             _close_entity(kind)
             st.rerun()
         if saved:
-            applied_uris = rest.get("applied_to_uris") or rest["applied_to"]
             try:
                 changed = ont.update_restriction(
                     {
@@ -4012,11 +4035,15 @@ def render_restriction_editor(ont, rest, row_key, class_names, property_names):
                         "on_class": rest.get("on_class_uri") or rest.get("on_class"),
                     },
                     {
-                        "class_name": new_class,
-                        "property_name": new_property,
+                        "class_name": cls_lookup.get(new_class, new_class),
+                        "property_name": prop_lookup.get(new_property, new_property),
                         "restriction_type": new_type,
                         "value": new_value,
-                        "on_class": new_on_class,
+                        "on_class": (
+                            on_lookup.get(new_on_class, new_on_class)
+                            if new_on_class
+                            else None
+                        ),
                     },
                 )
             except ValueError as exc:
@@ -4090,7 +4117,11 @@ def render_restrictions():
                 # the page is. (Keying by the restriction itself would collide
                 # when a class carries two identical ones.)
                 render_restriction_row(
-                    ont, rest, f"{_rest_page}_{_row_i}", class_names, all_props
+                    ont,
+                    rest,
+                    f"{_rest_page}_{_row_i}",
+                    classes,
+                    object_props + data_props,
                 )
 
     if _rest_tab == "Add Restriction":

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -3927,10 +3927,16 @@ def render_restrictions():
                             applied_uri = (
                                 rest.get("applied_to_uris") or rest["applied_to"]
                             )
+                            # Pass the value (and qualified class) as well, or a
+                            # sibling restriction on the same property and type
+                            # is deleted instead of this row (issue #152).
                             removed = ont.delete_restriction(
                                 applied_uri[0],
                                 rest.get("property_uri") or rest["property"],
                                 rest["type"],
+                                value=rest.get("value_uri") or rest.get("value"),
+                                on_class=rest.get("on_class_uri")
+                                or rest.get("on_class"),
                             )
                             if removed:
                                 save_checkpoint("Delete restriction")

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -3966,12 +3966,20 @@ def render_restriction_editor(ont, rest, row_key, classes, properties):
     on_options, on_lookup = _slot_options(classes, rest.get("on_class_uri"))
 
     # The value stays free text: it can be a class, a cardinality or a literal,
-    # and a form cannot swap the widget when the type picker changes. An
-    # imported class is pre-filled as its full URI, so saving round-trips it
-    # instead of resolving the local name into the base namespace (review P2).
+    # and a form cannot swap the widget when the type picker changes. It is
+    # pre-filled as a full URI in the two cases where a bare local name would
+    # not round-trip (review P2):
+    #   * an imported entity, since a local name resolves into the base
+    #     namespace and would point at a different thing;
+    #   * any resource-valued hasValue, since add_restriction stores a
+    #     non-http value as a literal — so saving an unchanged row would turn
+    #     owl:hasValue :alice into owl:hasValue "alice".
+    # A hasValue that already holds a literal has no value_uri and stays as it is.
     value_default = "" if rest["value"] is None else str(rest["value"])
     _value_uri = rest.get("value_uri")
-    if _value_uri and not str(_value_uri).startswith(str(ont.namespace)):
+    if _value_uri and (
+        rest["type"] == "hasValue" or not str(_value_uri).startswith(str(ont.namespace))
+    ):
         value_default = str(_value_uri)
 
     with st.form(f"edit_rest_form_{row_key}"):

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -4250,6 +4250,7 @@ def render_relations():
                 {
                     "icon": "📦",
                     "kind": "crel",
+                    "noun": "classes",
                     "label": "class relation",
                     "entities": classes,
                     "relation_types": ont.CLASS_RELATIONS,
@@ -4275,6 +4276,7 @@ def render_relations():
                 {
                     "icon": "🔗",
                     "kind": "prel",
+                    "noun": "properties",
                     "label": "property relation",
                     "entities": object_props + data_props,
                     "relation_types": ont.PROPERTY_RELATIONS,
@@ -4300,6 +4302,7 @@ def render_relations():
                 {
                     "icon": "👤",
                     "kind": "irel",
+                    "noun": "individuals",
                     "label": "individual relation",
                     "entities": individuals,
                     "relation_types": ont.INDIVIDUAL_RELATIONS,
@@ -4589,9 +4592,19 @@ def render_relation_rows(ont, rows, spec):
                 _close_entity(spec["kind"])
                 st.rerun()
             if saved:
+                new_subj_uri = row_lookup[new_subject]
+                new_obj_uri = row_lookup[new_object]
+                if new_subj_uri == new_obj_uri:
+                    # The add forms refuse this; the editor has to as well, or
+                    # it becomes the way to assert "A disjointWith A"
+                    # (review P2).
+                    show_message(
+                        f"Please select two different {spec['noun']}!", "error"
+                    )
+                    return
                 changed = spec["update"](
                     (subj_uri, rel["relation"], obj_uri),
-                    (row_lookup[new_subject], new_type, row_lookup[new_object]),
+                    (new_subj_uri, new_type, new_obj_uri),
                 )
                 if changed:
                     save_checkpoint(f"Edit {spec['label']}")

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -4046,7 +4046,9 @@ def render_restriction_editor(ont, rest, row_key, classes, properties):
                         ),
                     },
                 )
-            except ValueError as exc:
+            except Exception as exc:
+                # As wide as the Add form's handler: a rejected edit must show
+                # up as a message, never as a page-breaking traceback.
                 show_message(str(exc), "error")
                 return
             if changed:
@@ -4062,16 +4064,93 @@ def render_restriction_editor(ont, rest, row_key, classes, properties):
                 )
 
 
+def render_add_restriction(ont, classes, properties):
+    """Render the "Add Restriction" tab.
+
+    Split out of :func:`render_restrictions` for the same reason as the row
+    renderer: the page's tab picker is a ``segmented_control``, which
+    Streamlit's AppTest mis-serializes, so the form cannot be driven through
+    the page in tests.
+    """
+    st.subheader("Add Restriction")
+
+    if not classes:
+        st.warning("Please create at least one class first.")
+        return
+    if not properties:
+        st.warning("Please create at least one property first.")
+        return
+
+    with st.form("add_restriction_form"):
+        # Pick by URI, not by local name: a name resolves into the base
+        # namespace, so a restriction meant for an imported other:Foo
+        # was silently created on a base-namespace twin instead.
+        cls_opts, cls_lookup = build_uri_options(classes)
+        prop_opts, prop_lookup = build_uri_options(properties)
+        target_disp = st.selectbox("Apply to Class", options=cls_opts)
+        property_disp = st.selectbox("On Property", options=prop_opts)
+
+        # Straight from the engine, so a type can never be offered here
+        # that it doesn't understand, or omitted when it gains one.
+        restriction_type = st.selectbox(
+            "Restriction Type", options=list(ont.RESTRICTION_TYPES)
+        )
+
+        st.write("**Restriction Value:**")
+        value = None
+        if restriction_type in ["someValuesFrom", "allValuesFrom"]:
+            value = cls_lookup[
+                st.selectbox("Value (Class)", options=cls_opts, key="rest_class_value")
+            ]
+        elif restriction_type == "hasValue":
+            ind_opts, ind_lookup = build_uri_options(ont.get_individuals())
+            value_type = st.radio("Value Type", ["Literal", "Individual"])
+            if value_type == "Literal":
+                value = st.text_input("Literal Value")
+            elif ind_opts:
+                value = ind_lookup[st.selectbox("Individual", options=ind_opts)]
+            else:
+                # Offering a "No individuals" placeholder let that string
+                # be stored as the value.
+                st.info("No individuals yet — create one, or use a literal.")
+        else:
+            value = st.number_input("Cardinality", min_value=0, value=1)
+
+        on_class = None
+        if "Qualified" in restriction_type:
+            on_class = cls_lookup[
+                st.selectbox(
+                    "Qualified on Class",
+                    options=cls_opts,
+                    key="qualified_class",
+                )
+            ]
+
+        submitted = st.form_submit_button("Add Restriction")
+        if submitted:
+            try:
+                ont.add_restriction(
+                    cls_lookup[target_disp],
+                    prop_lookup[property_disp],
+                    restriction_type,
+                    value,
+                    on_class=on_class,
+                )
+                save_checkpoint("Add restriction")
+                show_message("Restriction added!", "success")
+                st.rerun()
+            except Exception as e:
+                show_message(f"Error adding restriction: {str(e)}", "error")
+
+
 def render_restrictions():
     """Render the restrictions management page."""
     st.header("Restrictions")
 
     ont = st.session_state.ontology
     classes = ont.get_classes()
-    class_names = [c["name"] for c in classes]
     object_props = ont.get_object_properties()
     data_props = ont.get_data_properties()
-    all_props = [p["name"] for p in object_props] + [p["name"] for p in data_props]
     restrictions = ont.get_restrictions()
 
     _rest_tab = st.segmented_control(
@@ -4125,71 +4204,7 @@ def render_restrictions():
                 )
 
     if _rest_tab == "Add Restriction":
-        st.subheader("Add Restriction")
-
-        if not class_names:
-            st.warning("Please create at least one class first.")
-        elif not all_props:
-            st.warning("Please create at least one property first.")
-        else:
-            with st.form("add_restriction_form"):
-                target_class = st.selectbox("Apply to Class", options=class_names)
-                property_name = st.selectbox("On Property", options=all_props)
-
-                restriction_types = [
-                    "someValuesFrom",
-                    "allValuesFrom",
-                    "hasValue",
-                    "minCardinality",
-                    "maxCardinality",
-                    "exactCardinality",
-                    "minQualifiedCardinality",
-                    "maxQualifiedCardinality",
-                    "qualifiedCardinality",
-                ]
-                restriction_type = st.selectbox(
-                    "Restriction Type", options=restriction_types
-                )
-
-                st.write("**Restriction Value:**")
-                if restriction_type in ["someValuesFrom", "allValuesFrom"]:
-                    value = st.selectbox(
-                        "Value (Class)", options=class_names, key="rest_class_value"
-                    )
-                elif restriction_type == "hasValue":
-                    value_type = st.radio("Value Type", ["Literal", "Individual"])
-                    if value_type == "Literal":
-                        value = st.text_input("Literal Value")
-                    else:
-                        ind_names = [i["name"] for i in ont.get_individuals()]
-                        value = st.selectbox(
-                            "Individual",
-                            options=ind_names if ind_names else ["No individuals"],
-                        )
-                else:
-                    value = st.number_input("Cardinality", min_value=0, value=1)
-
-                on_class = None
-                if "Qualified" in restriction_type:
-                    on_class = st.selectbox(
-                        "Qualified on Class", options=class_names, key="qualified_class"
-                    )
-
-                submitted = st.form_submit_button("Add Restriction")
-                if submitted:
-                    try:
-                        ont.add_restriction(
-                            target_class,
-                            property_name,
-                            restriction_type,
-                            value,
-                            on_class=on_class,
-                        )
-                        save_checkpoint("Add restriction")
-                        show_message("Restriction added!", "success")
-                        st.rerun()
-                    except Exception as e:
-                        show_message(f"Error adding restriction: {str(e)}", "error")
+        render_add_restriction(ont, classes, object_props + data_props)
 
 
 def render_relations():
@@ -4333,7 +4348,7 @@ def render_relations():
                 with col2:
                     relation_type = st.selectbox(
                         "Relation Type",
-                        options=["subClassOf", "equivalentClass", "disjointWith"],
+                        options=list(ont.CLASS_RELATIONS),
                         key="crel_type",
                     )
                 with col3:
@@ -4395,7 +4410,7 @@ def render_relations():
                 with col2:
                     relation_type = st.selectbox(
                         "Relation Type",
-                        options=["subPropertyOf", "equivalentProperty", "inverseOf"],
+                        options=list(ont.PROPERTY_RELATIONS),
                         key="prel_type",
                     )
                 with col3:
@@ -4456,7 +4471,7 @@ def render_relations():
                 with col2:
                     relation_type = st.selectbox(
                         "Relation Type",
-                        options=["sameAs", "differentFrom"],
+                        options=list(ont.INDIVIDUAL_RELATIONS),
                         key="irel_type",
                     )
                 with col3:
@@ -4582,6 +4597,15 @@ def render_relation_rows(ont, rows, spec):
             new_object = st.selectbox(
                 "Object", row_options, index=obj_default, key=f"eo_{rel_uid}"
             )
+            # The add forms can point an object at an entity in an ontology that
+            # was never imported; without this the editor could keep such a
+            # target but never set one.
+            ext_obj_uri, ext_err = _external_uri_target(
+                ont,
+                row_lookup[new_object],
+                key=f"eo_ext_{rel_uid}",
+                label="the object",
+            )
             save_col, cancel_col = st.columns(2)
             with save_col:
                 saved = st.form_submit_button("💾 Save", use_container_width=True)
@@ -4593,7 +4617,10 @@ def render_relation_rows(ont, rows, spec):
                 st.rerun()
             if saved:
                 new_subj_uri = row_lookup[new_subject]
-                new_obj_uri = row_lookup[new_object]
+                new_obj_uri = ext_obj_uri
+                if ext_err:
+                    show_message(ext_err, "error")
+                    return
                 if new_subj_uri == new_obj_uri:
                     # The add forms refuse this; the editor has to as well, or
                     # it becomes the way to assert "A disjointWith A"

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -1651,6 +1651,25 @@ class OntologyManager:
 
     # ==================== RESTRICTION OPERATIONS ====================
 
+    @classmethod
+    def _cardinality_value(cls, restriction_type: str, value: Any) -> int:
+        """Return ``value`` as a cardinality, or raise ``ValueError``.
+
+        Cardinalities are written as ``xsd:nonNegativeInteger``, so a negative
+        number would serialize as invalid OWL. The Add form's number input
+        blocks that at the widget; checking here covers the edit form's free-text
+        value and any other caller (review P2).
+        """
+        try:
+            number = int(value)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"{restriction_type} needs a whole number, got {value!r}"
+            ) from None
+        if number < 0:
+            raise ValueError(f"{restriction_type} cannot be negative, got {number}")
+        return number
+
     def add_restriction(
         self,
         class_name: str,
@@ -1659,17 +1678,28 @@ class OntologyManager:
         value: Any,
         on_class: Optional[str] = None,
     ) -> BNode:
-        """Add a restriction to a class."""
+        """Add a restriction to a class.
+
+        Raises ``ValueError`` for a cardinality that is not a whole number of
+        zero or more, so no caller can write a value that breaks the
+        ``xsd:nonNegativeInteger`` it is stored as.
+        """
         class_uri = self._uri(class_name)
         prop_uri = self._uri(property_name)
+
+        # Everything that can be rejected is checked before the first triple is
+        # written: raising once the blank node existed left an orphan
+        # restriction behind, with no type and no value, that the Restrictions
+        # page then listed as an empty row.
+        restriction_pred = self.RESTRICTION_TYPES.get(restriction_type)
+        if not restriction_pred:
+            raise ValueError(f"Unknown restriction type: {restriction_type}")
+        if restriction_type in self._CARDINALITY_TYPES:
+            cardinality = self._cardinality_value(restriction_type, value)
 
         restriction = BNode()
         self.graph.add((restriction, RDF.type, OWL.Restriction))
         self.graph.add((restriction, OWL.onProperty, prop_uri))
-
-        restriction_pred = self.RESTRICTION_TYPES.get(restriction_type)
-        if not restriction_pred:
-            raise ValueError(f"Unknown restriction type: {restriction_type}")
 
         # Handle different value types
         if restriction_type in ["someValuesFrom", "allValuesFrom"]:
@@ -1679,28 +1709,12 @@ class OntologyManager:
                 self.graph.add((restriction, restriction_pred, Literal(value)))
             else:
                 self.graph.add((restriction, restriction_pred, self._uri(value)))
-        elif restriction_type in [
-            "minCardinality",
-            "maxCardinality",
-            "exactCardinality",
-        ]:
+        elif restriction_type in self._CARDINALITY_TYPES:
             self.graph.add(
                 (
                     restriction,
                     restriction_pred,
-                    Literal(int(value), datatype=XSD.nonNegativeInteger),
-                )
-            )
-        elif restriction_type in [
-            "minQualifiedCardinality",
-            "maxQualifiedCardinality",
-            "qualifiedCardinality",
-        ]:
-            self.graph.add(
-                (
-                    restriction,
-                    restriction_pred,
-                    Literal(int(value), datatype=XSD.nonNegativeInteger),
+                    Literal(cardinality, datatype=XSD.nonNegativeInteger),
                 )
             )
             if on_class:
@@ -1949,12 +1963,9 @@ class OntologyManager:
         if new_type not in self.RESTRICTION_TYPES:
             raise ValueError(f"Unknown restriction type: {new_type}")
         if new_type in self._CARDINALITY_TYPES:
-            try:
-                int(new.get("value"))  # type: ignore[arg-type]
-            except (TypeError, ValueError):
-                raise ValueError(
-                    f"{new_type} needs a whole number, got {new.get('value')!r}"
-                ) from None
+            # Checked here as well as in add_restriction, so a bad number is
+            # rejected before the original is detached.
+            self._cardinality_value(new_type, new.get("value"))
 
         node, _row = self._find_restriction(
             old_class,

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -1745,78 +1745,236 @@ class OntologyManager:
             )
         return self.add_restriction(source, property_name, restriction_type, target)
 
-    def get_restrictions(
-        self, class_name: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
-        """Get restrictions, optionally filtered by class."""
-        restrictions = []
+    def _iter_restrictions(self):
+        """Yield ``(node, row)`` for every restriction in the graph.
 
+        Shared by :meth:`get_restrictions`, :meth:`delete_restriction` and
+        :meth:`update_restriction` so all three agree on what a restriction row
+        is, and the last two can act on the exact node behind a row (issue #152).
+        """
         for restriction in self.graph.subjects(RDF.type, OWL.Restriction):
             prop = self.graph.value(restriction, OWL.onProperty)
             if not prop:
                 continue
+            yield restriction, self._restriction_row(restriction, prop)
 
-            rest_info: Dict[str, Any] = {
-                "property": self._local_name(prop),
-                # Full URIs alongside the display-friendly local names so callers
-                # can delete a restriction whose property/class live in an
-                # external namespace (local names would resolve to the wrong URI).
-                "property_uri": str(prop),
-                "type": None,
-                "value": None,
-                "value_uri": None,
-                "on_class": None,
-                "on_class_uri": None,
-                "applied_to": [],
-                "applied_to_uris": [],
-            }
+    def _restriction_row(self, restriction: Node, prop: Node) -> Dict[str, Any]:
+        """Build the display row for one restriction node."""
+        rest_info: Dict[str, Any] = {
+            "property": self._local_name(prop),
+            # Full URIs alongside the display-friendly local names so callers
+            # can delete a restriction whose property/class live in an
+            # external namespace (local names would resolve to the wrong URI).
+            "property_uri": str(prop),
+            "type": None,
+            "value": None,
+            "value_uri": None,
+            "on_class": None,
+            "on_class_uri": None,
+            "applied_to": [],
+            "applied_to_uris": [],
+        }
 
-            # Determine restriction type
-            for rtype, pred in self.RESTRICTION_TYPES.items():
-                val = self.graph.value(restriction, pred)
-                if val is not None:
-                    rest_info["type"] = rtype
-                    if isinstance(val, URIRef):
-                        rest_info["value"] = self._local_name(val)
-                        rest_info["value_uri"] = str(val)
-                    else:
-                        rest_info["value"] = str(val)
-                    break
+        # Determine restriction type
+        for rtype, pred in self.RESTRICTION_TYPES.items():
+            val = self.graph.value(restriction, pred)
+            if val is not None:
+                rest_info["type"] = rtype
+                if isinstance(val, URIRef):
+                    rest_info["value"] = self._local_name(val)
+                    rest_info["value_uri"] = str(val)
+                else:
+                    rest_info["value"] = str(val)
+                break
 
-            on_class = self.graph.value(restriction, OWL.onClass)
-            if on_class:
-                rest_info["on_class"] = self._local_name(on_class)
-                rest_info["on_class_uri"] = str(on_class)
+        on_class = self.graph.value(restriction, OWL.onClass)
+        if on_class:
+            rest_info["on_class"] = self._local_name(on_class)
+            rest_info["on_class_uri"] = str(on_class)
 
-            # Find classes this restriction applies to
-            for cls in self.graph.subjects(RDFS.subClassOf, restriction):
-                if isinstance(cls, URIRef):
-                    rest_info["applied_to"].append(self._local_name(cls))
-                    rest_info["applied_to_uris"].append(str(cls))
+        # Find classes this restriction applies to
+        for cls in self.graph.subjects(RDFS.subClassOf, restriction):
+            if isinstance(cls, URIRef):
+                rest_info["applied_to"].append(self._local_name(cls))
+                rest_info["applied_to_uris"].append(str(cls))
 
-            if class_name is None or class_name in rest_info["applied_to"]:
-                restrictions.append(rest_info)
+        return rest_info
 
-        return restrictions
+    def get_restrictions(
+        self, class_name: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """Get restrictions, optionally filtered by class."""
+        return [
+            row
+            for _node, row in self._iter_restrictions()
+            if class_name is None or class_name in row["applied_to"]
+        ]
+
+    def _restriction_matches(
+        self,
+        row: Dict[str, Any],
+        class_name: str,
+        property_name: str,
+        restriction_type: str,
+        value: Any = None,
+        on_class: Optional[str] = None,
+    ) -> bool:
+        """Whether ``row`` is the restriction described by these fields.
+
+        Names are compared as resolved URIs, so a local name matches only what it
+        actually resolves to: passing ``Foo`` never touches a restriction on an
+        imported ``other:Foo``, which is why callers holding URIs should pass
+        them. ``value`` and ``on_class`` only narrow the match when given, and a
+        literal value (a cardinality, a hasValue string) is compared as text
+        since it has no URI.
+        """
+
+        def _same_entity(row_uri, wanted) -> bool:
+            return row_uri is not None and str(row_uri) == str(self._uri(str(wanted)))
+
+        if row["type"] != restriction_type:
+            return False
+        if not _same_entity(row["property_uri"], property_name):
+            return False
+        if not any(_same_entity(uri, class_name) for uri in row["applied_to_uris"]):
+            return False
+        if value is not None:
+            if row["value_uri"] is not None:
+                if not _same_entity(row["value_uri"], value):
+                    return False
+            elif str(row["value"]) != str(value):
+                return False
+        if on_class is not None and not _same_entity(row["on_class_uri"], on_class):
+            return False
+        return True
+
+    def _find_restriction(
+        self,
+        class_name: str,
+        property_name: str,
+        restriction_type: str,
+        value: Any = None,
+        on_class: Optional[str] = None,
+    ):
+        """Return the ``(node, row)`` for one restriction, or ``(None, None)``.
+
+        Passing ``value`` (and ``on_class`` where it applies) is what makes the
+        match exact: a class can carry several restrictions on the same property
+        with the same type, differing only in value, and without them the first
+        one wins — which used to delete the wrong one (issue #152).
+        """
+        for node, row in self._iter_restrictions():
+            if self._restriction_matches(
+                row, class_name, property_name, restriction_type, value, on_class
+            ):
+                return node, row
+        return None, None
+
+    def _detach_restriction(self, node: Node, class_name: str) -> None:
+        """Unlink a restriction from one class, dropping the node once nothing
+        else refers to it (a restriction can be shared by several classes)."""
+        self.graph.remove((self._uri(class_name), RDFS.subClassOf, node))
+        if not any(self.graph.subjects(RDFS.subClassOf, node)):
+            self.graph.remove((node, None, None))
 
     def delete_restriction(
-        self, class_name: str, property_name: str, restriction_type: str
-    ):
-        """Delete a restriction from a class."""
-        class_uri = self._uri(class_name)
-        prop_uri = self._uri(property_name)
+        self,
+        class_name: str,
+        property_name: str,
+        restriction_type: str,
+        value: Any = None,
+        on_class: Optional[str] = None,
+    ) -> bool:
+        """Delete a restriction from a class.
 
-        for restriction in self.graph.subjects(RDF.type, OWL.Restriction):
-            if self.graph.value(restriction, OWL.onProperty) == prop_uri:
-                # Check if this restriction is on the target class
-                if (class_uri, RDFS.subClassOf, restriction) in self.graph:
-                    # Check restriction type
-                    pred = self.RESTRICTION_TYPES.get(restriction_type)
-                    if pred and self.graph.value(restriction, pred) is not None:
-                        self.graph.remove((class_uri, RDFS.subClassOf, restriction))
-                        self.graph.remove((restriction, None, None))
-                        return True
-        return False
+        Give ``value`` (and ``on_class`` for a qualified cardinality) to name
+        exactly which one: a class may carry several restrictions on the same
+        property and type, and without a value the first is removed, which is
+        rarely the one on screen (issue #152). Returns whether one was removed.
+        """
+        node, row = self._find_restriction(
+            class_name, property_name, restriction_type, value, on_class
+        )
+        if node is None or row is None:
+            return False
+        self._detach_restriction(node, class_name)
+        return True
+
+    # Restriction types whose value is a count rather than a class or literal.
+    _CARDINALITY_TYPES = (
+        "minCardinality",
+        "maxCardinality",
+        "exactCardinality",
+        "minQualifiedCardinality",
+        "maxQualifiedCardinality",
+        "qualifiedCardinality",
+    )
+
+    @staticmethod
+    def _restriction_spec(spec: Dict[str, Any], label: str) -> tuple:
+        """Pull the three identifying fields out of an update spec.
+
+        Raises rather than letting a missing field resolve to something else:
+        a spec without a class would otherwise match by property and type alone,
+        which is the ambiguity this whole path exists to remove.
+        """
+        missing = [
+            key
+            for key in ("class_name", "property_name", "restriction_type")
+            if not spec.get(key)
+        ]
+        if missing:
+            raise ValueError(
+                f"The {label} restriction is missing {', '.join(missing)}."
+            )
+        return (
+            str(spec["class_name"]),
+            str(spec["property_name"]),
+            str(spec["restriction_type"]),
+        )
+
+    def update_restriction(self, old: Dict[str, Any], new: Dict[str, Any]) -> bool:
+        """Replace one restriction with an edited one (issue #152).
+
+        Both dicts take ``class_name``, ``property_name``, ``restriction_type``,
+        ``value`` and optional ``on_class``; ``old`` should carry the value too,
+        or a sibling restriction on the same property may be edited instead. The
+        replacement is validated before the original is removed, so a rejected
+        edit cannot destroy the restriction it was meant to change. Returns
+        False when ``old`` is no longer in the graph.
+        """
+        old_class, old_property, old_type = self._restriction_spec(old, "old")
+        new_class, new_property, new_type = self._restriction_spec(new, "new")
+
+        if new_type not in self.RESTRICTION_TYPES:
+            raise ValueError(f"Unknown restriction type: {new_type}")
+        if new_type in self._CARDINALITY_TYPES:
+            try:
+                int(new.get("value"))  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"{new_type} needs a whole number, got {new.get('value')!r}"
+                ) from None
+
+        node, _row = self._find_restriction(
+            old_class,
+            old_property,
+            old_type,
+            old.get("value"),
+            old.get("on_class"),
+        )
+        if node is None:
+            return False
+
+        self._detach_restriction(node, old_class)
+        self.add_restriction(
+            new_class,
+            new_property,
+            new_type,
+            new.get("value"),
+            on_class=new.get("on_class"),
+        )
+        return True
 
     # ==================== ANNOTATION OPERATIONS ====================
 

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -1696,6 +1696,10 @@ class OntologyManager:
             raise ValueError(f"Unknown restriction type: {restriction_type}")
         if restriction_type in self._CARDINALITY_TYPES:
             cardinality = self._cardinality_value(restriction_type, value)
+        elif value is None or not str(value).strip():
+            # An empty value would be written as the base namespace itself
+            # (owl:someValuesFrom :), a restriction pointing at nothing.
+            raise ValueError(f"{restriction_type} needs a value.")
 
         restriction = BNode()
         self.graph.add((restriction, RDF.type, OWL.Restriction))
@@ -1962,10 +1966,12 @@ class OntologyManager:
 
         if new_type not in self.RESTRICTION_TYPES:
             raise ValueError(f"Unknown restriction type: {new_type}")
+        # Checked here as well as in add_restriction, so a bad replacement is
+        # rejected before the original is detached.
         if new_type in self._CARDINALITY_TYPES:
-            # Checked here as well as in add_restriction, so a bad number is
-            # rejected before the original is detached.
             self._cardinality_value(new_type, new.get("value"))
+        elif new.get("value") is None or not str(new.get("value")).strip():
+            raise ValueError(f"{new_type} needs a value.")
 
         node, _row = self._find_restriction(
             old_class,

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2681,6 +2681,52 @@ class OntologyManager:
         if relation:
             self.graph.remove((prop1_uri, relation, prop2_uri))
 
+    def _update_relation(
+        self,
+        relations: Dict[str, Any],
+        kind: str,
+        old: tuple,
+        new: tuple,
+    ) -> bool:
+        """Replace one relation triple with another (issue #152).
+
+        ``old`` and ``new`` are ``(subject, relation_type, object)`` local names
+        or URIs. Both relation types are resolved before anything is written, so
+        an unknown type raises instead of deleting the original and failing to
+        write the replacement. Returns False when ``old`` isn't asserted, which
+        is how a stale row (deleted in another tab, or already edited) is
+        reported rather than silently adding a second triple.
+        """
+        old_subj, old_type, old_obj = old
+        new_subj, new_type, new_obj = new
+        for relation_type in (old_type, new_type):
+            if relation_type not in relations:
+                raise ValueError(f"Unknown {kind} relation: {relation_type}")
+
+        old_triple = (
+            self._uri(old_subj),
+            relations[old_type],
+            self._uri(old_obj),
+        )
+        if old_triple not in self.graph:
+            return False
+
+        self.graph.remove(old_triple)
+        self.graph.add((self._uri(new_subj), relations[new_type], self._uri(new_obj)))
+        return True
+
+    def update_class_relation(self, old: tuple, new: tuple) -> bool:
+        """Replace a class relation with an edited one. See :meth:`_update_relation`."""
+        return self._update_relation(self.CLASS_RELATIONS, "class", old, new)
+
+    def update_property_relation(self, old: tuple, new: tuple) -> bool:
+        """Replace a property relation with an edited one."""
+        return self._update_relation(self.PROPERTY_RELATIONS, "property", old, new)
+
+    def update_individual_relation(self, old: tuple, new: tuple) -> bool:
+        """Replace an individual relation with an edited one."""
+        return self._update_relation(self.INDIVIDUAL_RELATIONS, "individual", old, new)
+
     def get_property_relations(
         self, prop_name: Optional[str] = None
     ) -> List[Dict[str, str]]:

--- a/tests/test_add_forms_parity.py
+++ b/tests/test_add_forms_parity.py
@@ -1,0 +1,89 @@
+"""The add forms must validate what the editors validate (issue #152 follow-up).
+
+Written after diffing the two paths: the editors were fixed first, which left the
+Add Restriction form picking entities by local name (so a restriction meant for an
+imported class landed on a base-namespace twin) and the relation forms carrying
+hand-written type lists that had drifted from the engine.
+"""
+
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+
+def _restrictions_script():
+    # Imports and data live in here: AppTest runs the script in its own
+    # namespace, so module-level names are not visible to it.
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    imported_ttl = """
+    @prefix : <http://test.org/ont#> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    @prefix other: <http://other.example/vocab#> .
+    :Local a owl:Class .
+    other:Foo a owl:Class . other:Bar a owl:Class .
+    other:relatedTo a owl:ObjectProperty .
+    """
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.load_from_string(imported_ttl, format="turtle")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    app.render_add_restriction(ont, ont.get_classes(), ont.get_object_properties())
+
+
+def test_add_restriction_keeps_an_imported_class_and_property():
+    """Picking Foo / relatedTo / Bar used to create the restriction on :Foo."""
+    at = AppTest.from_function(_restrictions_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+
+    # The pickers offer the imported entities; select them and submit.
+    at.selectbox[0].set_value("Foo")  # Apply to Class
+    at.selectbox[1].set_value("relatedTo")  # On Property
+    at.selectbox[2].set_value("someValuesFrom")
+    at.selectbox[3].set_value("Bar")  # Value (Class)
+    at.button[0].click().run(timeout=120)
+
+    assert not at.exception, at.exception
+    rows = at.session_state["ontology"].get_restrictions()
+    assert len(rows) == 1, rows
+    assert rows[0]["applied_to_uris"] == ["http://other.example/vocab#Foo"]
+    assert rows[0]["property_uri"] == "http://other.example/vocab#relatedTo"
+    assert rows[0]["value_uri"] == "http://other.example/vocab#Bar"
+
+
+def _relations_script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_object_property("worksFor")
+        om.add_object_property("employs")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["rel_active_tab"] = "Property Relations"
+
+    from orionbelt_ontology_builder import app
+
+    app.render_relations()
+
+
+def test_property_relation_form_offers_every_type_the_engine_has():
+    """The hand-written list had drifted: propertyDisjointWith was missing, so a
+    relation of that type could be viewed and edited but never created."""
+    at = AppTest.from_function(_relations_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+
+    type_picker = next(s for s in at.selectbox if s.label == "Relation Type")
+    assert set(type_picker.options) == set(OntologyManager.PROPERTY_RELATIONS)

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -202,12 +202,26 @@ def test_run_omits_theme_base_when_unset(monkeypatch, tmp_path):
     assert "theme.base" not in captured["options"]
 
 
-class _Event(list):
-    """Minimal stand-in for a pywebview event that supports ``+= handler``."""
+class _Event:
+    """Minimal stand-in for a pywebview event that supports ``+= handler``.
+
+    Holds its handlers rather than subclassing list: pywebview's Event isn't a
+    list either, and ``+=`` taking a single handler is incompatible with
+    ``list.__add__`` taking an iterable.
+    """
+
+    def __init__(self):
+        self.handlers = []
 
     def __iadd__(self, handler):
-        self.append(handler)
+        self.handlers.append(handler)
         return self
+
+    def __getitem__(self, index):
+        return self.handlers[index]
+
+    def __len__(self):
+        return len(self.handlers)
 
 
 class _FakeWindow:

--- a/tests/test_relation_edit_ui.py
+++ b/tests/test_relation_edit_ui.py
@@ -223,3 +223,37 @@ def test_pointing_a_relation_at_itself_is_refused():
     assert rels == [("Capacitor", "disjointWith", "Inductor")]
     # The editor stays open so the mistake can be corrected in place.
     assert "active_crel" in at.session_state
+
+
+def test_the_object_can_be_retargeted_to_a_new_external_uri():
+    """Parity with the add forms, which offer an external-URI field (diff B)."""
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    uid = _open_editor(at)
+
+    at.text_input(key=f"eo_ext_{uid}").set_value("http://other.example/vocab#Thing")
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    om = at.session_state["ontology"]
+    rels = [
+        (r["subject"], r["relation"], r["object_uri"]) for r in om.get_class_relations()
+    ]
+    assert rels == [("Capacitor", "disjointWith", "http://other.example/vocab#Thing")]
+
+
+def test_a_malformed_external_uri_is_reported_and_changes_nothing():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    uid = _open_editor(at)
+
+    at.text_input(key=f"eo_ext_{uid}").set_value("not-a-uri")
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    assert any("full http(s) URI" in e.value for e in at.error)
+    om = at.session_state["ontology"]
+    rels = [
+        (r["subject"], r["relation"], r["object"]) for r in om.get_class_relations()
+    ]
+    assert rels == [("Capacitor", "disjointWith", "Inductor")]

--- a/tests/test_relation_edit_ui.py
+++ b/tests/test_relation_edit_ui.py
@@ -133,3 +133,71 @@ def test_cancel_leaves_the_relation_alone():
 # form never re-renders and its handler never runs. It stays as a guard against a
 # stale row resurrecting a deleted relation, and update_class_relation returning
 # False for exactly that case is covered in test_relation_editing.py.
+
+
+def _external_script():
+    """A relation whose object is an external URI, which no local entity holds."""
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Alpha")
+        om.add_class("Beta")
+        om.add_class_relation("Alpha", "subClassOf", "http://external.example/Thing")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    app.render_relation_rows(
+        ont,
+        ont.get_class_relations(),
+        {
+            "icon": "📦",
+            "kind": "crel",
+            "label": "class relation",
+            "entities": ont.get_classes(),
+            "relation_types": ont.CLASS_RELATIONS,
+            "remove": ont.remove_class_relation,
+            "update": ont.update_class_relation,
+        },
+    )
+
+
+def _open_external_editor(at):
+    om = at.session_state["ontology"]
+    rel = om.get_class_relations()[0]
+    uid = _uid(f"{rel['subject_uri']}|{rel['relation']}|{rel['object_uri']}")
+    at.session_state["active_crel"] = (uid, "edit")
+    at.run(timeout=120)
+    return uid
+
+
+def test_an_external_target_is_offered_as_its_own_option():
+    at = AppTest.from_function(_external_script)
+    at.run(timeout=120)
+    uid = _open_external_editor(at)
+
+    assert not at.exception, at.exception
+    assert at.selectbox(key=f"eo_{uid}").value == "http://external.example/Thing"
+
+
+def test_editing_only_the_type_keeps_an_external_target():
+    """The object isn't a local entity, so the picker used to fall back to the
+    first class and silently rewrite it on save (review P2)."""
+    at = AppTest.from_function(_external_script)
+    at.run(timeout=120)
+    uid = _open_external_editor(at)
+
+    at.selectbox(key=f"et_{uid}").set_value("equivalentClass")
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    om = at.session_state["ontology"]
+    rels = [
+        (r["subject"], r["relation"], r["object_uri"]) for r in om.get_class_relations()
+    ]
+    assert rels == [("Alpha", "equivalentClass", "http://external.example/Thing")]

--- a/tests/test_relation_edit_ui.py
+++ b/tests/test_relation_edit_ui.py
@@ -33,6 +33,7 @@ def _script():
         {
             "icon": "📦",
             "kind": "crel",
+            "noun": "classes",
             "label": "class relation",
             "entities": ont.get_classes(),
             "relation_types": ont.CLASS_RELATIONS,
@@ -158,6 +159,7 @@ def _external_script():
         {
             "icon": "📦",
             "kind": "crel",
+            "noun": "classes",
             "label": "class relation",
             "entities": ont.get_classes(),
             "relation_types": ont.CLASS_RELATIONS,
@@ -201,3 +203,23 @@ def test_editing_only_the_type_keeps_an_external_target():
         (r["subject"], r["relation"], r["object_uri"]) for r in om.get_class_relations()
     ]
     assert rels == [("Alpha", "equivalentClass", "http://external.example/Thing")]
+
+
+def test_pointing_a_relation_at_itself_is_refused():
+    """The add forms reject this, so the editor must not become the way in."""
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    uid = _open_editor(at)
+
+    at.selectbox(key=f"eo_{uid}").set_value("Capacitor")  # same as the subject
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    assert any("two different classes" in e.value for e in at.error)
+    om = at.session_state["ontology"]
+    rels = [
+        (r["subject"], r["relation"], r["object"]) for r in om.get_class_relations()
+    ]
+    assert rels == [("Capacitor", "disjointWith", "Inductor")]
+    # The editor stays open so the mistake can be corrected in place.
+    assert "active_crel" in at.session_state

--- a/tests/test_relation_edit_ui.py
+++ b/tests/test_relation_edit_ui.py
@@ -1,0 +1,135 @@
+"""Editing a relation row in place (issue #152).
+
+Drives ``render_relation_rows`` directly rather than the whole Relations page:
+the page's tab picker is a ``segmented_control``, and AppTest mis-serializes a
+single-select one, so any interaction after the first run fails before reaching
+the row.
+"""
+
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder.app import _uid
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        for name in ("Capacitor", "Inductor", "Resistor"):
+            om.add_class(name)
+        om.add_class_relation("Capacitor", "disjointWith", "Inductor")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    app.render_relation_rows(
+        ont,
+        ont.get_class_relations(),
+        {
+            "icon": "📦",
+            "kind": "crel",
+            "label": "class relation",
+            "entities": ont.get_classes(),
+            "relation_types": ont.CLASS_RELATIONS,
+            "remove": ont.remove_class_relation,
+            "update": ont.update_class_relation,
+        },
+    )
+
+
+def _rel_uid(om, subject, relation, obj):
+    rel = next(
+        r
+        for r in om.get_class_relations()
+        if r["subject"] == subject and r["object"] == obj
+    )
+    return _uid(f"{rel['subject_uri']}|{relation}|{rel['object_uri']}")
+
+
+def _click(at, label):
+    """Click a button by label: the row's own ✏️/🗑️ come before the form's
+    Save/Cancel, so positional indexing picks the wrong one."""
+    button = next(b for b in at.button if b.label == label)
+    button.click().run(timeout=120)
+
+
+def _open_editor(at):
+    om = at.session_state["ontology"]
+    uid = _rel_uid(om, "Capacitor", "disjointWith", "Inductor")
+    at.session_state["active_crel"] = (uid, "edit")
+    at.run(timeout=120)
+    return uid
+
+
+def test_editor_opens_with_the_rows_own_values():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_editor(at)
+
+    assert not at.exception, at.exception
+    labels = {s.label for s in at.selectbox}
+    assert {"Subject", "Relation", "Object"} <= labels
+    assert at.selectbox(
+        key=f"et_{_rel_uid(at.session_state['ontology'], 'Capacitor', 'disjointWith', 'Inductor')}"
+    ).value == ("disjointWith")
+
+
+def test_saving_a_changed_object_rewrites_the_relation():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    uid = _open_editor(at)
+
+    at.selectbox(key=f"eo_{uid}").set_value("Resistor")
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    om = at.session_state["ontology"]
+    rels = [
+        (r["subject"], r["relation"], r["object"]) for r in om.get_class_relations()
+    ]
+    assert rels == [("Capacitor", "disjointWith", "Resistor")]
+    # The card closes on a successful save.
+    assert "active_crel" not in at.session_state
+
+
+def test_saving_a_changed_relation_type_rewrites_the_relation():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    uid = _open_editor(at)
+
+    at.selectbox(key=f"et_{uid}").set_value("subClassOf")
+    _click(at, "💾 Save")
+
+    om = at.session_state["ontology"]
+    rels = [
+        (r["subject"], r["relation"], r["object"]) for r in om.get_class_relations()
+    ]
+    assert rels == [("Capacitor", "subClassOf", "Inductor")]
+
+
+def test_cancel_leaves_the_relation_alone():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    uid = _open_editor(at)
+
+    at.selectbox(key=f"eo_{uid}").set_value("Resistor")
+    _click(at, "Cancel")
+
+    om = at.session_state["ontology"]
+    rels = [
+        (r["subject"], r["relation"], r["object"]) for r in om.get_class_relations()
+    ]
+    assert rels == [("Capacitor", "disjointWith", "Inductor")]
+    assert "active_crel" not in at.session_state
+
+
+# The "row is gone" branch in render_relation_rows cannot be reached from here:
+# removing the relation makes the rerun rebuild the list without that row, so the
+# form never re-renders and its handler never runs. It stays as a guard against a
+# stale row resurrecting a deleted relation, and update_class_relation returning
+# False for exactly that case is covered in test_relation_editing.py.

--- a/tests/test_relation_editing.py
+++ b/tests/test_relation_editing.py
@@ -1,0 +1,134 @@
+"""Editing a relation in place, rather than delete-and-recreate (issue #152)."""
+
+import pytest
+
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+
+@pytest.fixture
+def rel_om():
+    m = OntologyManager(base_uri="http://test.org/ont#")
+    for name in ("Capacitor", "Inductor", "Resistor", "Component"):
+        m.add_class(name)
+    m.add_class_relation("Capacitor", "disjointWith", "Inductor")
+    m.add_object_property("worksFor")
+    m.add_object_property("employs")
+    m.add_object_property("hires")
+    m.add_property_relation("worksFor", "inverseOf", "employs")
+    m.add_class("Person")
+    for who in ("alice", "bob", "robert"):
+        m.add_individual(who, "Person")
+    m.add_individual_relation("bob", "sameAs", "robert")
+    return m
+
+
+def _class_rel(om):
+    return [
+        (r["subject"], r["relation"], r["object"]) for r in om.get_class_relations()
+    ]
+
+
+def test_change_the_object(rel_om):
+    assert rel_om.update_class_relation(
+        ("Capacitor", "disjointWith", "Inductor"),
+        ("Capacitor", "disjointWith", "Resistor"),
+    )
+    assert _class_rel(rel_om) == [("Capacitor", "disjointWith", "Resistor")]
+
+
+def test_change_the_relation_type(rel_om):
+    assert rel_om.update_class_relation(
+        ("Capacitor", "disjointWith", "Inductor"),
+        ("Capacitor", "subClassOf", "Inductor"),
+    )
+    assert _class_rel(rel_om) == [("Capacitor", "subClassOf", "Inductor")]
+
+
+def test_change_the_subject(rel_om):
+    assert rel_om.update_class_relation(
+        ("Capacitor", "disjointWith", "Inductor"),
+        ("Resistor", "disjointWith", "Inductor"),
+    )
+    assert _class_rel(rel_om) == [("Resistor", "disjointWith", "Inductor")]
+
+
+def test_change_all_three_at_once(rel_om):
+    assert rel_om.update_class_relation(
+        ("Capacitor", "disjointWith", "Inductor"),
+        ("Resistor", "subClassOf", "Component"),
+    )
+    assert _class_rel(rel_om) == [("Resistor", "subClassOf", "Component")]
+
+
+def test_editing_a_stale_row_changes_nothing(rel_om):
+    """The row was already deleted or edited elsewhere: report it, don't add."""
+    assert not rel_om.update_class_relation(
+        ("Capacitor", "disjointWith", "Resistor"),
+        ("Capacitor", "disjointWith", "Component"),
+    )
+    assert _class_rel(rel_om) == [("Capacitor", "disjointWith", "Inductor")]
+
+
+def test_an_unknown_new_type_leaves_the_original_intact(rel_om):
+    """Both types resolve before anything is written, so a bad edit can't
+    delete the relation and then fail to write its replacement."""
+    with pytest.raises(ValueError, match="class relation"):
+        rel_om.update_class_relation(
+            ("Capacitor", "disjointWith", "Inductor"),
+            ("Capacitor", "subPropertyOf", "Inductor"),
+        )
+    assert _class_rel(rel_om) == [("Capacitor", "disjointWith", "Inductor")]
+
+
+def test_an_unknown_old_type_raises(rel_om):
+    with pytest.raises(ValueError, match="class relation"):
+        rel_om.update_class_relation(
+            ("Capacitor", "nonsense", "Inductor"),
+            ("Capacitor", "disjointWith", "Resistor"),
+        )
+
+
+def test_a_no_op_edit_keeps_the_relation(rel_om):
+    assert rel_om.update_class_relation(
+        ("Capacitor", "disjointWith", "Inductor"),
+        ("Capacitor", "disjointWith", "Inductor"),
+    )
+    assert _class_rel(rel_om) == [("Capacitor", "disjointWith", "Inductor")]
+
+
+def test_property_relations_edit_the_same_way(rel_om):
+    assert rel_om.update_property_relation(
+        ("worksFor", "inverseOf", "employs"),
+        ("worksFor", "subPropertyOf", "hires"),
+    )
+    rels = [
+        (r["subject"], r["relation"], r["object"])
+        for r in rel_om.get_property_relations()
+    ]
+    assert rels == [("worksFor", "subPropertyOf", "hires")]
+
+
+def test_individual_relations_edit_the_same_way(rel_om):
+    assert rel_om.update_individual_relation(
+        ("bob", "sameAs", "robert"),
+        ("bob", "differentFrom", "alice"),
+    )
+    rels = [
+        (r["subject"], r["relation"], r["object"])
+        for r in rel_om.get_individual_relations()
+    ]
+    assert rels == [("bob", "differentFrom", "alice")]
+
+
+def test_edit_is_undoable(rel_om):
+    """Editing goes through the graph, so the app's checkpoints cover it."""
+    before = rel_om.export_to_string("turtle")
+    rel_om.update_class_relation(
+        ("Capacitor", "disjointWith", "Inductor"),
+        ("Capacitor", "subClassOf", "Component"),
+    )
+    after = rel_om.export_to_string("turtle")
+    assert before != after
+    restored = OntologyManager(base_uri="http://test.org/ont#")
+    restored.load_from_string(before, "turtle")
+    assert _class_rel(restored) == [("Capacitor", "disjointWith", "Inductor")]

--- a/tests/test_restriction_edit_ui.py
+++ b/tests/test_restriction_edit_ui.py
@@ -211,3 +211,67 @@ def test_an_empty_value_is_reported_and_changes_nothing():
         ("hasPart", "someValuesFrom", "Engine"),
         ("hasPart", "someValuesFrom", "Wheel"),
     ]
+
+
+def _has_value_script():
+    """A hasValue restriction pointing at a local individual."""
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Person")
+        om.add_object_property("owns")
+        om.add_individual("alice", "Person")
+        om.add_restriction("Person", "owns", "hasValue", "http://test.org/ont#alice")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    app.render_restriction_row(
+        ont,
+        ont.get_restrictions()[0],
+        "0",
+        ont.get_classes(),
+        ont.get_object_properties(),
+    )
+
+
+def test_a_hasvalue_individual_survives_an_unchanged_save():
+    """A bare local name is stored as a literal, so owl:hasValue :alice would
+    quietly become owl:hasValue "alice" (review P2)."""
+    at = AppTest.from_function(_has_value_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    # Pre-filled as the URI, precisely so an unchanged save round-trips.
+    assert at.text_input(key="er_val_0").value == "http://test.org/ont#alice"
+
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    row = at.session_state["ontology"].get_restrictions()[0]
+    assert row["type"] == "hasValue"
+    assert row["value_uri"] == "http://test.org/ont#alice", (
+        "the individual became a literal"
+    )
+
+
+def test_a_hasvalue_literal_stays_a_literal():
+    """The pre-fill must not turn a genuine literal into a URI."""
+    at = AppTest.from_function(_has_value_script)
+    at.run(timeout=120)
+    ont = at.session_state["ontology"]
+    ont.delete_restriction("Person", "owns", "hasValue")
+    ont.add_restriction("Person", "owns", "hasValue", "42")
+    _open_row(at, 0)
+
+    assert at.text_input(key="er_val_0").value == "42"
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    row = at.session_state["ontology"].get_restrictions()[0]
+    assert row["value"] == "42" and row["value_uri"] is None

--- a/tests/test_restriction_edit_ui.py
+++ b/tests/test_restriction_edit_ui.py
@@ -29,11 +29,11 @@ def _script():
 
     ont = st.session_state.ontology
     rows = sorted(ont.get_restrictions(), key=lambda r: r["value"])
-    class_names = [c["name"] for c in ont.get_classes()]
-    props = [p["name"] for p in ont.get_object_properties()]
+    classes = ont.get_classes()
+    props = ont.get_object_properties()
     # Row 0 is Engine, row 1 is Wheel (sorted), so the test can address either.
     for index, rest in enumerate(rows):
-        app.render_restriction_row(ont, rest, str(index), class_names, props)
+        app.render_restriction_row(ont, rest, str(index), classes, props)
 
 
 def _click(at, label):
@@ -133,6 +133,80 @@ def test_a_negative_cardinality_is_reported_and_changes_nothing():
 
     assert not at.exception, at.exception
     assert any("negative" in e.value for e in at.error)
+    assert _rows(at.session_state["ontology"]) == [
+        ("hasPart", "someValuesFrom", "Engine"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]
+
+
+def _imported_script():
+    """A restriction whose class, property and value all live in an import."""
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        ttl = """
+        @prefix : <http://test.org/ont#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix other: <http://other.example/vocab#> .
+        :Local a owl:Class .
+        other:Foo a owl:Class . other:Bar a owl:Class .
+        other:relatedTo a owl:ObjectProperty .
+        other:Foo rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty other:relatedTo ; owl:someValuesFrom other:Bar ] .
+        """
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.load_from_string(ttl, format="turtle")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    app.render_restriction_row(
+        ont,
+        ont.get_restrictions()[0],
+        "0",
+        ont.get_classes(),
+        ont.get_object_properties(),
+    )
+
+
+def test_an_imported_restriction_keeps_its_namespace_through_an_edit():
+    """Selecting by local name resolved into the base namespace, rewriting
+    other:Foo / other:relatedTo / other:Bar as :Foo / :relatedTo / :Bar."""
+    at = AppTest.from_function(_imported_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    assert not at.exception, at.exception
+    # The value is offered as its URI, so saving round-trips it.
+    assert at.text_input(key="er_val_0").value == "http://other.example/vocab#Bar"
+
+    at.selectbox(key="er_type_0").set_value("allValuesFrom")
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    row = at.session_state["ontology"].get_restrictions()[0]
+    assert row["type"] == "allValuesFrom"
+    assert row["applied_to_uris"] == ["http://other.example/vocab#Foo"]
+    assert row["property_uri"] == "http://other.example/vocab#relatedTo"
+    assert row["value_uri"] == "http://other.example/vocab#Bar"
+
+
+def test_an_empty_value_is_reported_and_changes_nothing():
+    """It used to write owl:someValuesFrom : and destroy the original."""
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    at.text_input(key="er_val_0").set_value("")
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    assert any("needs a value" in e.value for e in at.error)
     assert _rows(at.session_state["ontology"]) == [
         ("hasPart", "someValuesFrom", "Engine"),
         ("hasPart", "someValuesFrom", "Wheel"),

--- a/tests/test_restriction_edit_ui.py
+++ b/tests/test_restriction_edit_ui.py
@@ -1,0 +1,121 @@
+"""Editing a restriction row in place (issue #152).
+
+Drives ``render_restriction_row`` directly: the Restrictions page's tab picker
+is a ``segmented_control``, which AppTest mis-serializes once interacted with.
+"""
+
+from streamlit.testing.v1 import AppTest
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        for name in ("Bicycle", "Wheel", "Engine", "Frame"):
+            om.add_class(name)
+        om.add_object_property("hasPart")
+        om.add_object_property("madeOf")
+        # Two restrictions differing only by value: the editor must act on the
+        # row it was opened for, not the first match.
+        om.add_restriction("Bicycle", "hasPart", "someValuesFrom", "Wheel")
+        om.add_restriction("Bicycle", "hasPart", "someValuesFrom", "Engine")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    rows = sorted(ont.get_restrictions(), key=lambda r: r["value"])
+    class_names = [c["name"] for c in ont.get_classes()]
+    props = [p["name"] for p in ont.get_object_properties()]
+    # Row 0 is Engine, row 1 is Wheel (sorted), so the test can address either.
+    for index, rest in enumerate(rows):
+        app.render_restriction_row(ont, rest, str(index), class_names, props)
+
+
+def _click(at, label):
+    next(b for b in at.button if b.label == label).click().run(timeout=120)
+
+
+def _open_row(at, index):
+    at.session_state["active_rest"] = (str(index), "edit")
+    at.run(timeout=120)
+
+
+def _rows(om):
+    return sorted((r["property"], r["type"], r["value"]) for r in om.get_restrictions())
+
+
+def test_editor_opens_with_the_rows_own_values():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)  # the Engine restriction
+
+    assert not at.exception, at.exception
+    assert at.selectbox(key="er_type_0").value == "someValuesFrom"
+    assert at.text_input(key="er_val_0").value == "Engine"
+
+
+def test_saving_edits_the_row_it_was_opened_for():
+    """The sibling restriction on the same property and type stays untouched."""
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    at.text_input(key="er_val_0").set_value("Frame")
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    assert _rows(at.session_state["ontology"]) == [
+        ("hasPart", "someValuesFrom", "Frame"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]
+    assert "active_rest" not in at.session_state
+
+
+def test_saving_can_change_the_property_and_type():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 1)  # the Wheel restriction
+
+    at.selectbox(key="er_prop_1").set_value("madeOf")
+    at.selectbox(key="er_type_1").set_value("allValuesFrom")
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    assert ("madeOf", "allValuesFrom", "Wheel") in _rows(at.session_state["ontology"])
+
+
+def test_cancel_leaves_the_restriction_alone():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    at.text_input(key="er_val_0").set_value("Frame")
+    _click(at, "Cancel")
+
+    assert _rows(at.session_state["ontology"]) == [
+        ("hasPart", "someValuesFrom", "Engine"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]
+    assert "active_rest" not in at.session_state
+
+
+def test_a_bad_cardinality_is_reported_and_changes_nothing():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    at.selectbox(key="er_type_0").set_value("exactCardinality")
+    at.text_input(key="er_val_0").set_value("two")
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    assert any("whole number" in e.value for e in at.error)
+    assert _rows(at.session_state["ontology"]) == [
+        ("hasPart", "someValuesFrom", "Engine"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]

--- a/tests/test_restriction_edit_ui.py
+++ b/tests/test_restriction_edit_ui.py
@@ -119,3 +119,21 @@ def test_a_bad_cardinality_is_reported_and_changes_nothing():
         ("hasPart", "someValuesFrom", "Engine"),
         ("hasPart", "someValuesFrom", "Wheel"),
     ]
+
+
+def test_a_negative_cardinality_is_reported_and_changes_nothing():
+    """The Add form's number input blocks this; the edit form takes free text."""
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    at.selectbox(key="er_type_0").set_value("maxCardinality")
+    at.text_input(key="er_val_0").set_value("-1")
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    assert any("negative" in e.value for e in at.error)
+    assert _rows(at.session_state["ontology"]) == [
+        ("hasPart", "someValuesFrom", "Engine"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]

--- a/tests/test_restriction_identity.py
+++ b/tests/test_restriction_identity.py
@@ -1,0 +1,215 @@
+"""Restrictions are identified by their whole spec, not (class, property, type).
+
+A class can carry several restrictions on the same property with the same type,
+differing only in value. Delete used to remove whichever came first, so the row
+on screen was rarely the one that went; editing would have rewritten the wrong
+one just as silently (issue #152).
+"""
+
+import pytest
+
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+
+@pytest.fixture
+def rest_om():
+    m = OntologyManager(base_uri="http://test.org/ont#")
+    for name in ("Bicycle", "Wheel", "Engine", "Frame", "Car"):
+        m.add_class(name)
+    m.add_object_property("hasPart")
+    m.add_object_property("madeOf")
+    m.add_restriction("Bicycle", "hasPart", "someValuesFrom", "Wheel")
+    m.add_restriction("Bicycle", "hasPart", "someValuesFrom", "Engine")
+    return m
+
+
+def _rows(om):
+    return sorted((r["property"], r["type"], r["value"]) for r in om.get_restrictions())
+
+
+def test_delete_removes_the_named_one(rest_om):
+    assert rest_om.delete_restriction(
+        "Bicycle", "hasPart", "someValuesFrom", value="Engine"
+    )
+    assert _rows(rest_om) == [("hasPart", "someValuesFrom", "Wheel")]
+
+
+def test_delete_without_a_value_still_removes_one(rest_om):
+    """Older callers keep working; they just cannot say which."""
+    assert rest_om.delete_restriction("Bicycle", "hasPart", "someValuesFrom")
+    assert len(rest_om.get_restrictions()) == 1
+
+
+def test_delete_reports_a_value_that_is_not_there(rest_om):
+    assert not rest_om.delete_restriction(
+        "Bicycle", "hasPart", "someValuesFrom", value="Frame"
+    )
+    assert len(rest_om.get_restrictions()) == 2
+
+
+def test_update_edits_the_named_one(rest_om):
+    assert rest_om.update_restriction(
+        {
+            "class_name": "Bicycle",
+            "property_name": "hasPart",
+            "restriction_type": "someValuesFrom",
+            "value": "Engine",
+        },
+        {
+            "class_name": "Bicycle",
+            "property_name": "hasPart",
+            "restriction_type": "someValuesFrom",
+            "value": "Frame",
+        },
+    )
+    assert _rows(rest_om) == [
+        ("hasPart", "someValuesFrom", "Frame"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]
+
+
+def test_update_can_change_every_part(rest_om):
+    assert rest_om.update_restriction(
+        {
+            "class_name": "Bicycle",
+            "property_name": "hasPart",
+            "restriction_type": "someValuesFrom",
+            "value": "Wheel",
+        },
+        {
+            "class_name": "Car",
+            "property_name": "madeOf",
+            "restriction_type": "allValuesFrom",
+            "value": "Frame",
+        },
+    )
+    rows = {
+        (r["applied_to"][0], r["property"], r["type"], r["value"])
+        for r in rest_om.get_restrictions()
+    }
+    assert ("Car", "madeOf", "allValuesFrom", "Frame") in rows
+    assert ("Bicycle", "hasPart", "someValuesFrom", "Engine") in rows
+    assert len(rows) == 2
+
+
+def test_update_to_a_cardinality(rest_om):
+    assert rest_om.update_restriction(
+        {
+            "class_name": "Bicycle",
+            "property_name": "hasPart",
+            "restriction_type": "someValuesFrom",
+            "value": "Wheel",
+        },
+        {
+            "class_name": "Bicycle",
+            "property_name": "hasPart",
+            "restriction_type": "exactCardinality",
+            "value": 2,
+        },
+    )
+    assert ("hasPart", "exactCardinality", "2") in _rows(rest_om)
+
+
+def test_update_of_a_stale_row_changes_nothing(rest_om):
+    assert not rest_om.update_restriction(
+        {
+            "class_name": "Bicycle",
+            "property_name": "hasPart",
+            "restriction_type": "someValuesFrom",
+            "value": "Frame",
+        },
+        {
+            "class_name": "Bicycle",
+            "property_name": "hasPart",
+            "restriction_type": "someValuesFrom",
+            "value": "Wheel",
+        },
+    )
+    assert len(rest_om.get_restrictions()) == 2
+
+
+def test_a_rejected_edit_keeps_the_original(rest_om):
+    """Validation runs before the original is detached."""
+    for bad in (
+        {"restriction_type": "nonsense", "value": "Wheel"},
+        {"restriction_type": "exactCardinality", "value": "two"},
+    ):
+        with pytest.raises(ValueError):
+            rest_om.update_restriction(
+                {
+                    "class_name": "Bicycle",
+                    "property_name": "hasPart",
+                    "restriction_type": "someValuesFrom",
+                    "value": "Wheel",
+                },
+                {"class_name": "Bicycle", "property_name": "hasPart", **bad},
+            )
+    assert _rows(rest_om) == [
+        ("hasPart", "someValuesFrom", "Engine"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]
+
+
+def test_qualified_cardinality_is_told_apart_by_its_class(rest_om):
+    rest_om.add_restriction(
+        "Car", "hasPart", "minQualifiedCardinality", 1, on_class="Wheel"
+    )
+    rest_om.add_restriction(
+        "Car", "hasPart", "minQualifiedCardinality", 1, on_class="Engine"
+    )
+    assert rest_om.delete_restriction(
+        "Car", "hasPart", "minQualifiedCardinality", value=1, on_class="Engine"
+    )
+    remaining = [
+        r for r in rest_om.get_restrictions() if r["type"] == "minQualifiedCardinality"
+    ]
+    assert len(remaining) == 1 and remaining[0]["on_class"] == "Wheel"
+
+
+def test_a_shared_restriction_is_only_unlinked_from_one_class(rest_om):
+    """Two classes can point at one restriction node; deleting for one must not
+    strip it from the other."""
+    from rdflib import RDFS
+
+    node = next(n for n, row in rest_om._iter_restrictions() if row["value"] == "Wheel")
+    rest_om.graph.add((rest_om._uri("Car"), RDFS.subClassOf, node))
+    assert sorted(
+        r["applied_to"] for r in rest_om.get_restrictions() if r["value"] == "Wheel"
+    ) == [["Bicycle", "Car"]]
+
+    assert rest_om.delete_restriction(
+        "Bicycle", "hasPart", "someValuesFrom", value="Wheel"
+    )
+    still_there = [r for r in rest_om.get_restrictions() if r["value"] == "Wheel"]
+    assert len(still_there) == 1
+    assert still_there[0]["applied_to"] == ["Car"]
+
+
+def test_local_name_still_does_not_match_an_external_namespace():
+    """Matching resolves names to URIs, so a local name cannot delete an
+    imported restriction by accident (the guarantee test_properties.py pins)."""
+    # The default prefix keeps the base namespace put; without it the loader
+    # infers the imported one and "Foo" would legitimately resolve to it.
+    ttl = """
+    @prefix : <http://test.org/ont#> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix other: <http://other.example/vocab#> .
+    :Local a owl:Class .
+    other:Foo a owl:Class ; rdfs:subClassOf [
+        a owl:Restriction ;
+        owl:onProperty other:relatedTo ;
+        owl:allValuesFrom other:Bar ] .
+    """
+    om = OntologyManager(base_uri="http://test.org/ont#")
+    om.load_from_string(ttl, format="turtle")
+    assert str(om.namespace) == "http://test.org/ont#"
+
+    assert not om.delete_restriction("Foo", "relatedTo", "allValuesFrom", value="Bar")
+    assert om.delete_restriction(
+        "http://other.example/vocab#Foo",
+        "http://other.example/vocab#relatedTo",
+        "allValuesFrom",
+        value="http://other.example/vocab#Bar",
+    )
+    assert om.get_restrictions() == []

--- a/tests/test_restriction_identity.py
+++ b/tests/test_restriction_identity.py
@@ -263,3 +263,34 @@ def test_a_rejected_add_leaves_no_orphan_restriction(rest_om):
             rest_om.add_restriction("Bicycle", "hasPart", restriction_type, value)
     assert len(rest_om.get_restrictions()) == before
     assert all(r["type"] is not None for r in rest_om.get_restrictions())
+
+
+def test_an_empty_value_is_rejected_on_add(rest_om):
+    """owl:someValuesFrom : is a restriction pointing at nothing."""
+    for restriction_type in ("someValuesFrom", "allValuesFrom", "hasValue"):
+        with pytest.raises(ValueError, match="needs a value"):
+            rest_om.add_restriction("Bicycle", "hasPart", restriction_type, "")
+        with pytest.raises(ValueError, match="needs a value"):
+            rest_om.add_restriction("Bicycle", "hasPart", restriction_type, None)
+
+
+def test_an_empty_value_is_rejected_on_edit(rest_om):
+    with pytest.raises(ValueError, match="needs a value"):
+        rest_om.update_restriction(
+            {
+                "class_name": "Bicycle",
+                "property_name": "hasPart",
+                "restriction_type": "someValuesFrom",
+                "value": "Wheel",
+            },
+            {
+                "class_name": "Bicycle",
+                "property_name": "hasPart",
+                "restriction_type": "someValuesFrom",
+                "value": "   ",
+            },
+        )
+    assert _rows(rest_om) == [
+        ("hasPart", "someValuesFrom", "Engine"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]

--- a/tests/test_restriction_identity.py
+++ b/tests/test_restriction_identity.py
@@ -213,3 +213,53 @@ def test_local_name_still_does_not_match_an_external_namespace():
         value="http://other.example/vocab#Bar",
     )
     assert om.get_restrictions() == []
+
+
+# --- cardinality values (review P2) -----------------------------------------
+
+
+def test_a_negative_cardinality_is_rejected_on_add(rest_om):
+    """It would serialize as an invalid xsd:nonNegativeInteger."""
+    with pytest.raises(ValueError, match="negative"):
+        rest_om.add_restriction("Bicycle", "hasPart", "minCardinality", -1)
+
+
+def test_a_negative_cardinality_is_rejected_on_edit(rest_om):
+    with pytest.raises(ValueError, match="negative"):
+        rest_om.update_restriction(
+            {
+                "class_name": "Bicycle",
+                "property_name": "hasPart",
+                "restriction_type": "someValuesFrom",
+                "value": "Wheel",
+            },
+            {
+                "class_name": "Bicycle",
+                "property_name": "hasPart",
+                "restriction_type": "maxCardinality",
+                "value": -3,
+            },
+        )
+    assert _rows(rest_om) == [
+        ("hasPart", "someValuesFrom", "Engine"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]
+
+
+def test_zero_is_a_valid_cardinality(rest_om):
+    rest_om.add_restriction("Car", "hasPart", "maxCardinality", 0)
+    assert ("hasPart", "maxCardinality", "0") in _rows(rest_om)
+
+
+def test_a_rejected_add_leaves_no_orphan_restriction(rest_om):
+    """Raising after the blank node existed left an empty row on the page."""
+    before = len(rest_om.get_restrictions())
+    for restriction_type, value in (
+        ("minCardinality", -1),
+        ("minCardinality", "two"),
+        ("nonsense", 1),
+    ):
+        with pytest.raises(ValueError):
+            rest_om.add_restriction("Bicycle", "hasPart", restriction_type, value)
+    assert len(rest_om.get_restrictions()) == before
+    assert all(r["type"] is not None for r in rest_om.get_restrictions())

--- a/tests/test_restrictions_view_ui.py
+++ b/tests/test_restrictions_view_ui.py
@@ -2,7 +2,9 @@
 
 Two identical restrictions produce two equal dicts from get_restrictions(), so
 keying delete buttons by list.index() collided (both del_rest_0). The view keys
-by rendered-row position instead; this guards that it renders cleanly.
+by page and rendered-row position instead; this guards that it renders cleanly.
+The assertion is on uniqueness, not on the key strings, so the keying scheme can
+change (it gained a page prefix in #152) without a false failure.
 """
 
 from streamlit.testing.v1 import AppTest
@@ -35,4 +37,5 @@ def test_duplicate_restrictions_render_without_key_clash():
     at.run(timeout=120)
     assert not at.exception, at.exception
     del_buttons = [b for b in at.button if b.key and b.key.startswith("del_rest_")]
-    assert {b.key for b in del_buttons} == {"del_rest_0", "del_rest_1"}
+    assert len(del_buttons) == 2, del_buttons
+    assert len({b.key for b in del_buttons}) == 2, "delete keys collided"


### PR DESCRIPTION
## Problem

Issue #152: the Relations and Restrictions pages could only view and delete. Unlike classes, properties and individuals they had no per-item editor, so correcting one part of a relation meant deleting it and re-adding it from memory. The thread settled on on-page editors as the first step, since the graph's "Open full editor" button needs them to exist before it can lead anywhere.

Fixing that surfaced a second problem. `delete_restriction()` matched on (class, property, type) and acted on whichever restriction came first, so a class carrying two restrictions on one property and type could not be told apart:

```
Bicycle hasPart someValuesFrom Wheel
Bicycle hasPart someValuesFrom Engine
delete_restriction("Bicycle", "hasPart", "someValuesFrom")   ->  removes Wheel
```

Deleting the wrong row is bad; editing the wrong row silently would be worse, so identity is fixed here rather than inherited.

## Fix

**Relations** (`cb002dc`): `update_{class,property,individual}_relation(old, new)` replace one triple with another through a shared helper. Both relation types resolve before anything is written, so an unknown type raises instead of deleting the original and failing to write its replacement. A row that is no longer asserted returns False rather than silently adding a second triple.

**Restriction identity** (`3fd85a9`): `delete_restriction()` takes optional `value` and `on_class` to name exactly which one, and the page passes them; omitting them keeps the old first-match behaviour for existing callers. `update_restriction(old, new)` sits on the same footing and validates the replacement (known type, whole number for a cardinality) *before* detaching the original, so a rejected edit cannot destroy what it was meant to change. `get_restrictions()`, delete and update now share `_iter_restrictions()` / `_restriction_row()`, so all three agree on what a row is. Matching resolves names to URIs, so a local name still cannot reach an imported restriction by accident. A restriction shared by several classes is unlinked from one, not stripped from the rest.

**UI** (`dd57f52`): every relation row gains an edit button opening a form pre-filled with its own subject, relation and object. The three lists share `render_relation_rows()` rather than three near-identical loops.

Restrictions get the same editor, and the list changes shape. One expander per restriction made a long list a wall of collapsed boxes, so rows now read class / property / type / value like the Relations lists, with the qualified class inline (`2 (on Wheel)`). They paginate through `_paginate_rows()`, which exists for exactly this plain-row case, so a large ontology no longer renders every restriction at once.

## Tests

19 new tests across four files: relation editing per kind (`test_relation_editing.py`), restriction identity and update including the shared-node and external-namespace cases (`test_restriction_identity.py`), and both editors driven through AppTest (`test_relation_edit_ui.py`, `test_restriction_edit_ui.py`), covering pre-filled values, saving each slot, cancel, and a rejected cardinality. Full suite 630 passed; ruff and mypy clean.

Verified live in the running app: editing `Puppy subClassOf Dog` to `equivalentClass` updates the list, closes the form and is undone by Undo; a restriction's value edited from `Animal` to `Dog` through the page; and 11 restrictions render as a scannable table.

Three notes for reviewers:

- `tests/test_restrictions_view_ui.py` asserted literal button keys (`del_rest_0`), which the new page prefix changes. Its guarantee is that duplicate restrictions do not collide, so it now asserts uniqueness instead of the key strings.
- The "row is gone" branch in `render_relation_rows` cannot be reached from the UI: removing the relation makes the rerun rebuild the list without that row, so the form never re-renders. It stays as a guard against resurrecting a deleted relation, and the engine returning False for that case is covered directly. A test that appeared to cover it was removed rather than left passing for the wrong reason.
- AppTest mis-serializes a single-select `segmented_control`, so both UI test files drive the row renderers directly rather than the whole page.

## Scope

This is stage 1 of #152. The graph's "Open full editor" button for relations and restrictions is stage 2 and needs restrictions represented in the graph first, so this does not close the issue.

Refs #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
