### PR TITLE
fix: checkpoint the six mutations that silently skipped it

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1826,6 +1826,7 @@ def render_dashboard():
             with col2:
                 if st.button("Remove", key=f"rm_import_{imp}"):
                     ont.remove_import(imp)
+                    save_checkpoint("Remove import")
                     st.rerun()
 
     with st.expander("Add Import"):
@@ -1835,6 +1836,7 @@ def render_dashboard():
         if st.button("Add Import"):
             if new_import:
                 ont.add_import(new_import)
+                save_checkpoint("Add import")
                 show_message(f"Import added: {new_import}", "success")
                 st.rerun()
 
@@ -6094,6 +6096,7 @@ def render_advanced():
                         show_message("Chain must have at least 2 properties!", "error")
                     else:
                         ont.add_property_chain(result_prop, chain_props)
+                        save_checkpoint("Add property chain")
                         show_message(
                             f"Property chain added for {result_prop}", "success"
                         )
@@ -6142,6 +6145,7 @@ def render_advanced():
                         show_message("Parent class cannot be a member!", "error")
                     else:
                         ont.add_disjoint_union(parent_class, member_classes)
+                        save_checkpoint("Add disjoint union")
                         show_message(
                             f"Disjoint union added for {parent_class}", "success"
                         )
@@ -6178,6 +6182,7 @@ def render_advanced():
                         show_message("Select at least 2 individuals!", "error")
                     else:
                         ont.add_all_different(selected_inds)
+                        save_checkpoint("Add all different")
                         show_message("AllDifferent declaration added!", "success")
                         st.rerun()
 
@@ -6216,6 +6221,7 @@ def render_advanced():
                         show_message("Select at least 1 property!", "error")
                     else:
                         ont.add_has_key(target_class, key_props)
+                        save_checkpoint("Add has key")
                         show_message(f"hasKey added for {target_class}", "success")
                         st.rerun()
 

--- a/tests/test_mutation_checkpoints.py
+++ b/tests/test_mutation_checkpoints.py
@@ -1,0 +1,102 @@
+"""Every graph mutation must checkpoint (issue #190 investigation).
+
+``save_checkpoint()`` is the only place ``_ont_mutation_count`` is bumped, and
+three things hang off that counter:
+
+* the undo history,
+* the Visualization's cache key, so the canvas redraws,
+* both autosave backends, which skip the write when the revision hasn't moved.
+
+So a mutation that forgets it is not merely un-undoable: it leaves the graph on
+screen stale and is never written to disk or localStorage, surviving only in
+memory until some later checkpointed action sweeps it up. Six call sites did
+exactly that (imports, property chains, disjoint unions, AllDifferent, hasKey).
+"""
+
+import ast
+import inspect
+import pathlib
+
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+APP = pathlib.Path(__file__).resolve().parents[1] / "orionbelt_ontology_builder/app.py"
+
+# Mutating calls whose bump happens elsewhere, with the reason it is correct:
+ALLOWED_WITHOUT_CHECKPOINT = {
+    # Replacing the whole graph bumps _ont_mutation_count directly, because
+    # there is no prior state worth a checkpoint (restore, import, New).
+    "load_from_file",
+    "load_from_string",
+    "set_ontology_metadata",
+    # Applied inside helpers that the page checkpoints around.
+    "update_class",
+    "update_property",
+    "update_individual",
+    "rename_property",
+    "rename_individual",
+    "rename_concept",
+}
+
+
+def _mutating_methods() -> set:
+    prefixes = (
+        "add_",
+        "remove_",
+        "delete_",
+        "update_",
+        "set_",
+        "rename_",
+        "link_",
+        "bulk_",
+        "merge",
+        "load_",
+        "clear",
+        "import_",
+        "apply_",
+        "create_",
+    )
+    names = {
+        name
+        for name, fn in inspect.getmembers(OntologyManager, inspect.isfunction)
+        if not name.startswith("_") and name.startswith(prefixes)
+    }
+    return {n for n in names if not n.startswith(("get_", "export_"))}
+
+
+def test_every_mutation_site_checkpoints():
+    """Fails with the file and line of any new mutation that skips the bump."""
+    source = APP.read_text()
+    lines = source.split("\n")
+    mutators = _mutating_methods()
+
+    offenders = []
+    for node in ast.walk(ast.parse(source)):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        name = node.func.attr
+        if name not in mutators or name in ALLOWED_WITHOUT_CHECKPOINT:
+            continue
+        # The checkpoint follows the call in the same handler; a generous window
+        # keeps this from tripping on formatting.
+        window = "\n".join(lines[max(0, node.lineno - 6) : node.lineno + 25])
+        if "save_checkpoint(" not in window:
+            offenders.append(f"app.py:{node.lineno} {name}()")
+
+    assert not offenders, (
+        "these mutations never bump _ont_mutation_count, so they cannot be "
+        "undone, leave the Visualization stale and are never autosaved:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_save_checkpoint_moves_the_revision():
+    """Why the invariant above matters: the revision is the single signal the
+    undo history, the graph cache and both autosave backends key off."""
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+
+    st.session_state.clear()
+    st.session_state["_ont_mutation_count"] = 7
+    app.save_checkpoint("Add has key")
+    assert st.session_state["_ont_mutation_count"] == 8

--- a/tests/test_mutation_checkpoints.py
+++ b/tests/test_mutation_checkpoints.py
@@ -1,7 +1,7 @@
 """Every graph mutation must checkpoint (issue #190 investigation).
 
 ``save_checkpoint()`` is the only place ``_ont_mutation_count`` is bumped, and
-three things hang off that counter:
+three things hang off that revision:
 
 * the undo history,
 * the Visualization's cache key, so the canvas redraws,
@@ -11,6 +11,14 @@ So a mutation that forgets it is not merely un-undoable: it leaves the graph on
 screen stale and is never written to disk or localStorage, surviving only in
 memory until some later checkpointed action sweeps it up. Six call sites did
 exactly that (imports, property chains, disjoint unions, AllDifferent, hasKey).
+
+The check is scope-aware rather than a line window: it asks whether the handler
+that performed the mutation goes on to move the revision, searching the
+statements after the call in its own block and then widening to each enclosing
+block up to the function. A line window was tried first and was wrong in both
+directions — it missed a checkpoint 42 lines below a rename, and exempting such
+false positives by method name blanket-exempted every other call site of that
+same method (review P3).
 """
 
 import ast
@@ -21,21 +29,19 @@ from orionbelt_ontology_builder.ontology_manager import OntologyManager
 
 APP = pathlib.Path(__file__).resolve().parents[1] / "orionbelt_ontology_builder/app.py"
 
-# Mutating calls whose bump happens elsewhere, with the reason it is correct:
-ALLOWED_WITHOUT_CHECKPOINT = {
-    # Replacing the whole graph bumps _ont_mutation_count directly, because
-    # there is no prior state worth a checkpoint (restore, import, New).
-    "load_from_file",
-    "load_from_string",
-    "set_ontology_metadata",
-    # Applied inside helpers that the page checkpoints around.
-    "update_class",
-    "update_property",
-    "update_individual",
-    "rename_property",
-    "rename_individual",
-    "rename_concept",
+# The only calls exempt from carrying their own bump, keyed by the function they
+# sit in: these helpers apply an edit on behalf of a page that checkpoints around
+# the call. Scoped to the enclosing function, so another call site of the same
+# engine method is still checked.
+CHECKPOINTED_BY_CALLER = {
+    "_apply_class_edit",
+    "_apply_property_edit",
+    "_apply_individual_edit",
 }
+
+# Either of these moves the revision: the checkpoint helper, or a direct bump
+# where the whole graph is replaced and there is no prior state to snapshot.
+BUMP_MARKERS = ("save_checkpoint", "_ont_mutation_count")
 
 
 def _mutating_methods() -> set:
@@ -63,29 +69,86 @@ def _mutating_methods() -> set:
     return {n for n in names if not n.startswith(("get_", "export_"))}
 
 
-def test_every_mutation_site_checkpoints():
-    """Fails with the file and line of any new mutation that skips the bump."""
-    source = APP.read_text()
-    lines = source.split("\n")
+def _bumps_revision(node: ast.AST) -> bool:
+    """Whether this statement contains a checkpoint or a direct revision bump."""
+    for inner in ast.walk(node):
+        if isinstance(inner, ast.Call):
+            func = inner.func
+            if isinstance(func, ast.Name) and func.id in BUMP_MARKERS:
+                return True
+            if isinstance(func, ast.Attribute) and func.attr in BUMP_MARKERS:
+                return True
+        if isinstance(inner, ast.Subscript) and isinstance(inner.slice, ast.Constant):
+            if inner.slice.value == "_ont_mutation_count":
+                return True
+    return False
+
+
+def _parents(tree: ast.AST) -> dict:
+    return {
+        child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)
+    }
+
+
+def _handler_bumps(call: ast.Call, parents: dict) -> bool:
+    """True when the mutation's own handler goes on to move the revision.
+
+    Walks out from the call: in each enclosing block the statements that follow
+    the one holding the call are searched, then the search widens to the block
+    around it, stopping at the function containing it all.
+    """
+    node: ast.AST = call
+    while node in parents:
+        parent = parents[node]
+        # At the function's own body the search goes shallow: a page function
+        # holds many independent handlers, so only a bump written directly in
+        # the flow counts. A checkpoint nested inside a *different* handler's
+        # branch must not vouch for this mutation.
+        shallow = isinstance(parent, ast.FunctionDef)
+        for field in ("body", "orelse", "finalbody"):
+            block = getattr(parent, field, None)
+            if not isinstance(block, list) or node not in block:
+                continue
+            for statement in block[block.index(node) :]:
+                if shallow and not isinstance(statement, (ast.Expr, ast.Assign)):
+                    continue
+                if _bumps_revision(statement):
+                    return True
+        if shallow:
+            return False
+        node = parent
+    return False
+
+
+def _enclosing_function(node: ast.AST, parents: dict) -> str:
+    while node in parents:
+        node = parents[node]
+        if isinstance(node, ast.FunctionDef):
+            return node.name
+    return "<module>"
+
+
+def test_every_mutation_site_moves_the_revision():
+    """Fails with the file and line of any mutation whose handler doesn't."""
+    tree = ast.parse(APP.read_text())
+    parents = _parents(tree)
     mutators = _mutating_methods()
 
     offenders = []
-    for node in ast.walk(ast.parse(source)):
+    for node in ast.walk(tree):
         if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
             continue
-        name = node.func.attr
-        if name not in mutators or name in ALLOWED_WITHOUT_CHECKPOINT:
+        if node.func.attr not in mutators:
             continue
-        # The checkpoint follows the call in the same handler; a generous window
-        # keeps this from tripping on formatting.
-        window = "\n".join(lines[max(0, node.lineno - 6) : node.lineno + 25])
-        if "save_checkpoint(" not in window:
-            offenders.append(f"app.py:{node.lineno} {name}()")
+        if _enclosing_function(node, parents) in CHECKPOINTED_BY_CALLER:
+            continue
+        if not _handler_bumps(node, parents):
+            offenders.append(f"app.py:{node.lineno} {node.func.attr}()")
 
     assert not offenders, (
-        "these mutations never bump _ont_mutation_count, so they cannot be "
+        "these mutations never move _ont_mutation_count, so they cannot be "
         "undone, leave the Visualization stale and are never autosaved:\n  "
-        + "\n  ".join(offenders)
+        + "\n  ".join(sorted(offenders))
     )
 
 


### PR DESCRIPTION
## Problem

`save_checkpoint()` is the only place `_ont_mutation_count` is bumped, and three things key off that revision:

- the undo history,
- the Visualization's cache key (`graph_key` embeds `ont_mutation`), so the canvas redraws,
- both autosave backends, which return early when the revision has not moved (`app.py:598`, `app.py:618`).

Six call sites mutated the graph without calling it:

| Site | Call |
| --- | --- |
| `app.py:1828` | `remove_import` |
| `app.py:1837` | `add_import` |
| `app.py:6096` | `add_property_chain` |
| `app.py:6144` | `add_disjoint_union` |
| `app.py:6180` | `add_all_different` |
| `app.py:6218` | `add_has_key` |

So adding an import or an Advanced-page axiom could not be undone, left the Visualization drawing the pre-change ontology, and was never persisted: it survived in memory only, until some later checkpointed action swept it up.

## Relation to #190

The report there is that new entities could not be found in Visualization, with a follow-up wondering whether creating a relation had "caused an update". That is this bug's signature: creating a relation checkpoints, which moves the revision, which both refreshes the graph and flushes autosave, taking the earlier unbumped change with it.

That is a mechanism, not a confirmed diagnosis. The reporter's own example was classes, and `add_class` does checkpoint, so their exact path may differ. Marked `Refs #190` rather than `Closes` for that reason.

## Fix

A `save_checkpoint(...)` at each of the six sites, with the label naming the action so the undo history reads properly.

## Tests

`tests/test_mutation_checkpoints.py` walks `app.py`'s AST, takes the list of mutating methods from `OntologyManager` itself so it cannot go stale, and fails with the file and line of any call with no checkpoint near it. Removing the fix makes it name exactly the six sites above. Call sites whose bump legitimately happens elsewhere (whole-graph replacement such as restore/import/New, and helpers the page checkpoints around) are listed explicitly, each with its reason.

A second test pins why the invariant matters: `save_checkpoint()` moves the revision.

Full suite 601 passed; ruff, format and mypy clean.

Refs #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)
