### PR TITLE
fix: keep the graph in fullscreen when selecting a node

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -7187,9 +7187,15 @@ def render_visualization():
             or st.session_state.last_graph_data is None
         )
 
+        # Reserve the status slot on every render, not only when rebuilding: this
+        # placeholder sits above the graph component, so an element that comes and
+        # goes shifts the component's position in Streamlit's element tree and
+        # makes Streamlit re-create its iframe — which drops graph fullscreen and
+        # reloads the viewer (issue #189).
+        status = st.empty()
+
         if needs_rebuild:
             # Build the graph using lightweight dicts (no pyvis overhead)
-            status = st.empty()
             status.info("Building graph...")
 
             class _GraphBuilder:

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -221,6 +221,27 @@ function fullscreenSupported() {
 var desktopFsOn = false;   // tracked pseudo-fullscreen state (no fullscreenchange)
 var pseudoFsPrevStyle = null;  // saved inline style of this iframe in the parent
 
+// While the graph is fullscreen, selections stay client-side. Sending one to
+// Streamlit reruns the app, which repaints the details panel / status bar that
+// nobody can see behind the fullscreen graph — and it was that rerun's rebuild
+// of this component that dropped fullscreen altogether (issue #189). vis still
+// highlights the clicked node locally, so the feedback is immediate; the last
+// selection is flushed on exit, so the panel comes back showing the node the
+// user left selected.
+var pendingSelection = null;
+
+function sendSelection(value) {
+    if (isFullscreen() || desktopFsOn) { pendingSelection = value; return; }
+    sendToStreamlit("streamlit:setComponentValue", {value: value});
+}
+
+function flushPendingSelection() {
+    if (!pendingSelection) return;
+    var value = pendingSelection;
+    pendingSelection = null;
+    sendToStreamlit("streamlit:setComponentValue", {value: value});
+}
+
 // Desktop graph-only fullscreen. The webview has no HTML Fullscreen API and the
 // native-window toggle alone fullscreens the whole app (sidebar + toolbar), not
 // the graph (issue #177 follow-up). So promote this same-origin iframe to a
@@ -284,6 +305,7 @@ function exitPseudoFullscreen() {
     unwatchFullscreenBox();
     setFullscreenIcon(false);
     scheduleFullscreenView(false);
+    flushPendingSelection();
 }
 
 // Toggle desktop fullscreen: the overlay (graph-only) plus, when available, the
@@ -457,6 +479,8 @@ function onFullscreenChange() {
         watchFullscreenBox();
     } else {
         unwatchFullscreenBox();
+        // Hand the panel/status bar the node the user left selected (issue #189).
+        flushPendingSelection();
     }
 }
 document.addEventListener('fullscreenchange', onFullscreenChange);
@@ -620,8 +644,16 @@ function renderGraph(args) {
     // toggled), so the node stays highlighted and the zoom/pan don't reset —
     // making the rebuild invisible. selectNodes() does not fire selectNode, so
     // this doesn't loop back to Streamlit.
-    if (args.selected_node !== null && args.selected_node !== undefined) {
-        try { network.selectNodes([args.selected_node]); } catch (e) {}
+    // A selection made while fullscreen hasn't reached Streamlit yet (it is
+    // flushed on exit), so args.selected_node is stale for the rebuilds that do
+    // still happen in fullscreen — a Ctrl/Cmd-click focus expand. Restore what
+    // the user actually has selected instead (issue #189).
+    var restoreNode = args.selected_node;
+    if (pendingSelection) {
+        restoreNode = pendingSelection.selected ? (pendingSelection.nodeId || null) : null;
+    }
+    if (restoreNode !== null && restoreNode !== undefined) {
+        try { network.selectNodes([restoreNode]); } catch (e) {}
     }
     // --- Find & centre (issue #144) ---------------------------------------
     // Python sends focus_node (the entity picked in "Find entity", present on
@@ -775,23 +807,19 @@ function renderGraph(args) {
 
     network.on('selectNode', function(params) {
         var nd = nodes.get(params.nodes[0]);
-        sendToStreamlit("streamlit:setComponentValue", {
-            value: {nodeId: params.nodes[0], ntype: nd.ntype || null, ename: nd.ename || null, label: nd.label, title: nd.title || '', selected: true}
-        });
+        sendSelection({nodeId: params.nodes[0], ntype: nd.ntype || null, ename: nd.ename || null, label: nd.label, title: nd.title || '', selected: true});
     });
     network.on('selectEdge', function(params) {
         if (params.nodes.length === 0 && params.edges.length > 0) {
             var ed = edges.get(params.edges[0]);
-            sendToStreamlit("streamlit:setComponentValue", {
-                value: {ntype: ed.ntype || null, ename: ed.ename || null, label: ed.label || '', title: ed.title || '', selected: true, isEdge: true}
-            });
+            sendSelection({ntype: ed.ntype || null, ename: ed.ename || null, label: ed.label || '', title: ed.title || '', selected: true, isEdge: true});
         }
     });
     network.on('deselectNode', function() {
-        sendToStreamlit("streamlit:setComponentValue", {value: {selected: false}});
+        sendSelection({selected: false});
     });
     network.on('deselectEdge', function() {
-        sendToStreamlit("streamlit:setComponentValue", {value: {selected: false}});
+        sendSelection({selected: false});
     });
 
     // Ctrl/Cmd-click a node to add it to the "Focus on one node" selection, so

--- a/tests/test_viz_fullscreen.py
+++ b/tests/test_viz_fullscreen.py
@@ -1,0 +1,84 @@
+"""Guards for the graph viewer's fullscreen behaviour (issue #189).
+
+Both invariants here are only observable in a real browser, so they are pinned at
+the source level: breaking either one silently drops fullscreen or repaints the
+details panel behind it, and no other test would notice.
+"""
+
+import ast
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+_VIEWER = _PKG / "lib" / "graph_viewer" / "index.html"
+
+
+def _status_placeholder_assignments(tree):
+    """Every ``status = st.empty()`` assignment in the tree, as AST nodes."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if "status" not in targets:
+            continue
+        call = node.value
+        if (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "empty"
+        ):
+            found.append(node)
+    return found
+
+
+def test_graph_status_placeholder_is_unconditional():
+    """The build-status placeholder must be created on every render.
+
+    It sits above the graph component, so emitting it only while rebuilding
+    shifts the component's slot in Streamlit's element tree from one render to
+    the next. Streamlit then re-creates the component's iframe, which reloads the
+    viewer and drops graph fullscreen — the first-click and Ctrl-click "falls
+    back to normal mode" glitches in issue #189.
+    """
+    tree = ast.parse((_PKG / "app.py").read_text(encoding="utf-8"))
+    placeholders = _status_placeholder_assignments(tree)
+    assert placeholders, "expected a `status = st.empty()` placeholder in app.py"
+
+    conditional = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        names = {n.id for n in ast.walk(node.test) if isinstance(n, ast.Name)}
+        if "needs_rebuild" not in names:
+            continue
+        for stmt in node.body:
+            conditional.extend(_status_placeholder_assignments(stmt))
+    assert not conditional, (
+        "`status = st.empty()` must sit outside `if needs_rebuild:` so the graph "
+        "component keeps its position in the element tree (issue #189)"
+    )
+
+
+def test_viewer_defers_selection_while_fullscreen():
+    """Selections must not round-trip to Streamlit while the graph is fullscreen.
+
+    A round-trip reruns the app and repaints the details panel / status bar
+    behind the fullscreen graph; the last selection is flushed on exit instead,
+    so the panel returns showing the node the user left selected.
+    """
+    src = _VIEWER.read_text(encoding="utf-8")
+
+    assert "function sendSelection(" in src
+    assert "function flushPendingSelection(" in src
+
+    # Every selection event goes through the deferring helper, never straight to
+    # setComponentValue.
+    for event in ("selectNode", "selectEdge", "deselectNode", "deselectEdge"):
+        handler = src.split(f"network.on('{event}'", 1)[1].split("});", 1)[0]
+        assert "sendSelection(" in handler, f"{event} must use sendSelection()"
+        assert "setComponentValue" not in handler, (
+            f"{event} must not send to Streamlit directly (issue #189)"
+        )
+
+    # Both exit paths — the web Fullscreen API and the desktop overlay — flush.
+    assert src.count("flushPendingSelection();") == 2


### PR DESCRIPTION
Closes #189.

## The bug

Two reported symptoms, one root cause:

- Clicking a node in fullscreen drops straight back to normal mode (first click only).
- Ctrl/Cmd-click in fullscreen does the same, every time.
- The `Open full editor` button flashes into view during those transitions.

The `Building graph...` placeholder (`status = st.empty()`) was created only on renders that rebuild the graph. It sits above the graph component, so it appearing and disappearing shifts the component's slot in Streamlit's element tree. Streamlit then re-creates the component's iframe, the viewer reloads, and the browser drops fullscreen because the fullscreen element was removed from the DOM.

That accounts for all three symptoms:

- **First click:** the render that built the graph carried the placeholder, the rerun triggered by the click does not, so everything below shifts by one slot.
- **Ctrl/Cmd-click:** forces a rebuild, so the placeholder returns and shifts things back.
- **Node to node clicks:** no structural change, so fullscreen survived. That is why only the first click broke.

Confirmed in Chrome against the running app: on the first click the iframe element identity changed at the same millisecond as `fullscreenchange -> false`, and the sibling count around the graph went from 11 to 12.

## The fix

1. Reserve the status placeholder on every render, so the graph component keeps its position in the element tree. On its own this keeps fullscreen alive through both a first click and a Ctrl/Cmd-click.

2. While fullscreen, selections no longer round-trip to Streamlit at all. They would only repaint the details panel and status bar sitting behind the fullscreen graph. vis still highlights the clicked node locally, so the feedback is immediate, and the last selection is flushed on exit so the panel comes back showing the node the user left selected. Wired into both exit paths, the web Fullscreen API and the desktop overlay.

3. Ctrl/Cmd-click still round-trips, since only Python can recompute the focused node set. The rebuild it triggers now restores the pending selection instead of the older node Python still holds, which would otherwise highlight the wrong node.

## Verification

Driven live in Chrome via Playwright against `streamlit run app.py`:

| Action in fullscreen | Before | After |
| --- | --- | --- |
| First node click | fullscreen exits, iframe re-created | stays fullscreen, same iframe |
| Node to node click | stays fullscreen | stays fullscreen |
| Ctrl/Cmd-click | fullscreen exits, iframe re-created | stays fullscreen, graph narrows 50 nodes to 2, correct node stays highlighted |
| Exit fullscreen | n/a | status bar shows `Handlebar - Class: Handlebar` with `Open full editor` |

652 tests pass, ruff and mypy clean. Two new guards in `tests/test_viz_fullscreen.py` pin the invariants at source level, since neither is observable outside a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
