### PR TITLE
fix: keep Find and centre working when the pick reveals a hidden node

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -595,6 +595,26 @@ function renderGraph(args) {
         return h;
     }
     var nodeHash = _hash(nodeArr.map(function(n) { return n.id; }).sort().join('|'));
+
+    // --- Find & centre pin (issues #144, #195) ----------------------------
+    // Resolve the pin *before* the physics options are built: when a pick is
+    // active the camera belongs to that node, so vis's post-stabilization
+    // auto-fit (stabilization.fit, on by default) has to be switched off — it
+    // frames the whole graph and undoes the centring. That is why picking an
+    // entity that was hidden by the class filter appeared to do nothing: the
+    // reveal changes the node set, which forces a stabilization pass, whereas
+    // picking an already-visible entity reuses the cached layout with physics
+    // off and no fit (issue #195).
+    var _findIds = {};
+    nodeArr.forEach(function(n) { _findIds[n.id] = true; });
+    var _find = {};
+    try { _find = JSON.parse(sessionStorage.getItem('viz_find') || '{}') || {}; } catch (e) {}
+    if (_find.seq !== args.focus_seq) {
+        _find = {seq: args.focus_seq, released: false, centred: false};
+    }
+    var _pin = (!_find.released && args.focus_node && _findIds[args.focus_node])
+        ? args.focus_node : null;
+
     var savedPos = null, savedView = null, pinnedIds = [];
     var _raw = null;
     try { _raw = JSON.parse(sessionStorage.getItem('viz_pos') || 'null'); } catch (e) {}
@@ -625,13 +645,13 @@ function renderGraph(args) {
             }
         });
         var iters2 = Math.min(Math.max(nCount * 3, 150), 500);
-        options.physics.stabilization = { enabled: true, iterations: Math.max(iters2 - 40, 80), updateInterval: 50 };
+        options.physics.stabilization = { enabled: true, iterations: Math.max(iters2 - 40, 80), updateInterval: 50, fit: !_pin };
     } else {
         // Fresh layout (Render, or nothing cached): deterministic thanks to the
         // pinned randomSeed set in Python (issue #141).
         var iters = Math.min(Math.max(nCount * 3, 150), 500);
         var batchIters = Math.max(iters - 40, 80);
-        options.physics.stabilization = { enabled: true, iterations: batchIters, updateInterval: 50 };
+        options.physics.stabilization = { enabled: true, iterations: batchIters, updateInterval: 50, fit: !_pin };
     }
     var nodes = new vis.DataSet(nodeArr);
     network = new vis.Network(el, {nodes: nodes, edges: edges}, options);
@@ -664,14 +684,9 @@ function renderGraph(args) {
     // While a pick is active we "pin" the camera on the node and keep it
     // selected across rebuilds instead of restoring the (now stale) saved
     // viewport; the pin is released the moment the user clicks or drags, so we
-    // never fight them, and a fresh pick (new seq) re-arms it.
-    var _find = {};
-    try { _find = JSON.parse(sessionStorage.getItem('viz_find') || '{}') || {}; } catch (e) {}
-    if (_find.seq !== args.focus_seq) {
-        _find = {seq: args.focus_seq, released: false, centred: false};
-    }
-    var _pin = (!_find.released && args.focus_node && nodes.get(args.focus_node))
-        ? args.focus_node : null;
+    // never fight them, and a fresh pick (new seq) re-arms it. _find and _pin
+    // are resolved further up, before the physics options are built.
+    //
     // Hold the camera on the pinned node across this rebuild instead of
     // restoring the (now stale) saved viewport; otherwise use the saved view.
     if (savedView && !_pin) {
@@ -680,12 +695,18 @@ function renderGraph(args) {
     if (_pin) {
         var _findFresh = !_find.centred;
         try { network.selectNodes([_pin]); } catch (e) {}
-        try {
-            network.focus(_pin, {
-                scale: 1.1,
-                animation: _find.centred ? false : {duration: 700, easingFunction: 'easeInOutQuad'}
-            });
-        } catch (e) {}
+        // Centre now only when the layout is already final. When physics still
+        // has to run, the node is still moving, so centring on its current
+        // position would land in the wrong place — the stabilization handler
+        // below does it once the nodes have settled (issue #195).
+        if (usedSaved) {
+            try {
+                network.focus(_pin, {
+                    scale: 1.1,
+                    animation: _find.centred ? false : {duration: 700, easingFunction: 'easeInOutQuad'}
+                });
+            } catch (e) {}
+        }
         if (_findFresh) sendFindSelection(_pin);
         _find.centred = true;
     }
@@ -733,7 +754,22 @@ function renderGraph(args) {
                         }));
                     } catch (e) {}
                 }
-                savePositions();
+                // The nodes have settled and vis's auto-fit was suppressed for
+                // this pass, so this is the point at which the Find pick can be
+                // centred accurately (issue #195). Cache the viewport only once
+                // the camera animation has finished, or we'd store a mid-flight
+                // frame.
+                if (_pin) {
+                    try {
+                        network.focus(_pin, {
+                            scale: 1.1,
+                            animation: {duration: 600, easingFunction: 'easeInOutQuad'}
+                        });
+                    } catch (e) {}
+                    setTimeout(savePositions, 700);
+                } else {
+                    savePositions();
+                }
             }, 500);
         });
     }

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -722,6 +722,15 @@ function renderGraph(args) {
     }
     network.on('dragStart', _releaseFindPin);
     network.on('click', _releaseFindPin);
+    // Is this render's pin still the live one? Deferred centring (below) runs a
+    // second or more after the render, by which time the user may have taken
+    // control or picked something else, so it has to re-read the shared state
+    // instead of trusting the pin captured at render time.
+    function _findPinLive() {
+        var f = {};
+        try { f = JSON.parse(sessionStorage.getItem('viz_find') || '{}') || {}; } catch (e) {}
+        return !f.released && f.seq === args.focus_seq;
+    }
     // Cache the layout AND viewport so re-mounts restore both instantly. Save
     // after the settle animation has frozen (not on stabilizationIterationsDone,
     // which fires ~500ms before the freeze while nodes still move), and after any
@@ -756,10 +765,13 @@ function renderGraph(args) {
                 }
                 // The nodes have settled and vis's auto-fit was suppressed for
                 // this pass, so this is the point at which the Find pick can be
-                // centred accurately (issue #195). Cache the viewport only once
-                // the camera animation has finished, or we'd store a mid-flight
-                // frame.
-                if (_pin) {
+                // centred accurately (issue #195). Re-read the pin rather than
+                // trusting the one captured at render time: the user may have
+                // clicked or dragged while physics was still running, and
+                // centring now would yank the camera back off whatever they
+                // just navigated to. Cache the viewport only once the camera
+                // animation has finished, or we'd store a mid-flight frame.
+                if (_pin && _findPinLive()) {
                     try {
                         network.focus(_pin, {
                             scale: 1.1,


### PR DESCRIPTION
Closes #195

## The bug

Picking an entity in **Find entity in graph** that is currently hidden by the
class filter does nothing visible: the graph stays framed on everything, and the
entity can only be found after adding its class to **Filter Classes** by hand
first.

## Cause

The Python side already handles the reveal (`app.py`): picking a filtered-out
class adds it back to the selection and reruns, so the node really does end up in
the graph. What loses the camera is the viewer.

Revealing the class changes the node set, which sends `graph_viewer/index.html`
down its stabilization path. vis-network's `physics.stabilization.fit` defaults
to `true`, and the code set `stabilization` without it, so the instant the layout
settled vis called `fit()` and overwrote the `network.focus()` that had just run.

Picking an entity that was already visible was unaffected: that reuses the cached
layout with physics disabled, so no stabilization and therefore no fit. That is
exactly why adding the class to the filter first makes Find work.

It also explains the reporter's "around 30 entities" observation: on a small
graph the auto-fit still leaves the node legible, so it only reads as broken once
the graph is big enough that framing everything zooms the node into obscurity.

Not a recent regression, it has been there since Find and centre landed (#162).

## Fix

* Resolve the find pin before the physics options are built, so the stabilization
  options can react to it.
* Set `fit: !_pin` on both stabilization branches, so vis stops framing the whole
  graph over an active pick.
* Centre from the `stabilizationIterationsDone` handler rather than immediately:
  while physics is running the node is still drifting, so centring early would
  land in the wrong place. Cache the viewport after the camera animation instead
  of mid-flight.

With no pin active nothing changes, so a plain render still auto-fits.

## Verification

Drove the running app with the bundled pizza sample (143 classes): removed one
class from the filter, then picked it in **Find entity in graph**, and read the
viewport out of the vis-network instance.

| Scenario | Viewport scale after the pick |
| --- | --- |
| Before the fix | 0.12 (whole graph framed, node lost) |
| After the fix | 1.1, viewport position equals the node position |

Confirmed unchanged by the fix:

* Find on an already-visible class still centres (scale 1.1).
* **Render** with an active pick re-centres on it.
* **Render** with no pick still auto-fits the graph (scale 0.22).

`pytest` (652 passed), `ruff check`, `ruff format --check` and `mypy` are all
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
