### PR TITLE
chore: bump version to 1.17.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.17.4` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.17.5` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -15,7 +15,7 @@ from pathlib import Path as _Path
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.17.4"
+APP_VERSION = "1.17.5"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.17.4"
+version = "1.17.5"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.17.4"
+version = "1.17.5"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Patch bump for the release. Covers the two fixes merged since v1.17.4:

* #193 keep the graph in fullscreen when selecting a node
* #197 keep Find and centre working when the pick reveals a hidden node

Version updated in `pyproject.toml`, `uv.lock`, `README.md` and `orionbelt_ontology_builder/app.py`. `uv lock --check` and the test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)