### PR TITLE
feat: paste a class list into the Visualization filter

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6683,10 +6683,10 @@ def build_class_hierarchy_text(classes):
     return "\n".join(lines)
 
 
-def reconcile_class_filter(all_class_names, selected, known, replaced=False):
+def reconcile_class_filter(all_class_uris, selected, known, replaced=False):
     """Reconcile the Visualization "Filter Classes" selection with the ontology.
 
-    Diffs the current class names against those seen on the previous render
+    Diffs the current class URIs against those seen on the previous render
     (``known``) rather than resetting on every edit, so adding a class or a
     restriction no longer wipes a narrowed filter (issue #180):
 
@@ -6698,19 +6698,24 @@ def reconcile_class_filter(all_class_names, selected, known, replaced=False):
 
     ``replaced`` marks that the whole ontology was swapped (load/import/new/undo)
     rather than incrementally edited. Diffing must not run then: an unrelated
-    ontology that happens to reuse a class name (e.g. ``Person``) could otherwise
-    inherit its hidden/narrowed state and load with classes missing. On a
-    replacement — or the first render, when ``selected``/``known`` is ``None`` —
-    everything is shown. Returns ``(selected_list, known_set)`` where
-    ``selected_list`` keeps the class-list order.
+    ontology that happens to reuse a class URI could otherwise inherit its
+    hidden/narrowed state and load with classes missing. On a replacement — or
+    the first render, when ``selected``/``known`` is ``None`` — everything is
+    shown. Returns ``(selected_list, known_set)`` where ``selected_list`` keeps
+    the class-list order.
+
+    Classes are identified by URI, not by the label the filter displays: that
+    label gains a namespace tag as soon as a second class takes the same local
+    name, and diffing on it would read every same-named class as newly created
+    and re-show a deliberately hidden one (issue #179 review).
     """
-    all_class_set = set(all_class_names)
+    all_class_set = set(all_class_uris)
     if replaced or selected is None or known is None:
-        selected_set = set(all_class_names)
+        selected_set = set(all_class_uris)
     else:
         newly_added = all_class_set - known
         selected_set = (set(selected) | newly_added) & all_class_set
-    ordered = [c for c in all_class_names if c in selected_set]
+    ordered = [c for c in all_class_uris if c in selected_set]
     return ordered, all_class_set
 
 
@@ -6726,25 +6731,27 @@ _CLASS_DISPLAY_GAP = re.compile(r"\s+\(")
 def build_class_filter_entries(classes):
     """Describe each class for the Visualization "Filter Classes" controls.
 
-    Returns a list of dicts with the class ``name``/``uri``, whether that local
-    name is ``ambiguous`` (carried by more than one URI), the bound ``prefix``
-    when it is, and the ``display`` string the filter lists — the same
+    Returns a list of dicts with the class ``name``/``uri``, the ``prefix`` bound
+    to its namespace, whether that local name is ``ambiguous`` (carried by more
+    than one URI), and the ``display`` string the filter lists — the same
     namespace-tagged form used everywhere else in the app, so two classes named
     ``zero`` show as ``zero (fn)`` / ``zero (ex)`` instead of two identical
     entries (issue #179). Order follows the class list.
+
+    ``prefix`` is filled in for every class, not only ambiguous ones, so
+    ``foaf:Agent`` is accepted on paste even where ``Agent`` is unique.
     """
     collisions = _build_name_collision_set(classes)
     entries = []
     for c in classes:
         name = c.get("name") or ""
         uri = c.get("uri") or ""
-        ambiguous = name in collisions
         entries.append(
             {
                 "name": name,
                 "uri": uri,
-                "ambiguous": ambiguous,
-                "prefix": _prefix_for_uri(uri) if ambiguous else "",
+                "ambiguous": name in collisions,
+                "prefix": _prefix_for_uri(uri),
                 "display": _disambiguated_name(c, collisions),
             }
         )
@@ -6776,8 +6783,9 @@ def parse_class_filter_text(text, entries):
     case-insensitive. A plain local name shared by several namespaces selects
     all of them — the prefixed form picks just one.
 
-    Returns ``(displays, unmatched)``: the matched display names in class-list
-    order without repeats, and the tokens nothing matched, in input order.
+    Returns ``(uris, unmatched)``: the matched class URIs in class-list order
+    without repeats, and the tokens nothing matched, in input order. URIs rather
+    than display labels, because the selection is stored by URI.
     """
     if not text or not text.strip():
         return [], []
@@ -6786,23 +6794,25 @@ def parse_class_filter_text(text, entries):
     lowered: dict[str, list[str]] = {}
     order: dict[str, int] = {}
 
-    def _register(key, display):
+    def _register(key, uri):
         for table, k in ((exact, key), (lowered, key.lower())):
             if not k:
                 continue
             bucket = table.setdefault(k, [])
-            if display not in bucket:
-                bucket.append(display)
+            if uri not in bucket:
+                bucket.append(uri)
 
     for index, entry in enumerate(entries):
-        display = entry["display"]
-        order.setdefault(display, index)
-        _register(entry["name"], display)
-        _register(display, display)
-        _register(_CLASS_DISPLAY_GAP.sub("(", display), display)
-        _register(entry["uri"], display)
+        uri = entry["uri"]
+        if not uri:
+            continue
+        order.setdefault(uri, index)
+        _register(entry["name"], uri)
+        _register(entry["display"], uri)
+        _register(_CLASS_DISPLAY_GAP.sub("(", entry["display"]), uri)
+        _register(uri, uri)
         if entry["prefix"]:
-            _register(f"{entry['prefix']}:{entry['name']}", display)
+            _register(f"{entry['prefix']}:{entry['name']}", uri)
 
     matched: list[str] = []
     unmatched: list[str] = []
@@ -6818,12 +6828,12 @@ def parse_class_filter_text(text, entries):
             if token not in unmatched:
                 unmatched.append(token)
             continue
-        for display in hits:
-            if display not in seen:
-                seen.add(display)
-                matched.append(display)
+        for uri in hits:
+            if uri not in seen:
+                seen.add(uri)
+                matched.append(uri)
 
-    matched.sort(key=lambda d: order.get(d, 0))
+    matched.sort(key=lambda u: order.get(u, 0))
     return matched, unmatched
 
 
@@ -6909,6 +6919,16 @@ def render_visualization():
             # (issue #142); changes to per-ontology filters do not.
             if cfg_key.removeprefix("_viz_cfg_") in _VIZ_PERSIST_KEYS:
                 st.session_state["_viz_settings_dirty"] = True
+
+        def _viz_class_filter_changed(uri_by_display):
+            """Persist the class filter by URI. The widget holds display labels,
+            which gain a namespace tag as soon as a second class takes the same
+            local name — storing those would make the next render read the
+            renamed entries as newly created and re-show hidden ones (#179)."""
+            picked = st.session_state.get("viz_selected_classes") or []
+            st.session_state["_viz_cfg_selected_class_uris"] = [
+                uri_by_display[d] for d in picked if d in uri_by_display
+            ]
 
         def _viz_focus_toggle():
             """Persist the focus toggle and, when it turns on, seed the focus
@@ -7072,13 +7092,20 @@ def render_visualization():
         # a narrowed filter whenever a class or restriction was added (#180).
         # A mutation-counter jump not matched by the edit counter means the whole
         # ontology was replaced (load/import/new/undo), so reset to "all" rather
-        # than diffing against a now-unrelated ontology that may reuse names.
-        # Options are the namespace-tagged display names, so two classes sharing
-        # a local name are separately selectable rather than showing as one
-        # duplicated entry that toggles both (issue #179).
+        # than diffing against a now-unrelated ontology that may reuse URIs.
+        #
+        # The widget lists the namespace-tagged display names, so two classes
+        # sharing a local name are separately selectable rather than showing as
+        # one duplicated entry that toggles both (issue #179). The *state* is
+        # keyed by URI: a display label grows its namespace tag the moment a
+        # second class takes the same local name, so a selection stored by label
+        # would read as "these classes just appeared" and re-show a hidden one.
         class_entries = build_class_filter_entries(classes) if classes else []
         all_class_names = [e["display"] for e in class_entries]
         all_class_set = set(all_class_names)
+        all_class_uris = [e["uri"] for e in class_entries]
+        display_by_uri = {e["uri"]: e["display"] for e in class_entries}
+        uri_by_display = {e["display"]: e["uri"] for e in class_entries}
         mutation = st.session_state.get("_ont_mutation_count", 0)
         edits = st.session_state.get("_ont_edit_count", 0)
         prev_mutation = st.session_state.get("_viz_cfg_seen_mutation")
@@ -7086,17 +7113,22 @@ def render_visualization():
         replaced = prev_mutation is not None and (mutation - prev_mutation) != (
             edits - prev_edits
         )
-        selected_classes_list, known_class_set = reconcile_class_filter(
-            all_class_names,
-            st.session_state.get("_viz_cfg_selected_classes"),
-            st.session_state.get("_viz_cfg_known_classes"),
+        selected_class_uris, known_class_uris = reconcile_class_filter(
+            all_class_uris,
+            st.session_state.get("_viz_cfg_selected_class_uris"),
+            st.session_state.get("_viz_cfg_known_class_uris"),
             replaced=replaced,
         )
-        st.session_state["_viz_cfg_selected_classes"] = selected_classes_list
-        st.session_state["_viz_cfg_known_classes"] = known_class_set
+        selected_classes_list = [display_by_uri[u] for u in selected_class_uris]
+        st.session_state["_viz_cfg_selected_class_uris"] = selected_class_uris
+        st.session_state["_viz_cfg_known_class_uris"] = known_class_uris
         st.session_state["_viz_cfg_seen_mutation"] = mutation
         st.session_state["_viz_cfg_seen_edits"] = edits
         st.session_state["viz_selected_classes"] = selected_classes_list
+        # Display mirror of the URI selection, refreshed here on every render and
+        # never written to elsewhere. The focus-mode controls below read it to
+        # seed themselves from the current selection.
+        st.session_state["_viz_cfg_selected_classes"] = selected_classes_list
 
         # Focus mode: centre the view on one node (class, individual or SKOS
         # concept) and show only its neighbourhood within N hops. The pruning
@@ -7158,12 +7190,14 @@ def render_visualization():
                         _reveal_rerun = False
                         if _kind == "Class":
                             _sel = list(
-                                st.session_state.get("_viz_cfg_selected_classes") or []
+                                st.session_state.get("_viz_cfg_selected_class_uris")
+                                or []
                             )
-                            if _name in all_class_set and _name not in _sel:
-                                st.session_state["_viz_cfg_selected_classes"] = _sel + [
-                                    _name
-                                ]
+                            _uri = uri_by_display.get(_name)
+                            if _uri and _uri not in _sel:
+                                st.session_state["_viz_cfg_selected_class_uris"] = (
+                                    _sel + [_uri]
+                                )
                                 _reveal_rerun = True
                         if st.session_state.get("_viz_cfg_focus_mode"):
                             _seeds = list(
@@ -7247,8 +7281,8 @@ def render_visualization():
                     help="Choose which classes to show in the graph. Empty shows "
                     "no classes; use 'Select all' to bring them back.",
                     key="viz_selected_classes",
-                    on_change=_viz_sync,
-                    args=("_viz_cfg_selected_classes", "viz_selected_classes"),
+                    on_change=_viz_class_filter_changed,
+                    args=(uri_by_display,),
                 )
                 # An empty (or narrowed) filter hides classes and there is no
                 # native way back — offer a one-click restore (issue B3). Only
@@ -7259,8 +7293,8 @@ def render_visualization():
                         key="viz_select_all_classes",
                         help="Show every class in the graph again.",
                     ):
-                        st.session_state["_viz_cfg_selected_classes"] = list(
-                            all_class_names
+                        st.session_state["_viz_cfg_selected_class_uris"] = list(
+                            all_class_uris
                         )
                         st.rerun()
 
@@ -7291,7 +7325,7 @@ def render_visualization():
                         # selection, so a partly matching paste still reports
                         # what it dropped.
                         st.session_state["_viz_class_paste_unknown"] = _unknown
-                        st.session_state["_viz_cfg_selected_classes"] = _pasted
+                        st.session_state["_viz_cfg_selected_class_uris"] = _pasted
                         st.rerun()
                     elif _unknown:
                         st.warning(f"No class matched: {_fmt_unknown(_unknown)}")
@@ -7301,13 +7335,13 @@ def render_visualization():
                 if _unknown_last:
                     st.warning(f"Ignored, no such class: {_fmt_unknown(_unknown_last)}")
                 if selected_classes:
-                    _selected_set = set(selected_classes)
+                    _selected_uris = set(selected_class_uris)
                     st.caption("Current selection — copy to restore it later:")
                     st.code(
                         " ".join(
                             class_filter_token(e)
                             for e in class_entries
-                            if e["display"] in _selected_set
+                            if e["uri"] in _selected_uris
                         ),
                         language=None,
                         wrap_lines=True,
@@ -7432,10 +7466,12 @@ def render_visualization():
 
             # Build sets for node existence checks (URI-keyed for cross-namespace safety)
             cls_collisions = _build_name_collision_set(classes)
-            # The filter selects display names; resolve them to URIs so hiding
-            # one of two same-named classes hides only that one (issue #179).
+            # What to draw comes from `selected_classes` (display labels, and in
+            # focus mode deliberately every class) rather than the stored URI
+            # selection; resolve it to URIs so hiding one of two same-named
+            # classes hides only that one (issue #179).
             _selected_displays = set(selected_classes) if selected_classes else set()
-            selected_class_uris = {
+            visible_class_uris = {
                 e["uri"] for e in class_entries if e["display"] in _selected_displays
             }
             displayed_class_uris: set = set()
@@ -7445,7 +7481,7 @@ def render_visualization():
                 for cls in classes:
                     if node_count >= max_nodes:
                         break
-                    if cls["uri"] not in selected_class_uris:
+                    if cls["uri"] not in visible_class_uris:
                         continue
                     cls_node_id = _uid(cls["uri"])
                     disp_cls_name = _disambiguated_name(cls, cls_collisions)
@@ -7871,7 +7907,7 @@ def render_visualization():
                 _uri_to_node = {}
                 if show_classes and selected_classes:
                     for cls in classes:
-                        if cls["uri"] in selected_class_uris:
+                        if cls["uri"] in visible_class_uris:
                             _uri_to_node[cls["uri"]] = _uid(cls["uri"])
                 if show_individuals and individuals:
                     for ind in individuals:

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6,6 +6,7 @@ and managing OWL ontologies.
 import hashlib
 import json
 import logging
+import re
 import streamlit as st
 import time
 import traceback
@@ -6713,6 +6714,126 @@ def reconcile_class_filter(all_class_names, selected, known, replaced=False):
     return ordered, all_class_set
 
 
+# Pasted class lists are split on whitespace, commas and semicolons, so any of
+# the ways a list gets copied around (one per line, comma-separated, the token
+# string the filter itself prints) parses the same way.
+_CLASS_TOKEN_SEPARATORS = re.compile(r"[\s,;]+")
+# Collapse "Person (foaf)" to "Person(foaf)" so the display form the multiselect
+# shows survives whitespace splitting and stays one token.
+_CLASS_DISPLAY_GAP = re.compile(r"\s+\(")
+
+
+def build_class_filter_entries(classes):
+    """Describe each class for the Visualization "Filter Classes" controls.
+
+    Returns a list of dicts with the class ``name``/``uri``, whether that local
+    name is ``ambiguous`` (carried by more than one URI), the bound ``prefix``
+    when it is, and the ``display`` string the filter lists — the same
+    namespace-tagged form used everywhere else in the app, so two classes named
+    ``zero`` show as ``zero (fn)`` / ``zero (ex)`` instead of two identical
+    entries (issue #179). Order follows the class list.
+    """
+    collisions = _build_name_collision_set(classes)
+    entries = []
+    for c in classes:
+        name = c.get("name") or ""
+        uri = c.get("uri") or ""
+        ambiguous = name in collisions
+        entries.append(
+            {
+                "name": name,
+                "uri": uri,
+                "ambiguous": ambiguous,
+                "prefix": _prefix_for_uri(uri) if ambiguous else "",
+                "display": _disambiguated_name(c, collisions),
+            }
+        )
+    return entries
+
+
+def class_filter_token(entry):
+    """Round-trippable token for one class-filter entry.
+
+    An unambiguous class is just its local name; an ambiguous one is written
+    ``prefix:Name`` (the syntax issue #179 asks for), falling back to the full
+    URI when its namespace has no bound prefix. Tokens are what the filter
+    prints for copying and what :func:`parse_class_filter_text` reads back.
+    """
+    if not entry["ambiguous"]:
+        return entry["name"]
+    if entry["prefix"]:
+        return f"{entry['prefix']}:{entry['name']}"
+    return entry["uri"] or entry["name"]
+
+
+def parse_class_filter_text(text, entries):
+    """Resolve pasted class names against the current classes.
+
+    Accepts whitespace-, comma- or semicolon-separated tokens in any of the
+    forms the app shows a class in: a plain local name (``Person``), a prefixed
+    name (``fn:zero``), the disambiguated display form (``zero (fn)``) or a full
+    URI, optionally wrapped in ``<>`` or quotes. Matching is exact first, then
+    case-insensitive. A plain local name shared by several namespaces selects
+    all of them — the prefixed form picks just one.
+
+    Returns ``(displays, unmatched)``: the matched display names in class-list
+    order without repeats, and the tokens nothing matched, in input order.
+    """
+    if not text or not text.strip():
+        return [], []
+
+    exact: dict[str, list[str]] = {}
+    lowered: dict[str, list[str]] = {}
+    order: dict[str, int] = {}
+
+    def _register(key, display):
+        for table, k in ((exact, key), (lowered, key.lower())):
+            if not k:
+                continue
+            bucket = table.setdefault(k, [])
+            if display not in bucket:
+                bucket.append(display)
+
+    for index, entry in enumerate(entries):
+        display = entry["display"]
+        order.setdefault(display, index)
+        _register(entry["name"], display)
+        _register(display, display)
+        _register(_CLASS_DISPLAY_GAP.sub("(", display), display)
+        _register(entry["uri"], display)
+        if entry["prefix"]:
+            _register(f"{entry['prefix']}:{entry['name']}", display)
+
+    matched: list[str] = []
+    unmatched: list[str] = []
+    seen: set[str] = set()
+    for raw in _CLASS_TOKEN_SEPARATORS.split(_CLASS_DISPLAY_GAP.sub("(", text)):
+        token = raw.strip().strip("\"'")
+        if token.startswith("<") and token.endswith(">"):
+            token = token[1:-1]
+        if not token:
+            continue
+        hits = exact.get(token) or lowered.get(token.lower())
+        if not hits:
+            if token not in unmatched:
+                unmatched.append(token)
+            continue
+        for display in hits:
+            if display not in seen:
+                seen.add(display)
+                matched.append(display)
+
+    matched.sort(key=lambda d: order.get(d, 0))
+    return matched, unmatched
+
+
+def _fmt_unknown(tokens, limit=20):
+    """Render unmatched paste tokens for a warning, capped so a wholly wrong
+    paste doesn't fill the panel."""
+    shown = ", ".join(tokens[:limit])
+    return f"{shown} (+{len(tokens) - limit} more)" if len(tokens) > limit else shown
+
+
 def render_visualization():
     """Render the visualization page."""
     st.header("Visualization")
@@ -6952,7 +7073,11 @@ def render_visualization():
         # A mutation-counter jump not matched by the edit counter means the whole
         # ontology was replaced (load/import/new/undo), so reset to "all" rather
         # than diffing against a now-unrelated ontology that may reuse names.
-        all_class_names = [c["name"] for c in classes] if classes else []
+        # Options are the namespace-tagged display names, so two classes sharing
+        # a local name are separately selectable rather than showing as one
+        # duplicated entry that toggles both (issue #179).
+        class_entries = build_class_filter_entries(classes) if classes else []
+        all_class_names = [e["display"] for e in class_entries]
         all_class_set = set(all_class_names)
         mutation = st.session_state.get("_ont_mutation_count", 0)
         edits = st.session_state.get("_ont_edit_count", 0)
@@ -6980,8 +7105,8 @@ def render_visualization():
         # to the same node ids the graph builder assigns.
         focus_targets: dict[str, str] = {}
         if show_classes:
-            for c in classes:
-                focus_targets[f"Class: {c['name']}"] = _uid(c["uri"])
+            for e in class_entries:
+                focus_targets[f"Class: {e['display']}"] = _uid(e["uri"])
         if show_individuals:
             for ind in individuals:
                 focus_targets[f"Individual: {ind['name']}"] = f"ind_{_uid(ind['uri'])}"
@@ -7139,6 +7264,55 @@ def render_visualization():
                         )
                         st.rerun()
 
+                # Picking a handful of classes out of a long multiselect is slow,
+                # and the selection is worth keeping — so the filter can also be
+                # driven by a pasted list, and prints the current one back in the
+                # same syntax to copy and restore later (issue #179).
+                _paste_text = st.text_area(
+                    "Or paste a class list",
+                    key="viz_class_paste",
+                    height=80,
+                    placeholder="Person Organization fn:zero",
+                    help="Separate names with spaces, commas or line breaks. "
+                    "Applying replaces the selection above. Names shared by "
+                    "several namespaces select all of them — write 'fn:zero' "
+                    "(or paste the full URI) to pick just one.",
+                )
+                if st.button(
+                    "Apply pasted list",
+                    key="viz_apply_class_paste",
+                    help="Show exactly the pasted classes.",
+                ):
+                    _pasted, _unknown = parse_class_filter_text(
+                        _paste_text, class_entries
+                    )
+                    if _pasted:
+                        # The warning has to outlive the rerun that applies the
+                        # selection, so a partly matching paste still reports
+                        # what it dropped.
+                        st.session_state["_viz_class_paste_unknown"] = _unknown
+                        st.session_state["_viz_cfg_selected_classes"] = _pasted
+                        st.rerun()
+                    elif _unknown:
+                        st.warning(f"No class matched: {_fmt_unknown(_unknown)}")
+                    else:
+                        st.info("Paste one or more class names first.")
+                _unknown_last = st.session_state.pop("_viz_class_paste_unknown", None)
+                if _unknown_last:
+                    st.warning(f"Ignored, no such class: {_fmt_unknown(_unknown_last)}")
+                if selected_classes:
+                    _selected_set = set(selected_classes)
+                    st.caption("Current selection — copy to restore it later:")
+                    st.code(
+                        " ".join(
+                            class_filter_token(e)
+                            for e in class_entries
+                            if e["display"] in _selected_set
+                        ),
+                        language=None,
+                        wrap_lines=True,
+                    )
+
         # Persist the display preferences (entity toggles, spacing, fit, ...) so
         # they survive a reload (#142). Runs after every control has synced its
         # value; no-ops when nothing changed.
@@ -7258,7 +7432,12 @@ def render_visualization():
 
             # Build sets for node existence checks (URI-keyed for cross-namespace safety)
             cls_collisions = _build_name_collision_set(classes)
-            selected_class_names = set(selected_classes) if selected_classes else set()
+            # The filter selects display names; resolve them to URIs so hiding
+            # one of two same-named classes hides only that one (issue #179).
+            _selected_displays = set(selected_classes) if selected_classes else set()
+            selected_class_uris = {
+                e["uri"] for e in class_entries if e["display"] in _selected_displays
+            }
             displayed_class_uris: set = set()
 
             # Add classes as nodes (only selected classes)
@@ -7266,7 +7445,7 @@ def render_visualization():
                 for cls in classes:
                     if node_count >= max_nodes:
                         break
-                    if cls["name"] not in selected_class_names:
+                    if cls["uri"] not in selected_class_uris:
                         continue
                     cls_node_id = _uid(cls["uri"])
                     disp_cls_name = _disambiguated_name(cls, cls_collisions)
@@ -7692,8 +7871,8 @@ def render_visualization():
                 _uri_to_node = {}
                 if show_classes and selected_classes:
                     for cls in classes:
-                        if cls["name"] in selected_classes:
-                            _uri_to_node[cls["uri"]] = cls["name"]
+                        if cls["uri"] in selected_class_uris:
+                            _uri_to_node[cls["uri"]] = _uid(cls["uri"])
                 if show_individuals and individuals:
                     for ind in individuals:
                         _uri_to_node[ind["uri"]] = f"ind_{ind['name']}"

--- a/tests/test_viz_class_paste.py
+++ b/tests/test_viz_class_paste.py
@@ -2,7 +2,9 @@
 
 The filter lists namespace-tagged display names so same-named classes from two
 namespaces are separately selectable, and accepts a pasted list of names,
-prefixed names or URIs to restore a saved selection in one go.
+prefixed names or URIs to restore a saved selection in one go. Both the parser
+and the stored selection work in URIs — display labels change under the filter
+whenever a second class takes the same local name.
 """
 
 import pytest
@@ -10,26 +12,26 @@ import pytest
 from orionbelt_ontology_builder import app
 
 
+BASE = "http://ex.org/base#"
+FN = "http://ex.org/fn#"
+MATH = "http://ex.org/math#"
+
 CLASSES = [
-    {"name": "Person", "uri": "http://ex.org/base#Person"},
-    {"name": "zero", "uri": "http://ex.org/fn#zero"},
-    {"name": "zero", "uri": "http://ex.org/math#zero"},
-    {"name": "Organization", "uri": "http://ex.org/base#Organization"},
+    {"name": "Person", "uri": f"{BASE}Person"},
+    {"name": "zero", "uri": f"{FN}zero"},
+    {"name": "zero", "uri": f"{MATH}zero"},
+    {"name": "Organization", "uri": f"{BASE}Organization"},
 ]
 
-PREFIXES = {
-    "http://ex.org/base#": "",
-    "http://ex.org/fn#": "fn",
-    "http://ex.org/math#": "math",
-}
+PREFIXES = {BASE: "base", FN: "fn", MATH: "math"}
 
 
 @pytest.fixture
-def entries(monkeypatch):
-    """Class-filter entries built with a stubbed prefix lookup.
+def prefixes(monkeypatch):
+    """Bind the test namespaces to prefixes.
 
     ``_prefix_for_uri`` reads the ontology out of session state, which does not
-    exist outside a Streamlit run, so bind the prefixes directly.
+    exist outside a Streamlit run, so resolve the prefixes directly.
     """
 
     def _prefix(uri):
@@ -39,11 +41,22 @@ def entries(monkeypatch):
         return ""
 
     monkeypatch.setattr(app, "_prefix_for_uri", _prefix)
+
+
+@pytest.fixture
+def entries(prefixes):
     return app.build_class_filter_entries(CLASSES)
 
 
 def _displays(entries):
     return [e["display"] for e in entries]
+
+
+def _uris(*names):
+    return [
+        {"Person": f"{BASE}Person", "Organization": f"{BASE}Organization"}[n]
+        for n in names
+    ]
 
 
 def test_same_name_classes_get_distinct_options(entries):
@@ -59,28 +72,31 @@ def test_entries_flag_only_the_ambiguous_name(entries):
     assert [e["ambiguous"] for e in entries] == [False, True, True, False]
 
 
+def test_every_entry_carries_its_prefix(entries):
+    # Not just the ambiguous ones: 'base:Person' has to parse too (review of
+    # #179), even though the printed token for it stays unprefixed.
+    assert [e["prefix"] for e in entries] == ["base", "fn", "math", "base"]
+
+
 def test_unprefixed_namespace_falls_back_to_the_namespace(monkeypatch):
     monkeypatch.setattr(app, "_prefix_for_uri", lambda uri: "")
     entries = app.build_class_filter_entries(CLASSES[1:3])
-    assert _displays(entries) == [
-        "zero (http://ex.org/fn#)",
-        "zero (http://ex.org/math#)",
-    ]
+    assert _displays(entries) == [f"zero ({FN})", f"zero ({MATH})"]
 
 
 def test_tokens_round_trip_through_the_parser(entries):
     tokens = " ".join(app.class_filter_token(e) for e in entries)
     assert tokens == "Person fn:zero math:zero Organization"
-    assert app.parse_class_filter_text(tokens, entries) == (_displays(entries), [])
+    assert app.parse_class_filter_text(tokens, entries) == (
+        [e["uri"] for e in entries],
+        [],
+    )
 
 
 def test_token_for_an_unprefixed_ambiguous_class_is_its_uri(monkeypatch):
     monkeypatch.setattr(app, "_prefix_for_uri", lambda uri: "")
     entries = app.build_class_filter_entries(CLASSES[1:3])
-    assert [app.class_filter_token(e) for e in entries] == [
-        "http://ex.org/fn#zero",
-        "http://ex.org/math#zero",
-    ]
+    assert [app.class_filter_token(e) for e in entries] == [f"{FN}zero", f"{MATH}zero"]
 
 
 def test_spaces_commas_semicolons_and_newlines_all_separate(entries):
@@ -92,74 +108,76 @@ def test_spaces_commas_semicolons_and_newlines_all_separate(entries):
         "  Person ,\n\n Organization  ",
     ):
         assert app.parse_class_filter_text(text, entries) == (
-            ["Person", "Organization"],
+            _uris("Person", "Organization"),
             [],
         )
 
 
 def test_result_follows_class_list_order_not_input_order(entries):
     matched, _ = app.parse_class_filter_text("Organization Person", entries)
-    assert matched == ["Person", "Organization"]
+    assert matched == _uris("Person", "Organization")
 
 
 def test_repeated_names_are_listed_once(entries):
-    assert app.parse_class_filter_text("Person Person", entries)[0] == ["Person"]
+    assert app.parse_class_filter_text("Person Person", entries)[0] == _uris("Person")
 
 
 def test_plain_ambiguous_name_selects_every_namespace(entries):
     assert app.parse_class_filter_text("zero", entries)[0] == [
-        "zero (fn)",
-        "zero (math)",
+        f"{FN}zero",
+        f"{MATH}zero",
     ]
 
 
 def test_prefixed_name_selects_one_namespace(entries):
-    assert app.parse_class_filter_text("fn:zero", entries)[0] == ["zero (fn)"]
+    assert app.parse_class_filter_text("fn:zero", entries)[0] == [f"{FN}zero"]
+
+
+def test_prefixed_name_works_for_an_unambiguous_class(entries):
+    # 'Person' is unique, so nothing forces the prefix — but pasting the
+    # prefixed form back must still resolve (review of #179).
+    assert app.parse_class_filter_text("base:Person", entries)[0] == _uris("Person")
 
 
 def test_display_form_survives_being_split_on_whitespace(entries):
     # Copied straight out of the multiselect, "zero (math)" contains a space.
     assert app.parse_class_filter_text("Person zero (math)", entries)[0] == [
-        "Person",
-        "zero (math)",
+        f"{BASE}Person",
+        f"{MATH}zero",
     ]
 
 
 def test_full_uri_selects_one_namespace(entries):
-    assert app.parse_class_filter_text("http://ex.org/fn#zero", entries)[0] == [
-        "zero (fn)"
-    ]
+    assert app.parse_class_filter_text(f"{FN}zero", entries)[0] == [f"{FN}zero"]
 
 
 def test_uri_in_angle_brackets_and_quotes(entries):
-    assert app.parse_class_filter_text("<http://ex.org/fn#zero>", entries)[0] == [
-        "zero (fn)"
-    ]
-    assert app.parse_class_filter_text("'Person'", entries)[0] == ["Person"]
+    assert app.parse_class_filter_text(f"<{FN}zero>", entries)[0] == [f"{FN}zero"]
+    assert app.parse_class_filter_text("'Person'", entries)[0] == _uris("Person")
 
 
 def test_case_insensitive_fallback(entries):
     assert app.parse_class_filter_text("person FN:ZERO", entries)[0] == [
-        "Person",
-        "zero (fn)",
+        f"{BASE}Person",
+        f"{FN}zero",
     ]
 
 
-def test_exact_case_wins_over_a_case_insensitive_match():
+def test_exact_case_wins_over_a_case_insensitive_match(prefixes):
     entries = app.build_class_filter_entries(
         [
-            {"name": "Person", "uri": "http://ex.org/base#Person"},
-            {"name": "person", "uri": "http://ex.org/other#person"},
+            {"name": "Person", "uri": f"{BASE}Person"},
+            {"name": "person", "uri": f"{FN}person"},
         ]
     )
-    assert app.parse_class_filter_text("person", entries)[0] == ["person"]
+    assert app.parse_class_filter_text("person", entries)[0] == [f"{FN}person"]
 
 
 def test_unknown_names_are_reported_and_the_rest_applied(entries):
     matched, unknown = app.parse_class_filter_text(
         "Person Nope Person Missing", entries
     )
-    assert matched == ["Person"]
+    assert matched == _uris("Person")
     assert unknown == ["Nope", "Missing"]
 
 
@@ -171,7 +189,34 @@ def test_empty_text_matches_nothing(entries):
 def test_pasted_selection_reconciles_like_any_other(entries):
     # What Apply stores must survive the next render's reconciliation unchanged.
     pasted, _ = app.parse_class_filter_text("Person fn:zero", entries)
-    all_names = _displays(entries)
-    selected, known = app.reconcile_class_filter(all_names, pasted, set(all_names))
-    assert selected == ["Person", "zero (fn)"]
-    assert known == set(all_names)
+    all_uris = [e["uri"] for e in entries]
+    selected, known = app.reconcile_class_filter(all_uris, pasted, set(all_uris))
+    assert selected == [f"{BASE}Person", f"{FN}zero"]
+    assert known == set(all_uris)
+
+
+def test_a_new_namespace_twin_does_not_unhide_its_sibling(prefixes):
+    """Regression for the review of #179.
+
+    A hidden class keeps its URI when a same-named class arrives, but its
+    display label gains a namespace tag. Reconciling on labels would read both
+    ``zero (fn)`` and ``zero (math)`` as brand new and show the class the user
+    had deliberately hidden — so the state is keyed by URI.
+    """
+    before = app.build_class_filter_entries(CLASSES[:2])
+    assert _displays(before) == ["Person", "zero"]
+
+    # User hides 'zero', leaving just Person selected.
+    selected, known = app.reconcile_class_filter(
+        [e["uri"] for e in before], [f"{BASE}Person"], {f"{BASE}Person", f"{FN}zero"}
+    )
+    assert selected == [f"{BASE}Person"]
+
+    # math:zero is imported; fn:zero is relabelled 'zero (fn)' but unchanged.
+    after = app.build_class_filter_entries(CLASSES[:3])
+    assert _displays(after) == ["Person", "zero (fn)", "zero (math)"]
+    selected, known = app.reconcile_class_filter(
+        [e["uri"] for e in after], selected, known
+    )
+    # Only the genuinely new class joins; fn:zero stays hidden.
+    assert selected == [f"{BASE}Person", f"{MATH}zero"]

--- a/tests/test_viz_class_paste.py
+++ b/tests/test_viz_class_paste.py
@@ -1,0 +1,177 @@
+"""Pasting a class list into the Visualization "Filter Classes" (issue #179).
+
+The filter lists namespace-tagged display names so same-named classes from two
+namespaces are separately selectable, and accepts a pasted list of names,
+prefixed names or URIs to restore a saved selection in one go.
+"""
+
+import pytest
+
+from orionbelt_ontology_builder import app
+
+
+CLASSES = [
+    {"name": "Person", "uri": "http://ex.org/base#Person"},
+    {"name": "zero", "uri": "http://ex.org/fn#zero"},
+    {"name": "zero", "uri": "http://ex.org/math#zero"},
+    {"name": "Organization", "uri": "http://ex.org/base#Organization"},
+]
+
+PREFIXES = {
+    "http://ex.org/base#": "",
+    "http://ex.org/fn#": "fn",
+    "http://ex.org/math#": "math",
+}
+
+
+@pytest.fixture
+def entries(monkeypatch):
+    """Class-filter entries built with a stubbed prefix lookup.
+
+    ``_prefix_for_uri`` reads the ontology out of session state, which does not
+    exist outside a Streamlit run, so bind the prefixes directly.
+    """
+
+    def _prefix(uri):
+        for ns, prefix in PREFIXES.items():
+            if uri.startswith(ns):
+                return prefix
+        return ""
+
+    monkeypatch.setattr(app, "_prefix_for_uri", _prefix)
+    return app.build_class_filter_entries(CLASSES)
+
+
+def _displays(entries):
+    return [e["display"] for e in entries]
+
+
+def test_same_name_classes_get_distinct_options(entries):
+    assert _displays(entries) == [
+        "Person",
+        "zero (fn)",
+        "zero (math)",
+        "Organization",
+    ]
+
+
+def test_entries_flag_only_the_ambiguous_name(entries):
+    assert [e["ambiguous"] for e in entries] == [False, True, True, False]
+
+
+def test_unprefixed_namespace_falls_back_to_the_namespace(monkeypatch):
+    monkeypatch.setattr(app, "_prefix_for_uri", lambda uri: "")
+    entries = app.build_class_filter_entries(CLASSES[1:3])
+    assert _displays(entries) == [
+        "zero (http://ex.org/fn#)",
+        "zero (http://ex.org/math#)",
+    ]
+
+
+def test_tokens_round_trip_through_the_parser(entries):
+    tokens = " ".join(app.class_filter_token(e) for e in entries)
+    assert tokens == "Person fn:zero math:zero Organization"
+    assert app.parse_class_filter_text(tokens, entries) == (_displays(entries), [])
+
+
+def test_token_for_an_unprefixed_ambiguous_class_is_its_uri(monkeypatch):
+    monkeypatch.setattr(app, "_prefix_for_uri", lambda uri: "")
+    entries = app.build_class_filter_entries(CLASSES[1:3])
+    assert [app.class_filter_token(e) for e in entries] == [
+        "http://ex.org/fn#zero",
+        "http://ex.org/math#zero",
+    ]
+
+
+def test_spaces_commas_semicolons_and_newlines_all_separate(entries):
+    for text in (
+        "Person Organization",
+        "Person, Organization",
+        "Person;Organization",
+        "Person\nOrganization",
+        "  Person ,\n\n Organization  ",
+    ):
+        assert app.parse_class_filter_text(text, entries) == (
+            ["Person", "Organization"],
+            [],
+        )
+
+
+def test_result_follows_class_list_order_not_input_order(entries):
+    matched, _ = app.parse_class_filter_text("Organization Person", entries)
+    assert matched == ["Person", "Organization"]
+
+
+def test_repeated_names_are_listed_once(entries):
+    assert app.parse_class_filter_text("Person Person", entries)[0] == ["Person"]
+
+
+def test_plain_ambiguous_name_selects_every_namespace(entries):
+    assert app.parse_class_filter_text("zero", entries)[0] == [
+        "zero (fn)",
+        "zero (math)",
+    ]
+
+
+def test_prefixed_name_selects_one_namespace(entries):
+    assert app.parse_class_filter_text("fn:zero", entries)[0] == ["zero (fn)"]
+
+
+def test_display_form_survives_being_split_on_whitespace(entries):
+    # Copied straight out of the multiselect, "zero (math)" contains a space.
+    assert app.parse_class_filter_text("Person zero (math)", entries)[0] == [
+        "Person",
+        "zero (math)",
+    ]
+
+
+def test_full_uri_selects_one_namespace(entries):
+    assert app.parse_class_filter_text("http://ex.org/fn#zero", entries)[0] == [
+        "zero (fn)"
+    ]
+
+
+def test_uri_in_angle_brackets_and_quotes(entries):
+    assert app.parse_class_filter_text("<http://ex.org/fn#zero>", entries)[0] == [
+        "zero (fn)"
+    ]
+    assert app.parse_class_filter_text("'Person'", entries)[0] == ["Person"]
+
+
+def test_case_insensitive_fallback(entries):
+    assert app.parse_class_filter_text("person FN:ZERO", entries)[0] == [
+        "Person",
+        "zero (fn)",
+    ]
+
+
+def test_exact_case_wins_over_a_case_insensitive_match():
+    entries = app.build_class_filter_entries(
+        [
+            {"name": "Person", "uri": "http://ex.org/base#Person"},
+            {"name": "person", "uri": "http://ex.org/other#person"},
+        ]
+    )
+    assert app.parse_class_filter_text("person", entries)[0] == ["person"]
+
+
+def test_unknown_names_are_reported_and_the_rest_applied(entries):
+    matched, unknown = app.parse_class_filter_text(
+        "Person Nope Person Missing", entries
+    )
+    assert matched == ["Person"]
+    assert unknown == ["Nope", "Missing"]
+
+
+def test_empty_text_matches_nothing(entries):
+    assert app.parse_class_filter_text("", entries) == ([], [])
+    assert app.parse_class_filter_text("   \n ", entries) == ([], [])
+
+
+def test_pasted_selection_reconciles_like_any_other(entries):
+    # What Apply stores must survive the next render's reconciliation unchanged.
+    pasted, _ = app.parse_class_filter_text("Person fn:zero", entries)
+    all_names = _displays(entries)
+    selected, known = app.reconcile_class_filter(all_names, pasted, set(all_names))
+    assert selected == ["Person", "zero (fn)"]
+    assert known == set(all_names)


### PR DESCRIPTION
Closes #179

## What

The Visualization "Filter Classes" control could only be driven one click at a time, and it listed raw local names, so two classes sharing a name (`fn:zero` and `math:zero`) showed up as two identical entries that toggled together.

**Namespace disambiguation.** The filter options are now the namespace-tagged display names the rest of the app already uses (`zero (fn)` / `zero (math)`), and the graph builder resolves the selection to URIs, so hiding one of two same-named classes hides only that one. The Find-entity picker beside it keyed on the bare name too and had the same collapse, so it moved to the same display names.

**Pasting.** A text area under the multiselect takes a pasted class list and applies it in one click. Tokens separate on whitespace, commas, semicolons or line breaks, and each may be:

- a plain local name: `Person` (an ambiguous name selects every namespace carrying it)
- a prefixed name: `fn:zero` (picks exactly one)
- the displayed form: `zero (fn)`
- a full URI, optionally in `<>` or quotes

Matching is exact first, then case-insensitive. Tokens that match nothing are reported in a warning instead of being silently dropped.

The panel also prints the current selection back in that same syntax, so a narrowed view can be copied and pasted back later. That was the use case in the issue: restoring a specific visualization with only the key classes included.

## Testing

- `tests/test_viz_class_paste.py`: 18 tests covering entry building, token round-trip, every separator and token form, ordering, dedup, case handling, unmatched reporting, and that a pasted selection survives the next render's reconciliation.
- Full suite (670), ruff format/check and mypy all pass.
- Verified live against an ontology with `fn:zero` + `math:zero`: pasting `Person, fn:zero\nNonsense` narrows the graph to exactly `Person` and `zero (fn)`, warns about `Nonsense`, and the printed tokens read `Person fn:zero`. Find-and-centre on `zero (math)` reveals only that class, and focus mode still seeds from the selection.

## Note

While rewiring the class filter I corrected one adjacent line: in the "Triples" view, class subjects were mapped to `cls["name"]` as their node id, but class nodes are keyed by a URI hash, so those triple edges pointed at nonexistent nodes. The same defect exists for individuals (`ind_{name}` vs `ind_{uid}`) at two other spots; I left those alone as unrelated scope and will file them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)