### PR TITLE
fix: draw graph edges that pointed at nodes never emitted

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -7356,7 +7356,7 @@ def render_visualization():
         selected_classes_key = (
             "_".join(sorted(selected_classes)) if selected_classes else "none"
         )
-        _graph_ver = 16  # Bump to invalidate cached graph data after code changes
+        _graph_ver = 17  # Bump to invalidate cached graph data after code changes
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.
@@ -7474,7 +7474,15 @@ def render_visualization():
             visible_class_uris = {
                 e["uri"] for e in class_entries if e["display"] in _selected_displays
             }
+            # Which nodes actually made it into the graph. Every edge endpoint
+            # has to be one of these: the builder does not validate endpoints, so
+            # an edge naming a node that was never emitted is silently dropped by
+            # vis-network and the relation just never draws (issue #200). Nodes
+            # go missing both because a filter excluded them and because the
+            # max_nodes cap cut the loop short.
             displayed_class_uris: set = set()
+            displayed_ind_ids: set = set()
+            skos_node_ids: set = set()
 
             # Add classes as nodes (only selected classes)
             if show_classes and selected_classes:
@@ -7672,6 +7680,7 @@ def render_visualization():
                         ntype="Individual",
                         ename=_uid(ind["uri"]),
                     )
+                    displayed_ind_ids.add(ind_node_id)
                     node_count += 1
 
                     # Connect to classes via URI so the edge points to the
@@ -7700,12 +7709,16 @@ def render_visualization():
                         ind["name"]: ind["uri"] for ind in individuals
                     }
                     for ind in individuals:
+                        src_node = f"ind_{_uid(ind['uri'])}"
+                        if src_node not in displayed_ind_ids:
+                            continue
                         for prop in ind.get("properties", []):
                             target_uri = ind_uri_by_name.get(prop["value"])
-                            if target_uri:
+                            tgt_node = f"ind_{_uid(target_uri)}" if target_uri else ""
+                            if tgt_node in displayed_ind_ids:
                                 net.add_edge(
-                                    f"ind_{_uid(ind['uri'])}",
-                                    f"ind_{_uid(target_uri)}",
+                                    src_node,
+                                    tgt_node,
                                     label=prop["property"],
                                     title=f"{prop['property']}:\n{ind['name']} → {prop['value']}",
                                     color="#FF9800",
@@ -7751,8 +7764,14 @@ def render_visualization():
                     for cls in classes:
                         if node_count >= max_nodes:
                             break
+                        # Annotating a class the filter hid (or the node cap cut)
+                        # would hang the annotation off a node that isn't there.
+                        if cls["uri"] not in displayed_class_uris:
+                            continue
                         try:
-                            annotations = ont.get_annotations(cls["name"])
+                            # By URI, not local name: two classes sharing a name
+                            # would otherwise each show the other's annotations.
+                            annotations = ont.get_annotations(cls["uri"])
                             for ann in annotations:
                                 if node_count >= max_nodes:
                                     break
@@ -7785,7 +7804,7 @@ def render_visualization():
                                 )
                                 node_count += 1
                                 net.add_edge(
-                                    cls["name"],
+                                    _uid(cls["uri"]),
                                     ann_id,
                                     title=f"Annotation: {pred_display}",
                                     color="#A1887F",
@@ -7800,8 +7819,11 @@ def render_visualization():
                     for ind in individuals:
                         if node_count >= max_nodes:
                             break
+                        ind_node_id = f"ind_{_uid(ind['uri'])}"
+                        if ind_node_id not in displayed_ind_ids:
+                            continue
                         try:
-                            annotations = ont.get_annotations(ind["name"])
+                            annotations = ont.get_annotations(ind["uri"])
                             for ann in annotations:
                                 if node_count >= max_nodes:
                                     break
@@ -7831,7 +7853,7 @@ def render_visualization():
                                 )
                                 node_count += 1
                                 net.add_edge(
-                                    f"ind_{ind['name']}",
+                                    ind_node_id,
                                     ann_id,
                                     title=f"Annotation: {pred_display}",
                                     color="#A1887F",
@@ -7844,7 +7866,6 @@ def render_visualization():
             # Add SKOS concepts and relations
             if show_skos and node_count < max_nodes:
                 concepts = ont.get_concepts()
-                skos_node_ids = set()
                 for concept in concepts:
                     if node_count >= max_nodes:
                         break
@@ -7903,19 +7924,23 @@ def render_visualization():
             if show_triples and node_count < max_nodes:
                 from rdflib import URIRef as _URIRef, Literal as _Literal
 
-                # Build URI → node_id mapping from all visible nodes
+                # Build URI → node_id mapping over the nodes actually emitted,
+                # so a triple edge always has a real subject to hang off.
                 _uri_to_node = {}
-                if show_classes and selected_classes:
+                if show_classes:
                     for cls in classes:
-                        if cls["uri"] in visible_class_uris:
+                        if cls["uri"] in displayed_class_uris:
                             _uri_to_node[cls["uri"]] = _uid(cls["uri"])
                 if show_individuals and individuals:
                     for ind in individuals:
-                        _uri_to_node[ind["uri"]] = f"ind_{ind['name']}"
+                        _ind_node = f"ind_{_uid(ind['uri'])}"
+                        if _ind_node in displayed_ind_ids:
+                            _uri_to_node[ind["uri"]] = _ind_node
                 if show_skos:
                     for concept in ont.get_concepts():
-                        if concept.get("uri"):
-                            _uri_to_node[concept["uri"]] = f"skos_{concept['name']}"
+                        _skos_node = f"skos_{concept['name']}"
+                        if concept.get("uri") and _skos_node in skos_node_ids:
+                            _uri_to_node[concept["uri"]] = _skos_node
 
                 # Query only triples with visible subjects (avoid full graph scan)
                 _triple_new = 0

--- a/tests/test_viz_graph_edges.py
+++ b/tests/test_viz_graph_edges.py
@@ -1,0 +1,167 @@
+"""Every graph edge must connect two nodes the builder emitted (issue #200).
+
+The builder does not validate edge endpoints — an edge naming a node that was
+never added is silently dropped by vis-network, so a relation just fails to
+draw with nothing in the logs. Annotation and raw-triple edges for classes and
+individuals were built from local names while the nodes are keyed by a URI
+hash, so none of them ever drew.
+
+These run the real ``render_visualization`` through ``AppTest`` and inspect the
+graph payload it caches, seeded through the environment because
+``AppTest.from_function`` executes the script source in a fresh namespace
+without the test's closures.
+"""
+
+import json
+import os
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+
+def _script():
+    import os
+
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_prefix("other", "http://other.example.org/ns#")
+
+        om.add_class("Person", comment="A person")
+        om.add_class("Employee", parent="Person")
+        om.add_class("Organization")
+        # Same local name in a second namespace: node ids are URI-keyed, so
+        # anything built from the local name points at the wrong node or none.
+        om.add_class("Person", namespace="http://other.example.org/ns#")
+
+        om.add_object_property("worksFor", domain="Person", range_="Organization")
+        om.add_data_property("age", domain="Person", range_="integer")
+
+        om.add_individual("alice", "Person")
+        om.add_individual("acme", "Organization")
+        om.add_individual_property("alice", "worksFor", "acme")
+
+        om.add_annotation("Person", "seeAlso", "http://example.org/person-docs")
+        om.add_annotation("alice", "seeAlso", "http://example.org/alice")
+
+        om.add_concept("Widget", pref_label="Widget")
+        om.add_concept("Gadget", broader="Widget")
+
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        # The cross-session settings restore mounts the localStorage component,
+        # which blocks forever without a browser to answer it. Mark it done.
+        st.session_state["_viz_settings_restored"] = True
+
+        # Turn everything on so every edge-building branch runs.
+        for key in (
+            "show_classes",
+            "show_obj_props",
+            "show_data_props",
+            "show_annotations",
+            "show_individuals",
+            "show_ind_edges",
+            "show_skos",
+            "show_triples",
+        ):
+            st.session_state[f"_viz_cfg_{key}"] = True
+
+        if os.environ.get("HIDE_CLASSES"):
+            hidden = set(os.environ["HIDE_CLASSES"].split(","))
+            entries = app.build_class_filter_entries(om.get_classes())
+            st.session_state["_viz_cfg_selected_class_uris"] = [
+                e["uri"] for e in entries if e["display"] not in hidden
+            ]
+            st.session_state["_viz_cfg_known_class_uris"] = {e["uri"] for e in entries}
+            st.session_state["_viz_cfg_seen_mutation"] = st.session_state.get(
+                "_ont_mutation_count", 0
+            )
+
+    app.render_visualization()
+
+
+def _graph(hide_classes=None):
+    """Render the visualization once and return its (nodes, edges)."""
+    os.environ["HIDE_CLASSES"] = ",".join(hide_classes or [])
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    data = at.session_state["last_graph_data"]
+    assert data, "the visualization built no graph"
+    return json.loads(data["nodes"]), json.loads(data["edges"])
+
+
+def _dangling(nodes, edges):
+    ids = {n["id"] for n in nodes}
+    return [
+        (e["from"], e["to"])
+        for e in edges
+        if e["from"] not in ids or e["to"] not in ids
+    ]
+
+
+@pytest.fixture(scope="module")
+def graph():
+    return _graph()
+
+
+def test_the_graph_has_nodes_and_edges(graph):
+    nodes, edges = graph
+    assert len(nodes) > 5 and len(edges) > 5
+
+
+def test_no_edge_points_at_a_missing_node(graph):
+    nodes, edges = graph
+    assert _dangling(nodes, edges) == []
+
+
+def test_annotation_edges_hang_off_their_subject(graph):
+    nodes, edges = graph
+    by_id = {n["id"]: n for n in nodes}
+    ann_ids = {n["id"] for n in nodes if n["id"].startswith("ann_")}
+    assert ann_ids
+    # Every annotation node is reachable, which none were while the edge named
+    # the subject's local name instead of its node id.
+    assert {e["to"] for e in edges if e["to"] in ann_ids} == ann_ids
+    sources = [by_id[e["from"]] for e in edges if e["to"] in ann_ids]
+    assert {s.get("ntype") for s in sources} == {"Class", "Individual"}
+    # Only one class carries an annotation: they are looked up by URI, so the
+    # second class named Person does not inherit the first one's.
+    assert sum(1 for s in sources if s.get("ntype") == "Class") == 1
+
+
+def test_individual_object_property_edge_is_drawn(graph):
+    nodes, edges = graph
+    ind_ids = {n["id"] for n in nodes if n["id"].startswith("ind_")}
+    assert len(ind_ids) == 2
+    assert any(
+        e["from"] in ind_ids and e["to"] in ind_ids and e.get("label") == "worksFor"
+        for e in edges
+    )
+
+
+def test_hiding_a_class_leaves_no_dangling_edges():
+    # The class filter removes nodes that annotation, triple and property edges
+    # would otherwise still reference.
+    nodes, edges = _graph(hide_classes=["Person", "Organization"])
+    assert _dangling(nodes, edges) == []
+
+
+def test_hiding_one_of_two_same_named_classes_keeps_the_other_linked():
+    nodes, edges = _graph(hide_classes=["Person (other)"])
+    assert _dangling(nodes, edges) == []
+    # Exactly one of the two Person nodes survives, with its subclass edge and
+    # its annotation still attached.
+    persons = [
+        n
+        for n in nodes
+        if n.get("ntype") == "Class" and str(n.get("label", "")).startswith("Person")
+    ]
+    assert len(persons) == 1
+    person_id = persons[0]["id"]
+    assert any(e["to"] == person_id and e.get("label") == "subClassOf" for e in edges)
+    assert any(e["from"] == person_id and e["to"].startswith("ann_") for e in edges)


### PR DESCRIPTION
Closes #200

## The bug

Graph nodes are keyed by a hash of the resource URI (`_uid(uri)`), but several edges were built from the local name. `_GraphBuilder.add_edge` does not validate endpoints, and vis-network silently drops an edge naming a node it does not have, so these relations never drew and nothing appeared in the console:

- annotation edges for classes (`cls["name"]` instead of `_uid(cls["uri"])`) and for individuals (`ind_<name>` instead of `ind_<uid>`) - no annotation ever drew, for either type
- raw-triple edges from individual subjects in the Triples view

A second, related class of dangling edge: some edges referenced nodes the node loop had skipped rather than misnamed. Annotations were built for every class including ones the filter had hidden, and individual-to-individual assertions were built for every individual even when the `max_nodes` cap had cut the node loop short.

## The fix

Emitted nodes are tracked as they are added - `displayed_ind_ids` alongside the existing `displayed_class_uris`, and `skos_node_ids` hoisted out of the SKOS block so the Triples view can consult it - and every edge is gated on both endpoints being present.

While fixing the annotation edges I also switched the lookup from `get_annotations(name)` to `get_annotations(uri)`. Same root cause: with two classes named `Person` in different namespaces, each was showing the other's annotations.

`_graph_ver` is bumped so a live session does not keep serving a cached graph built by the old code.

## Testing

`tests/test_viz_graph_edges.py` renders the real `render_visualization` through `AppTest` and inspects the graph payload it caches. The central assertion is the one the issue asked for: no edge endpoint may name a node the builder did not emit. That covers every node type at once rather than the two sites named in the issue, and it is what surfaced the hidden-class and node-cap cases above.

Confirmed the tests fail without the fix: 4 of 6 fail on the unpatched builder, including both dangling-edge assertions.

- 679 tests pass, ruff format/check and mypy clean.
- Verified live: with annotations, individuals and individual edges on, the payload now has `Person -> ann_1`, `alice -> ann_2`, `alice -> ann_3` and `alice -> acme (worksFor)`, and zero dangling endpoints. Before this change the three annotation edges were all dangling and drew nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)