### PR TITLE
feat: filter individuals, in a filter panel that stops growing

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -6683,44 +6683,70 @@ def build_class_hierarchy_text(classes):
     return "\n".join(lines)
 
 
-def reconcile_class_filter(all_class_uris, selected, known, replaced=False):
-    """Reconcile the Visualization "Filter Classes" selection with the ontology.
+# The node kinds the Visualization filter can narrow. One entry per kind is all
+# a new filter needs: the controls are rendered from this list, so adding a kind
+# costs a segment in the selector rather than another block of UI (issue #196).
+# ``toggle`` is the entity-type checkbox that has to be on for the kind to be in
+# the graph at all; a kind whose toggle is off is not offered. ``singular`` is
+# the prefix the Find-and-centre picker labels this kind with ("Class: Person").
+_FILTER_KINDS = (
+    {
+        "key": "class",
+        "toggle": "show_classes",
+        "label": "Classes",
+        "singular": "Class",
+        "noun": "class",
+        "plural": "classes",
+    },
+    {
+        "key": "ind",
+        "toggle": "show_individuals",
+        "label": "Individuals",
+        "singular": "Individual",
+        "noun": "individual",
+        "plural": "individuals",
+    },
+)
 
-    Diffs the current class URIs against those seen on the previous render
-    (``known``) rather than resetting on every edit, so adding a class or a
-    restriction no longer wipes a narrowed filter (issue #180):
 
-    - classes deleted since last render drop out of the selection;
-    - classes created since last render are added (new content is shown by
+def reconcile_filter_selection(all_uris, selected, known, replaced=False):
+    """Reconcile one Visualization filter's selection with the ontology.
+
+    Diffs the current URIs against those seen on the previous render (``known``)
+    rather than resetting on every edit, so adding an entity or a restriction no
+    longer wipes a narrowed filter (issue #180):
+
+    - entities deleted since last render drop out of the selection;
+    - entities created since last render are added (new content is shown by
       default, matching the "everything selected" default);
     - the rest of the selection is left as-is, so a deliberately emptied filter
       stays empty (nothing is "new" when the user clears it).
 
     ``replaced`` marks that the whole ontology was swapped (load/import/new/undo)
     rather than incrementally edited. Diffing must not run then: an unrelated
-    ontology that happens to reuse a class URI could otherwise inherit its
-    hidden/narrowed state and load with classes missing. On a replacement — or
+    ontology that happens to reuse a URI could otherwise inherit its
+    hidden/narrowed state and load with entities missing. On a replacement — or
     the first render, when ``selected``/``known`` is ``None`` — everything is
     shown. Returns ``(selected_list, known_set)`` where ``selected_list`` keeps
-    the class-list order.
+    the entity-list order.
 
-    Classes are identified by URI, not by the label the filter displays: that
-    label gains a namespace tag as soon as a second class takes the same local
-    name, and diffing on it would read every same-named class as newly created
+    Entities are identified by URI, not by the label the filter displays: that
+    label gains a namespace tag as soon as a second entity takes the same local
+    name, and diffing on it would read every same-named entity as newly created
     and re-show a deliberately hidden one (issue #179 review).
     """
-    all_class_set = set(all_class_uris)
+    all_set = set(all_uris)
     if replaced or selected is None or known is None:
-        selected_set = set(all_class_uris)
+        selected_set = set(all_uris)
     else:
-        newly_added = all_class_set - known
-        selected_set = (set(selected) | newly_added) & all_class_set
-    ordered = [c for c in all_class_uris if c in selected_set]
-    return ordered, all_class_set
+        newly_added = all_set - known
+        selected_set = (set(selected) | newly_added) & all_set
+    ordered = [u for u in all_uris if u in selected_set]
+    return ordered, all_set
 
 
-# Pasted class lists are split on whitespace, commas and semicolons, so any of
-# the ways a list gets copied around (one per line, comma-separated, the token
+# Pasted lists are split on whitespace, commas and semicolons, so any of the
+# ways a list gets copied around (one per line, comma-separated, the token
 # string the filter itself prints) parses the same way.
 _CLASS_TOKEN_SEPARATORS = re.compile(r"[\s,;]+")
 # Collapse "Person (foaf)" to "Person(foaf)" so the display form the multiselect
@@ -6728,43 +6754,45 @@ _CLASS_TOKEN_SEPARATORS = re.compile(r"[\s,;]+")
 _CLASS_DISPLAY_GAP = re.compile(r"\s+\(")
 
 
-def build_class_filter_entries(classes):
-    """Describe each class for the Visualization "Filter Classes" controls.
+def build_filter_entries(items):
+    """Describe entities for one Visualization filter's controls.
 
-    Returns a list of dicts with the class ``name``/``uri``, the ``prefix`` bound
-    to its namespace, whether that local name is ``ambiguous`` (carried by more
-    than one URI), and the ``display`` string the filter lists — the same
-    namespace-tagged form used everywhere else in the app, so two classes named
-    ``zero`` show as ``zero (fn)`` / ``zero (ex)`` instead of two identical
-    entries (issue #179). Order follows the class list.
+    ``items`` is any list of entity dicts carrying ``name`` and ``uri`` —
+    classes or individuals today. Returns a list of dicts with the ``name`` and
+    ``uri``, the ``prefix`` bound to its namespace, whether that local name is
+    ``ambiguous`` (carried by more than one URI within this list), and the
+    ``display`` string the filter lists — the same namespace-tagged form used
+    everywhere else in the app, so two entities named ``zero`` show as
+    ``zero (fn)`` / ``zero (ex)`` instead of two identical entries (issue #179).
+    Order follows the input list.
 
-    ``prefix`` is filled in for every class, not only ambiguous ones, so
+    ``prefix`` is filled in for every entity, not only ambiguous ones, so
     ``foaf:Agent`` is accepted on paste even where ``Agent`` is unique.
     """
-    collisions = _build_name_collision_set(classes)
+    collisions = _build_name_collision_set(items)
     entries = []
-    for c in classes:
-        name = c.get("name") or ""
-        uri = c.get("uri") or ""
+    for it in items:
+        name = it.get("name") or ""
+        uri = it.get("uri") or ""
         entries.append(
             {
                 "name": name,
                 "uri": uri,
                 "ambiguous": name in collisions,
                 "prefix": _prefix_for_uri(uri),
-                "display": _disambiguated_name(c, collisions),
+                "display": _disambiguated_name(it, collisions),
             }
         )
     return entries
 
 
-def class_filter_token(entry):
-    """Round-trippable token for one class-filter entry.
+def filter_entry_token(entry):
+    """Round-trippable token for one filter entry.
 
-    An unambiguous class is just its local name; an ambiguous one is written
+    An unambiguous entity is just its local name; an ambiguous one is written
     ``prefix:Name`` (the syntax issue #179 asks for), falling back to the full
     URI when its namespace has no bound prefix. Tokens are what the filter
-    prints for copying and what :func:`parse_class_filter_text` reads back.
+    prints for copying and what :func:`parse_filter_text` reads back.
     """
     if not entry["ambiguous"]:
         return entry["name"]
@@ -6773,17 +6801,17 @@ def class_filter_token(entry):
     return entry["uri"] or entry["name"]
 
 
-def parse_class_filter_text(text, entries):
-    """Resolve pasted class names against the current classes.
+def parse_filter_text(text, entries):
+    """Resolve pasted names against one filter's entries.
 
     Accepts whitespace-, comma- or semicolon-separated tokens in any of the
-    forms the app shows a class in: a plain local name (``Person``), a prefixed
+    forms the app shows an entity in: a plain local name (``Person``), a prefixed
     name (``fn:zero``), the disambiguated display form (``zero (fn)``) or a full
     URI, optionally wrapped in ``<>`` or quotes. Matching is exact first, then
     case-insensitive. A plain local name shared by several namespaces selects
     all of them — the prefixed form picks just one.
 
-    Returns ``(uris, unmatched)``: the matched class URIs in class-list order
+    Returns ``(uris, unmatched)``: the matched URIs in entry-list order
     without repeats, and the tokens nothing matched, in input order. URIs rather
     than display labels, because the selection is stored by URI.
     """
@@ -6920,13 +6948,13 @@ def render_visualization():
             if cfg_key.removeprefix("_viz_cfg_") in _VIZ_PERSIST_KEYS:
                 st.session_state["_viz_settings_dirty"] = True
 
-        def _viz_class_filter_changed(uri_by_display):
-            """Persist the class filter by URI. The widget holds display labels,
-            which gain a namespace tag as soon as a second class takes the same
+        def _viz_filter_changed(kind_key, uri_by_display):
+            """Persist a node filter by URI. The widget holds display labels,
+            which gain a namespace tag as soon as a second entity takes the same
             local name — storing those would make the next render read the
             renamed entries as newly created and re-show hidden ones (#179)."""
-            picked = st.session_state.get("viz_selected_classes") or []
-            st.session_state["_viz_cfg_selected_class_uris"] = [
+            picked = st.session_state.get(f"viz_selected_{kind_key}") or []
+            st.session_state[f"_viz_cfg_selected_{kind_key}_uris"] = [
                 uri_by_display[d] for d in picked if d in uri_by_display
             ]
 
@@ -7100,12 +7128,9 @@ def render_visualization():
         # keyed by URI: a display label grows its namespace tag the moment a
         # second class takes the same local name, so a selection stored by label
         # would read as "these classes just appeared" and re-show a hidden one.
-        class_entries = build_class_filter_entries(classes) if classes else []
-        all_class_names = [e["display"] for e in class_entries]
-        all_class_set = set(all_class_names)
-        all_class_uris = [e["uri"] for e in class_entries]
-        display_by_uri = {e["uri"]: e["display"] for e in class_entries}
-        uri_by_display = {e["display"]: e["uri"] for e in class_entries}
+        # Every filterable kind is reconciled the same way, so the per-kind state
+        # lives in one dict keyed by the kind's key rather than a parallel set of
+        # variables per kind (issue #196).
         mutation = st.session_state.get("_ont_mutation_count", 0)
         edits = st.session_state.get("_ont_edit_count", 0)
         prev_mutation = st.session_state.get("_viz_cfg_seen_mutation")
@@ -7113,21 +7138,45 @@ def render_visualization():
         replaced = prev_mutation is not None and (mutation - prev_mutation) != (
             edits - prev_edits
         )
-        selected_class_uris, known_class_uris = reconcile_class_filter(
-            all_class_uris,
-            st.session_state.get("_viz_cfg_selected_class_uris"),
-            st.session_state.get("_viz_cfg_known_class_uris"),
-            replaced=replaced,
-        )
-        selected_classes_list = [display_by_uri[u] for u in selected_class_uris]
-        st.session_state["_viz_cfg_selected_class_uris"] = selected_class_uris
-        st.session_state["_viz_cfg_known_class_uris"] = known_class_uris
+        _kind_items = {"class": classes, "ind": individuals}
+        filters: dict[str, dict] = {}
+        for _kind in _FILTER_KINDS:
+            _key = _kind["key"]
+            _entries = build_filter_entries(_kind_items.get(_key) or [])
+            _sel_uris, _known_uris = reconcile_filter_selection(
+                [e["uri"] for e in _entries],
+                st.session_state.get(f"_viz_cfg_selected_{_key}_uris"),
+                st.session_state.get(f"_viz_cfg_known_{_key}_uris"),
+                replaced=replaced,
+            )
+            st.session_state[f"_viz_cfg_selected_{_key}_uris"] = _sel_uris
+            st.session_state[f"_viz_cfg_known_{_key}_uris"] = _known_uris
+            _display_by_uri = {e["uri"]: e["display"] for e in _entries}
+            _selected_displays = [_display_by_uri[u] for u in _sel_uris]
+            # The multiselect holds display labels; seed its widget value here so
+            # the reconciled selection is what it renders.
+            st.session_state[f"viz_selected_{_key}"] = _selected_displays
+            filters[_key] = {
+                "kind": _kind,
+                "entries": _entries,
+                "displays": [e["display"] for e in _entries],
+                "uris": [e["uri"] for e in _entries],
+                "display_by_uri": _display_by_uri,
+                "uri_by_display": {e["display"]: e["uri"] for e in _entries},
+                "selected_uris": _sel_uris,
+                "selected_displays": _selected_displays,
+            }
         st.session_state["_viz_cfg_seen_mutation"] = mutation
         st.session_state["_viz_cfg_seen_edits"] = edits
-        st.session_state["viz_selected_classes"] = selected_classes_list
-        # Display mirror of the URI selection, refreshed here on every render and
-        # never written to elsewhere. The focus-mode controls below read it to
-        # seed themselves from the current selection.
+
+        class_entries = filters["class"]["entries"]
+        all_class_names = filters["class"]["displays"]
+        selected_classes_list = filters["class"]["selected_displays"]
+        ind_entries = filters["ind"]["entries"]
+        selected_ind_uris = set(filters["ind"]["selected_uris"])
+        # Display mirror of the class selection, refreshed here on every render
+        # and never written to elsewhere. The focus-mode controls below read it
+        # to seed themselves from the current selection.
         st.session_state["_viz_cfg_selected_classes"] = selected_classes_list
 
         # Focus mode: centre the view on one node (class, individual or SKOS
@@ -7140,8 +7189,8 @@ def render_visualization():
             for e in class_entries:
                 focus_targets[f"Class: {e['display']}"] = _uid(e["uri"])
         if show_individuals:
-            for ind in individuals:
-                focus_targets[f"Individual: {ind['name']}"] = f"ind_{_uid(ind['uri'])}"
+            for e in ind_entries:
+                focus_targets[f"Individual: {e['display']}"] = f"ind_{_uid(e['uri'])}"
         if show_data_props:
             for prop in data_props:
                 focus_targets[f"Data Property: {prop['name']}"] = (
@@ -7176,26 +7225,31 @@ def render_visualization():
                 )
                 if _find_choice:
                     _find_id = focus_targets.get(_find_choice)
-                    # The target may currently be hidden — by the class display
-                    # filter, or pruned away in focus mode — in which case its
+                    # The target may currently be hidden — by one of the display
+                    # filters, or pruned away in focus mode — in which case its
                     # node isn't in the graph and the JS focus() would silently
                     # no-op (PR #144 review P2). On a fresh pick, reveal it:
-                    # restore a filtered-out class and, in focus mode, add it as
+                    # restore a filtered-out entity and, in focus mode, add it as
                     # a seed so the prune keeps it. Guarded by the find seq so
                     # this runs once per pick.
                     _cur_seq = st.session_state.get("_viz_find_seq", 0)
                     if st.session_state.get("_viz_find_revealed_seq") != _cur_seq:
                         st.session_state["_viz_find_revealed_seq"] = _cur_seq
-                        _kind, _, _name = _find_choice.partition(": ")
+                        _label, _, _name = _find_choice.partition(": ")
                         _reveal_rerun = False
-                        if _kind == "Class":
+                        # Every filterable kind can hide its entity, so look the
+                        # picked label up across them rather than only classes.
+                        for _fk in _FILTER_KINDS:
+                            if _label != _fk["singular"]:
+                                continue
+                            _key = _fk["key"]
+                            _uri = filters[_key]["uri_by_display"].get(_name)
                             _sel = list(
-                                st.session_state.get("_viz_cfg_selected_class_uris")
+                                st.session_state.get(f"_viz_cfg_selected_{_key}_uris")
                                 or []
                             )
-                            _uri = uri_by_display.get(_name)
                             if _uri and _uri not in _sel:
-                                st.session_state["_viz_cfg_selected_class_uris"] = (
+                                st.session_state[f"_viz_cfg_selected_{_key}_uris"] = (
                                     _sel + [_uri]
                                 )
                                 _reveal_rerun = True
@@ -7210,7 +7264,7 @@ def render_visualization():
                                 _reveal_rerun = True
                         if _reveal_rerun:
                             st.rerun()
-        with _filter_col.expander("Filter Classes", expanded=False):
+        with _filter_col.expander("Filter Nodes", expanded=False):
             focus_mode = st.checkbox(
                 "Focus on one node",
                 key="viz_focus_mode",
@@ -7275,77 +7329,142 @@ def render_visualization():
                 )
                 selected_classes = []
             else:
-                selected_classes = st.multiselect(
-                    "Select classes to display",
-                    options=all_class_names,
-                    help="Choose which classes to show in the graph. Empty shows "
-                    "no classes; use 'Select all' to bring them back.",
-                    key="viz_selected_classes",
-                    on_change=_viz_class_filter_changed,
-                    args=(uri_by_display,),
-                )
-                # An empty (or narrowed) filter hides classes and there is no
-                # native way back — offer a one-click restore (issue B3). Only
-                # shown when something is actually hidden.
-                if all_class_names and set(selected_classes) != all_class_set:
-                    if st.button(
-                        "Select all classes",
-                        key="viz_select_all_classes",
-                        help="Show every class in the graph again.",
-                    ):
-                        st.session_state["_viz_cfg_selected_class_uris"] = list(
-                            all_class_uris
-                        )
-                        st.rerun()
+                # One kind is edited at a time, chosen by a segmented control, so
+                # the panel stays the same height however many filterable kinds
+                # exist (issue #196). Each segment carries a "shown/total" count
+                # so a narrowing applied to a kind you're not looking at is still
+                # visible. Only kinds whose entity-type checkbox is on are
+                # offered — filtering something that isn't drawn is meaningless.
+                _toggles = {
+                    "show_classes": show_classes,
+                    "show_individuals": show_individuals,
+                }
+                _live = [
+                    f
+                    for f in filters.values()
+                    if _toggles.get(f["kind"]["toggle"]) and f["entries"]
+                ]
+                _by_key = {f["kind"]["key"]: f for f in _live}
 
-                # Picking a handful of classes out of a long multiselect is slow,
-                # and the selection is worth keeping — so the filter can also be
-                # driven by a pasted list, and prints the current one back in the
-                # same syntax to copy and restore later (issue #179).
-                _paste_text = st.text_area(
-                    "Or paste a class list",
-                    key="viz_class_paste",
-                    height=80,
-                    placeholder="Person Organization fn:zero",
-                    help="Separate names with spaces, commas or line breaks. "
-                    "Applying replaces the selection above. Names shared by "
-                    "several namespaces select all of them — write 'fn:zero' "
-                    "(or paste the full URI) to pick just one.",
-                )
-                if st.button(
-                    "Apply pasted list",
-                    key="viz_apply_class_paste",
-                    help="Show exactly the pasted classes.",
-                ):
-                    _pasted, _unknown = parse_class_filter_text(
-                        _paste_text, class_entries
+                def _seg_text(key):
+                    f = _by_key[key]
+                    shown, total = len(f["selected_uris"]), len(f["entries"])
+                    label = f["kind"]["label"]
+                    return label if shown == total else f"{label} {shown}/{total}"
+
+                if not _live:
+                    st.info("Enable Classes or Individuals above to filter them.")
+                    active = None
+                else:
+                    # Options are the stable kind keys and the count lives in
+                    # format_func, so a narrowing that rewrites the caption never
+                    # invalidates the widget's stored value.
+                    _prev = st.session_state.get("_viz_cfg_filter_kind")
+                    _picked = st.segmented_control(
+                        "Filter kind",
+                        options=list(_by_key),
+                        format_func=_seg_text,
+                        default=_prev if _prev in _by_key else next(iter(_by_key)),
+                        label_visibility="collapsed",
+                        key="viz_filter_kind",
                     )
-                    if _pasted:
-                        # The warning has to outlive the rerun that applies the
-                        # selection, so a partly matching paste still reports
-                        # what it dropped.
-                        st.session_state["_viz_class_paste_unknown"] = _unknown
-                        st.session_state["_viz_cfg_selected_class_uris"] = _pasted
-                        st.rerun()
-                    elif _unknown:
-                        st.warning(f"No class matched: {_fmt_unknown(_unknown)}")
-                    else:
-                        st.info("Paste one or more class names first.")
-                _unknown_last = st.session_state.pop("_viz_class_paste_unknown", None)
-                if _unknown_last:
-                    st.warning(f"Ignored, no such class: {_fmt_unknown(_unknown_last)}")
-                if selected_classes:
-                    _selected_uris = set(selected_class_uris)
-                    st.caption("Current selection — copy to restore it later:")
-                    st.code(
-                        " ".join(
-                            class_filter_token(e)
-                            for e in class_entries
-                            if e["uri"] in _selected_uris
-                        ),
-                        language=None,
-                        wrap_lines=True,
+                    active = _by_key.get(_picked) or _live[0]
+                    st.session_state["_viz_cfg_filter_kind"] = active["kind"]["key"]
+
+                if active is not None:
+                    _key = active["kind"]["key"]
+                    _noun = active["kind"]["noun"]
+                    _plural = active["kind"]["plural"]
+                    _entries = active["entries"]
+                    st.multiselect(
+                        f"Select {_plural} to display",
+                        options=active["displays"],
+                        help=f"Choose which {_plural} to show in the graph. Empty "
+                        f"shows none; use 'Select all' to bring them back.",
+                        key=f"viz_selected_{_key}",
+                        on_change=_viz_filter_changed,
+                        args=(_key, active["uri_by_display"]),
+                        label_visibility="collapsed",
+                        placeholder=f"No {_plural} shown — pick some, or Select all",
                     )
+                    _picked_uris = (
+                        st.session_state.get(f"_viz_cfg_selected_{_key}_uris") or []
+                    )
+                    _narrowed = len(_picked_uris) != len(_entries)
+                    _bcol1, _bcol2 = st.columns([1, 1])
+                    # An empty (or narrowed) filter hides nodes and there is no
+                    # native way back — offer a one-click restore (issue B3).
+                    with _bcol1:
+                        if st.button(
+                            "Select all",
+                            key=f"viz_select_all_{_key}",
+                            disabled=not _narrowed,
+                            use_container_width=True,
+                            help=f"Show every {_noun} in the graph again.",
+                        ):
+                            st.session_state[f"_viz_cfg_selected_{_key}_uris"] = list(
+                                active["uris"]
+                            )
+                            st.rerun()
+                    # Picking a handful out of a long multiselect is slow, and the
+                    # selection is worth keeping — so the filter can also be driven
+                    # by a pasted list, and prints the current one back in the same
+                    # syntax to copy and restore later (issue #179). It lives in a
+                    # popover so it costs one button rather than five rows.
+                    with _bcol2.popover("Paste / copy", use_container_width=True):
+                        _paste_text = st.text_area(
+                            f"Paste a list of {_plural}",
+                            key=f"viz_paste_{_key}",
+                            height=80,
+                            placeholder="Person Organization fn:zero",
+                            help="Separate names with spaces, commas or line "
+                            "breaks. Applying replaces the selection. Names "
+                            "shared by several namespaces select all of them — "
+                            "write 'fn:zero' (or paste the full URI) to pick "
+                            "just one.",
+                        )
+                        if st.button(
+                            "Apply pasted list",
+                            key=f"viz_apply_paste_{_key}",
+                            help=f"Show exactly the pasted {_plural}.",
+                        ):
+                            _pasted, _unknown = parse_filter_text(_paste_text, _entries)
+                            if _pasted:
+                                # The warning has to outlive the rerun that
+                                # applies the selection, so a partly matching
+                                # paste still reports what it dropped.
+                                st.session_state["_viz_paste_unknown"] = _unknown
+                                st.session_state[f"_viz_cfg_selected_{_key}_uris"] = (
+                                    _pasted
+                                )
+                                st.rerun()
+                            elif _unknown:
+                                st.warning(
+                                    f"No {_noun} matched: {_fmt_unknown(_unknown)}"
+                                )
+                            else:
+                                st.info(f"Paste one or more {_noun} names first.")
+                        _unknown_last = st.session_state.pop("_viz_paste_unknown", None)
+                        if _unknown_last:
+                            st.warning(
+                                f"Ignored, no such {_noun}: "
+                                f"{_fmt_unknown(_unknown_last)}"
+                            )
+                        if _picked_uris:
+                            _sel_set = set(_picked_uris)
+                            st.caption("Current selection — copy to restore it later:")
+                            st.code(
+                                " ".join(
+                                    filter_entry_token(e)
+                                    for e in _entries
+                                    if e["uri"] in _sel_set
+                                ),
+                                language=None,
+                                wrap_lines=True,
+                            )
+                # Authoritative regardless of which segment is on screen: the
+                # class filter still applies while you are editing another kind.
+                selected_classes = selected_classes_list
 
         # Persist the display preferences (entity toggles, spacing, fit, ...) so
         # they survive a reload (#142). Runs after every control has synced its
@@ -7356,12 +7475,16 @@ def render_visualization():
         selected_classes_key = (
             "_".join(sorted(selected_classes)) if selected_classes else "none"
         )
-        _graph_ver = 17  # Bump to invalidate cached graph data after code changes
+        # Narrowing the individuals filter has to invalidate the cached graph too.
+        selected_inds_key = (
+            "_".join(sorted(selected_ind_uris)) if selected_ind_uris else "none"
+        )
+        _graph_ver = 18  # Bump to invalidate cached graph data after code changes
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.
         ont_mutation = st.session_state.get("_ont_mutation_count", 0)
-        graph_key = f"v{_graph_ver}_m{ont_mutation}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{height}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}_{focus_mode}_{'-'.join(sorted(focus_seed_ids))}_{focus_depth}"
+        graph_key = f"v{_graph_ver}_m{ont_mutation}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{height}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}_{hash(selected_inds_key)}_{focus_mode}_{'-'.join(sorted(focus_seed_ids))}_{focus_depth}"
         if "last_graph_key" not in st.session_state:
             st.session_state.last_graph_key = None
             st.session_state.last_graph_data = None
@@ -7647,12 +7770,19 @@ def render_visualization():
 
             # Add individuals
             if show_individuals and individuals and node_count < max_nodes:
+                ind_collisions = _build_name_collision_set(individuals)
                 for ind in individuals:
                     if node_count >= max_nodes:
                         break
+                    # Individuals filter (issue #196). Focus mode builds the full
+                    # graph and prunes afterwards, so it ignores the filter the
+                    # same way the class one does.
+                    if not focus_mode and ind["uri"] not in selected_ind_uris:
+                        continue
                     ind_node_id = f"ind_{_uid(ind['uri'])}"
-                    label = ind["label"] if ind["label"] else ind["name"]
-                    title = f"Individual: {ind['name']}"
+                    disp_ind_name = _disambiguated_name(ind, ind_collisions)
+                    label = ind["label"] if ind["label"] else disp_ind_name
+                    title = f"Individual: {disp_ind_name}"
                     if ind["classes"]:
                         title += f"\nType: {', '.join(ind['classes'])}"
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -7360,6 +7360,13 @@ def render_visualization():
                     # format_func, so a narrowing that rewrites the caption never
                     # invalidates the widget's stored value.
                     _prev = st.session_state.get("_viz_cfg_filter_kind")
+                    # A kind can vanish under the selector — its entity-type
+                    # checkbox is turned off, or its last entity is deleted. The
+                    # widget's own stored value is validated against the options
+                    # too, so a stale one raises rather than falling back to the
+                    # default; drop it and let `default` re-seed the control.
+                    if st.session_state.get("viz_filter_kind") not in _by_key:
+                        st.session_state.pop("viz_filter_kind", None)
                     _picked = st.segmented_control(
                         "Filter kind",
                         options=list(_by_key),
@@ -7833,17 +7840,18 @@ def render_visualization():
                                     arrows="to",
                                 )
 
-                # Add edges between individuals (object property assertions)
+                # Add edges between individuals (object property assertions).
+                # Keyed on the assertion's target URI, not its local name: two
+                # individuals in different namespaces can share a name, and a
+                # name lookup would draw the edge to whichever of them happened
+                # to be seen last (PR #202 review).
                 if show_ind_edges:
-                    ind_uri_by_name: dict[str, str] = {
-                        ind["name"]: ind["uri"] for ind in individuals
-                    }
                     for ind in individuals:
                         src_node = f"ind_{_uid(ind['uri'])}"
                         if src_node not in displayed_ind_ids:
                             continue
                         for prop in ind.get("properties", []):
-                            target_uri = ind_uri_by_name.get(prop["value"])
+                            target_uri = prop.get("value_uri")
                             tgt_node = f"ind_{_uid(target_uri)}" if target_uri else ""
                             if tgt_node in displayed_ind_ids:
                                 net.add_edge(

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -1633,16 +1633,21 @@ class OntologyManager:
                     ind_info["classes"].append(self._local_name(class_uri))
                     ind_info["class_uris"].append(str(class_uri))
 
-            # Get property assertions
+            # Get property assertions. ``value`` is the local name for display;
+            # ``value_uri`` carries the full URI of an object value (empty for a
+            # literal) so callers can resolve the target unambiguously — two
+            # individuals in different namespaces can share a local name.
             for pred, obj in self.graph.predicate_objects(ind_uri):
                 if pred not in [RDF.type, RDFS.label, RDFS.comment]:
                     prop_name = self._local_name(pred)
-                    if isinstance(obj, URIRef):
-                        value = self._local_name(obj)
-                    else:
-                        value = str(obj)
+                    is_ref = isinstance(obj, URIRef)
+                    value = self._local_name(obj) if is_ref else str(obj)
                     ind_info["properties"].append(
-                        {"property": prop_name, "value": value}
+                        {
+                            "property": prop_name,
+                            "value": value,
+                            "value_uri": str(obj) if is_ref else "",
+                        }
                     )
 
             individuals.append(ind_info)

--- a/tests/test_individuals.py
+++ b/tests/test_individuals.py
@@ -21,3 +21,34 @@ def test_rename_individual(populated_om):
     names = [i["name"] for i in populated_om.get_individuals()]
     assert "alice_smith" in names
     assert "alice" not in names
+
+
+def test_property_assertion_exposes_the_target_uri(populated_om):
+    """Object values carry ``value_uri`` so callers can resolve them exactly.
+
+    ``value`` is only a local name, which two individuals in different
+    namespaces can share — resolving by it draws graph edges to the wrong one
+    (PR #202 review).
+    """
+    populated_om.add_prefix("other", "http://other.example.org/ns#")
+    populated_om.add_individual("bob", "Person")
+    populated_om.add_individual(
+        "bob", "Person", namespace="http://other.example.org/ns#"
+    )
+    populated_om.add_individual_property("alice", "knows", "bob")
+
+    alice = next(i for i in populated_om.get_individuals() if i["name"] == "alice")
+    knows = [p for p in alice["properties"] if p["property"] == "knows"]
+    assert len(knows) == 1
+    assert knows[0]["value"] == "bob"
+    # The base-namespace bob, not the one from the other namespace.
+    assert knows[0]["value_uri"] == str(populated_om.namespace["bob"])
+    assert "other.example.org" not in knows[0]["value_uri"]
+
+
+def test_literal_property_assertion_has_no_target_uri(populated_om):
+    populated_om.add_individual_property("alice", "age", 42, is_object_property=False)
+    alice = next(i for i in populated_om.get_individuals() if i["name"] == "alice")
+    age = next(p for p in alice["properties"] if p["property"] == "age")
+    assert age["value"] == "42"
+    assert age["value_uri"] == ""

--- a/tests/test_viz_class_filter.py
+++ b/tests/test_viz_class_filter.py
@@ -9,7 +9,7 @@ from orionbelt_ontology_builder import app
 
 def _reconcile(all_names, selected, known):
     """Run one render's reconciliation, returning the new (selected, known)."""
-    return app.reconcile_class_filter(all_names, selected, known)
+    return app.reconcile_filter_selection(all_names, selected, known)
 
 
 def test_first_render_selects_everything():
@@ -65,13 +65,15 @@ def test_overlapping_replacement_would_hide_classes_without_the_flag():
     # inherit that hidden state (review of #180). Diffing alone returns []...
     assert _reconcile(["B"], [], {"A", "B"})[0] == []
     # ...so the replacement flag forces "show everything".
-    selected, known = app.reconcile_class_filter(["B"], [], {"A", "B"}, replaced=True)
+    selected, known = app.reconcile_filter_selection(
+        ["B"], [], {"A", "B"}, replaced=True
+    )
     assert selected == ["B"]
     assert known == {"B"}
 
 
 def test_replaced_flag_ignores_prior_narrowing():
-    selected, _ = app.reconcile_class_filter(
+    selected, _ = app.reconcile_filter_selection(
         ["Person", "Org"], ["Org"], {"Person", "Org"}, replaced=True
     )
     assert selected == ["Person", "Org"]

--- a/tests/test_viz_class_paste.py
+++ b/tests/test_viz_class_paste.py
@@ -45,7 +45,7 @@ def prefixes(monkeypatch):
 
 @pytest.fixture
 def entries(prefixes):
-    return app.build_class_filter_entries(CLASSES)
+    return app.build_filter_entries(CLASSES)
 
 
 def _displays(entries):
@@ -80,14 +80,14 @@ def test_every_entry_carries_its_prefix(entries):
 
 def test_unprefixed_namespace_falls_back_to_the_namespace(monkeypatch):
     monkeypatch.setattr(app, "_prefix_for_uri", lambda uri: "")
-    entries = app.build_class_filter_entries(CLASSES[1:3])
+    entries = app.build_filter_entries(CLASSES[1:3])
     assert _displays(entries) == [f"zero ({FN})", f"zero ({MATH})"]
 
 
 def test_tokens_round_trip_through_the_parser(entries):
-    tokens = " ".join(app.class_filter_token(e) for e in entries)
+    tokens = " ".join(app.filter_entry_token(e) for e in entries)
     assert tokens == "Person fn:zero math:zero Organization"
-    assert app.parse_class_filter_text(tokens, entries) == (
+    assert app.parse_filter_text(tokens, entries) == (
         [e["uri"] for e in entries],
         [],
     )
@@ -95,8 +95,8 @@ def test_tokens_round_trip_through_the_parser(entries):
 
 def test_token_for_an_unprefixed_ambiguous_class_is_its_uri(monkeypatch):
     monkeypatch.setattr(app, "_prefix_for_uri", lambda uri: "")
-    entries = app.build_class_filter_entries(CLASSES[1:3])
-    assert [app.class_filter_token(e) for e in entries] == [f"{FN}zero", f"{MATH}zero"]
+    entries = app.build_filter_entries(CLASSES[1:3])
+    assert [app.filter_entry_token(e) for e in entries] == [f"{FN}zero", f"{MATH}zero"]
 
 
 def test_spaces_commas_semicolons_and_newlines_all_separate(entries):
@@ -107,90 +107,88 @@ def test_spaces_commas_semicolons_and_newlines_all_separate(entries):
         "Person\nOrganization",
         "  Person ,\n\n Organization  ",
     ):
-        assert app.parse_class_filter_text(text, entries) == (
+        assert app.parse_filter_text(text, entries) == (
             _uris("Person", "Organization"),
             [],
         )
 
 
 def test_result_follows_class_list_order_not_input_order(entries):
-    matched, _ = app.parse_class_filter_text("Organization Person", entries)
+    matched, _ = app.parse_filter_text("Organization Person", entries)
     assert matched == _uris("Person", "Organization")
 
 
 def test_repeated_names_are_listed_once(entries):
-    assert app.parse_class_filter_text("Person Person", entries)[0] == _uris("Person")
+    assert app.parse_filter_text("Person Person", entries)[0] == _uris("Person")
 
 
 def test_plain_ambiguous_name_selects_every_namespace(entries):
-    assert app.parse_class_filter_text("zero", entries)[0] == [
+    assert app.parse_filter_text("zero", entries)[0] == [
         f"{FN}zero",
         f"{MATH}zero",
     ]
 
 
 def test_prefixed_name_selects_one_namespace(entries):
-    assert app.parse_class_filter_text("fn:zero", entries)[0] == [f"{FN}zero"]
+    assert app.parse_filter_text("fn:zero", entries)[0] == [f"{FN}zero"]
 
 
 def test_prefixed_name_works_for_an_unambiguous_class(entries):
     # 'Person' is unique, so nothing forces the prefix — but pasting the
     # prefixed form back must still resolve (review of #179).
-    assert app.parse_class_filter_text("base:Person", entries)[0] == _uris("Person")
+    assert app.parse_filter_text("base:Person", entries)[0] == _uris("Person")
 
 
 def test_display_form_survives_being_split_on_whitespace(entries):
     # Copied straight out of the multiselect, "zero (math)" contains a space.
-    assert app.parse_class_filter_text("Person zero (math)", entries)[0] == [
+    assert app.parse_filter_text("Person zero (math)", entries)[0] == [
         f"{BASE}Person",
         f"{MATH}zero",
     ]
 
 
 def test_full_uri_selects_one_namespace(entries):
-    assert app.parse_class_filter_text(f"{FN}zero", entries)[0] == [f"{FN}zero"]
+    assert app.parse_filter_text(f"{FN}zero", entries)[0] == [f"{FN}zero"]
 
 
 def test_uri_in_angle_brackets_and_quotes(entries):
-    assert app.parse_class_filter_text(f"<{FN}zero>", entries)[0] == [f"{FN}zero"]
-    assert app.parse_class_filter_text("'Person'", entries)[0] == _uris("Person")
+    assert app.parse_filter_text(f"<{FN}zero>", entries)[0] == [f"{FN}zero"]
+    assert app.parse_filter_text("'Person'", entries)[0] == _uris("Person")
 
 
 def test_case_insensitive_fallback(entries):
-    assert app.parse_class_filter_text("person FN:ZERO", entries)[0] == [
+    assert app.parse_filter_text("person FN:ZERO", entries)[0] == [
         f"{BASE}Person",
         f"{FN}zero",
     ]
 
 
 def test_exact_case_wins_over_a_case_insensitive_match(prefixes):
-    entries = app.build_class_filter_entries(
+    entries = app.build_filter_entries(
         [
             {"name": "Person", "uri": f"{BASE}Person"},
             {"name": "person", "uri": f"{FN}person"},
         ]
     )
-    assert app.parse_class_filter_text("person", entries)[0] == [f"{FN}person"]
+    assert app.parse_filter_text("person", entries)[0] == [f"{FN}person"]
 
 
 def test_unknown_names_are_reported_and_the_rest_applied(entries):
-    matched, unknown = app.parse_class_filter_text(
-        "Person Nope Person Missing", entries
-    )
+    matched, unknown = app.parse_filter_text("Person Nope Person Missing", entries)
     assert matched == _uris("Person")
     assert unknown == ["Nope", "Missing"]
 
 
 def test_empty_text_matches_nothing(entries):
-    assert app.parse_class_filter_text("", entries) == ([], [])
-    assert app.parse_class_filter_text("   \n ", entries) == ([], [])
+    assert app.parse_filter_text("", entries) == ([], [])
+    assert app.parse_filter_text("   \n ", entries) == ([], [])
 
 
 def test_pasted_selection_reconciles_like_any_other(entries):
     # What Apply stores must survive the next render's reconciliation unchanged.
-    pasted, _ = app.parse_class_filter_text("Person fn:zero", entries)
+    pasted, _ = app.parse_filter_text("Person fn:zero", entries)
     all_uris = [e["uri"] for e in entries]
-    selected, known = app.reconcile_class_filter(all_uris, pasted, set(all_uris))
+    selected, known = app.reconcile_filter_selection(all_uris, pasted, set(all_uris))
     assert selected == [f"{BASE}Person", f"{FN}zero"]
     assert known == set(all_uris)
 
@@ -203,19 +201,19 @@ def test_a_new_namespace_twin_does_not_unhide_its_sibling(prefixes):
     ``zero (fn)`` and ``zero (math)`` as brand new and show the class the user
     had deliberately hidden — so the state is keyed by URI.
     """
-    before = app.build_class_filter_entries(CLASSES[:2])
+    before = app.build_filter_entries(CLASSES[:2])
     assert _displays(before) == ["Person", "zero"]
 
     # User hides 'zero', leaving just Person selected.
-    selected, known = app.reconcile_class_filter(
+    selected, known = app.reconcile_filter_selection(
         [e["uri"] for e in before], [f"{BASE}Person"], {f"{BASE}Person", f"{FN}zero"}
     )
     assert selected == [f"{BASE}Person"]
 
     # math:zero is imported; fn:zero is relabelled 'zero (fn)' but unchanged.
-    after = app.build_class_filter_entries(CLASSES[:3])
+    after = app.build_filter_entries(CLASSES[:3])
     assert _displays(after) == ["Person", "zero (fn)", "zero (math)"]
-    selected, known = app.reconcile_class_filter(
+    selected, known = app.reconcile_filter_selection(
         [e["uri"] for e in after], selected, known
     )
     # Only the genuinely new class joins; fn:zero stays hidden.

--- a/tests/test_viz_graph_edges.py
+++ b/tests/test_viz_graph_edges.py
@@ -218,3 +218,68 @@ def test_class_and_individual_filters_are_independent():
     assert _labels(nodes, "Individual") == ["acme"]
     assert "Organization" not in _labels(nodes, "Class")
     assert _dangling(nodes, edges) == []
+
+
+# --- Same-named individuals across namespaces (PR #202 review) --------------
+
+
+def _twin_script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_prefix("other", "http://other.example.org/ns#")
+        om.add_class("Person")
+        om.add_individual("alice", "Person")
+        om.add_individual("bob", "Person")
+        # A second bob, same local name, different namespace.
+        om.add_individual("bob", "Person", namespace="http://other.example.org/ns#")
+        # alice knows the *base* bob.
+        om.add_individual_property("alice", "knows", "bob")
+
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["_viz_settings_restored"] = True
+        for key in ("show_classes", "show_individuals", "show_ind_edges"):
+            st.session_state[f"_viz_cfg_{key}"] = True
+
+    app.render_visualization()
+
+
+def _twin_graph():
+    at = AppTest.from_function(_twin_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    data = at.session_state["last_graph_data"]
+    assert data, "the visualization built no graph"
+    return json.loads(data["nodes"]), json.loads(data["edges"])
+
+
+def test_same_named_individuals_are_separate_nodes():
+    nodes, _ = _twin_graph()
+    labels = _labels(nodes, "Individual")
+    assert labels[0] == "alice"
+    # Both bobs are present and namespace-tagged apart. The second one shows its
+    # bound prefix; the base namespace has none, so it falls back to the
+    # namespace itself.
+    bobs = labels[1:]
+    assert len(bobs) == 2 and all(b.startswith("bob (") for b in bobs)
+    assert sum(1 for b in bobs if b == "bob (other)") == 1
+
+
+def test_knows_edge_targets_the_right_namespace():
+    """Regression: the target was resolved by local name, so the edge could
+    land on whichever same-named individual was seen last."""
+    nodes, edges = _twin_graph()
+    assert _dangling(nodes, edges) == []
+    by_id = {n["id"]: n for n in nodes}
+    knows = [e for e in edges if e.get("label") == "knows"]
+    assert len(knows) == 1
+    assert by_id[knows[0]["from"]]["label"] == "alice"
+    # The base-namespace bob, not the one from the other namespace.
+    target = by_id[knows[0]["to"]]["label"]
+    assert target.startswith("bob (")
+    assert target != "bob (other)"

--- a/tests/test_viz_graph_edges.py
+++ b/tests/test_viz_graph_edges.py
@@ -70,13 +70,20 @@ def _script():
         ):
             st.session_state[f"_viz_cfg_{key}"] = True
 
-        if os.environ.get("HIDE_CLASSES"):
-            hidden = set(os.environ["HIDE_CLASSES"].split(","))
-            entries = app.build_class_filter_entries(om.get_classes())
-            st.session_state["_viz_cfg_selected_class_uris"] = [
+        for env, kind, items in (
+            ("HIDE_CLASSES", "class", om.get_classes()),
+            ("HIDE_INDS", "ind", om.get_individuals()),
+        ):
+            if not os.environ.get(env):
+                continue
+            hidden = set(os.environ[env].split(","))
+            entries = app.build_filter_entries(items)
+            st.session_state[f"_viz_cfg_selected_{kind}_uris"] = [
                 e["uri"] for e in entries if e["display"] not in hidden
             ]
-            st.session_state["_viz_cfg_known_class_uris"] = {e["uri"] for e in entries}
+            st.session_state[f"_viz_cfg_known_{kind}_uris"] = {
+                e["uri"] for e in entries
+            }
             st.session_state["_viz_cfg_seen_mutation"] = st.session_state.get(
                 "_ont_mutation_count", 0
             )
@@ -84,9 +91,10 @@ def _script():
     app.render_visualization()
 
 
-def _graph(hide_classes=None):
+def _graph(hide_classes=None, hide_inds=None):
     """Render the visualization once and return its (nodes, edges)."""
     os.environ["HIDE_CLASSES"] = ",".join(hide_classes or [])
+    os.environ["HIDE_INDS"] = ",".join(hide_inds or [])
     at = AppTest.from_function(_script)
     at.run(timeout=120)
     assert not at.exception, at.exception
@@ -165,3 +173,48 @@ def test_hiding_one_of_two_same_named_classes_keeps_the_other_linked():
     person_id = persons[0]["id"]
     assert any(e["to"] == person_id and e.get("label") == "subClassOf" for e in edges)
     assert any(e["from"] == person_id and e["to"].startswith("ann_") for e in edges)
+
+
+# --- Individuals filter (issue #196) ---------------------------------------
+
+
+def _labels(nodes, ntype):
+    return sorted(str(n.get("label")) for n in nodes if n.get("ntype") == ntype)
+
+
+def test_individuals_all_shown_by_default(graph):
+    nodes, _ = graph
+    assert _labels(nodes, "Individual") == ["acme", "alice"]
+
+
+def test_hiding_an_individual_removes_only_that_node():
+    nodes, edges = _graph(hide_inds=["acme"])
+    assert _labels(nodes, "Individual") == ["alice"]
+    assert _dangling(nodes, edges) == []
+    # alice's worksFor assertion pointed at acme, so the individual-to-individual
+    # edge has to go with it. (The Triples view still draws its own edge to a
+    # generic triple node for the same statement — that is its job.)
+    ind_ids = {n["id"] for n in nodes if n["id"].startswith("ind_")}
+    assert not any(
+        e["from"] in ind_ids and e["to"] in ind_ids and e.get("label") == "worksFor"
+        for e in edges
+    )
+    # Her own type edge and annotation survive.
+    assert any(e["from"].startswith("ind_") and e.get("label") == "type" for e in edges)
+    assert any(
+        e["from"].startswith("ind_") and e["to"].startswith("ann_") for e in edges
+    )
+
+
+def test_hiding_every_individual_leaves_the_classes_intact():
+    nodes, edges = _graph(hide_inds=["alice", "acme"])
+    assert _labels(nodes, "Individual") == []
+    assert _dangling(nodes, edges) == []
+    assert _labels(nodes, "Class")
+
+
+def test_class_and_individual_filters_are_independent():
+    nodes, edges = _graph(hide_classes=["Organization"], hide_inds=["alice"])
+    assert _labels(nodes, "Individual") == ["acme"]
+    assert "Organization" not in _labels(nodes, "Class")
+    assert _dangling(nodes, edges) == []


### PR DESCRIPTION
Closes #196

## What

The Visualization filter only covered classes. Individuals were all-or-nothing via the entity-type checkbox, and while Find-and-centre already listed them, it could never reveal a hidden one because nothing could hide one.

## The panel shape

Rather than stack a second block of controls under the first, the panel edits one kind at a time, picked by a segmented control. The height is constant however many kinds exist, so a future Data Properties or SKOS filter costs one segment rather than five more rows.

Before, nine rows:

```
▼ Filter Classes
  ☐ Focus on one node
  Select classes to display
  [Person ×] [Organization ×]          ▾
  ( Select all classes )
  Or paste a class list
  [                                    ]
  [                                    ]
  ( Apply pasted list )
  Current selection — copy to restore it later:
  ┌────────────────────────────────────┐
  │ Person Organization                │
  └────────────────────────────────────┘
```

After, five, with the new filter in it:

```
▼ Filter Nodes
  ☐ Focus on one node
  [ Classes │ Individuals 2/5 ]
  [alice ×] [acme ×]                   ▾
  ( Select all )   ( Paste / copy )
```

Measured in the browser: 265px, versus 303px for the class-only panel it replaces.

What buys the room is moving the paste/copy affordance added in #179 into a popover behind one button. The trade-off is that the copyable token string is now a click away rather than on screen; it is a save/restore affordance rather than something you read at a glance, so that seems the right place for it.

Each segment shows a "shown/total" count when that kind is narrowed, so a filter applied to a kind you are not currently looking at stays visible. Only kinds whose entity-type checkbox is on are offered, since filtering something that is not drawn is meaningless.

## Implementation

The filter helpers were already generic over `{name, uri}` entries and never looked at anything class-specific, so they only needed renaming: `build_class_filter_entries` -> `build_filter_entries`, `parse_class_filter_text` -> `parse_filter_text`, `class_filter_token` -> `filter_entry_token`, `reconcile_class_filter` -> `reconcile_filter_selection`.

Per-kind state lives in one dict keyed by kind rather than parallel variables per kind, driven by a `_FILTER_KINDS` descriptor list. The Find-reveal branch walks those kinds instead of special-casing `Class`. Individual labels are namespace-disambiguated the same way class labels are, so two individuals sharing a local name are separately selectable.

The segmented control uses stable kind keys as its options with the count rendered via `format_func`. That matters: with the count baked into the option strings, a narrowing rewrites the stored widget value out of existence and the control breaks. I confirmed that failure mode before settling on `format_func`.

Because #201 made every edge gate on the nodes actually emitted, hiding an individual takes its type links, object-property assertions and annotations with it for free.

## Testing

- Four new cases in `tests/test_viz_graph_edges.py`: individuals shown by default, hiding one removes only that node and leaves no dangling edges, hiding all of them leaves the classes intact, and the two filters are independent.
- 683 tests pass, ruff format/check and mypy clean.
- Verified live end to end: switching segments, narrowing by multiselect, pasting `alice, acme\nnobody` (applies both, reports `Ignored, no such individual: nobody`), Select all, and Find-and-centre on the hidden `carol`, which reveals her, adds her to the graph and centres the camera on her node. Focus mode still builds the full graph and prunes, ignoring both filters as before. Zero dangling edges throughout.

Note: `st.segmented_control` cannot be driven through `AppTest` (its test harness iterates the value as a list and fails), so the segment switching itself is covered by the live check rather than a unit test. The filter state it selects between is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)