### PR TITLE
fix: pin the ruff lint rule set so version bumps do not widen it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,13 @@ Repository = "https://github.com/ralforion/orionbelt-ontology-builder"
 Issues = "https://github.com/ralforion/orionbelt-ontology-builder/issues"
 Demo = "https://orionbelt.streamlit.app"
 
+[tool.ruff.lint]
+# The rule set the project has always linted against. Ruff up to 0.15.x applied
+# exactly these by default, so this was implicit; 0.16.0 widened the default to
+# ~35 rule families, which would have changed what CI enforces as a side effect
+# of a Dependabot bump. Pinning it keeps lint scope a deliberate choice.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.mypy]
 python_version = "3.12"
 ignore_missing_imports = true


### PR DESCRIPTION
## Problem

Dependabot PR #205 (ruff 0.15.22 -> 0.16.0) fails CI with 391 lint findings, none of which come from a code change.

The repo has no `[tool.ruff.lint]` config, so it relies on ruff's default rule selection. Up to 0.15.x that default was `E4`, `E7`, `E9`, `F`. Ruff 0.16.0 widens the default to roughly 35 rule families (UP, BLE, S, SIM, RUF, I, PL, ...), so bumping the pinned linter silently changes what CI enforces.

Top contributors to the 391: UP006 (167), UP045 (70), BLE001 (49), I001 (28).

## Fix

Declare the four groups explicitly in `pyproject.toml`. Behaviour is unchanged on the currently pinned 0.15.22, and #205 becomes mergeable.

## Verification

Both `ruff check` and `ruff format --check` over the CI target set:

- ruff 0.15.22: all checks passed
- ruff 0.16.0: all checks passed, 67 files already formatted
- `uv run mypy`: success, no issues in 66 source files

## Follow-up

Adopting some of ruff's new default rules is worthwhile but is a separate, code-touching change (286 of the 391 are auto-fixable). Not bundled here.