### PR TITLE
chore: adopt ruff's full default rule set alongside the 0.16.0 bump

### DIFF
--- a/ontology_manager.py
+++ b/ontology_manager.py
@@ -5,15 +5,15 @@ keeps working. New code should prefer
 `from orionbelt_ontology_builder.ontology_manager import ...`.
 """
 
-from orionbelt_ontology_builder.ontology_manager import *  # noqa: F401, F403
+from orionbelt_ontology_builder.ontology_manager import *
 from orionbelt_ontology_builder.ontology_manager import (  # noqa: F401
-    IMPORT_REPLACE,
+    _DOMAIN_INCLUDES,
+    _GIST,
+    _RANGE_INCLUDES,
+    _SCHEMA,
     IMPORT_MERGE,
     IMPORT_MERGE_OVERWRITE,
+    IMPORT_REPLACE,
     OntologyManager,
     UndoManager,
-    _SCHEMA,
-    _GIST,
-    _DOMAIN_INCLUDES,
-    _RANGE_INCLUDES,
 )

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -7,11 +7,12 @@ import hashlib
 import json
 import logging
 import re
-import streamlit as st
 import time
 import traceback
 from datetime import datetime
 from pathlib import Path as _Path
+
+import streamlit as st
 
 from . import local_store
 
@@ -1038,7 +1039,8 @@ def save_checkpoint(label: str = "Edit"):
 def log_error(error: Exception, context: str = ""):
     """Log a runtime error to session state for display."""
     entry = {
-        "time": datetime.now().strftime("%H:%M:%S"),
+        # Local wall-clock time: the log is read by whoever is at the app.
+        "time": datetime.now().astimezone().strftime("%H:%M:%S"),
         "context": context,
         "error": str(error),
         "traceback": traceback.format_exc(),
@@ -1500,7 +1502,7 @@ def _external_uri_target(ont, default_uri, key, label):
     ).strip()
     if not ext:
         return default_uri, None
-    if not (ext.startswith("http://") or ext.startswith("https://")):
+    if not ext.startswith(("http://", "https://")):
         return default_uri, "External URI must be a full http(s) URI."
     if reason := ont.invalid_name_reason(ext):
         return default_uri, reason
@@ -1527,10 +1529,13 @@ def _apply_class_edit(
     without a namespace selector). Shows an error and returns False if the target
     URI is already taken. The caller owns the undo checkpoint and rerun.
     """
-    if new_name and new_name != class_info["name"]:
-        if reason := ont.invalid_name_reason(new_name):
-            show_message(reason, "error")
-            return False
+    if (
+        new_name
+        and new_name != class_info["name"]
+        and (reason := ont.invalid_name_reason(new_name))
+    ):
+        show_message(reason, "error")
+        return False
     ok, current_ref = _rename_or_move(
         ont,
         ont.rename_class,
@@ -1839,12 +1844,11 @@ def render_dashboard():
         new_import = st.text_input(
             "Import URI", placeholder="http://example.org/other-ontology"
         )
-        if st.button("Add Import"):
-            if new_import:
-                ont.add_import(new_import)
-                save_checkpoint("Add import")
-                show_message(f"Import added: {new_import}", "success")
-                st.rerun()
+        if st.button("Add Import") and new_import:
+            ont.add_import(new_import)
+            save_checkpoint("Add import")
+            show_message(f"Import added: {new_import}", "success")
+            st.rerun()
 
     # Prefixes section
     st.subheader("Namespace Prefixes")
@@ -2901,10 +2905,13 @@ def render_properties():
                                 )
 
                             if st.form_submit_button("Save Changes"):
-                                if new_name and new_name != prop["name"]:
-                                    if reason := ont.invalid_name_reason(new_name):
-                                        show_message(reason, "error")
-                                        st.rerun()
+                                if (
+                                    new_name
+                                    and new_name != prop["name"]
+                                    and (reason := ont.invalid_name_reason(new_name))
+                                ):
+                                    show_message(reason, "error")
+                                    st.rerun()
                                 # Rename/move first so later updates hit the new URI.
                                 ok, current_ref = _rename_or_move(
                                     ont,
@@ -3106,10 +3113,13 @@ def render_properties():
                                 )
 
                             if st.form_submit_button("Save Changes"):
-                                if new_name and new_name != prop["name"]:
-                                    if reason := ont.invalid_name_reason(new_name):
-                                        show_message(reason, "error")
-                                        st.rerun()
+                                if (
+                                    new_name
+                                    and new_name != prop["name"]
+                                    and (reason := ont.invalid_name_reason(new_name))
+                                ):
+                                    show_message(reason, "error")
+                                    st.rerun()
                                 # Rename/move first so later updates hit the new URI.
                                 ok, current_ref = _rename_or_move(
                                     ont,
@@ -3644,10 +3654,13 @@ def render_individuals():
                                 )
 
                             if st.form_submit_button("Save Changes"):
-                                if new_name and new_name != ind["name"]:
-                                    if reason := ont.invalid_name_reason(new_name):
-                                        show_message(reason, "error")
-                                        st.rerun()
+                                if (
+                                    new_name
+                                    and new_name != ind["name"]
+                                    and (reason := ont.invalid_name_reason(new_name))
+                                ):
+                                    show_message(reason, "error")
+                                    st.rerun()
                                 # Rename/move first so later updates hit the new URI.
                                 ok, current_ref = _rename_or_move(
                                     ont,
@@ -4151,7 +4164,7 @@ def render_add_restriction(ont, classes, properties):
                 show_message("Restriction added!", "success")
                 st.rerun()
             except Exception as e:
-                show_message(f"Error adding restriction: {str(e)}", "error")
+                show_message(f"Error adding restriction: {e!s}", "error")
 
 
 def render_restrictions():
@@ -4919,7 +4932,7 @@ def render_annotations():
             # Filter by resource type
             col1, col2 = st.columns([1, 3])
             with col1:
-                filter_types = ["All"] + list(set(r["type"] for r in all_resources))
+                filter_types = ["All"] + list({r["type"] for r in all_resources})
                 selected_type = st.selectbox(
                     "Filter by Type", options=filter_types, key="filter_type"
                 )
@@ -5188,10 +5201,13 @@ def render_skos_vocabulary():
                                 key=f"custom_uri_scheme_{_sk}",
                             )
                             if st.form_submit_button("Save Changes"):
-                                if new_name and new_name != scheme["name"]:
-                                    if reason := ont.invalid_name_reason(new_name):
-                                        show_message(reason, "error")
-                                        st.rerun()
+                                if (
+                                    new_name
+                                    and new_name != scheme["name"]
+                                    and (reason := ont.invalid_name_reason(new_name))
+                                ):
+                                    show_message(reason, "error")
+                                    st.rerun()
                                 renamed = bool(new_name and new_name != scheme["name"])
                                 # Address the scheme by its actual URI so a scheme
                                 # in a non-base namespace resolves; target is the
@@ -5469,10 +5485,13 @@ def render_skos_vocabulary():
                             if st.form_submit_button("Save Changes"):
                                 # Rename first (updates all references) so the
                                 # rest of the update targets the new name.
-                                if new_name and new_name != concept["name"]:
-                                    if reason := ont.invalid_name_reason(new_name):
-                                        show_message(reason, "error")
-                                        st.rerun()
+                                if (
+                                    new_name
+                                    and new_name != concept["name"]
+                                    and (reason := ont.invalid_name_reason(new_name))
+                                ):
+                                    show_message(reason, "error")
+                                    st.rerun()
                                 renamed = bool(new_name and new_name != concept["name"])
                                 # Address the concept by its actual URI so a
                                 # concept in a non-base namespace (e.g. moved via
@@ -5512,12 +5531,12 @@ def render_skos_vocabulary():
                                         else None
                                     )
 
-                                    _update_kwargs = dict(
-                                        new_pref_label=new_pref,
-                                        new_definition=new_def,
-                                        add_scheme=add_s,
-                                        remove_scheme=remove_s,
-                                    )
+                                    _update_kwargs = {
+                                        "new_pref_label": new_pref,
+                                        "new_definition": new_def,
+                                        "add_scheme": add_s,
+                                        "remove_scheme": remove_s,
+                                    }
                                     if broader_changed:
                                         _update_kwargs["new_broader"] = broader_val
                                     ont.update_concept(target, **_update_kwargs)
@@ -5710,7 +5729,7 @@ def render_import_export():
                 )
                 st.rerun()
             except Exception as e:
-                show_message(f"Error importing ontology: {str(e)}", "error")
+                show_message(f"Error importing ontology: {e!s}", "error")
 
         # Step 1: Source selection (only when no preview active)
         if st.session_state.import_preview is None:
@@ -5757,7 +5776,7 @@ def render_import_export():
                                 st.session_state.import_format = format_
                                 st.rerun()
                         except Exception as e:
-                            show_message(f"Error parsing file: {str(e)}", "error")
+                            show_message(f"Error parsing file: {e!s}", "error")
 
             else:
                 content = st.text_area("Paste Ontology Content", height=300)
@@ -5780,7 +5799,7 @@ def render_import_export():
                                 st.session_state.import_format = format_
                                 st.rerun()
                         except Exception as e:
-                            show_message(f"Error parsing content: {str(e)}", "error")
+                            show_message(f"Error parsing content: {e!s}", "error")
 
         # Step 2: Review panel
         else:
@@ -5794,9 +5813,9 @@ def render_import_export():
 
             # Import mode selector
             from .ontology_manager import (
-                IMPORT_REPLACE,
                 IMPORT_MERGE,
                 IMPORT_MERGE_OVERWRITE,
+                IMPORT_REPLACE,
             )
 
             strategy = st.radio(
@@ -5871,7 +5890,7 @@ def render_import_export():
                         )
                         st.rerun()
                     except Exception as e:
-                        show_message(f"Error applying import: {str(e)}", "error")
+                        show_message(f"Error applying import: {e!s}", "error")
             with col_cancel:
                 if st.button("Cancel"):
                     st.session_state.import_preview = None
@@ -5973,7 +5992,7 @@ def render_import_export():
                 st.session_state["_export_ext"] = ext
             except Exception as e:
                 st.session_state.pop("_export_content", None)
-                show_message(f"Error exporting ontology: {str(e)}", "error")
+                show_message(f"Error exporting ontology: {e!s}", "error")
 
         # Kept in session_state so the save/download controls (which each cause a
         # rerun) still have the generated content.
@@ -6031,7 +6050,7 @@ def render_import_export():
                     st.rerun()
 
     if _ie_tab == "Templates":
-        from .templates import get_template_names, get_template, render_template
+        from .templates import get_template, get_template_names, render_template
 
         def _on_apply_template():
             selected = st.session_state.template_select
@@ -6088,8 +6107,8 @@ def render_import_export():
 
     if _ie_tab == "Upper Ontologies":
         from .templates import (
-            get_upper_ontology_names,
             get_upper_ontology,
+            get_upper_ontology_names,
             load_upper_ontology_module,
         )
 
@@ -6124,7 +6143,7 @@ def render_import_export():
                 )
             except Exception as e:
                 st.session_state["_upper_onto_err"] = (
-                    f"Error loading upper ontology: {str(e)}"
+                    f"Error loading upper ontology: {e!s}"
                 )
 
         st.subheader("Upper Ontologies")
@@ -6180,8 +6199,8 @@ def render_import_export():
 
     if _ie_tab == "Reference Ontologies":
         from .templates import (
-            get_reference_ontology_names,
             get_reference_ontology,
+            get_reference_ontology_names,
             load_reference_ontology_module,
         )
 
@@ -6218,7 +6237,7 @@ def render_import_export():
                 )
             except Exception as e:
                 st.session_state["_ref_onto_err"] = (
-                    f"Error loading reference ontology: {str(e)}"
+                    f"Error loading reference ontology: {e!s}"
                 )
 
         st.subheader("Reference Ontologies")
@@ -6628,7 +6647,7 @@ def render_validation():
                 )
                 st.write(f"New triple count: {len(ont.graph)}")
             except Exception as e:
-                show_message(f"Error during reasoning: {str(e)}", "error")
+                show_message(f"Error during reasoning: {e!s}", "error")
 
 
 def build_class_hierarchy_text(classes):
@@ -7539,7 +7558,7 @@ def render_visualization():
             class _GraphBuilder:
                 """Minimal replacement for pyvis.Network — just collects nodes/edges."""
 
-                __slots__ = ("nodes", "edges", "_node_ids", "options")
+                __slots__ = ("_node_ids", "edges", "nodes", "options")
 
                 def __init__(self):
                     self.nodes = []
@@ -8060,7 +8079,8 @@ def render_visualization():
 
             # Add raw RDF triples for visible nodes
             if show_triples and node_count < max_nodes:
-                from rdflib import URIRef as _URIRef, Literal as _Literal
+                from rdflib import Literal as _Literal
+                from rdflib import URIRef as _URIRef
 
                 # Build URI → node_id mapping over the nodes actually emitted,
                 # so a triple edge always has a real subject to hang off.
@@ -8243,7 +8263,7 @@ def render_visualization():
 
             except Exception as e:
                 status.empty()
-                st.error(f"Error building graph: {str(e)}")
+                st.error(f"Error building graph: {e!s}")
 
         # Always display the graph component (even on rerun after selection)
         gdata = st.session_state.get("last_graph_data")
@@ -8260,9 +8280,10 @@ def render_visualization():
             import hashlib as _hashlib
 
             try:
-                _gv_src = open(
+                with open(
                     _os.path.join(_component_path, "index.html"), encoding="utf-8"
-                ).read()
+                ) as _gv_fh:
+                    _gv_src = _gv_fh.read()
                 _gv_ver = _hashlib.md5(_gv_src.encode("utf-8")).hexdigest()[:8]
             except OSError:
                 _gv_ver = "0"
@@ -8459,13 +8480,12 @@ def render_visualization():
                             data_props,
                             individuals,
                         )
-                        if show_view:
-                            if st.button(
-                                "Open full editor" if ntype == "Class" else "Open",
-                                key="panel_open_editor",
-                                use_container_width=True,
-                            ):
-                                _open_full_editor(ntype, ename)
+                        if show_view and st.button(
+                            "Open full editor" if ntype == "Class" else "Open",
+                            key="panel_open_editor",
+                            use_container_width=True,
+                        ):
+                            _open_full_editor(ntype, ename)
             else:
                 # Status bar under the graph (shown when the panel is hidden).
                 if has_selection:
@@ -8827,11 +8847,12 @@ def main():
     # Visualization panel / status bar (issue #80).
     if selection == "Visualization":
         st.session_state.pop("_back_to_viz", None)
-    elif st.session_state.get("_back_to_viz"):
-        if st.button("← Back to graph", key="back_to_viz"):
-            st.session_state.pop("_back_to_viz", None)
-            st.session_state.search_navigate_to = "Visualization"
-            st.rerun()
+    elif st.session_state.get("_back_to_viz") and st.button(
+        "← Back to graph", key="back_to_viz"
+    ):
+        st.session_state.pop("_back_to_viz", None)
+        st.session_state.search_navigate_to = "Visualization"
+        st.rerun()
 
     # Show any flash message from a previous action (set_flash_message), for
     # every page rather than only Import/Export, so bulk-add results and delete

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -6,12 +6,13 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from rdflib import Graph, Namespace, URIRef, Literal, BNode
-from rdflib.namespace import RDF, RDFS, OWL, XSD, SKOS, DC, DCTERMS
-from rdflib.term import Node
-from rdflib.collection import Collection
-from typing import Optional, List, Dict, Tuple, Any, Set, cast
+from typing import Any, ClassVar, cast
+
 import owlrl
+from rdflib import BNode, Graph, Literal, Namespace, URIRef
+from rdflib.collection import Collection
+from rdflib.namespace import DC, DCTERMS, OWL, RDF, RDFS, SKOS, XSD
+from rdflib.term import Node
 
 #: RDF serialization format for a file, keyed by lower-case extension. Used so a
 #: linked working file can be a format other than Turtle (e.g. .owl/.rdf).
@@ -36,8 +37,8 @@ def rdf_format_for_path(path, default: str = "turtle") -> str:
 _UNSET: Any = object()  # sentinel: "parameter not provided"
 
 # A triple and a list of (old_triple, new_triple) rename operations.
-_Triple = Tuple[Node, Node, Node]
-_TripleUpdates = List[Tuple[_Triple, _Triple]]
+_Triple = tuple[Node, Node, Node]
+_TripleUpdates = list[tuple[_Triple, _Triple]]
 
 # domainIncludes/rangeIncludes from Schema.org and gist
 _SCHEMA = Namespace("https://schema.org/")
@@ -55,7 +56,7 @@ class OntologyManager:
     """Manages OWL ontology operations including CRUD for classes, properties, individuals, and restrictions."""
 
     # Common XSD datatypes for data properties
-    XSD_DATATYPES = {
+    XSD_DATATYPES: ClassVar[dict[str, URIRef]] = {
         "string": XSD.string,
         "integer": XSD.integer,
         "float": XSD.float,
@@ -71,7 +72,7 @@ class OntologyManager:
     }
 
     # Restriction types
-    RESTRICTION_TYPES = {
+    RESTRICTION_TYPES: ClassVar[dict[str, URIRef]] = {
         "someValuesFrom": OWL.someValuesFrom,
         "allValuesFrom": OWL.allValuesFrom,
         "hasValue": OWL.hasValue,
@@ -103,7 +104,7 @@ class OntologyManager:
         # Tracked so the creation picker offers them even when the name collides
         # with one of rdflib's auto-bound defaults (e.g. an explicit 'foaf').
         # Reset on load/restore so it can never go stale against the graph.
-        self._user_added_prefixes: Dict[str, str] = {}
+        self._user_added_prefixes: dict[str, str] = {}
 
         # Create ontology declaration
         self.ontology_uri = URIRef(base_uri.rstrip("#").rstrip("/"))
@@ -145,14 +146,22 @@ class OntologyManager:
         """Remove an owl:imports declaration."""
         self.graph.remove((self.ontology_uri, OWL.imports, URIRef(import_uri)))
 
-    def get_imports(self) -> List[str]:
+    def get_imports(self) -> list[str]:
         """Get all owl:imports URIs."""
         return [str(o) for o in self.graph.objects(self.ontology_uri, OWL.imports)]
 
     # Standard prefixes that cannot be removed
-    STANDARD_PREFIXES = {"owl", "rdf", "rdfs", "xsd", "skos", "dc", "dcterms"}
+    STANDARD_PREFIXES: ClassVar[set[str]] = {
+        "owl",
+        "rdf",
+        "rdfs",
+        "xsd",
+        "skos",
+        "dc",
+        "dcterms",
+    }
 
-    def get_prefixes(self) -> List[Dict[str, str]]:
+    def get_prefixes(self) -> list[dict[str, str]]:
         """Get namespace prefixes from the graph bindings and loaded declarations."""
         prefixes = []
         seen = set()
@@ -174,7 +183,7 @@ class OntologyManager:
         prefixes.sort(key=lambda x: "" if x["prefix"] == "(default)" else x["prefix"])
         return prefixes
 
-    def get_all_prefixes(self) -> List[Dict[str, str]]:
+    def get_all_prefixes(self) -> list[dict[str, str]]:
         """Get all namespace prefix bindings with source classification."""
         prefixes = []
         for prefix, ns in self.graph.namespaces():
@@ -232,7 +241,7 @@ class OntologyManager:
             new_graph.bind(p, ns, override=True)
         self.graph = new_graph
 
-    def _extract_prefixes_from_ttl(self, data: str) -> List[Dict[str, str]]:
+    def _extract_prefixes_from_ttl(self, data: str) -> list[dict[str, str]]:
         """Extract @prefix declarations from TTL content."""
         import re
 
@@ -249,11 +258,11 @@ class OntologyManager:
         prefixes.sort(key=lambda x: "" if x["prefix"] == "(default)" else x["prefix"])
         return prefixes
 
-    def _extract_prefixes_from_jsonld(self, data: str) -> List[Dict[str, str]]:
+    def _extract_prefixes_from_jsonld(self, data: str) -> list[dict[str, str]]:
         """Extract prefix declarations from JSON-LD @context."""
         import json
 
-        prefixes: List[Dict[str, str]] = []
+        prefixes: list[dict[str, str]] = []
         try:
             doc = json.loads(data)
         except (json.JSONDecodeError, TypeError):
@@ -274,7 +283,7 @@ class OntologyManager:
                 if key.startswith("@"):
                     continue
                 if isinstance(value, str) and (
-                    value.startswith("http://") or value.startswith("https://")
+                    value.startswith(("http://", "https://"))
                 ):
                     prefixes.append(
                         {
@@ -285,7 +294,7 @@ class OntologyManager:
         prefixes.sort(key=lambda x: "" if x["prefix"] == "(default)" else x["prefix"])
         return prefixes
 
-    def get_ontology_metadata(self) -> Dict[str, str]:
+    def get_ontology_metadata(self) -> dict[str, str]:
         """Get ontology-level metadata."""
         metadata = {}
         for pred, key in [
@@ -350,7 +359,7 @@ class OntologyManager:
         # Re-bind the default namespace
         self.graph.bind("", self.namespace)
 
-    def _uri(self, local_name: str, namespace: Optional[str] = None) -> URIRef:
+    def _uri(self, local_name: str, namespace: str | None = None) -> URIRef:
         """Create a URI from a local name.
 
         A value that is already a full ``http(s)`` URI is returned unchanged.
@@ -358,7 +367,7 @@ class OntologyManager:
         (any bound namespace, e.g. a custom prefix), or in the base namespace
         by default.
         """
-        if local_name.startswith("http://") or local_name.startswith("https://"):
+        if local_name.startswith(("http://", "https://")):
             return URIRef(local_name)
         if namespace:
             return URIRef(namespace + local_name)
@@ -380,7 +389,7 @@ class OntologyManager:
     _INVALID_URI_CHARS = frozenset('<>"{}|\\^`')
 
     @classmethod
-    def invalid_name_reason(cls, name: str) -> Optional[str]:
+    def invalid_name_reason(cls, name: str) -> str | None:
         """Return a human-readable reason ``name`` is not a valid entity name,
         or ``None`` if it is valid.
 
@@ -392,7 +401,7 @@ class OntologyManager:
         """
         if name is None or not name.strip():
             return "Name cannot be empty."
-        if name.startswith("http://") or name.startswith("https://"):
+        if name.startswith(("http://", "https://")):
             if any(c.isspace() or c in cls._INVALID_URI_CHARS for c in name):
                 return (
                     "A full URI cannot contain spaces or any of the characters "
@@ -401,7 +410,7 @@ class OntologyManager:
             return None
         # Name the specific disallowed characters so a comma (or any other
         # punctuation) is reported, not just the first problem found.
-        bad: List[str] = []
+        bad: list[str] = []
         for c in name:
             if not cls._LOCAL_NAME_CHAR_RE.match(c):
                 token = "spaces" if c.isspace() else f"'{c}'"
@@ -447,7 +456,7 @@ class OntologyManager:
     # stays correct across versions.
     _RDFLIB_DEFAULT_PREFIXES = frozenset(p for p, _ in Graph().namespaces())
 
-    def get_creatable_namespaces(self) -> List[str]:
+    def get_creatable_namespaces(self) -> list[str]:
         """Namespaces offered when creating a new entity, base namespace first.
 
         Includes the base (default) namespace, every namespace already used by
@@ -491,10 +500,10 @@ class OntologyManager:
     def add_class(
         self,
         name: str,
-        parent: Optional[str] = None,
-        label: Optional[str] = None,
-        comment: Optional[str] = None,
-        namespace: Optional[str] = None,
+        parent: str | None = None,
+        label: str | None = None,
+        comment: str | None = None,
+        namespace: str | None = None,
     ) -> URIRef:
         """Add a new OWL class.
 
@@ -521,10 +530,10 @@ class OntologyManager:
     def update_class(
         self,
         name: str,
-        new_label: Optional[str] = None,
-        new_comment: Optional[str] = None,
-        new_parent: Optional[str] = None,
-        remove_parent: Optional[str] = None,
+        new_label: str | None = None,
+        new_comment: str | None = None,
+        new_parent: str | None = None,
+        remove_parent: str | None = None,
     ):
         """Update an existing class."""
         if new_parent:
@@ -601,7 +610,7 @@ class OntologyManager:
 
     def get_delete_impact(
         self, name: str, resource_type: str = "class"
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Analyse the impact of deleting a resource before executing it.
 
         Args:
@@ -611,7 +620,7 @@ class OntologyManager:
         Returns a dict with categorised impact counts and details.
         """
         uri = self._uri(name)
-        impact: Dict[str, Any] = {
+        impact: dict[str, Any] = {
             "resource": name,
             "resource_type": resource_type,
             "direct_triples": 0,
@@ -706,7 +715,7 @@ class OntologyManager:
 
         return impact
 
-    def format_delete_impact(self, impact: Dict[str, Any]) -> str:
+    def format_delete_impact(self, impact: dict[str, Any]) -> str:
         """Format an impact dict into a human-readable summary string."""
         parts = []
         rt = impact["resource_type"]
@@ -751,7 +760,7 @@ class OntologyManager:
         self.graph.remove((class_uri, None, None))
         self.graph.remove((None, None, class_uri))
 
-    def get_classes(self) -> List[Dict[str, Any]]:
+    def get_classes(self) -> list[dict[str, Any]]:
         """Get all classes with their details.
 
         Each entry includes both local-name lists (`parents`, `children`) and
@@ -764,7 +773,7 @@ class OntologyManager:
             if isinstance(class_uri, BNode):
                 continue  # Skip anonymous classes (restrictions)
 
-            class_info: Dict[str, Any] = {
+            class_info: dict[str, Any] = {
                 "uri": str(class_uri),
                 "name": self._local_name(class_uri),
                 "label": str(self.graph.value(class_uri, RDFS.label) or ""),
@@ -791,9 +800,9 @@ class OntologyManager:
 
         return sorted(classes, key=lambda x: x["name"])
 
-    def get_class_hierarchy(self) -> Dict[str, List[str]]:
+    def get_class_hierarchy(self) -> dict[str, list[str]]:
         """Get class hierarchy as adjacency list."""
-        hierarchy: Dict[str, List[str]] = {}
+        hierarchy: dict[str, list[str]] = {}
         for class_uri in self.graph.subjects(RDF.type, OWL.Class):
             if isinstance(class_uri, BNode):
                 continue
@@ -809,9 +818,9 @@ class OntologyManager:
     @staticmethod
     def parse_bulk_text(
         text: str,
-        columns: Optional[List[str]] = None,
-        default_columns: Optional[List[str]] = None,
-    ) -> List[Dict[str, str]]:
+        columns: list[str] | None = None,
+        default_columns: list[str] | None = None,
+    ) -> list[dict[str, str]]:
         """Parse multi-line text into list of dicts.
 
         Supports:
@@ -894,7 +903,7 @@ class OntologyManager:
         # Simple mode: one name per line
         return [{"name": line} for line in lines]
 
-    def bulk_add_classes(self, entries: List[Dict[str, str]]) -> Dict[str, Any]:
+    def bulk_add_classes(self, entries: list[dict[str, str]]) -> dict[str, Any]:
         """Batch create classes.
 
         Each entry dict can have: name, label, parent, namespace. Duplicates are
@@ -920,7 +929,7 @@ class OntologyManager:
 
         Returns {created: [], updated: [], errors: [], skipped: []}.
         """
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "created": [],
             "updated": [],
             "errors": [],
@@ -985,15 +994,15 @@ class OntologyManager:
         return result
 
     def bulk_add_properties(
-        self, entries: List[Dict[str, str]], property_type: str = "object"
-    ) -> Dict[str, Any]:
+        self, entries: list[dict[str, str]], property_type: str = "object"
+    ) -> dict[str, Any]:
         """Batch create properties.
 
         Each entry dict can have: name, domain, range, label, namespace.
         property_type: "object" or "data". Duplicates are detected by full URI.
         Returns {created: [], errors: [], skipped: []}.
         """
-        result: Dict[str, Any] = {"created": [], "errors": [], "skipped": []}
+        result: dict[str, Any] = {"created": [], "errors": [], "skipped": []}
         if property_type == "object":
             existing = {p["uri"] for p in self.get_object_properties()}
         else:
@@ -1036,14 +1045,14 @@ class OntologyManager:
 
         return result
 
-    def bulk_add_individuals(self, entries: List[Dict[str, str]]) -> Dict[str, Any]:
+    def bulk_add_individuals(self, entries: list[dict[str, str]]) -> dict[str, Any]:
         """Batch create individuals.
 
         Each entry dict can have: name, class, label, namespace. Duplicates are
         detected by full URI.
         Returns {created: [], errors: [], skipped: []}.
         """
-        result: Dict[str, Any] = {"created": [], "errors": [], "skipped": []}
+        result: dict[str, Any] = {"created": [], "errors": [], "skipped": []}
         existing = {i["uri"] for i in self.get_individuals()}
 
         for entry in entries:
@@ -1074,9 +1083,9 @@ class OntologyManager:
 
         return result
 
-    def bulk_delete_classes(self, names: List[str]) -> Dict[str, Any]:
+    def bulk_delete_classes(self, names: list[str]) -> dict[str, Any]:
         """Batch delete classes. Returns {deleted: [], errors: []}."""
-        result: Dict[str, Any] = {"deleted": [], "errors": []}
+        result: dict[str, Any] = {"deleted": [], "errors": []}
         for name in names:
             try:
                 self.delete_class(name)
@@ -1085,9 +1094,9 @@ class OntologyManager:
                 result["errors"].append({"name": name, "error": str(e)})
         return result
 
-    def bulk_delete_properties(self, names: List[str]) -> Dict[str, Any]:
+    def bulk_delete_properties(self, names: list[str]) -> dict[str, Any]:
         """Batch delete properties. Returns {deleted: [], errors: []}."""
-        result: Dict[str, Any] = {"deleted": [], "errors": []}
+        result: dict[str, Any] = {"deleted": [], "errors": []}
         for name in names:
             try:
                 self.delete_property(name)
@@ -1096,9 +1105,9 @@ class OntologyManager:
                 result["errors"].append({"name": name, "error": str(e)})
         return result
 
-    def bulk_delete_individuals(self, names: List[str]) -> Dict[str, Any]:
+    def bulk_delete_individuals(self, names: list[str]) -> dict[str, Any]:
         """Batch delete individuals. Returns {deleted: [], errors: []}."""
-        result: Dict[str, Any] = {"deleted": [], "errors": []}
+        result: dict[str, Any] = {"deleted": [], "errors": []}
         for name in names:
             try:
                 self.delete_individual(name)
@@ -1107,14 +1116,14 @@ class OntologyManager:
                 result["errors"].append({"name": name, "error": str(e)})
         return result
 
-    def bulk_update_annotations(self, updates: List[Dict[str, str]]) -> Dict[str, Any]:
+    def bulk_update_annotations(self, updates: list[dict[str, str]]) -> dict[str, Any]:
         """Apply batch annotation changes.
 
         Each update dict has: resource, predicate, value, lang (optional),
         and action ("add" or "delete"). If action is omitted, defaults to "add".
         Returns {applied: int, errors: []}.
         """
-        result: Dict[str, Any] = {"applied": 0, "errors": []}
+        result: dict[str, Any] = {"applied": 0, "errors": []}
 
         for update in updates:
             resource = update.get("resource", "").strip()
@@ -1163,10 +1172,10 @@ class OntologyManager:
     def add_object_property(
         self,
         name: str,
-        domain: Optional[str] = None,
-        range_: Optional[str] = None,
-        label: Optional[str] = None,
-        comment: Optional[str] = None,
+        domain: str | None = None,
+        range_: str | None = None,
+        label: str | None = None,
+        comment: str | None = None,
         functional: bool = False,
         inverse_functional: bool = False,
         transitive: bool = False,
@@ -1174,8 +1183,8 @@ class OntologyManager:
         asymmetric: bool = False,
         reflexive: bool = False,
         irreflexive: bool = False,
-        inverse_of: Optional[str] = None,
-        namespace: Optional[str] = None,
+        inverse_of: str | None = None,
+        namespace: str | None = None,
     ) -> URIRef:
         """Add a new object property.
 
@@ -1221,12 +1230,12 @@ class OntologyManager:
     def add_data_property(
         self,
         name: str,
-        domain: Optional[str] = None,
+        domain: str | None = None,
         range_: str = "string",
-        label: Optional[str] = None,
-        comment: Optional[str] = None,
+        label: str | None = None,
+        comment: str | None = None,
         functional: bool = False,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
     ) -> URIRef:
         """Add a new data property.
 
@@ -1256,10 +1265,10 @@ class OntologyManager:
     def update_property(
         self,
         name: str,
-        new_label: Optional[str] = None,
-        new_comment: Optional[str] = None,
-        new_domain: Optional[str] = None,
-        new_range: Optional[str] = None,
+        new_label: str | None = None,
+        new_comment: str | None = None,
+        new_domain: str | None = None,
+        new_range: str | None = None,
     ):
         """Update an existing property."""
         if new_domain:
@@ -1381,14 +1390,14 @@ class OntologyManager:
         self.graph.remove((None, None, prop_uri))
         self.graph.remove((None, prop_uri, None))
 
-    def get_object_properties(self) -> List[Dict[str, Any]]:
+    def get_object_properties(self) -> list[dict[str, Any]]:
         """Get all object properties with their details."""
         properties = []
         for prop_uri in self.graph.subjects(RDF.type, OWL.ObjectProperty):
             if isinstance(prop_uri, BNode):
                 continue
 
-            prop_info: Dict[str, Any] = {
+            prop_info: dict[str, Any] = {
                 "uri": str(prop_uri),
                 "name": self._local_name(prop_uri),
                 "label": str(self.graph.value(prop_uri, RDFS.label) or ""),
@@ -1444,7 +1453,7 @@ class OntologyManager:
 
         return sorted(properties, key=lambda x: x["name"])
 
-    def get_data_properties(self) -> List[Dict[str, Any]]:
+    def get_data_properties(self) -> list[dict[str, Any]]:
         """Get all data properties with their details."""
         properties = []
         for prop_uri in self.graph.subjects(RDF.type, OWL.DatatypeProperty):
@@ -1492,9 +1501,9 @@ class OntologyManager:
         self,
         name: str,
         class_name: str,
-        label: Optional[str] = None,
-        comment: Optional[str] = None,
-        namespace: Optional[str] = None,
+        label: str | None = None,
+        comment: str | None = None,
+        namespace: str | None = None,
     ) -> URIRef:
         """Add a new individual (instance).
 
@@ -1538,10 +1547,10 @@ class OntologyManager:
     def update_individual(
         self,
         name: str,
-        new_label: Optional[str] = None,
-        new_comment: Optional[str] = None,
-        add_class: Optional[str] = None,
-        remove_class: Optional[str] = None,
+        new_label: str | None = None,
+        new_comment: str | None = None,
+        add_class: str | None = None,
+        remove_class: str | None = None,
     ):
         """Update an existing individual."""
         if add_class:
@@ -1605,7 +1614,7 @@ class OntologyManager:
         self.graph.remove((ind_uri, None, None))
         self.graph.remove((None, None, ind_uri))
 
-    def get_individuals(self) -> List[Dict[str, Any]]:
+    def get_individuals(self) -> list[dict[str, Any]]:
         """Get all individuals with their details."""
         individuals = []
         seen = set()
@@ -1615,7 +1624,7 @@ class OntologyManager:
                 continue
             seen.add(str(ind_uri))
 
-            ind_info: Dict[str, Any] = {
+            ind_info: dict[str, Any] = {
                 "uri": str(ind_uri),
                 "name": self._local_name(ind_uri),
                 "label": str(self.graph.value(ind_uri, RDFS.label) or ""),
@@ -1681,7 +1690,7 @@ class OntologyManager:
         property_name: str,
         restriction_type: str,
         value: Any,
-        on_class: Optional[str] = None,
+        on_class: str | None = None,
     ) -> BNode:
         """Add a restriction to a class.
 
@@ -1735,7 +1744,7 @@ class OntologyManager:
         return restriction
 
     #: ``link_classes`` semantics keyword -> restriction predicate name.
-    LINK_SEMANTICS = {
+    LINK_SEMANTICS: ClassVar[dict[str, str]] = {
         "all": "allValuesFrom",
         "some": "someValuesFrom",
     }
@@ -1781,9 +1790,9 @@ class OntologyManager:
                 continue
             yield restriction, self._restriction_row(restriction, prop)
 
-    def _restriction_row(self, restriction: Node, prop: Node) -> Dict[str, Any]:
+    def _restriction_row(self, restriction: Node, prop: Node) -> dict[str, Any]:
         """Build the display row for one restriction node."""
-        rest_info: Dict[str, Any] = {
+        rest_info: dict[str, Any] = {
             "property": self._local_name(prop),
             # Full URIs alongside the display-friendly local names so callers
             # can delete a restriction whose property/class live in an
@@ -1823,9 +1832,7 @@ class OntologyManager:
 
         return rest_info
 
-    def get_restrictions(
-        self, class_name: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
+    def get_restrictions(self, class_name: str | None = None) -> list[dict[str, Any]]:
         """Get restrictions, optionally filtered by class."""
         return [
             row
@@ -1835,12 +1842,12 @@ class OntologyManager:
 
     def _restriction_matches(
         self,
-        row: Dict[str, Any],
+        row: dict[str, Any],
         class_name: str,
         property_name: str,
         restriction_type: str,
         value: Any = None,
-        on_class: Optional[str] = None,
+        on_class: str | None = None,
     ) -> bool:
         """Whether ``row`` is the restriction described by these fields.
 
@@ -1867,9 +1874,7 @@ class OntologyManager:
                     return False
             elif str(row["value"]) != str(value):
                 return False
-        if on_class is not None and not _same_entity(row["on_class_uri"], on_class):
-            return False
-        return True
+        return on_class is None or _same_entity(row["on_class_uri"], on_class)
 
     def _find_restriction(
         self,
@@ -1877,7 +1882,7 @@ class OntologyManager:
         property_name: str,
         restriction_type: str,
         value: Any = None,
-        on_class: Optional[str] = None,
+        on_class: str | None = None,
     ):
         """Return the ``(node, row)`` for one restriction, or ``(None, None)``.
 
@@ -1906,7 +1911,7 @@ class OntologyManager:
         property_name: str,
         restriction_type: str,
         value: Any = None,
-        on_class: Optional[str] = None,
+        on_class: str | None = None,
     ) -> bool:
         """Delete a restriction from a class.
 
@@ -1934,7 +1939,7 @@ class OntologyManager:
     )
 
     @staticmethod
-    def _restriction_spec(spec: Dict[str, Any], label: str) -> tuple:
+    def _restriction_spec(spec: dict[str, Any], label: str) -> tuple:
         """Pull the three identifying fields out of an update spec.
 
         Raises rather than letting a missing field resolve to something else:
@@ -1956,7 +1961,7 @@ class OntologyManager:
             str(spec["restriction_type"]),
         )
 
-    def update_restriction(self, old: Dict[str, Any], new: Dict[str, Any]) -> bool:
+    def update_restriction(self, old: dict[str, Any], new: dict[str, Any]) -> bool:
         """Replace one restriction with an edited one (issue #152).
 
         Both dicts take ``class_name``, ``property_name``, ``restriction_type``,
@@ -2003,7 +2008,7 @@ class OntologyManager:
     # Common annotation predicate local names -> URIs. Shared by add and
     # delete so the two never drift apart (a stale subset on delete is what
     # made skos:example and others impossible to remove).
-    _ANNOTATION_PREDICATES = {
+    _ANNOTATION_PREDICATES: ClassVar[dict[str, URIRef]] = {
         "label": RDFS.label,
         "comment": RDFS.comment,
         "seeAlso": RDFS.seeAlso,
@@ -2029,7 +2034,7 @@ class OntologyManager:
         (falls back to the base namespace).
         """
         predicate = predicate.strip()
-        if predicate.startswith("http://") or predicate.startswith("https://"):
+        if predicate.startswith(("http://", "https://")):
             return URIRef(predicate)
         mapped = self._ANNOTATION_PREDICATES.get(predicate)
         if mapped is not None:
@@ -2052,7 +2057,7 @@ class OntologyManager:
         """
         return str(self._resolve_predicate_uri(predicate))
 
-    def invalid_annotation_predicate_reason(self, predicate: str) -> Optional[str]:
+    def invalid_annotation_predicate_reason(self, predicate: str) -> str | None:
         """Return a human-readable reason ``predicate`` can't be used as an
         annotation type, or ``None`` if it can.
 
@@ -2067,7 +2072,7 @@ class OntologyManager:
         if predicate is None or not predicate.strip():
             return "Annotation type cannot be empty."
         predicate = predicate.strip()
-        if predicate.startswith("http://") or predicate.startswith("https://"):
+        if predicate.startswith(("http://", "https://")):
             if any(c.isspace() or c in self._INVALID_URI_CHARS for c in predicate):
                 return (
                     "A full URI cannot contain spaces or any of the characters "
@@ -2110,7 +2115,7 @@ class OntologyManager:
             raise ValueError(reason)
 
     def add_annotation(
-        self, subject: str, predicate: str, value: str, lang: Optional[str] = None
+        self, subject: str, predicate: str, value: str, lang: str | None = None
     ):
         """Add an annotation to any resource.
 
@@ -2157,7 +2162,7 @@ class OntologyManager:
 
         self.graph.add((subj_uri, pred_uri, literal))
 
-    def get_annotations(self, subject: str) -> List[Dict[str, str]]:
+    def get_annotations(self, subject: str) -> list[dict[str, str]]:
         """Get all annotations/predicates for a resource (like Protege shows)."""
         subj_uri = self._uri(subject)
         annotations = []
@@ -2218,7 +2223,7 @@ class OntologyManager:
         annotations.sort(key=lambda x: x["predicate"])
         return annotations
 
-    def get_used_annotation_predicates(self) -> List[Dict[str, str]]:
+    def get_used_annotation_predicates(self) -> list[dict[str, str]]:
         """Get all unique annotation predicates used in the ontology."""
         structural_predicates = {
             RDF.type,
@@ -2254,7 +2259,7 @@ class OntologyManager:
             if isinstance(obj, BNode):
                 continue
             # Only include predicates with literal values (annotations)
-            if isinstance(obj, Literal) or isinstance(obj, URIRef):
+            if isinstance(obj, (Literal, URIRef)):
                 pred_uri = str(pred)
                 if pred_uri not in predicates:
                     predicates[pred_uri] = {
@@ -2279,9 +2284,9 @@ class OntologyManager:
         self,
         subject: str,
         predicate: str,
-        value: Optional[str] = None,
-        lang: Optional[str] = None,
-        datatype: Optional[str] = None,
+        value: str | None = None,
+        lang: str | None = None,
+        datatype: str | None = None,
     ):
         """Delete an annotation from a resource.
 
@@ -2315,7 +2320,7 @@ class OntologyManager:
 
     # ==================== SKOS VOCABULARY OPERATIONS ====================
 
-    SKOS_RELATIONS = {
+    SKOS_RELATIONS: ClassVar[dict[str, URIRef]] = {
         "broader": SKOS.broader,
         "narrower": SKOS.narrower,
         "related": SKOS.related,
@@ -2326,15 +2331,20 @@ class OntologyManager:
         "relatedMatch": SKOS.relatedMatch,
     }
 
-    SKOS_INVERSES = {
+    SKOS_INVERSES: ClassVar[dict[URIRef, URIRef]] = {
         SKOS.broader: SKOS.narrower,
         SKOS.narrower: SKOS.broader,
     }
 
-    SKOS_SYMMETRIC = {SKOS.related, SKOS.closeMatch, SKOS.exactMatch, SKOS.relatedMatch}
+    SKOS_SYMMETRIC: ClassVar[set[URIRef]] = {
+        SKOS.related,
+        SKOS.closeMatch,
+        SKOS.exactMatch,
+        SKOS.relatedMatch,
+    }
 
     def add_concept_scheme(
-        self, name: str, label: Optional[str] = None, comment: Optional[str] = None
+        self, name: str, label: str | None = None, comment: str | None = None
     ) -> URIRef:
         """Add a new SKOS ConceptScheme."""
         self._require_valid_name(name)
@@ -2346,7 +2356,7 @@ class OntologyManager:
             self.graph.add((scheme_uri, RDFS.comment, Literal(comment)))
         return scheme_uri
 
-    def get_concept_schemes(self) -> List[Dict[str, Any]]:
+    def get_concept_schemes(self) -> list[dict[str, Any]]:
         """Get all SKOS ConceptSchemes."""
         schemes = []
         for uri in self.graph.subjects(RDF.type, SKOS.ConceptScheme):
@@ -2438,11 +2448,11 @@ class OntologyManager:
     def add_concept(
         self,
         name: str,
-        scheme: Optional[str] = None,
-        pref_label: Optional[str] = None,
-        definition: Optional[str] = None,
-        broader: Optional[str] = None,
-        lang: Optional[str] = None,
+        scheme: str | None = None,
+        pref_label: str | None = None,
+        definition: str | None = None,
+        broader: str | None = None,
+        lang: str | None = None,
     ) -> URIRef:
         """Add a SKOS Concept with optional scheme/broader links."""
         self._require_valid_name(name)
@@ -2479,7 +2489,7 @@ class OntologyManager:
 
         return concept_uri
 
-    def get_concepts(self, scheme: Optional[str] = None) -> List[Dict[str, Any]]:
+    def get_concepts(self, scheme: str | None = None) -> list[dict[str, Any]]:
         """Get SKOS Concepts, optionally filtered by scheme."""
         # Resolve scheme name to URI by looking it up in the graph
         scheme_uri = None
@@ -2497,9 +2507,12 @@ class OntologyManager:
                 continue
 
             # Filter by scheme if specified
-            if scheme and scheme_uri:
-                if (uri, SKOS.inScheme, scheme_uri) not in self.graph:
-                    continue
+            if (
+                scheme
+                and scheme_uri
+                and (uri, SKOS.inScheme, scheme_uri) not in self.graph
+            ):
+                continue
 
             name = self._local_name(uri)
 
@@ -2558,8 +2571,8 @@ class OntologyManager:
         new_pref_label: str = _UNSET,
         new_definition: str = _UNSET,
         new_broader: str = _UNSET,
-        add_scheme: Optional[str] = None,
-        remove_scheme: Optional[str] = None,
+        add_scheme: str | None = None,
+        remove_scheme: str | None = None,
     ):
         """Update a SKOS Concept's properties."""
         if new_broader is not _UNSET and new_broader:
@@ -2668,11 +2681,9 @@ class OntologyManager:
         self.graph.remove((uri, None, None))
         self.graph.remove((None, None, uri))
 
-    def get_concept_hierarchy(
-        self, scheme: Optional[str] = None
-    ) -> Dict[str, List[str]]:
+    def get_concept_hierarchy(self, scheme: str | None = None) -> dict[str, list[str]]:
         """Return concept hierarchy as {parent: [children]} dict."""
-        hierarchy: Dict[str, List[str]] = {}
+        hierarchy: dict[str, list[str]] = {}
         concepts = self.get_concepts(scheme=scheme)
 
         for concept in concepts:
@@ -2686,7 +2697,7 @@ class OntologyManager:
 
         return hierarchy
 
-    def validate_skos(self) -> List[Dict[str, str]]:
+    def validate_skos(self) -> list[dict[str, str]]:
         """Validate SKOS concepts and schemes.
 
         Checks:
@@ -2727,7 +2738,7 @@ class OntologyManager:
         # Duplicate prefLabels within schemes
         for scheme in schemes:
             scheme_concepts = self.get_concepts(scheme=scheme["name"])
-            labels_seen: Dict[str, str] = {}
+            labels_seen: dict[str, str] = {}
             for concept in scheme_concepts:
                 lbl = concept["prefLabel"]
                 if lbl and lbl in labels_seen:
@@ -2745,7 +2756,7 @@ class OntologyManager:
         # Broader/narrower cycle detection
         concept_names = {c["name"] for c in concepts}
         for concept in concepts:
-            visited: Set[str] = set()
+            visited: set[str] = set()
             current = concept["name"]
             chain = [current]
             has_cycle = False
@@ -2782,14 +2793,14 @@ class OntologyManager:
     # ==================== RELATIONS OPERATIONS ====================
 
     # Class relation types
-    CLASS_RELATIONS = {
+    CLASS_RELATIONS: ClassVar[dict[str, URIRef]] = {
         "subClassOf": RDFS.subClassOf,
         "equivalentClass": OWL.equivalentClass,
         "disjointWith": OWL.disjointWith,
     }
 
     # Property relation types
-    PROPERTY_RELATIONS = {
+    PROPERTY_RELATIONS: ClassVar[dict[str, URIRef]] = {
         "subPropertyOf": RDFS.subPropertyOf,
         "equivalentProperty": OWL.equivalentProperty,
         "inverseOf": OWL.inverseOf,
@@ -2797,7 +2808,7 @@ class OntologyManager:
     }
 
     # Individual relation types
-    INDIVIDUAL_RELATIONS = {
+    INDIVIDUAL_RELATIONS: ClassVar[dict[str, URIRef]] = {
         "sameAs": OWL.sameAs,
         "differentFrom": OWL.differentFrom,
     }
@@ -2819,8 +2830,8 @@ class OntologyManager:
             self.graph.remove((class1_uri, relation, class2_uri))
 
     def get_class_relations(
-        self, class_name: Optional[str] = None
-    ) -> List[Dict[str, str]]:
+        self, class_name: str | None = None
+    ) -> list[dict[str, str]]:
         """Get all class relations, optionally filtered by class.
 
         Each result dict includes both local names (subject/object) and full
@@ -2863,7 +2874,7 @@ class OntologyManager:
 
     def _update_relation(
         self,
-        relations: Dict[str, Any],
+        relations: dict[str, Any],
         kind: str,
         old: tuple,
         new: tuple,
@@ -2908,8 +2919,8 @@ class OntologyManager:
         return self._update_relation(self.INDIVIDUAL_RELATIONS, "individual", old, new)
 
     def get_property_relations(
-        self, prop_name: Optional[str] = None
-    ) -> List[Dict[str, str]]:
+        self, prop_name: str | None = None
+    ) -> list[dict[str, str]]:
         """Get all property relations, optionally filtered by property.
 
         Each result dict includes both local names and full URIs.
@@ -2949,8 +2960,8 @@ class OntologyManager:
             self.graph.remove((ind1_uri, relation, ind2_uri))
 
     def get_individual_relations(
-        self, ind_name: Optional[str] = None
-    ) -> List[Dict[str, str]]:
+        self, ind_name: str | None = None
+    ) -> list[dict[str, str]]:
         """Get all individual relations (sameAs, differentFrom).
 
         Each result dict includes both local names and full URIs.
@@ -2975,17 +2986,17 @@ class OntologyManager:
 
     # ==================== ADVANCED OWL FEATURES ====================
 
-    def add_property_chain(self, property_name: str, chain_properties: List[str]):
+    def add_property_chain(self, property_name: str, chain_properties: list[str]):
         """Add a property chain axiom (owl:propertyChainAxiom)."""
         prop_uri = self._uri(property_name)
-        chain_uris: List[Node] = [self._uri(p) for p in chain_properties]
+        chain_uris: list[Node] = [self._uri(p) for p in chain_properties]
 
         # Create RDF list for the chain
         chain_list = BNode()
         Collection(self.graph, chain_list, chain_uris)
         self.graph.add((prop_uri, OWL.propertyChainAxiom, chain_list))
 
-    def get_property_chains(self) -> List[Dict[str, Any]]:
+    def get_property_chains(self) -> list[dict[str, Any]]:
         """Get all property chain axioms."""
         chains = []
         for prop, chain_list in self.graph.subject_objects(OWL.propertyChainAxiom):
@@ -3005,8 +3016,8 @@ class OntologyManager:
         self,
         class_name: str,
         expression_type: str,
-        classes: Optional[List[str]] = None,
-        individuals: Optional[List[str]] = None,
+        classes: list[str] | None = None,
+        individuals: list[str] | None = None,
     ):
         """Add a class expression (unionOf, intersectionOf, complementOf, oneOf)."""
         class_uri = self._uri(class_name)
@@ -3017,14 +3028,14 @@ class OntologyManager:
 
         elif expression_type == "oneOf" and individuals:
             # oneOf takes a list of individuals
-            ind_uris: List[Node] = [self._uri(i) for i in individuals]
+            ind_uris: list[Node] = [self._uri(i) for i in individuals]
             list_node = BNode()
             Collection(self.graph, list_node, ind_uris)
             self.graph.add((class_uri, OWL.oneOf, list_node))
 
         elif expression_type in ["unionOf", "intersectionOf"] and classes:
             # unionOf and intersectionOf take a list of classes
-            class_uris: List[Node] = [self._uri(c) for c in classes]
+            class_uris: list[Node] = [self._uri(c) for c in classes]
             list_node = BNode()
             Collection(self.graph, list_node, class_uris)
             if expression_type == "unionOf":
@@ -3033,8 +3044,8 @@ class OntologyManager:
                 self.graph.add((class_uri, OWL.intersectionOf, list_node))
 
     def get_class_expressions(
-        self, class_name: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
+        self, class_name: str | None = None
+    ) -> list[dict[str, Any]]:
         """Get class expressions for a class or all classes."""
         expressions = []
 
@@ -3074,17 +3085,17 @@ class OntologyManager:
 
         return expressions
 
-    def add_all_different(self, individuals: List[str]):
+    def add_all_different(self, individuals: list[str]):
         """Add an owl:AllDifferent declaration for a list of individuals."""
         all_diff = BNode()
         self.graph.add((all_diff, RDF.type, OWL.AllDifferent))
 
-        ind_uris: List[Node] = [self._uri(i) for i in individuals]
+        ind_uris: list[Node] = [self._uri(i) for i in individuals]
         list_node = BNode()
         Collection(self.graph, list_node, ind_uris)
         self.graph.add((all_diff, OWL.distinctMembers, list_node))
 
-    def get_all_different(self) -> List[List[str]]:
+    def get_all_different(self) -> list[list[str]]:
         """Get all owl:AllDifferent declarations."""
         all_diffs = []
         for all_diff in self.graph.subjects(RDF.type, OWL.AllDifferent):
@@ -3099,16 +3110,16 @@ class OntologyManager:
                     pass
         return all_diffs
 
-    def add_has_key(self, class_name: str, properties: List[str]):
+    def add_has_key(self, class_name: str, properties: list[str]):
         """Add an owl:hasKey axiom to a class."""
         class_uri = self._uri(class_name)
-        prop_uris: List[Node] = [self._uri(p) for p in properties]
+        prop_uris: list[Node] = [self._uri(p) for p in properties]
 
         list_node = BNode()
         Collection(self.graph, list_node, prop_uris)
         self.graph.add((class_uri, OWL.hasKey, list_node))
 
-    def get_has_keys(self, class_name: Optional[str] = None) -> List[Dict[str, Any]]:
+    def get_has_keys(self, class_name: str | None = None) -> list[dict[str, Any]]:
         """Get owl:hasKey axioms."""
         keys = []
         for subj, key_list in self.graph.subject_objects(OWL.hasKey):
@@ -3132,16 +3143,16 @@ class OntologyManager:
                     pass
         return keys
 
-    def add_disjoint_union(self, class_name: str, disjoint_classes: List[str]):
+    def add_disjoint_union(self, class_name: str, disjoint_classes: list[str]):
         """Add an owl:disjointUnionOf axiom (class is disjoint union of listed classes)."""
         class_uri = self._uri(class_name)
-        class_uris: List[Node] = [self._uri(c) for c in disjoint_classes]
+        class_uris: list[Node] = [self._uri(c) for c in disjoint_classes]
 
         list_node = BNode()
         Collection(self.graph, list_node, class_uris)
         self.graph.add((class_uri, OWL.disjointUnionOf, list_node))
 
-    def get_disjoint_unions(self) -> List[Dict[str, Any]]:
+    def get_disjoint_unions(self) -> list[dict[str, Any]]:
         """Get all owl:disjointUnionOf declarations."""
         unions = []
         for subj, union_list in self.graph.subject_objects(OWL.disjointUnionOf):
@@ -3178,7 +3189,7 @@ class OntologyManager:
         self.graph.parse(file_path, format=format)
         self._update_namespace_from_graph()
 
-    def save_to_file(self, file_path, format: Optional[str] = None) -> None:
+    def save_to_file(self, file_path, format: str | None = None) -> None:
         """Serialize the graph straight to ``file_path``, atomically.
 
         Streams the serialization to a temp file in the same directory via
@@ -3217,7 +3228,7 @@ class OntologyManager:
         self.graph.parse(data=data, format=format)
         self._update_namespace_from_graph()
 
-    def preview_import(self, data: str, format: str = "turtle") -> Dict[str, Any]:
+    def preview_import(self, data: str, format: str = "turtle") -> dict[str, Any]:
         """Parse import data and return a preview without modifying the current graph.
 
         Returns a dict with:
@@ -3263,7 +3274,7 @@ class OntologyManager:
             "prefix_conflicts": prefix_conflicts,
         }
 
-    def detect_conflicts(self, other_graph: Graph) -> List[Dict[str, Any]]:
+    def detect_conflicts(self, other_graph: Graph) -> list[dict[str, Any]]:
         """Detect conflicts between current graph and another graph.
 
         A conflict exists when both graphs have triples with the same subject
@@ -3316,7 +3327,7 @@ class OntologyManager:
 
     def merge_from_graph(
         self, other_graph: Graph, strategy: str = IMPORT_MERGE
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Merge another graph into the current graph using the specified strategy.
 
         Returns a dict with:
@@ -3383,13 +3394,13 @@ class OntologyManager:
 
     def merge_from_string(
         self, data: str, format: str = "turtle", strategy: str = IMPORT_MERGE
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Parse data and merge into current graph."""
         temp = Graph()
         temp.parse(data=data, format=format)
         return self.merge_from_graph(temp, strategy=strategy)
 
-    def _detect_prefix_conflicts(self, other_graph: Graph) -> List[Dict[str, str]]:
+    def _detect_prefix_conflicts(self, other_graph: Graph) -> list[dict[str, str]]:
         """Compare namespace bindings between current and incoming graph."""
         current_ns = {prefix: str(ns) for prefix, ns in self.graph.namespaces()}
         conflicts = []
@@ -3406,7 +3417,7 @@ class OntologyManager:
         return conflicts
 
     def _reconcile_prefixes_after_merge(
-        self, other_graph: Graph, prefix_resolution: Optional[Dict[str, str]] = None
+        self, other_graph: Graph, prefix_resolution: dict[str, str] | None = None
     ):
         """Re-bind prefixes after a merge operation."""
         for prefix, ns in other_graph.namespaces():
@@ -3452,7 +3463,7 @@ class OntologyManager:
 
     def _detect_base_uri(self, uri_str: str) -> str:
         """Detect the base URI with separator from an ontology URI string."""
-        if uri_str.endswith("#") or uri_str.endswith("/"):
+        if uri_str.endswith(("#", "/")):
             return uri_str
 
         sample_uri = self._find_sample_resource_uri()
@@ -3464,7 +3475,7 @@ class OntologyManager:
                 return uri_str + "#"
         return uri_str + "#"
 
-    def _find_sample_resource_uri(self) -> Optional[str]:
+    def _find_sample_resource_uri(self) -> str | None:
         """Find a sample resource URI from classes or properties in the graph."""
         for rdf_type in (
             OWL.Class,
@@ -3477,7 +3488,7 @@ class OntologyManager:
                     return str(s)
         return None
 
-    def _infer_namespace_from_graph(self) -> Optional[str]:
+    def _infer_namespace_from_graph(self) -> str | None:
         """Infer namespace from graph prefixes and resource URIs when no owl:Ontology exists."""
         STANDARD_NAMESPACES = {
             str(OWL),
@@ -3527,7 +3538,7 @@ class OntologyManager:
 
     # ==================== SEARCH ====================
 
-    def search(self, query: str) -> List[Dict[str, str]]:
+    def search(self, query: str) -> list[dict[str, str]]:
         """Search across resource names, labels, comments and SKOS labels.
 
         Matches (case-insensitive, partial) against the local name, rdfs:label,
@@ -3543,8 +3554,8 @@ class OntologyManager:
             return []
 
         q = query.strip().lower()
-        results: List[Dict[str, str]] = []
-        seen: Set[str] = set()
+        results: list[dict[str, str]] = []
+        seen: set[str] = set()
 
         type_map = [
             (OWL.Class, "Class"),
@@ -3606,7 +3617,7 @@ class OntologyManager:
 
     # ==================== RESOURCE USAGES ====================
 
-    def get_resource_usages(self, name: str) -> Dict[str, List[Dict[str, str]]]:
+    def get_resource_usages(self, name: str) -> dict[str, list[dict[str, str]]]:
         """Find all places a resource is referenced in the graph.
 
         Returns a dict with:
@@ -3624,7 +3635,7 @@ class OntologyManager:
             OWL.disjointWith,
         }
 
-        outbound: List[Dict[str, str]] = []
+        outbound: list[dict[str, str]] = []
         for p, o in self.graph.predicate_objects(uri):
             if p in structural_preds:
                 continue
@@ -3636,7 +3647,7 @@ class OntologyManager:
                 }
             )
 
-        inbound: List[Dict[str, str]] = []
+        inbound: list[dict[str, str]] = []
         for s, p in self.graph.subject_predicates(uri):
             if isinstance(s, BNode):
                 continue
@@ -3647,7 +3658,7 @@ class OntologyManager:
                 }
             )
 
-        as_predicate: List[Dict[str, str]] = []
+        as_predicate: list[dict[str, str]] = []
         for s, o in self.graph.subject_objects(uri):
             as_predicate.append(
                 {
@@ -3682,7 +3693,7 @@ class OntologyManager:
 
     # ==================== DIFF & COMPARISON ====================
 
-    def compare_graphs(self, other_graph: Graph) -> Dict[str, Any]:
+    def compare_graphs(self, other_graph: Graph) -> dict[str, Any]:
         """Compare the current graph against another graph.
 
         Returns a dict with:
@@ -3764,15 +3775,15 @@ class OntologyManager:
         diff["summary"] = self._summarize_changes(diff)
         return diff
 
-    def compare_to_string(self, data: str, format: str = "turtle") -> Dict[str, Any]:
+    def compare_to_string(self, data: str, format: str = "turtle") -> dict[str, Any]:
         """Parse data into a temporary graph and compare to current state."""
         temp = Graph()
         temp.parse(data=data, format=format)
         return self.compare_graphs(temp)
 
-    def _group_triples_by_subject(self, triples) -> Dict[str, List[Dict]]:
+    def _group_triples_by_subject(self, triples) -> dict[str, list[dict]]:
         """Group a set of triples by subject local name for display."""
-        groups: Dict[str, List[Dict]] = {}
+        groups: dict[str, list[dict]] = {}
         for s, p, o in triples:
             if isinstance(s, BNode):
                 continue
@@ -3789,7 +3800,7 @@ class OntologyManager:
         return groups
 
     def _classify_resource_change(
-        self, subject: str, added_subjects: Set[str], removed_subjects: Set[str]
+        self, subject: str, added_subjects: set[str], removed_subjects: set[str]
     ) -> str:
         """Classify what happened to a resource: 'added', 'removed', or 'modified'."""
         in_added = subject in added_subjects
@@ -3800,7 +3811,7 @@ class OntologyManager:
             return "removed"
         return "modified"
 
-    def _summarize_changes(self, diff: Dict[str, Any]) -> List[str]:
+    def _summarize_changes(self, diff: dict[str, Any]) -> list[str]:
         """Generate plain-language summaries for each changed resource."""
         summaries = []
 
@@ -3869,7 +3880,7 @@ class OntologyManager:
         return summaries
 
     def format_diff_report(
-        self, diff: Dict[str, Any], report_format: str = "markdown"
+        self, diff: dict[str, Any], report_format: str = "markdown"
     ) -> str:
         """Format a diff result as a human-readable report."""
         stats = diff["stats"]
@@ -3932,7 +3943,7 @@ class OntologyManager:
 
     # ==================== VALIDATION & REASONING ====================
 
-    def validate(self, check_missing_domain_range: bool = True) -> List[Dict[str, str]]:
+    def validate(self, check_missing_domain_range: bool = True) -> list[dict[str, str]]:
         """Validate the ontology and return issues."""
         issues = []
         # ``pred`` is reused across loops that bind it to both predicate URIRefs
@@ -4091,7 +4102,7 @@ class OntologyManager:
                 )
 
         # Check domain/range usage for property assertions on individuals
-        def _expand_superclasses(class_uris: Set[str]) -> Set[str]:
+        def _expand_superclasses(class_uris: set[str]) -> set[str]:
             """Expand a set of class URIs to include all superclasses."""
             expanded = set(class_uris)
             frontier = list(class_uris)
@@ -4179,7 +4190,7 @@ class OntologyManager:
         # Check for duplicate rdfs:label values across resources
         from collections import defaultdict
 
-        label_to_resources: Dict[str, List[str]] = defaultdict(list)
+        label_to_resources: dict[str, list[str]] = defaultdict(list)
         for subj, label_val in self.graph.subject_objects(RDFS.label):
             if isinstance(subj, URIRef) and isinstance(label_val, Literal):
                 label_str = str(label_val)
@@ -4226,7 +4237,7 @@ class OntologyManager:
             + _RANGE_INCLUDES
         )
         defined = set(self.graph.subjects())
-        external: Dict[str, str] = {}
+        external: dict[str, str] = {}
         for pred in _link_preds:
             for _subj, obj in self.graph.subject_objects(pred):
                 if not isinstance(obj, URIRef) or obj in defined:
@@ -4264,7 +4275,7 @@ class OntologyManager:
 
     # ==================== STATISTICS ====================
 
-    def get_statistics(self) -> Dict[str, int]:
+    def get_statistics(self) -> dict[str, int]:
         """Get ontology statistics."""
         # Count ontology metadata triples (declaration + metadata)
         ontology_meta_count = len(list(self.graph.predicate_objects(self.ontology_uri)))
@@ -4315,8 +4326,8 @@ class UndoManager:
     def __init__(self, manager: OntologyManager, max_history: int = 50):
         self.manager = manager
         self.max_history = max_history
-        self._undo_stack: List[Tuple[str, bytes]] = []  # (label, snapshot)
-        self._redo_stack: List[Tuple[str, bytes]] = []
+        self._undo_stack: list[tuple[str, bytes]] = []  # (label, snapshot)
+        self._redo_stack: list[tuple[str, bytes]] = []
         # Capture initial state
         self._undo_stack.append(("Initial state", manager.take_snapshot()))
 
@@ -4334,7 +4345,7 @@ class UndoManager:
     def can_redo(self) -> bool:
         return len(self._redo_stack) > 0
 
-    def undo(self) -> Optional[str]:
+    def undo(self) -> str | None:
         """Undo the last change. Returns the label of the restored state, or None."""
         if not self.can_undo():
             return None
@@ -4344,7 +4355,7 @@ class UndoManager:
         self.manager.restore_snapshot(snapshot)
         return label
 
-    def redo(self) -> Optional[str]:
+    def redo(self) -> str | None:
         """Redo the last undone change. Returns the label, or None."""
         if not self.can_redo():
             return None
@@ -4354,11 +4365,11 @@ class UndoManager:
         return label
 
     @property
-    def undo_labels(self) -> List[str]:
+    def undo_labels(self) -> list[str]:
         """Labels in the undo stack (most recent last), excluding the bottom."""
         return [label for label, _ in self._undo_stack[1:]]
 
     @property
-    def redo_labels(self) -> List[str]:
+    def redo_labels(self) -> list[str]:
         """Labels in the redo stack (next redo last)."""
         return [label for label, _ in self._redo_stack]

--- a/orionbelt_ontology_builder/templates.py
+++ b/orionbelt_ontology_builder/templates.py
@@ -4,7 +4,6 @@ import hashlib
 import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Optional
 
 TEMPLATES = [
     {
@@ -324,7 +323,7 @@ def get_template_names() -> list:
     return [t["name"] for t in TEMPLATES]
 
 
-def get_template(name: str) -> Optional[dict]:
+def get_template(name: str) -> dict | None:
     """Return a template by name, or None if not found."""
     for t in TEMPLATES:
         if t["name"] == name:
@@ -417,7 +416,7 @@ def get_upper_ontology_names() -> list:
     return sorted((o["name"] for o in UPPER_ONTOLOGIES), key=str.lower)
 
 
-def get_upper_ontology(name: str) -> Optional[dict]:
+def get_upper_ontology(name: str) -> dict | None:
     """Return an upper ontology definition by name, or None if not found."""
     for o in UPPER_ONTOLOGIES:
         if o["name"] == name:
@@ -507,7 +506,7 @@ def get_reference_ontology_names() -> list:
     return sorted((o["name"] for o in REFERENCE_ONTOLOGIES), key=str.lower)
 
 
-def get_reference_ontology(name: str) -> Optional[dict]:
+def get_reference_ontology(name: str) -> dict | None:
     """Return a reference ontology definition by name, or None if not found."""
     for o in REFERENCE_ONTOLOGIES:
         if o["name"] == name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ gtk = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
-    "ruff==0.15.22",
+    "ruff==0.16.0",
     "mypy==2.3.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,20 @@ Repository = "https://github.com/ralforion/orionbelt-ontology-builder"
 Issues = "https://github.com/ralforion/orionbelt-ontology-builder/issues"
 Demo = "https://orionbelt.streamlit.app"
 
+[tool.ruff.lint]
+# No `select`: we lint against ruff's own default rule set. Up to 0.15.x that
+# was just E4/E7/E9/F; 0.16.0 widened it to roughly 35 families (UP, SIM, RUF,
+# PERF, PTH, ...) and we adopt that rather than pinning back to the old four.
+ignore = [
+    # Both of these encode the same deliberate choice: optional or degradable
+    # paths — graph rendering, theme detection, the desktop webview hooks —
+    # are wrapped in broad handlers so a failure downgrades the UI instead of
+    # killing the Streamlit session. Errors that the user needs to see are
+    # surfaced explicitly through log_error() / show_message().
+    "BLE001", # blind `except Exception`
+    "S110",   # try-except-pass
+]
+
 [tool.mypy]
 python_version = "3.12"
 ignore_missing_imports = true

--- a/templates.py
+++ b/templates.py
@@ -1,20 +1,20 @@
 """Compatibility shim — re-exports the templates package module."""
 
-from orionbelt_ontology_builder.templates import *  # noqa: F401, F403
+from orionbelt_ontology_builder.templates import *
 from orionbelt_ontology_builder.templates import (  # noqa: F401
-    UPPER_ONTOLOGIES,
-    REFERENCE_ONTOLOGIES,
-    TEMPLATES,
-    SAMPLES_DIR,
     CACHE_DIR,
-    get_template_names,
-    get_template,
-    render_template,
-    get_upper_ontology_names,
-    get_upper_ontology,
-    load_upper_ontology_module,
-    get_reference_ontology_names,
-    get_reference_ontology,
-    load_reference_ontology_module,
+    REFERENCE_ONTOLOGIES,
+    SAMPLES_DIR,
+    TEMPLATES,
+    UPPER_ONTOLOGIES,
     _fetch_with_cache,
+    get_reference_ontology,
+    get_reference_ontology_names,
+    get_template,
+    get_template_names,
+    get_upper_ontology,
+    get_upper_ontology_names,
+    load_reference_ontology_module,
+    load_upper_ontology_module,
+    render_template,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from ontology_manager import OntologyManager
 
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -1,8 +1,9 @@
 """Tests for bulk operations."""
 
 import pytest
-from ontology_manager import OntologyManager
 from rdflib.namespace import RDFS
+
+from ontology_manager import OntologyManager
 
 
 @pytest.fixture

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -65,7 +65,8 @@ class TestCrossNamespaceDuplicates:
     """
 
     def _make_two_orgs(self):
-        from rdflib import RDF, OWL, RDFS, Literal, URIRef
+        from rdflib import OWL, RDF, RDFS, Literal, URIRef
+
         from ontology_manager import OntologyManager
 
         om = OntologyManager(base_uri="http://example.org/myont#")
@@ -98,7 +99,7 @@ class TestCrossNamespaceDuplicates:
         assert remaining[0]["uri"] == gist_uri
 
     def test_rename_by_uri_only_affects_one(self):
-        om, foaf_uri, gist_uri = self._make_two_orgs()
+        om, foaf_uri, _gist_uri = self._make_two_orgs()
         result = om.rename_class(foaf_uri, "SocialOrganization")
         assert result is True
         names = sorted(c["name"] for c in om.get_classes())
@@ -108,7 +109,7 @@ class TestCrossNamespaceDuplicates:
 
     def test_class_relations_expose_uris(self):
         """Regression for Relations tab key collisions."""
-        from rdflib import URIRef, OWL
+        from rdflib import OWL, URIRef
 
         om, foaf_uri, gist_uri = self._make_two_orgs()
         om.graph.add((URIRef(foaf_uri), OWL.equivalentClass, URIRef(gist_uri)))
@@ -138,7 +139,7 @@ class TestCrossNamespaceDuplicates:
     def test_add_class_relation_with_uris_targets_correct_resources(self):
         """Regression: Add Class Relation must place the triple between the
         URIs the user picked, not synthesise new base-namespace classes."""
-        from rdflib import URIRef, OWL
+        from rdflib import OWL, URIRef
 
         om, foaf_uri, gist_uri = self._make_two_orgs()
         om.add_class_relation(foaf_uri, "equivalentClass", gist_uri)
@@ -154,7 +155,7 @@ class TestCrossNamespaceDuplicates:
     def test_individuals_expose_class_uris(self):
         """Regression: get_individuals must expose class_uris so the graph
         viewer can target the correct duplicate-named class."""
-        from rdflib import URIRef, RDF, OWL
+        from rdflib import OWL, RDF, URIRef
 
         om, foaf_uri, _gist_uri = self._make_two_orgs()
         alice = om.namespace["alice"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import sys
 from importlib.metadata import entry_points
 from pathlib import Path
 
-import orionbelt_ontology_builder.cli as cli
+from orionbelt_ontology_builder import cli
 from orionbelt_ontology_builder.local_store import BRAND_PRIMARY_COLOR, ENV_FLAG
 
 

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -8,7 +8,7 @@ from importlib.metadata import entry_points
 
 import pytest
 
-import orionbelt_ontology_builder.desktop as desktop
+from orionbelt_ontology_builder import desktop
 from orionbelt_ontology_builder.app import APP_NAME
 from orionbelt_ontology_builder.local_store import BRAND_PRIMARY_COLOR, ENV_FLAG
 
@@ -409,7 +409,7 @@ def test_copy_to_clipboard_uses_platform_command(monkeypatch):
     """Each platform writes stdin to its native clipboard tool (issue #120)."""
     calls = {}
 
-    def _fake_run(command, input, check):  # noqa: A002 - mirror subprocess.run
+    def _fake_run(command, input, check):
         calls["command"] = command
         calls["input"] = input
         return types.SimpleNamespace(returncode=0)
@@ -430,7 +430,7 @@ def test_copy_to_clipboard_falls_back_across_linux_tools(monkeypatch):
     """On Linux, an unavailable tool is skipped for the next candidate."""
     tried = []
 
-    def _fake_run(command, input, check):  # noqa: A002 - mirror subprocess.run
+    def _fake_run(command, input, check):
         tried.append(command[0])
         if command[0] == "wl-copy":
             raise FileNotFoundError("wl-copy")
@@ -447,7 +447,7 @@ def test_copy_to_clipboard_returns_false_when_unavailable(monkeypatch):
     """With no working clipboard tool, it reports failure instead of raising."""
     monkeypatch.setattr(sys, "platform", "linux")
 
-    def _fake_run(command, input, check):  # noqa: A002 - mirror subprocess.run
+    def _fake_run(command, input, check):
         raise FileNotFoundError(command[0])
 
     monkeypatch.setattr(desktop.subprocess, "run", _fake_run)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,8 +1,9 @@
 """Tests for the diff engine (compare_graphs, summaries, reports)."""
 
 import pytest
-from rdflib import Graph, URIRef, Literal, BNode
-from rdflib.namespace import RDF, RDFS, OWL
+from rdflib import BNode, Graph, Literal, URIRef
+from rdflib.namespace import OWL, RDF, RDFS
+
 from ontology_manager import OntologyManager
 
 

--- a/tests/test_import_namespace.py
+++ b/tests/test_import_namespace.py
@@ -2,7 +2,6 @@
 
 from ontology_manager import OntologyManager
 
-
 TURTLE_WITH_ONTOLOGY = """\
 @prefix : <http://imported.org/ont#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -1,8 +1,8 @@
 """Tests for JSON-LD import support."""
 
 import pytest
-from ontology_manager import OntologyManager
 
+from ontology_manager import OntologyManager
 
 JSONLD_MINIMAL = """{
   "@context": {

--- a/tests/test_local_file_persist.py
+++ b/tests/test_local_file_persist.py
@@ -16,9 +16,8 @@ import time
 
 import pytest
 
-import orionbelt_ontology_builder.app as app
-from orionbelt_ontology_builder import local_store
 from ontology_manager import OntologyManager, rdf_format_for_path
+from orionbelt_ontology_builder import app, local_store
 
 
 class _FakeSessionState(dict):

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -3,13 +3,13 @@
 import pytest
 from rdflib import Graph, URIRef
 from rdflib.namespace import RDFS
+
 from ontology_manager import (
-    OntologyManager,
-    IMPORT_REPLACE,
     IMPORT_MERGE,
     IMPORT_MERGE_OVERWRITE,
+    IMPORT_REPLACE,
+    OntologyManager,
 )
-
 
 SECOND_ONT_TTL = """
 @prefix owl: <http://www.w3.org/2002/07/owl#> .

--- a/tests/test_mutation_checkpoints.py
+++ b/tests/test_mutation_checkpoints.py
@@ -78,9 +78,12 @@ def _bumps_revision(node: ast.AST) -> bool:
                 return True
             if isinstance(func, ast.Attribute) and func.attr in BUMP_MARKERS:
                 return True
-        if isinstance(inner, ast.Subscript) and isinstance(inner.slice, ast.Constant):
-            if inner.slice.value == "_ont_mutation_count":
-                return True
+        if (
+            isinstance(inner, ast.Subscript)
+            and isinstance(inner.slice, ast.Constant)
+            and inner.slice.value == "_ont_mutation_count"
+        ):
+            return True
     return False
 
 

--- a/tests/test_name_validation.py
+++ b/tests/test_name_validation.py
@@ -1,8 +1,8 @@
 """Tests for entity name validation (issue #93)."""
 
 import pytest
-from ontology_manager import OntologyManager
 
+from ontology_manager import OntologyManager
 
 VALID = [
     "OutputTable",

--- a/tests/test_prefixes.py
+++ b/tests/test_prefixes.py
@@ -1,6 +1,7 @@
 """Tests for prefix management."""
 
 import pytest
+
 from ontology_manager import OntologyManager
 
 

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -6,7 +6,9 @@ using ontologies from samples/ directory.
 
 import os
 import subprocess
+
 import pytest
+
 from ontology_manager import OntologyManager
 
 SAMPLES_DIR = os.path.join(

--- a/tests/test_skos.py
+++ b/tests/test_skos.py
@@ -1,6 +1,7 @@
 """Tests for SKOS vocabulary operations."""
 
 import pytest
+
 from ontology_manager import OntologyManager
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -5,20 +5,21 @@ from unittest.mock import patch
 
 import pytest
 from rdflib import Graph
+
+from ontology_manager import OntologyManager
 from orionbelt_ontology_builder import templates as templates_module
 from orionbelt_ontology_builder.templates import (
-    get_template_names,
-    get_template,
-    render_template,
-    get_upper_ontology_names,
-    get_upper_ontology,
-    load_upper_ontology_module,
-    get_reference_ontology_names,
-    get_reference_ontology,
-    load_reference_ontology_module,
     _fetch_with_cache,
+    get_reference_ontology,
+    get_reference_ontology_names,
+    get_template,
+    get_template_names,
+    get_upper_ontology,
+    get_upper_ontology_names,
+    load_reference_ontology_module,
+    load_upper_ontology_module,
+    render_template,
 )
-from ontology_manager import OntologyManager
 
 
 class TestTemplateDefinitions:
@@ -250,12 +251,14 @@ class TestReferenceOntologies:
             def read(self):
                 return payload
 
-        with patch(
-            "orionbelt_ontology_builder.templates.urllib.request.urlopen",
-            return_value=_Resp(),
+        with (
+            patch(
+                "orionbelt_ontology_builder.templates.urllib.request.urlopen",
+                return_value=_Resp(),
+            ),
+            pytest.raises(RuntimeError, match="SHA256 mismatch"),
         ):
-            with pytest.raises(RuntimeError, match="SHA256 mismatch"):
-                _fetch_with_cache("https://example.invalid/x", wrong_sha)
+            _fetch_with_cache("https://example.invalid/x", wrong_sha)
 
         # Mismatched fetch must NOT poison the cache
         assert not (tmp_path / f"{wrong_sha}.dat").exists()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -44,7 +44,7 @@ def test_missing_domain_range(om):
 
 def test_no_missing_domain_when_domain_includes_present(om):
     """Properties with schema:domainIncludes or gist:domainIncludes should not warn (issue #2)."""
-    from ontology_manager import _SCHEMA, _GIST
+    from ontology_manager import _GIST, _SCHEMA
 
     om.add_class("Person")
     om.add_object_property("schemaProp")
@@ -64,7 +64,7 @@ def test_no_missing_domain_when_domain_includes_present(om):
 
 def test_no_missing_range_when_range_includes_present(om):
     """Properties with schema:rangeIncludes or gist:rangeIncludes should not warn (issue #2)."""
-    from ontology_manager import _SCHEMA, _GIST
+    from ontology_manager import _GIST, _SCHEMA
 
     om.add_class("Person")
     om.add_object_property("schemaProp", domain="Person")

--- a/tests/test_viz_class_paste.py
+++ b/tests/test_viz_class_paste.py
@@ -11,7 +11,6 @@ import pytest
 
 from orionbelt_ontology_builder import app
 
-
 BASE = "http://ex.org/base#"
 FN = "http://ex.org/fn#"
 MATH = "http://ex.org/math#"

--- a/tests/test_viz_settings.py
+++ b/tests/test_viz_settings.py
@@ -29,7 +29,7 @@ class _FakeLS:
     def getItem(self, _key):
         return self._value
 
-    def setItem(self, _key, value, key=None):  # noqa: A002 - mirrors the real API
+    def setItem(self, _key, value, key=None):
         self.saved = value
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -142,7 +142,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "(python_full_version < '3.11' and implementation_name != 'PyPy') or (implementation_name != 'PyPy' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -287,7 +287,7 @@ name = "clr-loader"
 version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "python_full_version < '3.11' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/46/7eea92b6aa2d68af78e049cbecec5f757f1aad44ecdecdc16bbad7eead51/clr_loader-0.3.1.tar.gz", hash = "sha256:2e073e9aaf49d1ae2f56ecba27987ad5fb68be4bcd9dd34a5bed8f0e4e128366", size = 86805, upload-time = "2026-04-18T17:49:44.287Z" }
 wheels = [
@@ -444,7 +444,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -510,17 +510,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -546,18 +546,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -569,7 +569,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -737,7 +737,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1164,7 +1164,7 @@ requires-dist = [
     { name = "pywebview", extras = ["pyside6"], marker = "sys_platform != 'darwin' and extra == 'desktop'" },
     { name = "pywebview", extras = ["pyside6"], marker = "sys_platform != 'darwin' and extra == 'qt'" },
     { name = "rdflib", specifier = ">=7.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.22" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.0" },
     { name = "streamlit", specifier = "==1.49.1" },
     { name = "streamlit-desktop-app", marker = "extra == 'desktop'", specifier = ">=0.3.3" },
     { name = "streamlit-desktop-app", marker = "extra == 'gtk'", specifier = ">=0.3.3" },
@@ -1288,7 +1288,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1585,7 +1585,7 @@ name = "pygobject"
 version = "3.56.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycairo" },
+    { name = "pycairo", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/61/978c5fbca34f10a90df362502fbb5a005637909e7b5a0e9212349ea9d010/pygobject-3.56.3.tar.gz", hash = "sha256:12760e4a0e3d04b6eb95e06f7a27e362c826d567ea613373a92c003b6c70d2d6", size = 1411853, upload-time = "2026-05-08T20:46:39.904Z" }
 
@@ -1594,8 +1594,8 @@ name = "pygobject-stubs"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygobject" },
-    { name = "typing-extensions" },
+    { name = "pygobject", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8c/be/bf49399ad2e788121f595903a56447d4b778d67acbb01ecfc1c6d5cf91f6/pygobject_stubs-2.17.0.tar.gz", hash = "sha256:66884d26974dd7fb99a8bc5972b5bdeb4b7399ecc7ac53913a6cafa6ab21491f", size = 1010510, upload-time = "2026-03-20T17:08:59.656Z" }
 
@@ -1661,7 +1661,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -1681,8 +1681,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pyobjc-framework-cocoa", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [
@@ -1702,8 +1702,8 @@ name = "pyobjc-framework-security"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pyobjc-framework-cocoa", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/b8/4267b802d8dba6de468e7d0765b05cc4e146fa376ed9f55e0b6461016bef/pyobjc_framework_security-12.2.1.tar.gz", hash = "sha256:d7831b1537f4346892e7f2f0e2b09d79bee98919b0767f4061278d0e03028f2d", size = 181065, upload-time = "2026-06-19T16:21:40.151Z" }
 wheels = [
@@ -1723,8 +1723,8 @@ name = "pyobjc-framework-webkit"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pyobjc-framework-cocoa", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/d2/b230c594f70ecb970b4cef67bae2648d1bfa5b381e9b7e3710bf24ec8887/pyobjc_framework_webkit-12.2.1.tar.gz", hash = "sha256:a56acae55b50d549b20dff2921ad1099add8fbc377d0de09ddc2ba50957f7def", size = 332374, upload-time = "2026-06-19T16:22:01.988Z" }
 wheels = [
@@ -1843,7 +1843,7 @@ name = "pythonnet"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "clr-loader" },
+    { name = "clr-loader", marker = "python_full_version < '3.11' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/57/da1992e44663b71365c6e842c8d7fa453d4ec45fb99a68cfee5b7e944d3c/pythonnet-3.1.0.tar.gz", hash = "sha256:7b34c382905d10a371509ffafd64cae0416305c28817738a9cd138336f4e9991", size = 250599, upload-time = "2026-05-23T20:30:21.578Z" }
 wheels = [
@@ -1899,8 +1899,8 @@ wheels = [
 
 [package.optional-dependencies]
 gtk = [
-    { name = "pygobject" },
-    { name = "pygobject-stubs" },
+    { name = "pygobject", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "pygobject-stubs", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 pyside6 = [
     { name = "pyside6" },
@@ -2094,27 +2094,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.22"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
-    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #205 (whose commit is included here) and replaces #206, which took the narrower approach of pinning the old rule set.

## Background

The repo had no `[tool.ruff.lint]` config, so it relied on ruff's default rule selection. Up to 0.15.x that default was just `E4`, `E7`, `E9`, `F`. Ruff 0.16.0 widens it to roughly 35 families (UP, SIM, RUF, PERF, PTH, S, BLE, ...), which is why the Dependabot bump failed CI with 391 findings.

This PR takes the wider set rather than pinning back to the old four, and cleans up everything it reports.

## How the 391 findings were resolved

| Route | Count | Rules |
| --- | --- | --- |
| ruff safe fixes | 293 | UP006 (167), UP045 (70), I001 (28), RUF010 (10), UP035, RUF100, F401 |
| ruff unsafe fixes, reviewed by hand | 12 | PIE810, C401, C408, SIM101, SIM103, RUF059 |
| manual edits | 24 | RUF012 (11), SIM102 (11), SIM115, DTZ005 |
| ignored in config | 65 | BLE001 (49), S110 (16) |

The bulk is mechanical: `List[str]` to `list[str]`, `Optional[X]` to `X | None`, import ordering, and `{str(e)}` to `{e!s}` inside f-strings.

The manual edits are the interesting ones:

- **RUF012** - 11 class-level constant dicts and sets on `OntologyManager` now carry `ClassVar[...]` annotations.
- **SIM102** - 11 nested `if` statements merged. Each was checked for a trailing `else`/`elif` first, since merging would change which branch runs; none had one.
- **SIM115** - the graph-viewer source hash now reads `index.html` through a `with` block.
- **DTZ005** - the error-log timestamp uses `datetime.now().astimezone()`, keeping local wall-clock time (which is what the reader wants) while satisfying the rule.

## The two ignored rules

`BLE001` (blind `except Exception`) and `S110` (try-except-pass) both encode the same deliberate design choice, so they are ignored project-wide with the rationale written into `pyproject.toml` rather than sprinkled across 65 `noqa` comments: optional or degradable paths, including graph rendering, theme detection and the desktop webview hooks, are wrapped in broad handlers so a failure downgrades the UI instead of killing the Streamlit session. Errors the user needs to see are surfaced explicitly via `log_error()` / `show_message()`.

One side effect worth flagging: `F403` is not in ruff 0.16.0's default set, so `RUF100` removed the now-dead `# noqa: F401, F403` from the star imports in the `ontology_manager.py` and `templates.py` shims. The `# noqa: F401` on the explicit re-export blocks below them is still needed and was kept. Both shims were verified to still re-export correctly at runtime.

## Verification

- `ruff check`: all checks passed
- `ruff format --check`: 67 files already formatted
- `pytest`: 687 passed
- `mypy`: no issues found in 66 source files
- Smoke test of the engine (create classes, hierarchy, prefixes, turtle serialisation) and of both compatibility shims

## Follow-up

Now that the wide set is in place there is no `select` pinning it, so a future ruff release that adds to its default will surface here as new findings. That is the intended behaviour, but worth knowing when the next bump lands.