### PR TITLE
fix: log swallowed exceptions instead of silently passing

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -274,7 +274,9 @@ def _configure_page() -> None:
         if st.context.theme.get("type") == "dark":
             st.markdown(_DARK_CSS, unsafe_allow_html=True)
     except Exception:
-        pass
+        logger.debug(
+            "Dark-theme CSS skipped: st.context.theme unavailable", exc_info=True
+        )
     if "app_started" not in st.session_state:
         st.session_state.app_started = True
         logger.info(f"{APP_NAME} v{APP_VERSION}")
@@ -7969,7 +7971,9 @@ def render_visualization():
                                     dashes=True,
                                 )
                         except Exception:
-                            pass  # Skip problematic annotations
+                            logger.debug(
+                                "Skipping a class annotation node", exc_info=True
+                            )
 
                 # Annotations for individuals
                 if show_individuals and individuals:
@@ -8018,7 +8022,9 @@ def render_visualization():
                                     dashes=True,
                                 )
                         except Exception:
-                            pass  # Skip problematic annotations
+                            logger.debug(
+                                "Skipping an individual annotation node", exc_info=True
+                            )
 
             # Add SKOS concepts and relations
             if show_skos and node_count < max_nodes:
@@ -8298,7 +8304,10 @@ def render_visualization():
             try:
                 _gv_dark = st.context.theme.get("type") == "dark"
             except Exception:
-                pass
+                logger.debug(
+                    "Graph theme defaulting to light: st.context.theme unavailable",
+                    exc_info=True,
+                )
             _gv_theme = (
                 {"bg": "#0e1117", "panel": "#262730", "text": "#fafafa"}
                 if _gv_dark
@@ -8611,7 +8620,10 @@ def main():
     try:
         _theme_type = st.context.theme.type
     except Exception:
-        pass
+        logger.debug(
+            "Sidebar logo defaulting to colour: st.context.theme unavailable",
+            exc_info=True,
+        )
     # st.context.theme is stale on the first render of a session — it reports the
     # default ("light") until the browser tells the server the active theme, so
     # only trust it from the second render on (issues #70, #78).

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -20,6 +20,7 @@ This reuses the same in-package Streamlit entry script as the console launcher
 """
 
 import importlib.util
+import logging
 import os
 import subprocess
 import sys
@@ -27,6 +28,8 @@ from pathlib import Path
 
 from .app import APP_NAME
 from .local_store import BRAND_PRIMARY_COLOR, ENV_FLAG, data_dir, resolved_startup_base
+
+logger = logging.getLogger(__name__)
 
 
 def _preferred_gui() -> str | None:
@@ -198,7 +201,7 @@ def _install_window_bridges(app_name: str):
             try:
                 window.set_title(title if title and title != "Streamlit" else app_name)
             except Exception:
-                pass
+                logger.debug("Backend rejected set_title()", exc_info=True)
             return True
 
         def orionbelt_copy_to_clipboard(text):
@@ -232,7 +235,9 @@ def _install_window_bridges(app_name: str):
                 orionbelt_toggle_fullscreen,
             )
         except Exception:
-            pass
+            logger.debug(
+                "JS bridge not exposed; backend has no window.expose()", exc_info=True
+            )
 
         def _clear_native_fullscreen_flag():
             # pywebview decides which way toggle_fullscreen() goes purely from a
@@ -249,7 +254,9 @@ def _install_window_bridges(app_name: str):
                 try:
                     view.is_fullscreen = False
                 except Exception:
-                    pass
+                    logger.debug(
+                        "Could not clear the native fullscreen flag", exc_info=True
+                    )
 
         def _on_window_restored():
             # macOS fires the window's "restored" event when it leaves fullscreen
@@ -265,24 +272,32 @@ def _install_window_bridges(app_name: str):
                     " window.__orionbeltNativeFullscreenExit()"
                 )
             except Exception:
-                pass
+                logger.debug(
+                    "Fullscreen-exit notice not delivered to the page", exc_info=True
+                )
 
         try:
             window.events.restored += _on_window_restored
         except Exception:
-            pass
+            logger.debug(
+                "Backend has no 'restored' event; fullscreen-exit sync disabled",
+                exc_info=True,
+            )
 
         def _inject():
             for script in (_TITLE_SYNC_JS, _CLIPBOARD_BRIDGE_JS):
                 try:
                     window.evaluate_js(script)
                 except Exception:
-                    pass
+                    logger.debug("Startup script injection failed", exc_info=True)
 
         try:
             window.events.loaded += _inject
         except Exception:
-            pass
+            logger.debug(
+                "Backend has no 'loaded' event; script injection disabled",
+                exc_info=True,
+            )
         return window
 
     webview.create_window = _create

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2,6 +2,7 @@
 OntologyManager - Core class for managing OWL ontologies using rdflib.
 """
 
+import logging
 import os
 import re
 import tempfile
@@ -13,6 +14,8 @@ from rdflib import BNode, Graph, Literal, Namespace, URIRef
 from rdflib.collection import Collection
 from rdflib.namespace import DC, DCTERMS, OWL, RDF, RDFS, SKOS, XSD
 from rdflib.term import Node
+
+logger = logging.getLogger(__name__)
 
 #: RDF serialization format for a file, keyed by lower-case extension. Used so a
 #: linked working file can be a format other than Turtle (e.g. .owl/.rdf).
@@ -3078,7 +3081,12 @@ class OntologyManager:
                                 if isinstance(m, URIRef)
                             ]
                         except Exception:
-                            pass
+                            logger.debug(
+                                "Skipping malformed RDF list in a %s expression on %s",
+                                expr_type,
+                                subj_name,
+                                exc_info=True,
+                            )
 
                     if expr["members"]:
                         expressions.append(expr)
@@ -3107,7 +3115,9 @@ class OntologyManager:
                         [self._local_name(m) for m in members if isinstance(m, URIRef)]
                     )
                 except Exception:
-                    pass
+                    logger.debug(
+                        "Skipping malformed owl:distinctMembers list", exc_info=True
+                    )
         return all_diffs
 
     def add_has_key(self, class_name: str, properties: list[str]):
@@ -3140,7 +3150,7 @@ class OntologyManager:
                         }
                     )
                 except Exception:
-                    pass
+                    logger.debug("Skipping malformed owl:hasKey list", exc_info=True)
         return keys
 
     def add_disjoint_union(self, class_name: str, disjoint_classes: list[str]):
@@ -3170,7 +3180,9 @@ class OntologyManager:
                         }
                     )
                 except Exception:
-                    pass
+                    logger.debug(
+                        "Skipping malformed owl:disjointUnionOf list", exc_info=True
+                    )
         return unions
 
     # ==================== IMPORT/EXPORT OPERATIONS ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,13 +84,15 @@ Demo = "https://orionbelt.streamlit.app"
 # was just E4/E7/E9/F; 0.16.0 widened it to roughly 35 families (UP, SIM, RUF,
 # PERF, PTH, ...) and we adopt that rather than pinning back to the old four.
 ignore = [
-    # Both of these encode the same deliberate choice: optional or degradable
-    # paths — graph rendering, theme detection, the desktop webview hooks —
-    # are wrapped in broad handlers so a failure downgrades the UI instead of
-    # killing the Streamlit session. Errors that the user needs to see are
-    # surfaced explicitly through log_error() / show_message().
+    # Optional or degradable paths — graph rendering, theme detection, the
+    # desktop webview hooks — are wrapped in `except Exception` so a failure
+    # downgrades the UI instead of killing the Streamlit session. The specific
+    # type genuinely is not knowable there: it varies by pywebview backend and
+    # by Streamlit version. Every such handler logs at debug level with a
+    # traceback (so nothing is swallowed silently, which is what S110 guards
+    # against), and errors the user must see go through log_error() /
+    # show_message().
     "BLE001", # blind `except Exception`
-    "S110",   # try-except-pass
 ]
 
 [tool.mypy]


### PR DESCRIPTION
Follow-up to #207, which suppressed `S110` (try-except-pass) in the ruff ignore list. That silenced the linter without addressing what the rule is for, so this fixes the 16 sites properly and re-enables it.

## Why it mattered

`S110` is not really about the `try`. It is about the empty handler: a failure leaves no trace at all. Several of these blocks wrap multiple statements, so a bug introduced inside one later would disappear with no log line and no indication why the feature stopped working. Silencing the rule did nothing to prevent that.

## What changed

All 16 handlers now log at debug level with `exc_info=True` and a message naming what was skipped. Runtime behaviour is unchanged: the same paths still degrade rather than crash.

| File | Sites | What is being guarded |
| --- | --- | --- |
| `desktop.py` | 7 | pywebview backend capabilities (`window.expose`, `evaluate_js`, `restored`/`loaded` events) that exist on some platform backends and not others |
| `app.py` | 5 | `st.context.theme` availability, and per-node annotation rendering in the graph |
| `ontology_manager.py` | 4 | malformed RDF collections in user-supplied ontologies |

Adds a module logger to `desktop.py` and `ontology_manager.py`; `app.py` already had one.

## Config

`S110` is removed from the ignore list and is now enforced. `BLE001` stays ignored, but the comment is rewritten to say why the broad catch is correct in these specific places (the exception type genuinely varies by pywebview backend and Streamlit version) and to record that nothing is swallowed silently any more.

## Verification

- `ruff check` clean **with `S110` active** — confirmed present in `--show-settings` output rather than merely absent from findings
- `ruff format --check`: 67 files already formatted
- `pytest`: 687 passed
- `mypy`: no issues in 66 source files
- Fault injection on `get_all_different()`: forcing the guarded call to raise returns `[]` (graceful) and emits `Skipping malformed owl:distinctMembers list` followed by a full traceback
- Zero remaining `except Exception:` / `pass` pairs in the package