### PR TITLE
fix: justify each blind except in place, drop the BLE001 ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,10 @@ Thumbs.db
 
 # Screenshot artifacts written to the repo root during browser-driven verification
 /*.png
+
+# Coverage.py artifacts (pytest --cov); the .coverage database embeds absolute
+# local paths, so it must never be committed.
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -230,7 +230,7 @@ def _page_title() -> str:
     if ont is not None:
         try:
             name = (ont.get_ontology_metadata().get("label") or "").strip()
-        except Exception:
+        except Exception:  # noqa: BLE001 - best-effort label read; falls back to the URI
             name = ""
         if not name:
             base = ont.base_uri.rstrip("#/")
@@ -356,7 +356,8 @@ def _get_local_storage():
             from streamlit_local_storage import LocalStorage
 
             st.session_state["_local_storage"] = LocalStorage()
-        except Exception as e:  # pragma: no cover - depends on browser/runtime
+        # Optional dependency; failure mode depends on browser/runtime.
+        except Exception as e:  # noqa: BLE001  # pragma: no cover
             logger.warning(f"localStorage autosave unavailable: {e}")
             st.session_state["_local_storage"] = None
     ls = st.session_state["_local_storage"]
@@ -472,7 +473,7 @@ def _restore_autosave_from_disk(ont):
     fmt = "turtle" if label == "recovery file" else _rdf_format_for_path(path)
     try:
         ont.load_from_file(str(path), format=fmt)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - autosave restore must never break startup
         log_error(e, context="Autosave restore (disk)")
         _block_disk_persist(
             f"The {label} couldn't be read or parsed. Disk autosave is paused so "
@@ -538,7 +539,7 @@ def maybe_restore_autosave():
 
     try:
         ont.load_from_string(saved, format="turtle")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - autosave restore must never break startup
         log_error(e, context="Autosave restore")
         st.session_state["_autosave_restored"] = True
         return
@@ -654,7 +655,7 @@ def _persist_autosave_to_localstorage():
 
     try:
         ttl = st.session_state.ontology.export_to_string(format="turtle")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - autosave export must never break the session
         log_error(e, context="Autosave export")
         return
 
@@ -706,7 +707,7 @@ def persist_autosave():
             _persist_autosave_to_disk()
         else:
             _persist_autosave_to_localstorage()
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - autosave must never break the session
         log_error(e, context="Autosave")
         if local_store.local_persist_enabled():
             _block_disk_persist(
@@ -832,7 +833,7 @@ def _load_linked_file(target) -> bool:
         OntologyManager = get_ontology_manager_class()
         new_ont = OntologyManager()
         new_ont.load_from_file(str(target), format=_rdf_format_for_path(target))
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - a bad linked file must not break the session
         log_error(e, context="Linked file load")
         return False
     st.session_state.ontology = new_ont
@@ -4072,7 +4073,7 @@ def render_restriction_editor(ont, rest, row_key, classes, properties):
                         ),
                     },
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 - a rejected edit must show as a message, not a traceback
                 # As wide as the Add form's handler: a rejected edit must show
                 # up as a message, never as a page-breaking traceback.
                 show_message(str(exc), "error")
@@ -4165,7 +4166,7 @@ def render_add_restriction(ont, classes, properties):
                 save_checkpoint("Add restriction")
                 show_message("Restriction added!", "success")
                 st.rerun()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - a rejected edit must show as a message, not a traceback
                 show_message(f"Error adding restriction: {e!s}", "error")
 
 
@@ -5730,7 +5731,7 @@ def render_import_export():
                     st.session_state.get("import_uploader_key", 0) + 1
                 )
                 st.rerun()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - malformed import must show as a message, not a traceback
                 show_message(f"Error importing ontology: {e!s}", "error")
 
         # Step 1: Source selection (only when no preview active)
@@ -5777,7 +5778,7 @@ def render_import_export():
                                 st.session_state.import_content = content
                                 st.session_state.import_format = format_
                                 st.rerun()
-                        except Exception as e:
+                        except Exception as e:  # noqa: BLE001 - malformed import must show as a message, not a traceback
                             show_message(f"Error parsing file: {e!s}", "error")
 
             else:
@@ -5800,7 +5801,7 @@ def render_import_export():
                                 st.session_state.import_content = content
                                 st.session_state.import_format = format_
                                 st.rerun()
-                        except Exception as e:
+                        except Exception as e:  # noqa: BLE001 - malformed import must show as a message, not a traceback
                             show_message(f"Error parsing content: {e!s}", "error")
 
         # Step 2: Review panel
@@ -5891,7 +5892,7 @@ def render_import_export():
                             "success",
                         )
                         st.rerun()
-                    except Exception as e:
+                    except Exception as e:  # noqa: BLE001 - malformed import must show as a message, not a traceback
                         show_message(f"Error applying import: {e!s}", "error")
             with col_cancel:
                 if st.button("Cancel"):
@@ -5992,7 +5993,7 @@ def render_import_export():
                     format=format_
                 )
                 st.session_state["_export_ext"] = ext
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - export failure must show as a message, not a traceback
                 st.session_state.pop("_export_content", None)
                 show_message(f"Error exporting ontology: {e!s}", "error")
 
@@ -6143,7 +6144,7 @@ def render_import_export():
                     f"— {s['classes']} classes, {s['object_properties']} obj props, "
                     f"{s['data_properties']} data props, {s['content_triples']} triples"
                 )
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - a bad upper ontology must show as a message
                 st.session_state["_upper_onto_err"] = (
                     f"Error loading upper ontology: {e!s}"
                 )
@@ -6237,7 +6238,7 @@ def render_import_export():
                     f"— {s['classes']} classes, {s['object_properties']} obj props, "
                     f"{s['data_properties']} data props, {s['content_triples']} triples"
                 )
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - a bad reference ontology must show as a message
                 st.session_state["_ref_onto_err"] = (
                     f"Error loading reference ontology: {e!s}"
                 )
@@ -6648,7 +6649,7 @@ def render_validation():
                     "success",
                 )
                 st.write(f"New triple count: {len(ont.graph)}")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - reasoner failure must show as a message, not a traceback
                 show_message(f"Error during reasoning: {e!s}", "error")
 
 
@@ -8267,7 +8268,7 @@ def render_visualization():
                 # PR review). seq is now bumped only for a real re-layout below.
                 status.empty()
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - a graph build failure must not break the page
                 status.empty()
                 st.error(f"Error building graph: {e!s}")
 
@@ -8601,7 +8602,7 @@ def render_source():
     try:
         turtle_src = ont.export_to_string(format="turtle")
         st.code(turtle_src, language="turtle", line_numbers=True)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - serialization failure must show as a message
         st.error(f"Error serializing ontology: {e}")
 
 
@@ -8874,7 +8875,7 @@ def main():
     # Render selected page
     try:
         pages[selection]()
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - a crash in any page must not kill the app
         log_error(e, context=f"Page: {selection}")
         st.error(f"An error occurred: {e}")
         st.caption(f"[Report this issue on GitHub]({GITHUB_ISSUES_URL}/new)")

--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -210,7 +210,7 @@ def _install_window_bridges(app_name: str):
             # reaches their real clipboard (issue #120).
             try:
                 return _copy_to_clipboard("" if text is None else str(text))
-            except Exception:
+            except Exception:  # noqa: BLE001 - clipboard bridge is best-effort across backends
                 return False
 
         def orionbelt_toggle_fullscreen():
@@ -225,7 +225,7 @@ def _install_window_bridges(app_name: str):
             try:
                 window.toggle_fullscreen()
                 return True
-            except Exception:
+            except Exception:  # noqa: BLE001 - pywebview backends differ on toggle_fullscreen
                 return None
 
         try:
@@ -248,7 +248,7 @@ def _install_window_bridges(app_name: str):
             # today's behaviour.
             try:
                 view = window.gui.BrowserView.instances.get(window.uid)
-            except Exception:
+            except Exception:  # noqa: BLE001 - platform window internals vary by backend
                 return
             if view is not None and getattr(view, "is_fullscreen", False):
                 try:

--- a/orionbelt_ontology_builder/local_store.py
+++ b/orionbelt_ontology_builder/local_store.py
@@ -157,7 +157,7 @@ def detect_system_base() -> str | None:
         import darkdetect
 
         detected = darkdetect.theme()  # "Dark" / "Light" / None
-    except Exception:
+    except Exception:  # noqa: BLE001 - darkdetect is optional and platform-specific
         return None
     if isinstance(detected, str) and detected.lower() in ("light", "dark"):
         return detected.lower()

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -958,7 +958,7 @@ class OntologyManager:
                     continue
                 try:
                     self._require_valid_name(parent)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 - one bad row must not abort the batch
                     result["errors"].append({"name": name, "error": str(e)})
                     continue
                 class_ref = self._uri(name, namespace)
@@ -981,7 +981,7 @@ class OntologyManager:
                 existing.add(uri)
                 if parent:
                     referenced_parents.add(str(self._uri(parent)))
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - one bad row must not abort the batch
                 result["errors"].append({"name": name, "error": str(e)})
 
         # Backfill: any referenced parent that no successful row declared as a
@@ -991,7 +991,7 @@ class OntologyManager:
                 created_uri = self.add_class(parent_uri)
                 existing.add(parent_uri)
                 result["created"].append(self._local_name(created_uri))
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - one bad row must not abort the batch
                 result["errors"].append({"name": parent_uri, "error": str(e)})
 
         return result
@@ -1043,7 +1043,7 @@ class OntologyManager:
                     )
                 result["created"].append(name)
                 existing.add(uri)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - one bad row must not abort the batch
                 result["errors"].append({"name": name, "error": str(e)})
 
         return result
@@ -1081,7 +1081,7 @@ class OntologyManager:
                 )
                 result["created"].append(name)
                 existing.add(uri)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - one bad row must not abort the batch
                 result["errors"].append({"name": name, "error": str(e)})
 
         return result
@@ -1093,7 +1093,7 @@ class OntologyManager:
             try:
                 self.delete_class(name)
                 result["deleted"].append(name)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - one bad row must not abort the batch
                 result["errors"].append({"name": name, "error": str(e)})
         return result
 
@@ -1104,7 +1104,7 @@ class OntologyManager:
             try:
                 self.delete_property(name)
                 result["deleted"].append(name)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - one bad row must not abort the batch
                 result["errors"].append({"name": name, "error": str(e)})
         return result
 
@@ -1115,7 +1115,7 @@ class OntologyManager:
             try:
                 self.delete_individual(name)
                 result["deleted"].append(name)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - one bad row must not abort the batch
                 result["errors"].append({"name": name, "error": str(e)})
         return result
 
@@ -1160,7 +1160,7 @@ class OntologyManager:
                         continue
                     self.add_annotation(resource, predicate, value, lang=lang)
                 result["applied"] += 1
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - one bad row must not abort the batch
                 result["errors"].append(
                     {
                         "resource": resource,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,17 +83,10 @@ Demo = "https://orionbelt.streamlit.app"
 # No `select`: we lint against ruff's own default rule set. Up to 0.15.x that
 # was just E4/E7/E9/F; 0.16.0 widened it to roughly 35 families (UP, SIM, RUF,
 # PERF, PTH, ...) and we adopt that rather than pinning back to the old four.
-ignore = [
-    # Optional or degradable paths — graph rendering, theme detection, the
-    # desktop webview hooks — are wrapped in `except Exception` so a failure
-    # downgrades the UI instead of killing the Streamlit session. The specific
-    # type genuinely is not knowable there: it varies by pywebview backend and
-    # by Streamlit version. Every such handler logs at debug level with a
-    # traceback (so nothing is swallowed silently, which is what S110 guards
-    # against), and errors the user must see go through log_error() /
-    # show_message().
-    "BLE001", # blind `except Exception`
-]
+# Nothing is ignored project-wide. The broad `except Exception` handlers this
+# app genuinely needs — resilience boundaries around user-supplied ontologies,
+# bulk rows, page dispatch and the pywebview backends — carry an inline
+# `# noqa: BLE001` naming the reason, so a *new* blind except still fails CI.
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
Completes the lint work from #207 and #208. `pyproject.toml` now has an empty ignore list.

## What this does, and what it deliberately does not

`BLE001` was ignored project-wide, so a brand-new `except Exception` written tomorrow would go unnoticed. That is the actual problem worth fixing. The ignore is gone and each of the 33 remaining sites carries an inline `# noqa: BLE001` naming why it is broad, so CI fails on any new one.

**The handlers themselves are not narrowed**, and that is a considered decision rather than a shortcut. Each is a resilience boundary sitting above rdflib and owlrl, where the exception type is not knowable in advance:

| Location | Sites | Why broad is correct |
| --- | ---: | --- |
| `ontology_manager.py` | 9 | Bulk add/delete collect per-row errors and continue. Narrowing would let one unanticipated failure abort the whole batch. |
| `app.py` | 20 | Page dispatch, autosave, import/export, reasoning. These wrap user-supplied ontologies and must surface as a message, never a page-breaking traceback. |
| `desktop.py` | 3 | pywebview capability probes; behaviour differs per platform backend. |
| `local_store.py` | 1 | `darkdetect` is optional and platform-specific. |

The engine itself only ever raises `ValueError` (13 `raise` statements, all `ValueError`), so narrowing looks tempting. But these boundaries sit *above* rdflib and owlrl, which raise a wide and unstable set of types on malformed input. Narrowing to `ValueError` would convert a gracefully degraded feature into a crash on exactly the inputs these guards exist for. Lint cleanliness is not worth that trade.

Note that 16 of the original 49 sites already dropped off in #208: `BLE001` exempts handlers that log the caught exception, so making them log resolved them honestly rather than by suppression.

## Verification

- `ruff check` clean with **no project-wide ignores at all**
- `ruff format` idempotent: 67 files unchanged on a second pass
- `RUF100` is active in the default set and reports nothing, confirming no directive is stale
- `pytest`: 687 passed
- `mypy`: no issues in 66 source files
- **Fault injection**: appending a fresh `try/except Exception/return None` to `local_store.py` is reported as `BLE001`; removing it returns to clean. This is the property the change exists to guarantee.

## One wrinkle worth flagging

The `streamlit_local_storage` handler already carried a `# pragma: no cover`. Appending the directive pushed the line past the formatter's limit, and the resulting wrap split `except (Exception) as e:` across lines, which detached the `noqa` from the diagnostic and silently reintroduced the finding. The block was restructured so the line stays short and the comment lives above it. Coverage still honours the pragma.