### PR TITLE
fix: rank exact matches first in entity dropdowns (#210)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1139,10 +1139,27 @@ def confirm_delete(resource_name: str, resource_type: str, key_suffix: str) -> b
     return False
 
 
+# Separates the local name from the label in display strings. Neither the order
+# nor the separator is cosmetic.
+#
+# Streamlit filters selectboxes client-side with fzy, which awards a match a
+# word-boundary bonus taken from the character *preceding* it: 0.9 after '/',
+# 0.8 after a space (or '-', '_'), 0.7 for a camelCase hump, and 0.0 after '('.
+# The old 'Label (name)' format gave the local name no bonus at all, so an
+# unrelated camelCase compound could outscore an exact match — searching
+# 'HamTopping' in pizza.owl ranked 'ParmaHamTopping' first (issue #210). Leading
+# with the name, behind a separator that ends in a space, restores the bonus.
+#
+# Name-first also keeps the option list sorted consistently: a resource whose
+# label matches its name renders as the bare name, so a label-first format would
+# sort part of the list by label and the rest by name.
+LABEL_NAME_SEPARATOR = " · "
+
+
 def format_label_name(name: str, label: str) -> str:
-    """Format display string as 'Label (name)' if label exists and differs from name."""
+    """Format display string as 'name · Label' if label exists and differs from name."""
     if label and label != name:
-        return f"{label} ({name})"
+        return f"{name}{LABEL_NAME_SEPARATOR}{label}"
     return name
 
 
@@ -1343,7 +1360,7 @@ def build_uri_options(items: list, include_none: bool = False) -> tuple:
 
 
 def build_class_options(classes: list, include_none: bool = False) -> tuple:
-    """Build class dropdown options with 'Label (disambiguated name)' format.
+    """Build class dropdown options with 'disambiguated name · Label' format.
 
     Thin wrapper around :func:`build_uri_options` kept for clarity at call
     sites that work specifically with classes.
@@ -2463,7 +2480,7 @@ def render_classes():
         if not classes:
             st.info("No classes to edit.")
         else:
-            # Build options with Label (disambiguated name) format; lookup is by URI
+            # Build options with disambiguated name · Label format; lookup is by URI
             class_options, class_lookup = build_class_options(classes)
             selected_display = st.selectbox(
                 "Select Class", options=class_options, key="edit_class_select"
@@ -4864,16 +4881,10 @@ def render_annotations():
     data_props = ont.get_data_properties()
     individuals = ont.get_individuals()
 
-    # Build resources with labels for display: "Label (name)" format
-    def format_resource(name, label, res_type):
-        if label and label != name:
-            return f"{label} ({name})"
-        return name
-
     # Combine all resources with their labels
     all_resources = []
     for c in classes:
-        display = format_resource(c["name"], c.get("label"), "Class")
+        display = format_label_name(c["name"], c.get("label"))
         all_resources.append(
             {
                 "name": c["name"],
@@ -4883,7 +4894,7 @@ def render_annotations():
             }
         )
     for p in object_props:
-        display = format_resource(p["name"], p.get("label"), "Object Property")
+        display = format_label_name(p["name"], p.get("label"))
         all_resources.append(
             {
                 "name": p["name"],
@@ -4893,7 +4904,7 @@ def render_annotations():
             }
         )
     for p in data_props:
-        display = format_resource(p["name"], p.get("label"), "Data Property")
+        display = format_label_name(p["name"], p.get("label"))
         all_resources.append(
             {
                 "name": p["name"],
@@ -4903,7 +4914,7 @@ def render_annotations():
             }
         )
     for i in individuals:
-        display = format_resource(i["name"], i.get("label"), "Individual")
+        display = format_label_name(i["name"], i.get("label"))
         all_resources.append(
             {
                 "name": i["name"],

--- a/tests/test_dropdown_search_ranking.py
+++ b/tests/test_dropdown_search_ranking.py
@@ -1,0 +1,179 @@
+"""Dropdown search puts an exact local-name match first (issue #210).
+
+Streamlit filters a selectbox client-side: it keeps every option whose label
+contains the typed text as a *subsequence*, then sorts by an fzy score. That
+scorer is not configurable from Python (it is bundled JS, and it is byte-for-byte
+identical in every Streamlit release from 1.49 through 1.60), so the only lever
+the app has is the option string it emits.
+
+fzy scores a match partly by the character *preceding* it: 0.9 after ``/``, 0.8
+after a space / ``-`` / ``_``, 0.7 for a camelCase hump, and 0.0 after ``(``.
+The old ``'Label (name)'`` format therefore gave the local name no boundary
+bonus at all, and an unrelated camelCase compound could outscore an exact match:
+searching ``HamTopping`` in pizza.owl ranked ``ParmaHamTopping`` first. The
+name now leads, behind a separator that ends in a space, which restores the
+bonus.
+
+``_score`` / ``_has_match`` below are a direct port of that bundled scorer, so
+these tests fail if the display format stops ranking exact matches first.
+"""
+
+from orionbelt_ontology_builder import app
+
+# fzy constants, as bundled by Streamlit.
+_SCORE_MIN = float("-inf")
+_SCORE_MAX = float("inf")
+_GAP_LEADING = -0.005
+_GAP_TRAILING = -0.005
+_GAP_INNER = -0.01
+_MATCH_CONSECUTIVE = 1.0
+_MATCH_SLASH = 0.9
+_MATCH_WORD = 0.8
+_MATCH_CAPITAL = 0.7
+_MATCH_DOT = 0.6
+
+
+def _precompute_bonus(haystack: str) -> list[float]:
+    """Per-character bonus, derived from the preceding character."""
+    bonuses = []
+    prev = "/"
+    for ch in haystack:
+        if prev == "/":
+            bonuses.append(_MATCH_SLASH)
+        elif prev in "-_ ":
+            bonuses.append(_MATCH_WORD)
+        elif prev == ".":
+            bonuses.append(_MATCH_DOT)
+        elif prev.islower() and ch.isupper():
+            bonuses.append(_MATCH_CAPITAL)
+        else:
+            bonuses.append(0.0)
+        prev = ch
+    return bonuses
+
+
+def _has_match(needle: str, haystack: str) -> bool:
+    """Whether ``needle`` appears in ``haystack`` as a subsequence."""
+    needle, haystack = needle.lower(), haystack.lower()
+    at = 0
+    for ch in needle:
+        at = haystack.find(ch, at) + 1
+        if at == 0:
+            return False
+    return True
+
+
+def _score(needle: str, haystack: str) -> float:
+    n, m = len(needle), len(haystack)
+    if not n or not m:
+        return _SCORE_MIN
+    # An option equal to the query (or merely the same length) wins outright.
+    if needle == haystack or m == n:
+        return _SCORE_MAX
+    if m > 1024:
+        return _SCORE_MIN
+
+    bonus = _precompute_bonus(haystack)
+    needle, haystack = needle.lower(), haystack.lower()
+    # best[i][j]: score of a match ending exactly at j; running[i][j]: best so far.
+    best = [[_SCORE_MIN] * m for _ in range(n)]
+    running = [[_SCORE_MIN] * m for _ in range(n)]
+
+    for i in range(n):
+        prev_running = _SCORE_MIN
+        gap = _GAP_TRAILING if i == n - 1 else _GAP_INNER
+        for j in range(m):
+            if needle[i] == haystack[j]:
+                if i == 0:
+                    score = j * _GAP_LEADING + bonus[j]
+                elif j:
+                    score = max(
+                        running[i - 1][j - 1] + bonus[j],
+                        best[i - 1][j - 1] + _MATCH_CONSECUTIVE,
+                    )
+                else:
+                    score = _SCORE_MIN
+                best[i][j] = score
+                prev_running = max(score, prev_running + gap)
+            else:
+                best[i][j] = _SCORE_MIN
+                prev_running = prev_running + gap
+            running[i][j] = prev_running
+
+    return running[n - 1][m - 1]
+
+
+def _rank(query: str, options: list[str]) -> list[str]:
+    """The order Streamlit's selectbox shows for ``query``."""
+    matches = [o for o in options if _has_match(query, o)]
+    return sorted(matches, key=lambda o: -_score(query, o))
+
+
+def _options(*items: tuple[str, str]) -> list[str]:
+    """Dropdown options for (name, label) pairs, ordered as the app orders them."""
+    return sorted(
+        (app.format_label_name(name, label) for name, label in items),
+        key=str.lower,
+    )
+
+
+def test_exact_name_outranks_longer_fuzzy_match():
+    """The scenario from issue #210."""
+    exact = app.format_label_name("trans-fn", "transcendental function")
+    options = _options(
+        ("trans-fn", "transcendental function"),
+        ("transfer-fn", "transfer function"),
+    )
+    assert _rank("trans-fn", options)[0] == exact
+
+
+def test_exact_name_outranks_camelcase_compound():
+    """A camelCase hump earns 0.7; the exact match must still win.
+
+    Regression for the pizza.owl case, where 'HamTopping' used to rank
+    'ParmaHamTopping' first.
+    """
+    exact = app.format_label_name("HamTopping", "CoberturaDePresunto")
+    options = _options(
+        ("HamTopping", "CoberturaDePresunto"),
+        ("ParmaHamTopping", "CoberturaDePrezuntoParma"),
+    )
+    assert _rank("HamTopping", options)[0] == exact
+
+
+def test_exact_name_outranks_longer_name_sharing_a_prefix():
+    exact = app.format_label_name("OnionTopping", "CoberturaDeCebola")
+    options = _options(
+        ("OnionTopping", "CoberturaDeCebola"),
+        ("RedOnionTopping", "CoberturaDeCebolaVermelha"),
+        ("SlicedOnionTopping", "CoberturaDeCebolaFatiada"),
+    )
+    assert _rank("OnionTopping", options)[0] == exact
+
+
+def test_label_search_still_ranks_its_own_entity_first():
+    """Moving the name out of parentheses must not cost label searches."""
+    wanted = app.format_label_name("PriceSpecification", "Price specification")
+    options = _options(
+        ("PriceSpecification", "Price specification"),
+        ("UnitPriceSpecification", "Unit price specification"),
+    )
+    assert _rank("Price specification", options)[0] == wanted
+
+
+def test_unlabelled_name_is_an_exact_option_match():
+    """Without a label the option *is* the name, which fzy scores as a certainty."""
+    options = _options(("Person", ""), ("PersonAddress", ""), ("LegalPerson", ""))
+    assert _rank("Person", options)[0] == "Person"
+    assert _score("Person", "Person") == _SCORE_MAX
+
+
+def test_separator_gives_the_local_name_a_word_boundary_bonus():
+    """Guards the reason for the separator, not just its appearance.
+
+    A separator ending in '(' (the old format) would silently reintroduce
+    issue #210, so assert the bonus fzy actually awards.
+    """
+    display = app.format_label_name("HamTopping", "CoberturaDePresunto")
+    name_starts_at = display.index("HamTopping")
+    assert _precompute_bonus(display)[name_starts_at] >= _MATCH_WORD


### PR DESCRIPTION
Closes #210.

## What was happening

Typing an exact local name into an entity dropdown could rank a different, longer entity first. The reported case: with classes `trans-fn` and `transfer-fn`, searching `trans-fn` put `transfer-fn` on top.

## Root cause

It is not our alphabetical ordering. Once you type, Streamlit discards the option order entirely and re-sorts client-side with fzy. That scorer is not configurable from Python, and I extracted it from every release between 1.49.1 and 1.60.0: it is byte-for-byte identical throughout (same gap penalties, same bonus table). 1.56.0 adds a `filter_mode` parameter, but that only lets you opt out of fuzzy, it does not improve fuzzy's ranking. So upgrading Streamlit would not have helped.

fzy scores a match partly by the character immediately **preceding** it:

| char before the match | bonus |
| --- | --- |
| `(` | **0.0** |
| space, `-`, `_` | 0.8 |
| `/` | 0.9 |
| camelCase hump (`a` to `H`) | 0.7 |

Our display format was `Label (name)`, so the local name sat behind a `(` and earned nothing, while an unrelated camelCase compound earned 0.7. In pizza.owl that made `CoberturaDePrezuntoParma (ParmaHamTopping)` beat `CoberturaDePresunto (HamTopping)` by 0.65 when searching `HamTopping`.

fzy does already rank exact matches first, returning an infinite score when the typed text equals the whole option string. That is why an unlabelled class always ranked correctly, and why the bug only ever showed up on labelled ones.

## The fix

Display resources as `name · Label` instead of `Label (name)`. The separator ends in a space, which restores the word-boundary bonus for the local name.

Leading with the name also fixes a sorting inconsistency: a resource whose label matches its name already renders as the bare name, so the label-first format sorted part of each list by label and the rest by name. In pizza.owl that filed `PizzaBase` under B while its unlabelled siblings sorted by name.

## Measured effect

Over all 402 classes in the seven bundled ontologies, searching each by its exact local name and by its exact label:

| format | name mis-ranked | label mis-ranked |
| --- | --- | --- |
| `Label (name)` (before) | 8 | 1 |
| `name · Label` (after) | 1 | 1 |

Seven searches improve, none regress:

| ontology | search | rank before | rank after |
| --- | --- | --- | --- |
| pizza.owl | `PepperTopping` | 5th | 1st |
| pizza.owl | `TomatoTopping` | 3rd | 1st |
| pizza.owl | `HamTopping` | 2nd | 1st |
| pizza.owl | `OnionTopping` | 2nd | 1st |
| pizza.owl | `GreenPepperTopping` | 2nd | 1st |
| pizza.owl | `VegetableTopping` | 2nd | 1st |
| pizza.owl | `VegetarianPizza` | 2nd | 1st |

The one remaining miss in each column is the same case, `Wine` losing to `Winery` in wine.owl. That one needs an exact-match boost we cannot inject into Streamlit's scorer; the wanted entity still lands second.

Fuzzy search is unchanged, and no dependency was touched.

## Also in this PR

`render_annotations` had a private `format_resource` helper that duplicated `format_label_name` and ignored its `res_type` argument. Removed in favour of the shared function, so the Annotations page picks up the same fix.

## Testing

- New `tests/test_dropdown_search_ranking.py` ports Streamlit's bundled fzy scorer and asserts exact matches rank first, including the reported `trans-fn` case, the `HamTopping` camelCase case, and that the separator actually earns the word-boundary bonus (so reverting to parentheses fails the suite rather than silently regressing).
- Full suite: 693 passed. ruff 0.16.0 format and check clean, mypy clean.
- Verified live in the running app on the reported path, Classes > Add Class > Parent Class. Typing `trans-fn` now shows `trans-fn · transcendental function` first and pre-highlighted; typing `HamTopping` shows `HamTopping · CoberturaDePresunto` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)