### PR TITLE
feat: persist node filters and focus seeds per linked file (#164)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -865,6 +865,15 @@ def _clear_viz_file_session_state() -> None:
         st.session_state.pop(f"_viz_cfg_known_{kind['key']}_uris", None)
     st.session_state.pop("_viz_cfg_focus_seeds", None)
     st.session_state.pop("_viz_pending_focus_seed_ids", None)
+    # The mutation counters seen on the last render belong to the file we just
+    # left, and loading the new one bumps the ontology's counter without a
+    # matching edit. Left in place they would read as "the ontology was
+    # replaced", which resets the filter to everything shown and so discards the
+    # state we are about to restore. Nothing can leak across the switch anyway:
+    # the selection itself was just cleared, so the only thing the reconcile has
+    # to diff against is the new file's own saved state.
+    st.session_state.pop("_viz_cfg_seen_mutation", None)
+    st.session_state.pop("_viz_cfg_seen_edits", None)
 
 
 def _restore_viz_file_state() -> dict:
@@ -889,6 +898,40 @@ def _restore_viz_file_state() -> dict:
     store = local_store.load_config().get(VIZ_FILE_STATE_KEY)
     entry = store.get(file_id) if isinstance(store, dict) else None
     return entry if isinstance(entry, dict) else {}
+
+
+def viz_ontology_was_replaced() -> bool:
+    """Whether the whole ontology was swapped since the last graph render.
+
+    A mutation-counter jump not matched by the edit counter means a
+    load/import/new/undo rather than an incremental edit, so the node filters
+    reset to "everything shown" instead of diffing against an ontology that may
+    reuse URIs for unrelated entities.
+
+    Must be evaluated *after* :func:`_restore_viz_file_state`, which clears the
+    counters when the linked file changed: loading the new file bumps the
+    ontology counter, and treating that as a replacement would throw away the
+    state being restored for it (issue #164).
+    """
+    mutation = st.session_state.get("_ont_mutation_count", 0)
+    edits = st.session_state.get("_ont_edit_count", 0)
+    prev_mutation = st.session_state.get("_viz_cfg_seen_mutation")
+    prev_edits = st.session_state.get("_viz_cfg_seen_edits", 0)
+    return prev_mutation is not None and (mutation - prev_mutation) != (
+        edits - prev_edits
+    )
+
+
+def viz_mark_ontology_seen() -> None:
+    """Record the counters this render reconciled against.
+
+    The counterpart to :func:`viz_ontology_was_replaced`, which compares the
+    next render's counters with these.
+    """
+    st.session_state["_viz_cfg_seen_mutation"] = st.session_state.get(
+        "_ont_mutation_count", 0
+    )
+    st.session_state["_viz_cfg_seen_edits"] = st.session_state.get("_ont_edit_count", 0)
 
 
 def seed_filter_from_saved(all_uris, hidden, selected, known):
@@ -7314,17 +7357,12 @@ def render_visualization():
         # Every filterable kind is reconciled the same way, so the per-kind state
         # lives in one dict keyed by the kind's key rather than a parallel set of
         # variables per kind (issue #196).
-        mutation = st.session_state.get("_ont_mutation_count", 0)
-        edits = st.session_state.get("_ont_edit_count", 0)
-        prev_mutation = st.session_state.get("_viz_cfg_seen_mutation")
-        prev_edits = st.session_state.get("_viz_cfg_seen_edits", 0)
-        replaced = prev_mutation is not None and (mutation - prev_mutation) != (
-            edits - prev_edits
-        )
         _kind_items = {"class": classes, "ind": individuals}
         # Filters and focus seeds the user left behind for this linked file
-        # (issue #164). Empty on the cloud, and after the first render.
+        # (issue #164). Empty on the cloud, and after the first render. Runs
+        # before the replacement check below, which reads counters it clears.
         _file_state = _restore_viz_file_state()
+        replaced = viz_ontology_was_replaced()
         _saved_seed_ids = _str_list(_file_state.get("focus_seed_ids"))
         if _saved_seed_ids and "_viz_cfg_focus_seeds" not in st.session_state:
             # Held until focus_targets exists further down — that's the map from
@@ -7364,8 +7402,7 @@ def render_visualization():
                 "selected_uris": _sel_uris,
                 "selected_displays": _selected_displays,
             }
-        st.session_state["_viz_cfg_seen_mutation"] = mutation
-        st.session_state["_viz_cfg_seen_edits"] = edits
+        viz_mark_ontology_seen()
 
         class_entries = filters["class"]["entries"]
         all_class_names = filters["class"]["displays"]

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -852,6 +852,37 @@ def _str_list(value) -> list[str]:
     return [v for v in value if isinstance(v, str)]
 
 
+def viz_drop_focus_seeds() -> None:
+    """Forget the focus seeds so they re-derive from the current selection."""
+    st.session_state.pop("_viz_cfg_focus_seeds", None)
+    st.session_state.pop("_viz_cfg_focus_seed_ids_by_label", None)
+
+
+def prune_reused_focus_seeds(seeds, seen_ids_by_label, focus_targets):
+    """Drop seeds whose label has come to name a different entity.
+
+    Seeds are held as the labels the multiselect shows, and the focus block
+    prunes them by label alone — but a label does not identify anything. Import
+    an ontology that also has a ``Person`` over one that had it and the stale
+    seed passes that prune, silently re-pointing the focus at an unrelated class
+    and (since #164) persisting it as that class.
+
+    Comparing each label against the node id it resolved to last render catches
+    that, whatever caused it. The replacement counters do not: an import goes
+    through ``save_checkpoint``, which bumps the edit counter alongside the
+    mutation counter, so it is deliberately *not* a "replacement" (issue #180).
+
+    A label with no recorded id is one the user just picked, so it is kept.
+    """
+    if not seeds or not seen_ids_by_label:
+        return list(seeds or [])
+    return [
+        s
+        for s in seeds
+        if s not in seen_ids_by_label or seen_ids_by_label[s] == focus_targets.get(s)
+    ]
+
+
 def _clear_viz_file_session_state() -> None:
     """Drop the session keys that belong to one specific ontology.
 
@@ -863,7 +894,7 @@ def _clear_viz_file_session_state() -> None:
     for kind in _FILTER_KINDS:
         st.session_state.pop(f"_viz_cfg_selected_{kind['key']}_uris", None)
         st.session_state.pop(f"_viz_cfg_known_{kind['key']}_uris", None)
-    st.session_state.pop("_viz_cfg_focus_seeds", None)
+    viz_drop_focus_seeds()
     st.session_state.pop("_viz_pending_focus_seed_ids", None)
     # The mutation counters seen on the last render belong to the file we just
     # left, and loading the new one bumps the ontology's counter without a
@@ -7435,6 +7466,16 @@ def render_visualization():
             for concept in ont.get_concepts():
                 focus_targets[f"Concept: {concept['name']}"] = f"skos_{concept['name']}"
 
+        # Seeds whose label now names a *different* entity than it did last
+        # render belong to an ontology that has since been swapped out, so drop
+        # them before anything reads or persists them.
+        if "_viz_cfg_focus_seeds" in st.session_state:
+            st.session_state["_viz_cfg_focus_seeds"] = prune_reused_focus_seeds(
+                st.session_state["_viz_cfg_focus_seeds"],
+                st.session_state.get("_viz_cfg_focus_seed_ids_by_label"),
+                focus_targets,
+            )
+
         # Seeds saved for this linked file are stored as node ids (#164); turn
         # them back into the labels the multiselect works in. An id whose entity
         # is gone — or whose type is toggled off, and so isn't in focus_targets —
@@ -7543,6 +7584,12 @@ def render_visualization():
                     saved_seeds = [focus_labels[0]]
                 st.session_state["_viz_cfg_focus_seeds"] = saved_seeds
                 st.session_state["viz_focus_seeds"] = saved_seeds
+                # Remember what each label resolved to, so the next render can
+                # tell a label that has come to name a different entity from one
+                # that still names the same (see prune_reused_focus_seeds).
+                st.session_state["_viz_cfg_focus_seed_ids_by_label"] = {
+                    s: focus_targets.get(s) for s in saved_seeds
+                }
                 fcol1, fcol2 = st.columns([3, 1])
                 with fcol1:
                     focus_seeds = st.multiselect(

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -852,18 +852,37 @@ def _str_list(value) -> list[str]:
     return [v for v in value if isinstance(v, str)]
 
 
+def _clear_viz_file_session_state() -> None:
+    """Drop the session keys that belong to one specific ontology.
+
+    The filter selections and focus seeds name entities of the file they were
+    made against, so they must not survive a switch to another one: they would
+    both suppress the new file's saved state (a selection already in session
+    wins over it) and then be written back out under the new file's key.
+    """
+    for kind in _FILTER_KINDS:
+        st.session_state.pop(f"_viz_cfg_selected_{kind['key']}_uris", None)
+        st.session_state.pop(f"_viz_cfg_known_{kind['key']}_uris", None)
+    st.session_state.pop("_viz_cfg_focus_seeds", None)
+    st.session_state.pop("_viz_pending_focus_seed_ids", None)
+
+
 def _restore_viz_file_state() -> dict:
     """Return the linked file's saved viz state, once per file (issue #164).
 
     Yields the saved entry on the first Visualization render for a given linked
     path and ``{}`` afterwards, since session state then holds the reconciled
-    selection. Linking a different file mid-session re-runs, so the new file's
-    state applies instead of the previous one's.
+    selection. Linking a different file mid-session clears the previous file's
+    per-ontology state first, so the new file's own state is what applies.
     """
     file_id = _viz_file_state_id()
     marker = "_viz_file_state_for"
-    if marker in st.session_state and st.session_state[marker] == file_id:
-        return {}
+    if marker in st.session_state:
+        if st.session_state[marker] == file_id:
+            return {}
+        # A switch, not the first render: the state in session belongs to the
+        # file we just left.
+        _clear_viz_file_session_state()
     st.session_state[marker] = file_id
     if file_id is None:
         return {}
@@ -887,7 +906,7 @@ def seed_filter_from_saved(all_uris, hidden, selected, known):
     return [uri for uri in all_uris if uri not in hidden], set(all_uris)
 
 
-def _viz_file_state_payload(filters: dict) -> dict:
+def _viz_file_state_payload(filters: dict, focus_targets: dict) -> dict:
     """The per-file viz state worth saving: hidden entities and focus seeds.
 
     Stores what the user *hid* rather than what is selected. Everything is shown
@@ -903,13 +922,19 @@ def _viz_file_state_payload(filters: dict) -> dict:
         hidden = [uri for uri in entry["uris"] if uri not in selected]
         if hidden:
             data[f"hidden_{key}_uris"] = hidden
+    # Seeds are stored as the graph's node ids, not the labels the multiselect
+    # shows. A label picks up a namespace tag the moment a second entity takes
+    # the same local name, so a saved label would stop matching a file that
+    # gained one while the app was closed (the lesson of issue #179). Node ids
+    # for classes, individuals and data properties derive from the URI instead.
     seeds = st.session_state.get("_viz_cfg_focus_seeds") or []
-    if seeds:
-        data["focus_seeds"] = list(seeds)
+    seed_ids = [focus_targets[s] for s in seeds if s in focus_targets]
+    if seed_ids:
+        data["focus_seed_ids"] = seed_ids
     return data
 
 
-def _persist_viz_file_state(filters: dict) -> None:
+def _persist_viz_file_state(filters: dict, focus_targets: dict) -> None:
     """Save the linked file's node filters and focus seeds (issue #164).
 
     No-ops when nothing changed since the last render, and when the state
@@ -918,30 +943,33 @@ def _persist_viz_file_state(filters: dict) -> None:
     file_id = _viz_file_state_id()
     if file_id is None:
         return
-    payload = _viz_file_state_payload(filters)
+    payload = _viz_file_state_payload(filters, focus_targets)
     fingerprint = json.dumps([file_id, payload], sort_keys=True)
     if fingerprint == st.session_state.get("_viz_file_state_fingerprint"):
         return
-    st.session_state["_viz_file_state_fingerprint"] = fingerprint
     try:
         cfg = local_store.load_config()
         store = cfg.get(VIZ_FILE_STATE_KEY)
         if not isinstance(store, dict):
             store = {}
         existing = store.get(file_id)
-        if payload == existing or (not payload and existing is None):
-            return
-        # Re-insert so this file counts as the most recently changed: dicts keep
-        # insertion order and JSON preserves it, so eviction drops the stalest.
-        store.pop(file_id, None)
-        if payload:
-            store[file_id] = payload
-        while len(store) > VIZ_FILE_STATE_MAX_FILES:
-            store.pop(next(iter(store)))
-        cfg[VIZ_FILE_STATE_KEY] = store
-        local_store.save_config(cfg)
+        if payload != existing and (payload or existing is not None):
+            # Re-insert so this file counts as the most recently changed: dicts
+            # keep insertion order and JSON preserves it, so eviction drops the
+            # stalest.
+            store.pop(file_id, None)
+            if payload:
+                store[file_id] = payload
+            while len(store) > VIZ_FILE_STATE_MAX_FILES:
+                store.pop(next(iter(store)))
+            cfg[VIZ_FILE_STATE_KEY] = store
+            local_store.save_config(cfg)
     except OSError as e:
+        # Leave the fingerprint unset so an unwritable config.json is retried on
+        # a later rerun instead of being silently given up on.
         log_error(e, context="Viz per-file state save")
+        return
+    st.session_state["_viz_file_state_fingerprint"] = fingerprint
 
 
 def _load_linked_file(target) -> bool:
@@ -7297,11 +7325,11 @@ def render_visualization():
         # Filters and focus seeds the user left behind for this linked file
         # (issue #164). Empty on the cloud, and after the first render.
         _file_state = _restore_viz_file_state()
-        _saved_seeds = _str_list(_file_state.get("focus_seeds"))
-        if _saved_seeds and "_viz_cfg_focus_seeds" not in st.session_state:
-            # The focus-mode block prunes seeds the ontology no longer has, so a
-            # file edited outside the app degrades instead of breaking.
-            st.session_state["_viz_cfg_focus_seeds"] = _saved_seeds
+        _saved_seed_ids = _str_list(_file_state.get("focus_seed_ids"))
+        if _saved_seed_ids and "_viz_cfg_focus_seeds" not in st.session_state:
+            # Held until focus_targets exists further down — that's the map from
+            # node id back to the label the multiselect shows.
+            st.session_state["_viz_pending_focus_seed_ids"] = _saved_seed_ids
         filters: dict[str, dict] = {}
         for _kind in _FILTER_KINDS:
             _key = _kind["key"]
@@ -7369,6 +7397,19 @@ def render_visualization():
         if show_skos and _has_skos:
             for concept in ont.get_concepts():
                 focus_targets[f"Concept: {concept['name']}"] = f"skos_{concept['name']}"
+
+        # Seeds saved for this linked file are stored as node ids (#164); turn
+        # them back into the labels the multiselect works in. An id whose entity
+        # is gone — or whose type is toggled off, and so isn't in focus_targets —
+        # simply drops out, the same pruning the focus block does below.
+        _pending_seed_ids = st.session_state.pop("_viz_pending_focus_seed_ids", None)
+        if _pending_seed_ids and "_viz_cfg_focus_seeds" not in st.session_state:
+            _label_by_id = {node_id: label for label, node_id in focus_targets.items()}
+            _restored_seeds = [
+                _label_by_id[i] for i in _pending_seed_ids if i in _label_by_id
+            ]
+            if _restored_seeds:
+                st.session_state["_viz_cfg_focus_seeds"] = _restored_seeds
 
         # Find & centre on a specific entity (issue #144). Independent of focus
         # mode: picking an entity here selects and camera-centres it in the graph
@@ -7649,7 +7690,7 @@ def render_visualization():
         _persist_viz_settings()
         # The entity-naming state (node filters, focus seeds) is saved separately,
         # against the linked working file it belongs to (#164).
-        _persist_viz_file_state(filters)
+        _persist_viz_file_state(filters, focus_targets)
 
         # Store graph settings in session state for caching
         selected_classes_key = (

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -35,9 +35,9 @@ AUTOSAVE_MAX_BYTES = 4_000_000
 # Visualization display preferences persisted across sessions (issue #142), so a
 # user's Fit-to-window / entity-type / spacing etc. choices survive a reload.
 # Stored in the same backends as the ontology autosave (browser localStorage on
-# the cloud, config.json on desktop). Only ontology-INDEPENDENT settings are
-# persisted; the class filter and focus seeds reference entity names and are
-# left to their own per-ontology reset logic.
+# the cloud, config.json on desktop). Only ontology-INDEPENDENT settings belong
+# here; the node filters and focus seeds reference entity names, so they are
+# saved per linked file instead (see VIZ_FILE_STATE_KEY, issue #164).
 VIZ_SETTINGS_KEY = "orionbelt_viz_settings"
 _VIZ_PERSIST_KEYS = (
     "show_classes",
@@ -63,6 +63,17 @@ _VIZ_INT_RANGES = {
     "node_spacing": (50, 300),
     "focus_depth": (1, 5),
 }
+# Per-linked-file Visualization state (issue #164). The node filters and focus
+# seeds name specific entities, which is why #142 left them out of the settings
+# above: restoring "Class: Person" into a different ontology is meaningless. The
+# desktop app's linked working file removes that objection, since it identifies
+# the ontology and its path already lives in config.json. So this state is saved
+# per linked path and only restored while that same file is still linked; a
+# cloud session has no linked file and keeps resetting per session.
+VIZ_FILE_STATE_KEY = "viz_file_state"
+# Bound config.json's growth. Dicts keep insertion order, so the entry rewritten
+# longest ago is the one evicted.
+VIZ_FILE_STATE_MAX_FILES = 20
 # Disk autosave (local/desktop) is gated on the mutation counter and debounced:
 # the graph is only serialized when it actually changed and edits have settled,
 # so normal UI reruns do no work even for large ontologies. Important actions
@@ -820,6 +831,117 @@ def _persist_viz_settings() -> None:
             VIZ_SETTINGS_KEY, payload, key=f"orionbelt_viz_settings_set_{h[:12]}"
         )
     st.session_state["_viz_settings_saved_json"] = payload
+
+
+def _viz_file_state_id() -> str | None:
+    """Identity of the ontology the per-file viz state belongs to, else ``None``.
+
+    The linked working file's path (issue #164). Cloud sessions have no linked
+    file and no disk, so they get ``None`` and keep the per-session reset.
+    """
+    if not local_store.local_persist_enabled():
+        return None
+    path = local_store.get_linked_path()
+    return str(path) if path else None
+
+
+def _str_list(value) -> list[str]:
+    """Coerce a persisted value to a list of strings, dropping anything else."""
+    if not isinstance(value, list):
+        return []
+    return [v for v in value if isinstance(v, str)]
+
+
+def _restore_viz_file_state() -> dict:
+    """Return the linked file's saved viz state, once per file (issue #164).
+
+    Yields the saved entry on the first Visualization render for a given linked
+    path and ``{}`` afterwards, since session state then holds the reconciled
+    selection. Linking a different file mid-session re-runs, so the new file's
+    state applies instead of the previous one's.
+    """
+    file_id = _viz_file_state_id()
+    marker = "_viz_file_state_for"
+    if marker in st.session_state and st.session_state[marker] == file_id:
+        return {}
+    st.session_state[marker] = file_id
+    if file_id is None:
+        return {}
+    store = local_store.load_config().get(VIZ_FILE_STATE_KEY)
+    entry = store.get(file_id) if isinstance(store, dict) else None
+    return entry if isinstance(entry, dict) else {}
+
+
+def seed_filter_from_saved(all_uris, hidden, selected, known):
+    """Reconcile inputs for a node filter, seeded from saved per-file state.
+
+    Returns ``(selected, known)`` unchanged once the session has a selection of
+    its own. On the first render of a linked file it turns the saved hidden set
+    into the equivalent pair, so the saved state goes *through*
+    :func:`reconcile_filter_selection` rather than around it: an entity added to
+    the file since the last session is absent from the hidden set and therefore
+    shows up, the way new content always does.
+    """
+    if not hidden or selected is not None:
+        return selected, known
+    return [uri for uri in all_uris if uri not in hidden], set(all_uris)
+
+
+def _viz_file_state_payload(filters: dict) -> dict:
+    """The per-file viz state worth saving: hidden entities and focus seeds.
+
+    Stores what the user *hid* rather than what is selected. Everything is shown
+    by default, so the hidden set is normally empty or tiny, which keeps
+    config.json small for an ontology with thousands of entities. It also
+    restores identically: an entity added to the file since the last session is
+    absent from the hidden set and so shows up, exactly as
+    :func:`reconcile_filter_selection` would have decided.
+    """
+    data: dict[str, list[str]] = {}
+    for key, entry in filters.items():
+        selected = set(entry["selected_uris"])
+        hidden = [uri for uri in entry["uris"] if uri not in selected]
+        if hidden:
+            data[f"hidden_{key}_uris"] = hidden
+    seeds = st.session_state.get("_viz_cfg_focus_seeds") or []
+    if seeds:
+        data["focus_seeds"] = list(seeds)
+    return data
+
+
+def _persist_viz_file_state(filters: dict) -> None:
+    """Save the linked file's node filters and focus seeds (issue #164).
+
+    No-ops when nothing changed since the last render, and when the state
+    already on disk matches, so ordinary reruns don't rewrite config.json.
+    """
+    file_id = _viz_file_state_id()
+    if file_id is None:
+        return
+    payload = _viz_file_state_payload(filters)
+    fingerprint = json.dumps([file_id, payload], sort_keys=True)
+    if fingerprint == st.session_state.get("_viz_file_state_fingerprint"):
+        return
+    st.session_state["_viz_file_state_fingerprint"] = fingerprint
+    try:
+        cfg = local_store.load_config()
+        store = cfg.get(VIZ_FILE_STATE_KEY)
+        if not isinstance(store, dict):
+            store = {}
+        existing = store.get(file_id)
+        if payload == existing or (not payload and existing is None):
+            return
+        # Re-insert so this file counts as the most recently changed: dicts keep
+        # insertion order and JSON preserves it, so eviction drops the stalest.
+        store.pop(file_id, None)
+        if payload:
+            store[file_id] = payload
+        while len(store) > VIZ_FILE_STATE_MAX_FILES:
+            store.pop(next(iter(store)))
+        cfg[VIZ_FILE_STATE_KEY] = store
+        local_store.save_config(cfg)
+    except OSError as e:
+        log_error(e, context="Viz per-file state save")
 
 
 def _load_linked_file(target) -> bool:
@@ -7172,14 +7294,29 @@ def render_visualization():
             edits - prev_edits
         )
         _kind_items = {"class": classes, "ind": individuals}
+        # Filters and focus seeds the user left behind for this linked file
+        # (issue #164). Empty on the cloud, and after the first render.
+        _file_state = _restore_viz_file_state()
+        _saved_seeds = _str_list(_file_state.get("focus_seeds"))
+        if _saved_seeds and "_viz_cfg_focus_seeds" not in st.session_state:
+            # The focus-mode block prunes seeds the ontology no longer has, so a
+            # file edited outside the app degrades instead of breaking.
+            st.session_state["_viz_cfg_focus_seeds"] = _saved_seeds
         filters: dict[str, dict] = {}
         for _kind in _FILTER_KINDS:
             _key = _kind["key"]
             _entries = build_filter_entries(_kind_items.get(_key) or [])
-            _sel_uris, _known_uris = reconcile_filter_selection(
-                [e["uri"] for e in _entries],
+            _all_uris = [e["uri"] for e in _entries]
+            _prev_sel, _prev_known = seed_filter_from_saved(
+                _all_uris,
+                set(_str_list(_file_state.get(f"hidden_{_key}_uris"))),
                 st.session_state.get(f"_viz_cfg_selected_{_key}_uris"),
                 st.session_state.get(f"_viz_cfg_known_{_key}_uris"),
+            )
+            _sel_uris, _known_uris = reconcile_filter_selection(
+                _all_uris,
+                _prev_sel,
+                _prev_known,
                 replaced=replaced,
             )
             st.session_state[f"_viz_cfg_selected_{_key}_uris"] = _sel_uris
@@ -7510,6 +7647,9 @@ def render_visualization():
         # they survive a reload (#142). Runs after every control has synced its
         # value; no-ops when nothing changed.
         _persist_viz_settings()
+        # The entity-naming state (node filters, focus seeds) is saved separately,
+        # against the linked working file it belongs to (#164).
+        _persist_viz_file_state(filters)
 
         # Store graph settings in session state for caching
         selected_classes_key = (

--- a/tests/test_viz_file_state.py
+++ b/tests/test_viz_file_state.py
@@ -294,6 +294,66 @@ def test_a_real_ontology_swap_still_resets_the_filter(monkeypatch, tmp_path):
     assert app.viz_ontology_was_replaced() is True
 
 
+def test_a_reused_label_naming_a_different_entity_is_dropped():
+    """Regression: a seed label outlived the ontology it named.
+
+    Seeds are pruned by label, and a label does not identify an entity. Import
+    an ontology that also has a Person over the linked file and the stale
+    ``Class: Person`` survives that prune, silently re-pointing the focus at an
+    unrelated class — and persisting it as that class's node id.
+    """
+    seeds = ["Class: Person"]
+    seen = {"Class: Person": app._uid(NS + "Person")}
+    successor = {"Class: Person": app._uid("http://elsewhere#Person")}
+    assert app.prune_reused_focus_seeds(seeds, seen, successor) == []
+
+
+def test_a_label_still_naming_the_same_entity_is_kept():
+    seeds = ["Class: Person"]
+    seen = {"Class: Person": app._uid(NS + "Person")}
+    # Same entity, even though a namespace tag appeared alongside it.
+    assert app.prune_reused_focus_seeds(seeds, seen, FOCUS_TARGETS) == seeds
+
+
+def test_a_freshly_picked_seed_has_no_recorded_id_and_survives():
+    assert app.prune_reused_focus_seeds(
+        ["Class: Org"], {"Class: Person": "whatever"}, FOCUS_TARGETS
+    ) == ["Class: Org"]
+
+
+def test_pruning_is_a_noop_before_anything_was_recorded():
+    assert app.prune_reused_focus_seeds(["Class: Person"], None, FOCUS_TARGETS) == [
+        "Class: Person"
+    ]
+    assert app.prune_reused_focus_seeds(None, None, FOCUS_TARGETS) == []
+
+
+def test_dropped_seeds_are_not_persisted(monkeypatch):
+    session = _Session({"_viz_cfg_focus_seeds": ["Class: Person"]})
+    monkeypatch.setattr(app.st, "session_state", session)
+    successor = {"Class: Person": app._uid("http://elsewhere#Person")}
+    # What it would have written with the stale label left in place.
+    assert app._viz_file_state_payload(_filters(), successor) == {
+        "focus_seed_ids": [app._uid("http://elsewhere#Person")]
+    }
+    session["_viz_cfg_focus_seeds"] = app.prune_reused_focus_seeds(
+        session["_viz_cfg_focus_seeds"],
+        {"Class: Person": app._uid(NS + "Person")},
+        successor,
+    )
+    assert app._viz_file_state_payload(_filters(), successor) == {}
+
+
+def test_switching_files_also_forgets_the_focus_seeds(monkeypatch, tmp_path):
+    _desktop(monkeypatch, tmp_path, linked=FILE_A)
+    session = _Session(
+        {"_viz_file_state_for": FILE_B, "_viz_cfg_focus_seeds": ["Class: Person"]}
+    )
+    monkeypatch.setattr(app.st, "session_state", session)
+    app._restore_viz_file_state()
+    assert "_viz_cfg_focus_seeds" not in session
+
+
 def test_an_ordinary_edit_is_not_a_replacement(monkeypatch):
     monkeypatch.setattr(
         app.st,

--- a/tests/test_viz_file_state.py
+++ b/tests/test_viz_file_state.py
@@ -238,6 +238,76 @@ def test_relinking_mid_session_clears_the_previous_files_state(monkeypatch, tmp_
     assert known == {NS + "A", NS + "B"}
 
 
+def test_relinking_does_not_read_the_new_file_as_a_replaced_ontology(
+    monkeypatch, tmp_path
+):
+    """Regression: loading the newly linked file looked like an ontology swap.
+
+    ``_load_linked_file`` bumps the mutation counter without a matching edit, so
+    the counters left over from the previous file made ``replaced`` true. That
+    resets the filter to everything shown, which both discards the state being
+    restored for the new file and then writes that empty result back over it.
+    """
+    _desktop(monkeypatch, tmp_path, linked=FILE_A)
+    session = _Session(
+        {
+            "_viz_file_state_for": FILE_B,
+            # Seen on the last render, while FILE_B was linked.
+            "_viz_cfg_seen_mutation": 4,
+            "_viz_cfg_seen_edits": 0,
+            # Loading FILE_A bumped the ontology counter, with no user edit.
+            "_ont_mutation_count": 5,
+            "_ont_edit_count": 0,
+        }
+    )
+    monkeypatch.setattr(app.st, "session_state", session)
+    assert app.viz_ontology_was_replaced() is True  # before the switch is seen
+
+    app._restore_viz_file_state()
+
+    assert app.viz_ontology_was_replaced() is False
+    # So the new file's saved hidden set survives the reconcile.
+    selected, known = app.seed_filter_from_saved(
+        [NS + "A", NS + "B"], {NS + "B"}, None, None
+    )
+    result, _ = app.reconcile_filter_selection(
+        [NS + "A", NS + "B"], selected, known, replaced=app.viz_ontology_was_replaced()
+    )
+    assert result == [NS + "A"]
+
+
+def test_a_real_ontology_swap_still_resets_the_filter(monkeypatch, tmp_path):
+    # Importing over the same linked file is a genuine replacement: the saved
+    # hidden set names entities that may be gone, so everything shows again.
+    _desktop(monkeypatch, tmp_path, linked=FILE_A)
+    session = _Session(
+        {
+            "_viz_file_state_for": FILE_A,  # same file, no switch
+            "_viz_cfg_seen_mutation": 4,
+            "_viz_cfg_seen_edits": 0,
+            "_ont_mutation_count": 5,
+            "_ont_edit_count": 0,
+        }
+    )
+    monkeypatch.setattr(app.st, "session_state", session)
+    app._restore_viz_file_state()
+    assert app.viz_ontology_was_replaced() is True
+
+
+def test_an_ordinary_edit_is_not_a_replacement(monkeypatch):
+    monkeypatch.setattr(
+        app.st,
+        "session_state",
+        {
+            "_viz_cfg_seen_mutation": 4,
+            "_viz_cfg_seen_edits": 1,
+            "_ont_mutation_count": 5,
+            "_ont_edit_count": 2,
+        },
+    )
+    assert app.viz_ontology_was_replaced() is False
+
+
 def test_relinking_does_not_write_the_old_files_seeds_under_the_new_file(
     monkeypatch, tmp_path
 ):

--- a/tests/test_viz_file_state.py
+++ b/tests/test_viz_file_state.py
@@ -1,0 +1,279 @@
+"""Per-linked-file Visualization state: node filters and focus seeds (issue #164).
+
+Issue #142 kept these two out of the cross-session settings because they name
+entities, so restoring them into a different ontology would be meaningless. The
+desktop app's linked working file identifies the ontology, so they are saved
+against its path and only restored while that same file is still linked.
+"""
+
+import json
+
+from orionbelt_ontology_builder import app
+
+FILE_A = "/tmp/onto-a.ttl"
+FILE_B = "/tmp/onto-b.ttl"
+NS = "http://test.org/ont#"
+
+
+def _filters(class_uris=(), class_selected=None, ind_uris=(), ind_selected=None):
+    """A stand-in for the per-kind filter dict render_visualization builds."""
+    return {
+        "class": {
+            "uris": list(class_uris),
+            "selected_uris": list(
+                class_uris if class_selected is None else class_selected
+            ),
+        },
+        "ind": {
+            "uris": list(ind_uris),
+            "selected_uris": list(ind_uris if ind_selected is None else ind_selected),
+        },
+    }
+
+
+def _desktop(monkeypatch, tmp_path, linked=FILE_A):
+    """Point local_store at a temp config.json with ``linked`` linked."""
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
+    monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
+    if linked:
+        app.local_store.set_linked_path(linked)
+    return cfg_file
+
+
+# ---- What gets stored -------------------------------------------------------
+
+
+def test_payload_stores_what_is_hidden_not_what_is_selected(monkeypatch):
+    # Everything is shown by default, so recording the hidden set keeps
+    # config.json small for an ontology with thousands of entities.
+    monkeypatch.setattr(app.st, "session_state", {})
+    payload = app._viz_file_state_payload(
+        _filters(class_uris=[NS + "A", NS + "B", NS + "C"], class_selected=[NS + "A"])
+    )
+    assert payload == {"hidden_class_uris": [NS + "B", NS + "C"]}
+
+
+def test_payload_omits_untouched_filters_and_absent_seeds(monkeypatch):
+    monkeypatch.setattr(app.st, "session_state", {})
+    assert app._viz_file_state_payload(_filters(class_uris=[NS + "A"])) == {}
+
+
+def test_payload_includes_focus_seeds(monkeypatch):
+    monkeypatch.setattr(
+        app.st, "session_state", {"_viz_cfg_focus_seeds": ["Class: Person"]}
+    )
+    assert app._viz_file_state_payload(_filters())["focus_seeds"] == ["Class: Person"]
+
+
+# ---- Round trip -------------------------------------------------------------
+
+
+def test_disk_roundtrip_for_the_linked_file(monkeypatch, tmp_path):
+    cfg_file = _desktop(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        app.st, "session_state", {"_viz_cfg_focus_seeds": ["Class: Person"]}
+    )
+    app._persist_viz_file_state(
+        _filters(
+            class_uris=[NS + "A", NS + "B"],
+            class_selected=[NS + "A"],
+            ind_uris=[NS + "i1"],
+        )
+    )
+
+    stored = json.loads(cfg_file.read_text())[app.VIZ_FILE_STATE_KEY]
+    assert stored[FILE_A] == {
+        "hidden_class_uris": [NS + "B"],
+        "focus_seeds": ["Class: Person"],
+    }
+
+    # A fresh session restores it.
+    restore_state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", restore_state)
+    assert app._restore_viz_file_state() == stored[FILE_A]
+
+
+def test_restore_seeds_the_filter_so_hidden_entities_stay_hidden():
+    saved = {NS + "B"}
+    selected, known = app.seed_filter_from_saved(
+        [NS + "A", NS + "B"], saved, None, None
+    )
+    result, _ = app.reconcile_filter_selection([NS + "A", NS + "B"], selected, known)
+    assert result == [NS + "A"]
+
+
+def test_restore_still_shows_entities_added_to_the_file_since():
+    # The file gained C while the app was closed. C is not in the hidden set, so
+    # it must show, exactly as newly created content always does.
+    all_uris = [NS + "A", NS + "B", NS + "C"]
+    selected, known = app.seed_filter_from_saved(all_uris, {NS + "B"}, None, None)
+    result, _ = app.reconcile_filter_selection(all_uris, selected, known)
+    assert result == [NS + "A", NS + "C"]
+
+
+def test_restore_drops_entities_deleted_from_the_file_since():
+    selected, known = app.seed_filter_from_saved([NS + "A"], {NS + "B"}, None, None)
+    result, _ = app.reconcile_filter_selection([NS + "A"], selected, known)
+    assert result == [NS + "A"]
+
+
+def test_seeding_defers_to_a_selection_the_session_already_has():
+    # Only the first render of a linked file may seed; later renders must keep
+    # whatever the user has since picked.
+    selected, known = app.seed_filter_from_saved(
+        [NS + "A", NS + "B"], {NS + "B"}, [NS + "B"], {NS + "A", NS + "B"}
+    )
+    assert selected == [NS + "B"]
+    assert known == {NS + "A", NS + "B"}
+
+
+# ---- Scoping ----------------------------------------------------------------
+
+
+def test_state_is_scoped_to_the_linked_file(monkeypatch, tmp_path):
+    _desktop(monkeypatch, tmp_path, linked=FILE_A)
+    monkeypatch.setattr(app.st, "session_state", {})
+    app._persist_viz_file_state(
+        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
+    )
+
+    # Linking a different file must not inherit the first file's filters.
+    app.local_store.set_linked_path(FILE_B)
+    monkeypatch.setattr(app.st, "session_state", {})
+    assert app._restore_viz_file_state() == {}
+
+
+def test_relinking_mid_session_restores_the_new_file(monkeypatch, tmp_path):
+    _desktop(monkeypatch, tmp_path, linked=FILE_B)
+    monkeypatch.setattr(app.st, "session_state", {})
+    app._persist_viz_file_state(
+        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
+    )
+
+    session: dict = {}
+    monkeypatch.setattr(app.st, "session_state", session)
+    app.local_store.set_linked_path(FILE_A)
+    assert app._restore_viz_file_state() == {}  # nothing saved for A
+    app.local_store.set_linked_path(FILE_B)
+    assert app._restore_viz_file_state() == {"hidden_class_uris": [NS + "B"]}
+
+
+def test_restore_runs_once_per_file(monkeypatch, tmp_path):
+    _desktop(monkeypatch, tmp_path)
+    monkeypatch.setattr(app.st, "session_state", {})
+    app._persist_viz_file_state(
+        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
+    )
+    session: dict = {}
+    monkeypatch.setattr(app.st, "session_state", session)
+    assert app._restore_viz_file_state() != {}
+    # Session state now holds the reconciled selection; re-seeding it would undo
+    # whatever the user changed since.
+    assert app._restore_viz_file_state() == {}
+
+
+def test_cloud_neither_saves_nor_restores(monkeypatch, tmp_path):
+    cfg_file = _desktop(monkeypatch, tmp_path)
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
+    monkeypatch.setattr(app.st, "session_state", {})
+    app._persist_viz_file_state(
+        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
+    )
+    assert app.VIZ_FILE_STATE_KEY not in json.loads(cfg_file.read_text())
+    monkeypatch.setattr(app.st, "session_state", {})
+    assert app._restore_viz_file_state() == {}
+
+
+def test_no_linked_file_neither_saves_nor_restores(monkeypatch, tmp_path):
+    cfg_file = _desktop(monkeypatch, tmp_path, linked=None)
+    monkeypatch.setattr(app.st, "session_state", {})
+    app._persist_viz_file_state(
+        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
+    )
+    assert not cfg_file.exists() or app.VIZ_FILE_STATE_KEY not in json.loads(
+        cfg_file.read_text()
+    )
+    monkeypatch.setattr(app.st, "session_state", {})
+    assert app._restore_viz_file_state() == {}
+
+
+# ---- Housekeeping -----------------------------------------------------------
+
+
+def test_untouched_filters_write_nothing(monkeypatch, tmp_path):
+    cfg_file = _desktop(monkeypatch, tmp_path)
+    before = cfg_file.read_text()
+    monkeypatch.setattr(app.st, "session_state", {})
+    app._persist_viz_file_state(_filters(class_uris=[NS + "A"]))
+    assert cfg_file.read_text() == before
+
+
+def test_clearing_a_filter_removes_the_entry(monkeypatch, tmp_path):
+    cfg_file = _desktop(monkeypatch, tmp_path)
+    session: dict = {}
+    monkeypatch.setattr(app.st, "session_state", session)
+    app._persist_viz_file_state(
+        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
+    )
+    assert FILE_A in json.loads(cfg_file.read_text())[app.VIZ_FILE_STATE_KEY]
+    # Re-showing everything leaves nothing worth remembering.
+    app._persist_viz_file_state(_filters(class_uris=[NS + "A", NS + "B"]))
+    assert json.loads(cfg_file.read_text())[app.VIZ_FILE_STATE_KEY] == {}
+
+
+def test_remembered_files_are_capped(monkeypatch, tmp_path):
+    _desktop(monkeypatch, tmp_path, linked=None)
+    monkeypatch.setattr(app.st, "session_state", {})
+    total = app.VIZ_FILE_STATE_MAX_FILES + 3
+    for i in range(total):
+        app.local_store.set_linked_path(f"/tmp/onto-{i}.ttl")
+        app._persist_viz_file_state(
+            _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
+        )
+    stored = json.loads((tmp_path / "config.json").read_text())[app.VIZ_FILE_STATE_KEY]
+    assert len(stored) == app.VIZ_FILE_STATE_MAX_FILES
+    assert "/tmp/onto-0.ttl" not in stored  # oldest evicted
+    assert f"/tmp/onto-{total - 1}.ttl" in stored  # newest kept
+
+
+def test_unchanged_state_is_not_rewritten(monkeypatch, tmp_path):
+    cfg_file = _desktop(monkeypatch, tmp_path)
+    session: dict = {}
+    monkeypatch.setattr(app.st, "session_state", session)
+    filters = _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
+    app._persist_viz_file_state(filters)
+    stamp = cfg_file.stat().st_mtime_ns
+    for _ in range(3):
+        app._persist_viz_file_state(filters)
+    assert cfg_file.stat().st_mtime_ns == stamp
+
+
+def test_junk_on_disk_is_ignored(monkeypatch, tmp_path):
+    cfg_file = _desktop(monkeypatch, tmp_path)
+    cfg_file.write_text(
+        json.dumps(
+            {
+                "linked_path": FILE_A,
+                app.VIZ_FILE_STATE_KEY: {
+                    FILE_A: {
+                        "hidden_class_uris": [NS + "A", 7, None],  # non-strings
+                        "focus_seeds": "Class: Person",  # not a list
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(app.st, "session_state", {})
+    entry = app._restore_viz_file_state()
+    assert app._str_list(entry.get("hidden_class_uris")) == [NS + "A"]
+    assert app._str_list(entry.get("focus_seeds")) == []
+
+
+def test_non_dict_store_is_ignored(monkeypatch, tmp_path):
+    cfg_file = _desktop(monkeypatch, tmp_path)
+    cfg_file.write_text(
+        json.dumps({"linked_path": FILE_A, app.VIZ_FILE_STATE_KEY: ["nope"]})
+    )
+    monkeypatch.setattr(app.st, "session_state", {})
+    assert app._restore_viz_file_state() == {}

--- a/tests/test_viz_file_state.py
+++ b/tests/test_viz_file_state.py
@@ -8,11 +8,21 @@ against its path and only restored while that same file is still linked.
 
 import json
 
+import pytest
+
 from orionbelt_ontology_builder import app
 
 FILE_A = "/tmp/onto-a.ttl"
 FILE_B = "/tmp/onto-b.ttl"
 NS = "http://test.org/ont#"
+
+# label -> node id, the way render_visualization builds it. Class and individual
+# ids derive from the URI, which is why seeds are stored as ids (issue #179).
+FOCUS_TARGETS = {
+    "Class: Person": app._uid(NS + "Person"),
+    "Class: Org": app._uid(NS + "Org"),
+    "Individual: alice": f"ind_{app._uid(NS + 'alice')}",
+}
 
 
 def _filters(class_uris=(), class_selected=None, ind_uris=(), ind_selected=None):
@@ -31,6 +41,26 @@ def _filters(class_uris=(), class_selected=None, ind_uris=(), ind_selected=None)
     }
 
 
+def _hid_one(**kwargs):
+    """The common case: two classes, the second hidden."""
+    return _filters(
+        class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"], **kwargs
+    )
+
+
+class _Session(dict):
+    """Session state stand-in: app code reaches for both keys and attributes."""
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as e:
+            raise AttributeError(name) from e
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+
 def _desktop(monkeypatch, tmp_path, linked=FILE_A):
     """Point local_store at a temp config.json with ``linked`` linked."""
     cfg_file = tmp_path / "config.json"
@@ -41,6 +71,10 @@ def _desktop(monkeypatch, tmp_path, linked=FILE_A):
     return cfg_file
 
 
+def _stored(cfg_file):
+    return json.loads(cfg_file.read_text()).get(app.VIZ_FILE_STATE_KEY, {})
+
+
 # ---- What gets stored -------------------------------------------------------
 
 
@@ -49,21 +83,52 @@ def test_payload_stores_what_is_hidden_not_what_is_selected(monkeypatch):
     # config.json small for an ontology with thousands of entities.
     monkeypatch.setattr(app.st, "session_state", {})
     payload = app._viz_file_state_payload(
-        _filters(class_uris=[NS + "A", NS + "B", NS + "C"], class_selected=[NS + "A"])
+        _filters(class_uris=[NS + "A", NS + "B", NS + "C"], class_selected=[NS + "A"]),
+        FOCUS_TARGETS,
     )
     assert payload == {"hidden_class_uris": [NS + "B", NS + "C"]}
 
 
 def test_payload_omits_untouched_filters_and_absent_seeds(monkeypatch):
     monkeypatch.setattr(app.st, "session_state", {})
-    assert app._viz_file_state_payload(_filters(class_uris=[NS + "A"])) == {}
+    payload = app._viz_file_state_payload(
+        _filters(class_uris=[NS + "A"]), FOCUS_TARGETS
+    )
+    assert payload == {}
 
 
-def test_payload_includes_focus_seeds(monkeypatch):
+def test_payload_stores_seeds_as_node_ids_not_labels(monkeypatch):
+    # A display label gains a namespace tag as soon as a second entity takes the
+    # same local name, so a saved label would stop matching (issue #179).
     monkeypatch.setattr(
         app.st, "session_state", {"_viz_cfg_focus_seeds": ["Class: Person"]}
     )
-    assert app._viz_file_state_payload(_filters())["focus_seeds"] == ["Class: Person"]
+    payload = app._viz_file_state_payload(_filters(), FOCUS_TARGETS)
+    assert payload == {"focus_seed_ids": [app._uid(NS + "Person")]}
+
+
+def test_payload_drops_seeds_with_no_current_node(monkeypatch):
+    monkeypatch.setattr(
+        app.st, "session_state", {"_viz_cfg_focus_seeds": ["Class: Vanished"]}
+    )
+    assert app._viz_file_state_payload(_filters(), FOCUS_TARGETS) == {}
+
+
+def test_saved_seed_id_survives_a_label_that_gained_a_namespace_tag(monkeypatch):
+    # Same entity, but a second Person appeared while the app was closed, so its
+    # label is now disambiguated. Mapping id -> label still finds it.
+    monkeypatch.setattr(
+        app.st, "session_state", {"_viz_cfg_focus_seeds": ["Class: Person"]}
+    )
+    saved = app._viz_file_state_payload(_filters(), FOCUS_TARGETS)["focus_seed_ids"]
+    later_targets = {
+        "Class: Person (foaf)": app._uid(NS + "Person"),
+        "Class: Person (gist)": app._uid("http://other#Person"),
+    }
+    label_by_id = {node_id: label for label, node_id in later_targets.items()}
+    assert [label_by_id[i] for i in saved if i in label_by_id] == [
+        "Class: Person (foaf)"
+    ]
 
 
 # ---- Round trip -------------------------------------------------------------
@@ -74,30 +139,21 @@ def test_disk_roundtrip_for_the_linked_file(monkeypatch, tmp_path):
     monkeypatch.setattr(
         app.st, "session_state", {"_viz_cfg_focus_seeds": ["Class: Person"]}
     )
-    app._persist_viz_file_state(
-        _filters(
-            class_uris=[NS + "A", NS + "B"],
-            class_selected=[NS + "A"],
-            ind_uris=[NS + "i1"],
-        )
-    )
+    app._persist_viz_file_state(_hid_one(ind_uris=[NS + "i1"]), FOCUS_TARGETS)
 
-    stored = json.loads(cfg_file.read_text())[app.VIZ_FILE_STATE_KEY]
-    assert stored[FILE_A] == {
+    assert _stored(cfg_file)[FILE_A] == {
         "hidden_class_uris": [NS + "B"],
-        "focus_seeds": ["Class: Person"],
+        "focus_seed_ids": [app._uid(NS + "Person")],
     }
 
     # A fresh session restores it.
-    restore_state: dict = {}
-    monkeypatch.setattr(app.st, "session_state", restore_state)
-    assert app._restore_viz_file_state() == stored[FILE_A]
+    monkeypatch.setattr(app.st, "session_state", {})
+    assert app._restore_viz_file_state() == _stored(cfg_file)[FILE_A]
 
 
 def test_restore_seeds_the_filter_so_hidden_entities_stay_hidden():
-    saved = {NS + "B"}
     selected, known = app.seed_filter_from_saved(
-        [NS + "A", NS + "B"], saved, None, None
+        [NS + "A", NS + "B"], {NS + "B"}, None, None
     )
     result, _ = app.reconcile_filter_selection([NS + "A", NS + "B"], selected, known)
     assert result == [NS + "A"]
@@ -134,9 +190,7 @@ def test_seeding_defers_to_a_selection_the_session_already_has():
 def test_state_is_scoped_to_the_linked_file(monkeypatch, tmp_path):
     _desktop(monkeypatch, tmp_path, linked=FILE_A)
     monkeypatch.setattr(app.st, "session_state", {})
-    app._persist_viz_file_state(
-        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
-    )
+    app._persist_viz_file_state(_hid_one(), FOCUS_TARGETS)
 
     # Linking a different file must not inherit the first file's filters.
     app.local_store.set_linked_path(FILE_B)
@@ -144,15 +198,77 @@ def test_state_is_scoped_to_the_linked_file(monkeypatch, tmp_path):
     assert app._restore_viz_file_state() == {}
 
 
+def test_relinking_mid_session_clears_the_previous_files_state(monkeypatch, tmp_path):
+    """Regression: the state in session belongs to the file being left.
+
+    A session that has rendered the graph already holds a selection and seeds.
+    Left in place they would win over the newly linked file's saved state (a
+    selection already in session suppresses it), and then be written back out
+    under the new file's key.
+    """
+    _desktop(monkeypatch, tmp_path, linked=FILE_A)
+    session = {
+        "_viz_file_state_for": FILE_B,
+        "_viz_cfg_selected_class_uris": [NS + "OLD"],
+        "_viz_cfg_known_class_uris": {NS + "OLD"},
+        "_viz_cfg_selected_ind_uris": [NS + "oldind"],
+        "_viz_cfg_known_ind_uris": {NS + "oldind"},
+        "_viz_cfg_focus_seeds": ["Class: FromTheOtherFile"],
+    }
+    monkeypatch.setattr(app.st, "session_state", session)
+
+    app._restore_viz_file_state()
+
+    for stale in (
+        "_viz_cfg_selected_class_uris",
+        "_viz_cfg_known_class_uris",
+        "_viz_cfg_selected_ind_uris",
+        "_viz_cfg_known_ind_uris",
+        "_viz_cfg_focus_seeds",
+    ):
+        assert stale not in session, stale
+    # With the selection cleared, the new file's saved state is what applies.
+    selected, known = app.seed_filter_from_saved(
+        [NS + "A", NS + "B"],
+        {NS + "B"},
+        session.get("_viz_cfg_selected_class_uris"),
+        session.get("_viz_cfg_known_class_uris"),
+    )
+    assert selected == [NS + "A"]
+    assert known == {NS + "A", NS + "B"}
+
+
+def test_relinking_does_not_write_the_old_files_seeds_under_the_new_file(
+    monkeypatch, tmp_path
+):
+    cfg_file = _desktop(monkeypatch, tmp_path, linked=FILE_B)
+    session = _Session()
+    monkeypatch.setattr(app.st, "session_state", session)
+
+    # Render 1: the user picks a seed while FILE_B is linked. render_visualization
+    # always restores before it persists, so mirror that order here.
+    app._restore_viz_file_state()
+    session["_viz_cfg_focus_seeds"] = ["Class: Person"]
+    app._persist_viz_file_state(_hid_one(), FOCUS_TARGETS)
+
+    # Render 2: same session, now pointed at a file with nothing saved.
+    app.local_store.set_linked_path(FILE_A)
+    app._restore_viz_file_state()
+    app._persist_viz_file_state(
+        _filters(class_uris=[NS + "A", NS + "B"]), FOCUS_TARGETS
+    )
+
+    stored = _stored(cfg_file)
+    assert FILE_A not in stored
+    assert stored[FILE_B]["focus_seed_ids"] == [app._uid(NS + "Person")]
+
+
 def test_relinking_mid_session_restores_the_new_file(monkeypatch, tmp_path):
     _desktop(monkeypatch, tmp_path, linked=FILE_B)
     monkeypatch.setattr(app.st, "session_state", {})
-    app._persist_viz_file_state(
-        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
-    )
+    app._persist_viz_file_state(_hid_one(), FOCUS_TARGETS)
 
-    session: dict = {}
-    monkeypatch.setattr(app.st, "session_state", session)
+    monkeypatch.setattr(app.st, "session_state", {})
     app.local_store.set_linked_path(FILE_A)
     assert app._restore_viz_file_state() == {}  # nothing saved for A
     app.local_store.set_linked_path(FILE_B)
@@ -162,11 +278,8 @@ def test_relinking_mid_session_restores_the_new_file(monkeypatch, tmp_path):
 def test_restore_runs_once_per_file(monkeypatch, tmp_path):
     _desktop(monkeypatch, tmp_path)
     monkeypatch.setattr(app.st, "session_state", {})
-    app._persist_viz_file_state(
-        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
-    )
-    session: dict = {}
-    monkeypatch.setattr(app.st, "session_state", session)
+    app._persist_viz_file_state(_hid_one(), FOCUS_TARGETS)
+    monkeypatch.setattr(app.st, "session_state", {})
     assert app._restore_viz_file_state() != {}
     # Session state now holds the reconciled selection; re-seeding it would undo
     # whatever the user changed since.
@@ -177,10 +290,8 @@ def test_cloud_neither_saves_nor_restores(monkeypatch, tmp_path):
     cfg_file = _desktop(monkeypatch, tmp_path)
     monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
     monkeypatch.setattr(app.st, "session_state", {})
-    app._persist_viz_file_state(
-        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
-    )
-    assert app.VIZ_FILE_STATE_KEY not in json.loads(cfg_file.read_text())
+    app._persist_viz_file_state(_hid_one(), FOCUS_TARGETS)
+    assert _stored(cfg_file) == {}
     monkeypatch.setattr(app.st, "session_state", {})
     assert app._restore_viz_file_state() == {}
 
@@ -188,12 +299,8 @@ def test_cloud_neither_saves_nor_restores(monkeypatch, tmp_path):
 def test_no_linked_file_neither_saves_nor_restores(monkeypatch, tmp_path):
     cfg_file = _desktop(monkeypatch, tmp_path, linked=None)
     monkeypatch.setattr(app.st, "session_state", {})
-    app._persist_viz_file_state(
-        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
-    )
-    assert not cfg_file.exists() or app.VIZ_FILE_STATE_KEY not in json.loads(
-        cfg_file.read_text()
-    )
+    app._persist_viz_file_state(_hid_one(), FOCUS_TARGETS)
+    assert not cfg_file.exists() or _stored(cfg_file) == {}
     monkeypatch.setattr(app.st, "session_state", {})
     assert app._restore_viz_file_state() == {}
 
@@ -205,33 +312,30 @@ def test_untouched_filters_write_nothing(monkeypatch, tmp_path):
     cfg_file = _desktop(monkeypatch, tmp_path)
     before = cfg_file.read_text()
     monkeypatch.setattr(app.st, "session_state", {})
-    app._persist_viz_file_state(_filters(class_uris=[NS + "A"]))
+    app._persist_viz_file_state(_filters(class_uris=[NS + "A"]), FOCUS_TARGETS)
     assert cfg_file.read_text() == before
 
 
 def test_clearing_a_filter_removes_the_entry(monkeypatch, tmp_path):
     cfg_file = _desktop(monkeypatch, tmp_path)
-    session: dict = {}
-    monkeypatch.setattr(app.st, "session_state", session)
-    app._persist_viz_file_state(
-        _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
-    )
-    assert FILE_A in json.loads(cfg_file.read_text())[app.VIZ_FILE_STATE_KEY]
+    monkeypatch.setattr(app.st, "session_state", {})
+    app._persist_viz_file_state(_hid_one(), FOCUS_TARGETS)
+    assert FILE_A in _stored(cfg_file)
     # Re-showing everything leaves nothing worth remembering.
-    app._persist_viz_file_state(_filters(class_uris=[NS + "A", NS + "B"]))
-    assert json.loads(cfg_file.read_text())[app.VIZ_FILE_STATE_KEY] == {}
+    app._persist_viz_file_state(
+        _filters(class_uris=[NS + "A", NS + "B"]), FOCUS_TARGETS
+    )
+    assert _stored(cfg_file) == {}
 
 
 def test_remembered_files_are_capped(monkeypatch, tmp_path):
-    _desktop(monkeypatch, tmp_path, linked=None)
+    cfg_file = _desktop(monkeypatch, tmp_path, linked=None)
     monkeypatch.setattr(app.st, "session_state", {})
     total = app.VIZ_FILE_STATE_MAX_FILES + 3
     for i in range(total):
         app.local_store.set_linked_path(f"/tmp/onto-{i}.ttl")
-        app._persist_viz_file_state(
-            _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
-        )
-    stored = json.loads((tmp_path / "config.json").read_text())[app.VIZ_FILE_STATE_KEY]
+        app._persist_viz_file_state(_hid_one(), FOCUS_TARGETS)
+    stored = _stored(cfg_file)
     assert len(stored) == app.VIZ_FILE_STATE_MAX_FILES
     assert "/tmp/onto-0.ttl" not in stored  # oldest evicted
     assert f"/tmp/onto-{total - 1}.ttl" in stored  # newest kept
@@ -239,35 +343,63 @@ def test_remembered_files_are_capped(monkeypatch, tmp_path):
 
 def test_unchanged_state_is_not_rewritten(monkeypatch, tmp_path):
     cfg_file = _desktop(monkeypatch, tmp_path)
-    session: dict = {}
-    monkeypatch.setattr(app.st, "session_state", session)
-    filters = _filters(class_uris=[NS + "A", NS + "B"], class_selected=[NS + "A"])
-    app._persist_viz_file_state(filters)
+    monkeypatch.setattr(app.st, "session_state", {})
+    filters = _hid_one()
+    app._persist_viz_file_state(filters, FOCUS_TARGETS)
     stamp = cfg_file.stat().st_mtime_ns
     for _ in range(3):
-        app._persist_viz_file_state(filters)
+        app._persist_viz_file_state(filters, FOCUS_TARGETS)
     assert cfg_file.stat().st_mtime_ns == stamp
 
 
-def test_junk_on_disk_is_ignored(monkeypatch, tmp_path):
+def test_a_failed_write_is_retried(monkeypatch, tmp_path):
+    """Regression: recording the attempt before it succeeded gave up silently.
+
+    An unwritable config.json must not stop later reruns from trying again, or
+    a transient failure would lose the state for the rest of the session.
+    """
+    cfg_file = _desktop(monkeypatch, tmp_path)
+    session = _Session(error_log=[])
+    monkeypatch.setattr(app.st, "session_state", session)
+
+    calls = []
+
+    def _boom(_config):
+        calls.append(1)
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(app.local_store, "save_config", _boom)
+    app._persist_viz_file_state(_hid_one(), FOCUS_TARGETS)
+    assert "_viz_file_state_fingerprint" not in session
+
+    # The disk comes back; the same unchanged state still gets written.
+    monkeypatch.undo()
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
+    monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
+    monkeypatch.setattr(app.st, "session_state", session)
+    app._persist_viz_file_state(_hid_one(), FOCUS_TARGETS)
+    assert calls == [1]
+    assert _stored(cfg_file)[FILE_A] == {"hidden_class_uris": [NS + "B"]}
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"hidden_class_uris": [NS + "A", 7, None], "focus_seed_ids": "not-a-list"},
+        {"hidden_class_uris": "not-a-list"},
+    ],
+)
+def test_junk_on_disk_is_ignored(monkeypatch, tmp_path, raw):
     cfg_file = _desktop(monkeypatch, tmp_path)
     cfg_file.write_text(
-        json.dumps(
-            {
-                "linked_path": FILE_A,
-                app.VIZ_FILE_STATE_KEY: {
-                    FILE_A: {
-                        "hidden_class_uris": [NS + "A", 7, None],  # non-strings
-                        "focus_seeds": "Class: Person",  # not a list
-                    }
-                },
-            }
-        )
+        json.dumps({"linked_path": FILE_A, app.VIZ_FILE_STATE_KEY: {FILE_A: raw}})
     )
     monkeypatch.setattr(app.st, "session_state", {})
     entry = app._restore_viz_file_state()
-    assert app._str_list(entry.get("hidden_class_uris")) == [NS + "A"]
-    assert app._str_list(entry.get("focus_seeds")) == []
+    assert all(
+        isinstance(u, str) for u in app._str_list(entry.get("hidden_class_uris"))
+    )
+    assert app._str_list(entry.get("focus_seed_ids")) == []
 
 
 def test_non_dict_store_is_ignored(monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #164.

## Why

PR #163 persisted the Visualization display settings across sessions, but deliberately left out two: the node filters and the focus seeds. Both name specific entities, so restoring `Class: Person` into a different ontology would be meaningless.

As @SuperCowProducts pointed out on the issue, that objection does not hold on desktop: the linked working file identifies the ontology, and its path already lives in `config.json`. So this state can be saved against that path and restored while the same file is still linked.

Scope confirmed with the reporter: both the node filters and the focus seeds, not just the seeds. They are coupled anyway, since the focus seeds default to whatever is selected in the class filter, so restoring one without the other would leave the graph half restored.

## What is stored

A new `viz_file_state` entry in `config.json`, keyed by linked path:

```json
"viz_file_state": {
  "/home/me/pizza.owl": {
    "hidden_class_uris": ["http://...#Veneziana"],
    "focus_seeds": ["Class: American"]
  }
}
```

It records what the user **hid**, not what is selected. Everything is shown by default, so the hidden set is normally empty or tiny, which matters for an ontology with thousands of entities.

Storing the hidden set also restores identically to storing the full selection. The saved state is fed *through* `reconcile_filter_selection` rather than around it, so the existing rules still apply:

- an entity added to the file since the last session is absent from the hidden set, so it shows up, the way new content always does;
- an entity deleted since drops out;
- everything else keeps the state the user left it in.

Focus seeds are stored as their display labels, which is what session state already holds. The focus-mode block already prunes seeds the ontology no longer has and falls back to the first available node, so a file edited outside the app degrades rather than breaking.

## Scope and limits

- Desktop and local mode only, gated on `local_persist_enabled()` plus a linked path. A cloud session has neither and keeps today's per-session reset. That is a deliberate behavior difference between the two.
- "Same path" is a proxy for "same ontology", not a guarantee. Someone can edit the linked file outside the app; the prune above is what handles that.
- `config.json` growth is bounded to the 20 most recently changed files, oldest evicted first.
- Saving no-ops when nothing changed since the last render and when the state on disk already matches, so ordinary reruns do not rewrite the file.

## Testing

- New `tests/test_viz_file_state.py`, 19 tests: what the payload stores, the disk round trip, entities added or deleted from the file since, scoping to the linked path, relinking mid-session, restore running once per file, the cloud and no-linked-file cases, the eviction cap, the no-rewrite guard, and junk on disk.
- Full suite: 712 passed. ruff 0.16.0 format and check clean, mypy clean.
- Verified live in local-persist mode against an isolated `HOME`, so no real user config was touched. Linked `pizza.owl`, hid a class, turned focus mode on, confirmed `config.json`, then restarted the server: the hidden class was still hidden (98 of 99 chips, `Veneziana` absent) and all 98 focus seeds came back.

Note for reviewers: the class filter multiselect is not rendered while focus mode is on, so the filter restore has to be checked with focus mode off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)