### PR TITLE
chore: bump version to 1.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.17.5` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.18.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -17,7 +17,7 @@ import streamlit as st
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.17.5"
+APP_VERSION = "1.18.0"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.17.5"
+version = "1.18.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.17.5"
+version = "1.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Version bump for the v1.18.0 release.

Updates `pyproject.toml`, `orionbelt_ontology_builder/app.py` (`APP_VERSION`), the Docker pin example in `README.md`, and the `uv.lock` package entry.

## What ships in 1.18.0

Features:
- #212 persist node filters and focus seeds per linked file
- #202 filter individuals, in a filter panel that stops growing
- #199 paste a class list into the Visualization filter

Fixes:
- #211 rank exact matches first in entity dropdowns
- #201 draw graph edges that pointed at nodes never emitted

Housekeeping: exception-logging cleanup (#208, #209), ruff full default rule set + 0.16.0 (#207), Dependabot bumps (#203, #204).

Minor bump rather than patch because of the three user-facing features.

## Verification

- `uv run pytest`: 727 passed
- `uvx ruff@0.16.0 check .` and `format --check .`: clean
- `uv run mypy orionbelt_ontology_builder tests app.py ontology_manager.py templates.py`: no issues in 68 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)