### PR TITLE
fix: rank shorter names first in entity dropdowns (#214)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1387,6 +1387,40 @@ def format_label_name(name: str, label: str) -> str:
     return name
 
 
+# fzy also subtracts 0.005 for every character *after* the last matched one, so
+# a longer option scores lower purely for being longer. A resource with a short
+# name therefore lost to a longer one whenever its own label pushed the display
+# string past the competitor's: searching 'n' ranked 'node' above 'n · number'
+# (issue #214), because both matched at position 0 with the same 0.9 bonus and
+# only length separated them.
+#
+# Padding every option to one width makes that trailing penalty identical for
+# all of them, so length stops counting and the score reflects the match alone.
+# Equal scores keep the order the app supplied (Streamlit sorts with a stable
+# lodash sortBy), which is the builders' alphabetical sort — and for a prefix
+# query that puts the shortest name first.
+#
+# The width is a constant rather than the longest option in the list: padding is
+# applied through ``format_func``, so it never touches the option values the
+# rest of the app stores and looks up, but a width that moved with the option
+# set would still change a rendered label under a selection. 120 covers every
+# display string in the bundled ontologies (the longest is 103); anything past
+# it simply keeps today's behaviour. Well under fzy's 1024-character cutoff,
+# beyond which it stops scoring entirely.
+SEARCH_PAD_WIDTH = 120
+
+
+def _pad_option(display: object) -> str:
+    """Pad a dropdown option to :data:`SEARCH_PAD_WIDTH` for search ranking.
+
+    Pass as ``format_func`` to any selectbox fed by :func:`build_uri_options` or
+    :func:`build_class_options`. The padding is invisible (HTML collapses the
+    trailing spaces) and stays out of the widget's value, which remains the
+    unpadded display string every lookup is keyed by.
+    """
+    return str(display).ljust(SEARCH_PAD_WIDTH)
+
+
 def _uid(uri: str) -> str:
     """Stable short identifier for a URI — used as Streamlit key suffix.
 
@@ -1927,6 +1961,7 @@ def _render_panel_entity_editor(
                 "Domain",
                 cls_opts,
                 index=cls_opts.index(cur_dom) if cur_dom in cls_opts else 0,
+                format_func=_pad_option,
             )
             if ntype == "Object Property":
                 cur_rng = next(
@@ -1941,6 +1976,7 @@ def _render_panel_entity_editor(
                     "Range",
                     cls_opts,
                     index=cls_opts.index(cur_rng) if cur_rng in cls_opts else 0,
+                    format_func=_pad_option,
                 )
                 # Only apply when changed, so a range/domain that can't be shown
                 # in the dropdown (e.g. a class outside this ontology) isn't
@@ -2668,6 +2704,7 @@ def render_classes():
                 "Parent Class",
                 options=parent_options,
                 help="Select a parent class for hierarchy",
+                format_func=_pad_option,
             )
             ns_options, ns_lookup = build_namespace_options(ont)
             ns_display = st.selectbox(
@@ -2707,7 +2744,10 @@ def render_classes():
             # Build options with disambiguated name · Label format; lookup is by URI
             class_options, class_lookup = build_class_options(classes)
             selected_display = st.selectbox(
-                "Select Class", options=class_options, key="edit_class_select"
+                "Select Class",
+                options=class_options,
+                key="edit_class_select",
+                format_func=_pad_option,
             )
             selected_uri = class_lookup.get(selected_display)
             class_info = (
@@ -3137,6 +3177,7 @@ def render_properties():
                                     if cur_dom_disp in cls_opts
                                     else 0,
                                     key=f"objp_dom_{prop_uid}",
+                                    format_func=_pad_option,
                                 )
                             with col2:
                                 rng_disp = st.selectbox(
@@ -3146,6 +3187,7 @@ def render_properties():
                                     if cur_rng_disp in cls_opts
                                     else 0,
                                     key=f"objp_rng_{prop_uid}",
+                                    format_func=_pad_option,
                                 )
 
                             if st.form_submit_button("Save Changes"):
@@ -3340,6 +3382,7 @@ def render_properties():
                                     if cur_dom_disp in cls_opts
                                     else 0,
                                     key=f"dp_dom_{prop_uid}",
+                                    format_func=_pad_option,
                                 )
                             with col2:
                                 current_range = (
@@ -3428,14 +3471,22 @@ def render_properties():
                 )
                 with st.form("reuse_obj_prop_form"):
                     reuse_opts, reuse_lookup = build_uri_options(object_props)
-                    prop_disp = st.selectbox("Existing property *", options=reuse_opts)
+                    prop_disp = st.selectbox(
+                        "Existing property *",
+                        options=reuse_opts,
+                        format_func=_pad_option,
+                    )
 
                     cls_opts, cls_lookup = build_class_options(classes)
                     col1, col2 = st.columns(2)
                     with col1:
-                        source_disp = st.selectbox("Source class *", options=cls_opts)
+                        source_disp = st.selectbox(
+                            "Source class *", options=cls_opts, format_func=_pad_option
+                        )
                     with col2:
-                        target_disp = st.selectbox("Target class *", options=cls_opts)
+                        target_disp = st.selectbox(
+                            "Target class *", options=cls_opts, format_func=_pad_option
+                        )
 
                     link_disp = st.radio(
                         "Link type",
@@ -3491,9 +3542,13 @@ def render_properties():
                 )
                 col1, col2 = st.columns(2)
                 with col1:
-                    domain_disp = st.selectbox("Domain (Class)", options=cls_opts)
+                    domain_disp = st.selectbox(
+                        "Domain (Class)", options=cls_opts, format_func=_pad_option
+                    )
                 with col2:
-                    range_disp = st.selectbox("Range (Class)", options=cls_opts)
+                    range_disp = st.selectbox(
+                        "Range (Class)", options=cls_opts, format_func=_pad_option
+                    )
 
                 st.write("**Property Characteristics:**")
                 col1, col2, col3, col4 = st.columns(4)
@@ -3509,7 +3564,9 @@ def render_properties():
                 with col4:
                     symmetric = st.checkbox("Symmetric")
 
-                inverse_disp = st.selectbox("Inverse Of", options=obj_prop_opts)
+                inverse_disp = st.selectbox(
+                    "Inverse Of", options=obj_prop_opts, format_func=_pad_option
+                )
                 ns_options, ns_lookup = build_namespace_options(ont)
                 ns_display = st.selectbox(
                     "Namespace",
@@ -3562,7 +3619,10 @@ def render_properties():
             col1, col2 = st.columns(2)
             with col1:
                 domain_disp = st.selectbox(
-                    "Domain (Class)", options=cls_opts, key="data_prop_domain"
+                    "Domain (Class)",
+                    options=cls_opts,
+                    key="data_prop_domain",
+                    format_func=_pad_option,
                 )
             with col2:
                 datatypes = list(get_ontology_manager_class().XSD_DATATYPES.keys())
@@ -4248,6 +4308,7 @@ def render_restriction_editor(ont, rest, row_key, classes, properties):
             cls_options,
             index=_uri_option_index(cls_options, cls_lookup, applied_uris[0]),
             key=f"er_cls_{row_key}",
+            format_func=_pad_option,
         )
         new_property = st.selectbox(
             "Property",
@@ -4256,6 +4317,7 @@ def render_restriction_editor(ont, rest, row_key, classes, properties):
                 prop_options, prop_lookup, rest.get("property_uri") or rest["property"]
             ),
             key=f"er_prop_{row_key}",
+            format_func=_pad_option,
         )
         new_type = st.selectbox(
             "Restriction Type",
@@ -4281,6 +4343,7 @@ def render_restriction_editor(ont, rest, row_key, classes, properties):
                     else 0
                 ),
                 key=f"er_onclass_{row_key}",
+                format_func=_pad_option,
             )
 
         save_col, cancel_col = st.columns(2)
@@ -4355,8 +4418,12 @@ def render_add_restriction(ont, classes, properties):
         # was silently created on a base-namespace twin instead.
         cls_opts, cls_lookup = build_uri_options(classes)
         prop_opts, prop_lookup = build_uri_options(properties)
-        target_disp = st.selectbox("Apply to Class", options=cls_opts)
-        property_disp = st.selectbox("On Property", options=prop_opts)
+        target_disp = st.selectbox(
+            "Apply to Class", options=cls_opts, format_func=_pad_option
+        )
+        property_disp = st.selectbox(
+            "On Property", options=prop_opts, format_func=_pad_option
+        )
 
         # Straight from the engine, so a type can never be offered here
         # that it doesn't understand, or omitted when it gains one.
@@ -4368,7 +4435,12 @@ def render_add_restriction(ont, classes, properties):
         value = None
         if restriction_type in ["someValuesFrom", "allValuesFrom"]:
             value = cls_lookup[
-                st.selectbox("Value (Class)", options=cls_opts, key="rest_class_value")
+                st.selectbox(
+                    "Value (Class)",
+                    options=cls_opts,
+                    key="rest_class_value",
+                    format_func=_pad_option,
+                )
             ]
         elif restriction_type == "hasValue":
             ind_opts, ind_lookup = build_uri_options(ont.get_individuals())
@@ -4376,7 +4448,11 @@ def render_add_restriction(ont, classes, properties):
             if value_type == "Literal":
                 value = st.text_input("Literal Value")
             elif ind_opts:
-                value = ind_lookup[st.selectbox("Individual", options=ind_opts)]
+                value = ind_lookup[
+                    st.selectbox(
+                        "Individual", options=ind_opts, format_func=_pad_option
+                    )
+                ]
             else:
                 # Offering a "No individuals" placeholder let that string
                 # be stored as the value.
@@ -4391,6 +4467,7 @@ def render_add_restriction(ont, classes, properties):
                     "Qualified on Class",
                     options=cls_opts,
                     key="qualified_class",
+                    format_func=_pad_option,
                 )
             ]
 
@@ -4611,7 +4688,10 @@ def render_relations():
 
                 with col1:
                     class1_disp = st.selectbox(
-                        "Class 1", options=cls_opts, key="crel_class1"
+                        "Class 1",
+                        options=cls_opts,
+                        key="crel_class1",
+                        format_func=_pad_option,
                     )
                 with col2:
                     relation_type = st.selectbox(
@@ -4621,7 +4701,10 @@ def render_relations():
                     )
                 with col3:
                     class2_disp = st.selectbox(
-                        "Class 2", options=cls_opts, key="crel_class2"
+                        "Class 2",
+                        options=cls_opts,
+                        key="crel_class2",
+                        format_func=_pad_option,
                     )
 
                 st.caption("""
@@ -4673,7 +4756,10 @@ def render_relations():
 
                 with col1:
                     prop1_disp = st.selectbox(
-                        "Property 1", options=prop_opts, key="prel_prop1"
+                        "Property 1",
+                        options=prop_opts,
+                        key="prel_prop1",
+                        format_func=_pad_option,
                     )
                 with col2:
                     relation_type = st.selectbox(
@@ -4683,7 +4769,10 @@ def render_relations():
                     )
                 with col3:
                     prop2_disp = st.selectbox(
-                        "Property 2", options=prop_opts, key="prel_prop2"
+                        "Property 2",
+                        options=prop_opts,
+                        key="prel_prop2",
+                        format_func=_pad_option,
                     )
 
                 st.caption("""
@@ -4734,7 +4823,10 @@ def render_relations():
 
                 with col1:
                     ind1_disp = st.selectbox(
-                        "Individual 1", options=ind_opts, key="irel_ind1"
+                        "Individual 1",
+                        options=ind_opts,
+                        key="irel_ind1",
+                        format_func=_pad_option,
                     )
                 with col2:
                     relation_type = st.selectbox(
@@ -4744,7 +4836,10 @@ def render_relations():
                     )
                 with col3:
                     ind2_disp = st.selectbox(
-                        "Individual 2", options=ind_opts, key="irel_ind2"
+                        "Individual 2",
+                        options=ind_opts,
+                        key="irel_ind2",
+                        format_func=_pad_option,
                     )
 
                 st.caption("""
@@ -4854,7 +4949,11 @@ def render_relation_rows(ont, rows, spec):
             obj_default = _uri_option_index(row_options, row_lookup, obj_uri)
             types = list(spec["relation_types"])
             new_subject = st.selectbox(
-                "Subject", row_options, index=subj_default, key=f"es_{rel_uid}"
+                "Subject",
+                row_options,
+                index=subj_default,
+                key=f"es_{rel_uid}",
+                format_func=_pad_option,
             )
             new_type = st.selectbox(
                 "Relation",
@@ -4863,7 +4962,11 @@ def render_relation_rows(ont, rows, spec):
                 key=f"et_{rel_uid}",
             )
             new_object = st.selectbox(
-                "Object", row_options, index=obj_default, key=f"eo_{rel_uid}"
+                "Object",
+                row_options,
+                index=obj_default,
+                key=f"eo_{rel_uid}",
+                format_func=_pad_option,
             )
             # The add forms can point an object at an entity in an ontology that
             # was never imported; without this the editor could keep such a
@@ -5035,7 +5138,10 @@ def render_add_annotation(ont, all_resources):
             # Use display format with label
             resource_options = [f"{r['display']} [{r['type']}]" for r in all_resources]
             selected = st.selectbox(
-                "Select Resource", options=resource_options, key="ann_resource"
+                "Select Resource",
+                options=resource_options,
+                key="ann_resource",
+                format_func=_pad_option,
             )
 
             # Typing a type that isn't listed creates it, so an ID with no
@@ -5057,6 +5163,7 @@ def render_add_annotation(ont, all_resources):
                     "URI. A new name of your own is declared as an "
                     "annotation property in the ontology."
                 ),
+                format_func=_pad_option,
             )
 
             value = st.text_area("Value", key="ann_value")
@@ -5508,7 +5615,10 @@ def render_skos_vocabulary():
         else:
             # Filter by scheme
             filter_scheme = st.selectbox(
-                "Filter by Scheme", ["All"] + scheme_opts, key="concept_filter_scheme"
+                "Filter by Scheme",
+                ["All"] + scheme_opts,
+                key="concept_filter_scheme",
+                format_func=_pad_option,
             )
             filtered = (
                 concepts
@@ -5609,6 +5719,7 @@ def render_skos_vocabulary():
                                 "Target Concept",
                                 _rel_opts,
                                 key=f"rel_target_{_ck}",
+                                format_func=_pad_option,
                             )
                             if st.button("Add", key=f"add_rel_{_ck}") and rel_target:
                                 # Address both concepts by their actual URIs: a
@@ -5689,6 +5800,7 @@ def render_skos_vocabulary():
                                 if _cur_broader_disp in broader_options
                                 else 0,
                                 key=f"broader_{_ck}",
+                                format_func=_pad_option,
                             )
 
                             # Scheme — URI-keyed for the same reason.
@@ -5713,6 +5825,7 @@ def render_skos_vocabulary():
                                 if _cur_scheme_disp in scheme_options
                                 else 0,
                                 key=f"scheme_{_ck}",
+                                format_func=_pad_option,
                             )
                             new_name = _custom_uri_field(
                                 concept["uri"],
@@ -5795,13 +5908,17 @@ def render_skos_vocabulary():
             c_pref = st.text_input("Preferred Label")
             c_def = st.text_area("Definition")
             c_scheme = st.selectbox(
-                "Scheme", ["None"] + scheme_opts, key="concept_scheme_select"
+                "Scheme",
+                ["None"] + scheme_opts,
+                key="concept_scheme_select",
+                format_func=_pad_option,
             )
             _add_broader_opts, _add_broader_lookup = build_uri_options(concepts)
             c_broader = st.selectbox(
                 "Broader Concept",
                 ["None"] + _add_broader_opts,
                 key="concept_broader_select",
+                format_func=_pad_option,
             )
             c_lang = st.text_input("Language Tag (e.g., en, de)", key="concept_lang")
             if st.form_submit_button("Add Concept"):
@@ -5833,7 +5950,10 @@ def render_skos_vocabulary():
             st.info("No concepts to display.")
         else:
             h_scheme = st.selectbox(
-                "Scheme", ["All"] + scheme_opts, key="hierarchy_scheme_select"
+                "Scheme",
+                ["All"] + scheme_opts,
+                key="hierarchy_scheme_select",
+                format_func=_pad_option,
             )
             hierarchy = ont.get_concept_hierarchy(
                 scheme=scheme_lookup.get(h_scheme) if h_scheme != "All" else None

--- a/tests/test_dropdown_search_ranking.py
+++ b/tests/test_dropdown_search_ranking.py
@@ -1,22 +1,35 @@
-"""Dropdown search puts an exact local-name match first (issue #210).
+"""Dropdown search ranks the entity you typed first (issues #210 and #214).
 
 Streamlit filters a selectbox client-side: it keeps every option whose label
 contains the typed text as a *subsequence*, then sorts by an fzy score. That
 scorer is not configurable from Python (it is bundled JS, and it is byte-for-byte
-identical in every Streamlit release from 1.49 through 1.60), so the only lever
-the app has is the option string it emits.
+identical in every Streamlit release from 1.49 through 1.60), so the only levers
+the app has are the option string it emits and the label ``format_func`` renders.
 
-fzy scores a match partly by the character *preceding* it: 0.9 after ``/``, 0.8
-after a space / ``-`` / ``_``, 0.7 for a camelCase hump, and 0.0 after ``(``.
-The old ``'Label (name)'`` format therefore gave the local name no boundary
-bonus at all, and an unrelated camelCase compound could outscore an exact match:
-searching ``HamTopping`` in pizza.owl ranked ``ParmaHamTopping`` first. The
-name now leads, behind a separator that ends in a space, which restores the
-bonus.
+Two properties of the scorer drive the format:
 
-``_score`` / ``_has_match`` below are a direct port of that bundled scorer, so
-these tests fail if the display format stops ranking exact matches first.
+* It scores a match partly by the character *preceding* it: 0.9 after ``/``, 0.8
+  after a space / ``-`` / ``_``, 0.7 for a camelCase hump, and 0.0 after ``(``.
+  The old ``'Label (name)'`` format gave the local name no boundary bonus at all,
+  and an unrelated camelCase compound could outscore an exact match: searching
+  ``HamTopping`` in pizza.owl ranked ``ParmaHamTopping`` first (issue #210). The
+  name now leads, behind a separator that ends in a space.
+* It subtracts 0.005 for every character *after* the last match, so a longer
+  option scores lower purely for being longer. Searching ``n`` ranked ``node``
+  above ``n · number`` (issue #214). :func:`app._pad_option` pads every option to
+  one width through ``format_func``, which makes that penalty identical for all
+  of them; equal scores then keep the order the app supplied.
+
+``_score`` / ``_has_match`` below are a direct port of the bundled scorer, so
+these tests fail if either lever stops ranking the typed entity first. Note that
+Streamlit calls it as ``score(query, label, /*caseSensitive=*/true)``: options
+are *filtered* case-insensitively but *scored* case-sensitively, and the port
+mirrors that. It also means the ``haystack.length === needle.length`` shortcut to
+SCORE_MAX is disabled, so only a byte-identical option scores as a certainty.
 """
+
+import ast
+from pathlib import Path
 
 from orionbelt_ontology_builder import app
 
@@ -53,7 +66,10 @@ def _precompute_bonus(haystack: str) -> list[float]:
 
 
 def _has_match(needle: str, haystack: str) -> bool:
-    """Whether ``needle`` appears in ``haystack`` as a subsequence."""
+    """Whether ``needle`` appears in ``haystack`` as a subsequence.
+
+    Case-insensitive, unlike :func:`_score` — that asymmetry is Streamlit's.
+    """
     needle, haystack = needle.lower(), haystack.lower()
     at = 0
     for ch in needle:
@@ -67,14 +83,14 @@ def _score(needle: str, haystack: str) -> float:
     n, m = len(needle), len(haystack)
     if not n or not m:
         return _SCORE_MIN
-    # An option equal to the query (or merely the same length) wins outright.
-    if needle == haystack or m == n:
+    # An option equal to the query wins outright. Streamlit passes
+    # caseSensitive=true, which disables fzy's same-length shortcut.
+    if needle == haystack:
         return _SCORE_MAX
     if m > 1024:
         return _SCORE_MIN
 
     bonus = _precompute_bonus(haystack)
-    needle, haystack = needle.lower(), haystack.lower()
     # best[i][j]: score of a match ending exactly at j; running[i][j]: best so far.
     best = [[_SCORE_MIN] * m for _ in range(n)]
     running = [[_SCORE_MIN] * m for _ in range(n)]
@@ -104,9 +120,15 @@ def _score(needle: str, haystack: str) -> float:
 
 
 def _rank(query: str, options: list[str]) -> list[str]:
-    """The order Streamlit's selectbox shows for ``query``."""
+    """The order Streamlit's selectbox shows for ``query``.
+
+    Scores the rendered label, which is what the widget filters on, so the
+    ``format_func`` every entity dropdown passes is part of what is measured.
+    ``sorted`` is stable, like the lodash ``sortBy`` Streamlit ranks with, so
+    equal scores keep the order the app supplied.
+    """
     matches = [o for o in options if _has_match(query, o)]
-    return sorted(matches, key=lambda o: -_score(query, o))
+    return sorted(matches, key=lambda o: -_score(query, app._pad_option(o)))
 
 
 def _options(*items: tuple[str, str]) -> list[str]:
@@ -177,3 +199,113 @@ def test_separator_gives_the_local_name_a_word_boundary_bonus():
     display = app.format_label_name("HamTopping", "CoberturaDePresunto")
     name_starts_at = display.index("HamTopping")
     assert _precompute_bonus(display)[name_starts_at] >= _MATCH_WORD
+
+
+def test_short_labelled_name_outranks_longer_bare_name():
+    """The scenario from issue #214.
+
+    Both match at position 0 and earn the same 0.9 bonus; unpadded, 'node' won
+    only because 'n · number' is six characters longer.
+    """
+    short = app.format_label_name("n", "number")
+    options = _options(("n", "number"), ("node", "node"))
+    assert _rank("n", options)[0] == short
+    assert _score("n", "node") > _score("n", short)  # what padding cancels out
+
+
+def test_short_name_outranks_longer_one_sharing_its_prefix():
+    """The wine.owl case #210 had to leave mis-ranked, now that length is neutral."""
+    options = _options(("Wine", ""), ("Winery", "Wine estate"))
+    assert _rank("Wine", options)[0] == "Wine"
+
+
+def test_padding_is_invisible_and_leaves_the_option_value_alone():
+    """The value the widget returns is the key every lookup is built from."""
+    display = app.format_label_name("Person", "A person")
+    padded = app._pad_option(display)
+    assert padded.strip() == display
+    assert padded != display  # it really did pad
+    assert len(padded) == app.SEARCH_PAD_WIDTH
+
+
+def test_option_longer_than_the_pad_width_still_ranks_below_an_exact_match():
+    """Padding is a no-op past SEARCH_PAD_WIDTH; that must not invert a match."""
+    long_label = "x" * app.SEARCH_PAD_WIDTH
+    options = _options(("Order", ""), ("OrderLine", long_label))
+    assert len(app._pad_option(options[1])) > app.SEARCH_PAD_WIDTH
+    assert _rank("Order", options)[0] == "Order"
+
+
+def _entity_dropdowns_missing_format_func() -> list[tuple[int, str]]:
+    """Selectboxes fed by the option builders that do not pad their labels.
+
+    Every one of them filters on the rendered label, so a missed call site keeps
+    the issue #214 ranking with nothing to show for it.
+    """
+    tree = ast.parse(Path(app.__file__).read_text(encoding="utf-8"))
+    builders = {"build_uri_options", "build_class_options", "_slot_options"}
+    missing = []
+
+    def option_targets(node: ast.Assign) -> set[str]:
+        """Names bound to the options half of an ``(options, lookup)`` pair."""
+        names = set()
+        for target in node.targets:
+            elements = target.elts if isinstance(target, ast.Tuple) else [target]
+            # The builders return (options, lookup); only the first carries what
+            # the dropdown renders.
+            if elements and isinstance(elements[0], ast.Name):
+                names.add(elements[0].id)
+        return names
+
+    # Scope-by-scope: the same local name means different things in different
+    # functions (``prop_options`` is builder output in one and a list of bare
+    # names in another), so a module-wide name set would flag the wrong calls.
+    for scope in ast.walk(tree):
+        if not isinstance(scope, ast.FunctionDef):
+            continue
+        body = [n for stmt in scope.body for n in ast.walk(stmt)]
+
+        option_vars: set[str] = set()
+        for node in body:
+            if not isinstance(node, ast.Assign):
+                continue
+            calls = [n for n in ast.walk(node.value) if isinstance(n, ast.Call)]
+            called = {c.func.id for c in calls if isinstance(c.func, ast.Name)}
+            if called & builders:
+                option_vars |= option_targets(node)
+        # One more hop for plain copies (``row_options = list(options)``). Calls
+        # on an object are excluded, so a widget's *return* value never counts.
+        for node in body:
+            if not isinstance(node, ast.Assign):
+                continue
+            calls = [n for n in ast.walk(node.value) if isinstance(n, ast.Call)]
+            if any(isinstance(c.func, ast.Attribute) for c in calls):
+                continue
+            names = {n.id for n in ast.walk(node.value) if isinstance(n, ast.Name)}
+            if names & option_vars:
+                option_vars |= option_targets(node)
+
+        for node in body:
+            if not isinstance(node, ast.Call) or not isinstance(
+                node.func, ast.Attribute
+            ):
+                continue
+            if node.func.attr not in ("selectbox", "multiselect"):
+                continue
+            referenced = {
+                n.id
+                for arg in [*node.args, *(k.value for k in node.keywords)]
+                for n in ast.walk(arg)
+                if isinstance(n, ast.Name)
+            }
+            if not referenced & option_vars:
+                continue
+            if not any(k.arg == "format_func" for k in node.keywords):
+                first = node.args[0] if node.args else None
+                label = first.value if isinstance(first, ast.Constant) else "?"
+                missing.append((node.lineno, str(label)))
+    return sorted(missing)
+
+
+def test_every_entity_dropdown_pads_its_labels():
+    assert _entity_dropdowns_missing_format_func() == []


### PR DESCRIPTION
Closes #214.

## The bug

Streamlit filters selectboxes client-side with fzy, which subtracts 0.005 for every character *after* the last matched one. An option therefore scores lower purely for being longer. A resource with a short name lost to a longer one whenever its own label pushed the display string past the competitor's.

With classes `n` (label "number") and `node`, typing `n`:

| option | score |
|---|---|
| `node` | 0.885 |
| `n · number` | 0.855 |

Both match at position 0 and earn the same 0.9 word-boundary bonus. Only length separates them, so `node` came first.

## The fix

Pad every entity option to one width through `format_func`. The trailing penalty becomes identical for all options, so length stops counting and the score reflects the match alone. Equal scores keep the order the app supplied (Streamlit sorts with a stable lodash `sortBy`), which is the builders' alphabetical sort, and for a prefix query that is the shortest name.

Padding goes through `format_func` rather than into the option strings, so the value every lookup, `.index()` call and `session_state` injection is keyed by stays exactly as it is today. It is invisible to users because HTML collapses trailing spaces.

The width is a constant (120) rather than the longest option in the list, which would change a rendered label under a live selection. It covers every display string in the bundled ontologies (1980 entities, longest is 103, p99 is 61); anything past it simply keeps today's behaviour. Well under fzy's 1024-character cutoff.

This also settles the wine.owl case #210 had to leave mis-ranked: searching `Wine` no longer puts `Winery · Wine estate` first.

## Verified in the running app

Imported a small ontology with `n` (label "number"), `node`, `Nachos` and `OnionTopping`, then typed `n` in the Class Relations dropdown. `n · number` ranks first, `node` second, and the option list looks unchanged: no visible padding, in the closed box or the open list.

## Test changes

The scorer port in `tests/test_dropdown_search_ranking.py` was wrong. Streamlit calls it as `score(query, label, /*caseSensitive=*/true)`, so options are *filtered* case-insensitively but *scored* case-sensitively, and the same-length shortcut to `SCORE_MAX` is disabled. The port lowercased both sides, which mispredicted the order of anything matching on a lowercase run inside a name. It passed its own assertions but did not model what users see. With that corrected it reproduces the browser's ordering exactly, in both the padded and unpadded runs.

New tests cover the #214 scenario, the wine.owl case, that padding leaves the option value alone, and that an option longer than the pad width cannot outrank an exact match.

`test_every_entity_dropdown_pads_its_labels` walks `app.py`'s AST and fails if any selectbox fed by `build_uri_options` / `build_class_options` / `_slot_options` forgets `format_func`. That is how the one missed call site in `render_restriction_editor` was found. The analysis is per function scope, since `prop_options` means builder output in one function and a list of bare names in another.

## Checks

`pytest` (732 passed), `ruff format --check`, `ruff check` and `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)