### PR TITLE
fix: let focus mode reach nodes past the graph's render cap (#216)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -2378,6 +2378,27 @@ def render_dashboard():
 # every per-item list view shares this cap (issue #146).
 LIST_PAGE_SIZE = 50
 
+# How many nodes the Visualization graph may draw. vis-network (and the desktop
+# webview especially) bogs down well before a large ontology's worth of them.
+GRAPH_MAX_NODES = 500
+
+# How many it may *assemble* in focus mode, where the drawn graph is the pruned
+# neighbourhood of the seeds rather than everything built. Assembly is cheap —
+# plain dicts — so this can be far larger than what is drawn, which is what lets
+# a class deep into a big ontology be focused on at all (issue #216).
+FOCUS_BUILD_MAX_NODES = 5000
+
+
+def graph_node_cap(focus_pruning: bool) -> int:
+    """How many nodes a graph build may assemble (issue #216).
+
+    Going past what can be drawn is only safe because focus mode prunes back to
+    the seeds' neighbourhood afterwards, so the allowance is tied to that prune
+    actually running — not to focus mode being on. With the mode on but every
+    seed cleared nothing prunes, and the browser would be handed the lot.
+    """
+    return FOCUS_BUILD_MAX_NODES if focus_pruning else GRAPH_MAX_NODES
+
 
 def _page_bounds(total: int, page: int, page_size: int) -> tuple[int, int, int, int]:
     """Resolve a 1-based ``page`` over ``total`` items into slice bounds.
@@ -7491,10 +7512,13 @@ def render_visualization():
         )
         return
 
+    # Seeded in session_state rather than passed as ``default=``, the way the
+    # Classes, Relations and Restrictions pages do it.
+    if "viz_active_tab" not in st.session_state:
+        st.session_state["viz_active_tab"] = "Interactive Graph"
     _viz_tab = st.segmented_control(
         "Section",
         ["Interactive Graph", "Class Hierarchy", "Statistics"],
-        default="Interactive Graph",
         key="viz_active_tab",
         label_visibility="collapsed",
     )
@@ -8232,9 +8256,21 @@ def render_visualization():
                 },
             }
 
-            # Limit total nodes to prevent browser hanging
-            max_nodes = 500
+            # Focus mode assembles the whole graph and prunes it to the seeds'
+            # neighbourhood afterwards, so the browser only ever sees the prune —
+            # only that has to respect the render cap. Assembling under it
+            # instead cut the very nodes a focus needs: a class past the cap
+            # could not be focused on at all, and the graph came out empty with
+            # nothing said about why (issue #216).
+            #
+            # One flag drives both the allowance and the prune, so the two can't
+            # drift apart — see :func:`graph_node_cap` for why that matters.
+            focus_pruning = bool(focus_mode and focus_seed_ids)
+            max_nodes = graph_node_cap(focus_pruning)
             node_count = 0
+            # Why the graph is smaller than the ontology, shown above it. Empty
+            # when nothing was left out.
+            graph_notice = ""
 
             # Build sets for node existence checks (URI-keyed for cross-namespace safety)
             cls_collisions = _build_name_collision_set(classes)
@@ -8821,11 +8857,25 @@ def render_visualization():
                                 arrows="to",
                             )
 
+            # Classes that passed the filter but never got a node: the cap cut
+            # the loop short. This used to be silent, so a class simply went
+            # missing — along with every edge that needed it, which reads as
+            # unrelated classes losing their connections (issue #216). The focus
+            # block below replaces this with something more specific when it has
+            # it, since a focus that finds nothing is the sharper symptom.
+            _cut_classes = len(visible_class_uris) - len(displayed_class_uris)
+            if show_classes and _cut_classes > 0:
+                graph_notice = (
+                    f"{_cut_classes} of {len(visible_class_uris)} classes are not "
+                    f"drawn: the graph stops at {max_nodes} nodes. Hide some in "
+                    f"Filter Nodes, or focus on one node, to see the rest."
+                )
+
             # Focus mode: keep only the seed nodes' neighbourhood within
             # focus_depth hops over the assembled edges (BFS over all node
             # types, so depth counts real graph links rather than class hops).
             # Several seeds grow the neighbourhood from all of them at once.
-            if focus_mode and focus_seed_ids:
+            if focus_pruning:
                 present_ids = {n["id"] for n in net.nodes}
                 seeds = {sid for sid in focus_seed_ids if sid in present_ids}
                 if seeds:
@@ -8833,25 +8883,49 @@ def render_visualization():
                     for edge in net.edges:
                         adj.setdefault(edge["from"], set()).add(edge["to"])
                         adj.setdefault(edge["to"], set()).add(edge["from"])
-                    keep = set(seeds)
-                    frontier = set(seeds)
-                    for _ in range(focus_depth):
-                        nxt = set()
-                        for nid in frontier:
-                            nxt |= adj.get(nid, set()) - keep
-                        if not nxt:
+                    # Ring by ring, starting with the seeds themselves, and never
+                    # past what can be drawn — the assembly was allowed over that
+                    # only because this holds the line. The seeds alone can
+                    # already overflow it: they default to every selected class.
+                    # Truncating mid-ring keeps the nearer hops, which are the
+                    # ones that were asked for.
+                    keep: set = set()
+                    ring = set(seeds)
+                    for _ in range(focus_depth + 1):
+                        if not ring:
                             break
-                        keep |= nxt
-                        frontier = nxt
+                        room = GRAPH_MAX_NODES - len(keep)
+                        if len(ring) > room:
+                            keep |= set(sorted(ring)[:room])
+                            graph_notice = (
+                                f"This focus covers more than the "
+                                f"{GRAPH_MAX_NODES} nodes the graph can draw, so "
+                                f"only part of it is shown. Pick fewer focus "
+                                f"nodes, or a lower depth, to see it in full."
+                            )
+                            break
+                        keep |= ring
+                        nxt: set = set()
+                        for nid in ring:
+                            nxt |= adj.get(nid, set())
+                        ring = nxt - keep
                     net.nodes = [n for n in net.nodes if n["id"] in keep]
                     net.edges = [
                         e for e in net.edges if e["from"] in keep and e["to"] in keep
                     ]
                 else:
-                    # No seed was built (e.g. beyond the node cap) — show nothing
-                    # rather than the whole graph, which would be misleading.
+                    # No seed was built (past the assembly cap, or its type
+                    # toggled off) — show nothing rather than the whole graph,
+                    # which would be misleading. Say why, or the empty graph
+                    # looks like the focus itself is broken (issue #216).
                     net.nodes = []
                     net.edges = []
+                    graph_notice = (
+                        f"Nothing to focus on: this ontology is past the "
+                        f"{max_nodes} nodes the graph builds at once, and the "
+                        f"node you picked is not among them. Hide some classes "
+                        f"or individuals in Filter Nodes to bring it into range."
+                    )
 
             # Spread parallel edges so they don't overlap
             from collections import defaultdict as _defaultdict
@@ -8897,6 +8971,9 @@ def render_visualization():
                     "nodes": nodes_json,
                     "edges": edges_json,
                     "options": options_json,
+                    # Cached with the graph so it survives the reruns that reuse
+                    # it, rather than flashing once on the build that found it.
+                    "notice": graph_notice,
                 }
                 # NB: don't bump viz_render_seq here. The component re-renders on
                 # its own whenever nodes/edges change, and seq is the layout-cache
@@ -8912,6 +8989,12 @@ def render_visualization():
 
         # Always display the graph component (even on rerun after selection)
         gdata = st.session_state.get("last_graph_data")
+        # Why the graph is smaller than the ontology, in the slot the build
+        # status used. Written on every render, not only on a rebuild: the slot
+        # is reserved either way (issue #189), and the reason still holds while
+        # the cached graph is reused.
+        if gdata and gdata.get("notice"):
+            status.warning(gdata["notice"], icon="⚠️")
         if gdata:
             import os as _os
 

--- a/tests/test_viz_node_cap.py
+++ b/tests/test_viz_node_cap.py
@@ -1,0 +1,172 @@
+"""The graph's node cap, and what it does to focus mode (issue #216).
+
+The cap keeps vis-network from being handed more nodes than it can draw. It used
+to be applied while *assembling* the graph, which broke focus mode: focus builds
+everything and prunes to the seeds' neighbourhood afterwards, so a class past the
+cap never got a node, the seed was not found, and the graph came out empty — with
+nothing said about why. Classes are built in alphabetical order, so which ones
+this hit was a matter of their name.
+
+These run the real ``render_visualization`` through ``AppTest`` and inspect the
+graph payload it caches, seeded through the environment because
+``AppTest.from_function`` executes the script source in a fresh namespace without
+the test's closures.
+"""
+
+import json
+import os
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import app
+
+
+def _script():
+    import os
+
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        if os.environ["SHAPE"] == "chain":
+            # A subclass chain: every class has exactly one link either way, so
+            # a focus at depth 1 keeps a known handful.
+            for i in range(int(os.environ["N_CLASSES"])):
+                om.add_class(f"C{i:04d}", parent=f"C{i - 1:04d}" if i else None)
+        else:
+            # A star: one hub every other class is a subclass of, so a depth-1
+            # focus on the hub asks for more than the graph can draw.
+            om.add_class("Hub")
+            for i in range(int(os.environ["N_CLASSES"])):
+                om.add_class(f"C{i:04d}", parent="Hub")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        # The cross-session settings restore mounts the localStorage component,
+        # which blocks forever without a browser to answer it. Mark it done.
+        st.session_state["_viz_settings_restored"] = True
+        st.session_state["_viz_cfg_focus_mode"] = os.environ["SEED"] != ""
+        if os.environ["SEED"] == "*":
+            # What the multiselect defaults to: every selected class a seed.
+            st.session_state["_viz_cfg_focus_seeds"] = [
+                f"Class: {c['name']}" for c in om.get_classes()
+            ]
+        elif os.environ["SEED"]:
+            st.session_state["_viz_cfg_focus_seeds"] = [os.environ["SEED"]]
+        st.session_state["_viz_cfg_focus_depth"] = int(os.environ["DEPTH"])
+
+    app.render_visualization()
+
+
+def _graph(n_classes, seed="", shape="chain", depth=1):
+    """Render once and return ``(nodes, edges, notice)``. An empty seed means
+    focus mode off."""
+    os.environ["N_CLASSES"] = str(n_classes)
+    os.environ["SEED"] = seed
+    os.environ["SHAPE"] = shape
+    os.environ["DEPTH"] = str(depth)
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    data = at.session_state["last_graph_data"]
+    assert data, "the visualization built no graph"
+    return (
+        json.loads(data["nodes"]),
+        json.loads(data["edges"]),
+        data.get("notice") or "",
+    )
+
+
+# --- the bug ----------------------------------------------------------------
+
+
+def test_a_class_past_the_render_cap_can_still_be_focused_on():
+    """The regression: C0519 is the 520th class, so the cap cut it out of the
+    build and focusing on it drew nothing at all."""
+    over = app.GRAPH_MAX_NODES + 20
+    nodes, edges, notice = _graph(over, seed=f"Class: C{over - 1:04d}")
+
+    labels = {n.get("label") for n in nodes}
+    assert f"C{over - 1:04d}" in labels, "the seed itself is missing"
+    # Depth 1 over a subclass chain: the seed and its one parent.
+    assert labels == {f"C{over - 1:04d}", f"C{over - 2:04d}"}
+    assert len(edges) == 1
+    assert notice == ""
+
+
+def test_focusing_still_works_for_a_class_below_the_cap():
+    nodes, _, notice = _graph(app.GRAPH_MAX_NODES + 20, seed="Class: C0002")
+    assert {n.get("label") for n in nodes} == {"C0001", "C0002", "C0003"}
+    assert notice == ""
+
+
+# --- the cap still holds where it protects the browser ----------------------
+
+
+def test_without_focus_the_graph_stops_at_the_render_cap():
+    nodes, _, notice = _graph(app.GRAPH_MAX_NODES + 20)
+    assert len(nodes) == app.GRAPH_MAX_NODES
+    # Silence here is what made the missing classes a mystery to debug.
+    assert f"20 of {app.GRAPH_MAX_NODES + 20} classes are not drawn" in notice
+
+
+def test_a_neighbourhood_larger_than_the_cap_is_cut_and_said_so(monkeypatch):
+    """Focus assembles more than it draws, so the prune has to hold the line."""
+    monkeypatch.setattr(app, "GRAPH_MAX_NODES", 10)
+    nodes, edges, notice = _graph(40, seed="Class: Hub", shape="star")
+
+    assert len(nodes) == 10
+    kept = {n["id"] for n in nodes}
+    assert all(e["from"] in kept and e["to"] in kept for e in edges)
+    assert "more than the 10 nodes the graph can draw" in notice
+
+
+def test_more_seeds_than_the_cap_are_cut_before_any_hop(monkeypatch):
+    """The seeds alone can overflow the cap — they default to every selected
+    class — so the budget has to bind before the first ring, not after it."""
+    monkeypatch.setattr(app, "GRAPH_MAX_NODES", 10)
+    nodes, edges, notice = _graph(40, seed="*")
+
+    assert len(nodes) == 10
+    kept = {n["id"] for n in nodes}
+    assert all(e["from"] in kept and e["to"] in kept for e in edges)
+    assert "more than the 10 nodes the graph can draw" in notice
+
+
+def test_a_seed_past_the_assembly_cap_says_why_the_graph_is_empty(monkeypatch):
+    """The assembly cap is far above the render one, but it is still a cap; when
+    a seed falls past it the empty graph has to explain itself."""
+    monkeypatch.setattr(app, "FOCUS_BUILD_MAX_NODES", 5)
+    nodes, edges, notice = _graph(20, seed="Class: C0019")
+
+    assert nodes == [] and edges == []
+    assert "Nothing to focus on" in notice
+    assert "Filter Nodes" in notice
+
+
+def test_the_assembly_cap_is_only_raised_for_focus():
+    """A plain render must keep handing vis-network at most GRAPH_MAX_NODES."""
+    assert app.FOCUS_BUILD_MAX_NODES > app.GRAPH_MAX_NODES
+    nodes, _, _ = _graph(app.GRAPH_MAX_NODES + 200)
+    assert len(nodes) == app.GRAPH_MAX_NODES
+
+
+def test_the_assembly_allowance_needs_the_prune_not_just_the_mode():
+    """Clearing the focus multiselect leaves the mode on with no seed, so nothing
+    prunes on that render. Raising the cap for the mode alone handed the browser
+    every node in the ontology — caught in the running app, since driving the
+    multiselect takes a second AppTest run and this page's segmented control
+    cannot be re-serialized."""
+    assert app.graph_node_cap(True) == app.FOCUS_BUILD_MAX_NODES
+    assert app.graph_node_cap(False) == app.GRAPH_MAX_NODES
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3])
+def test_focus_depth_grows_the_neighbourhood_from_a_far_class(depth):
+    over = app.GRAPH_MAX_NODES + 20
+    nodes, _, _ = _graph(over, seed=f"Class: C{over - 1:04d}", depth=depth)
+    # The chain ends at the seed, so each hop adds exactly one class.
+    assert len(nodes) == depth + 1


### PR DESCRIPTION
Closes #216

## What was wrong

The graph draws at most 500 nodes, which is what keeps vis-network (and the desktop webview) responsive. That cap was applied while **assembling** the graph — but focus mode assembles everything and prunes to the seeds' neighbourhood afterwards, so a class past the cap never got a node at all. The seed was then not found, and focus deliberately drew nothing.

Classes are built in alphabetical order, so which ones this hit came down to their name. In @SuperCowProducts' ontology (539 classes, thanks for the file, it made this quick to pin down) `trig` is the 506th, so it and everything after it were unreachable, while earlier names worked. That also explains the rest of the report: deleting and recreating `trig` puts it back in the same alphabetical spot, and a fresh ontology with only `trig` and `trig-fn` is nowhere near the cap.

Reproduced with the attached ontology: focusing on `trig` built 0 nodes, on `trig-fn` 0 nodes, while `A` and `opt` built theirs fine.

## What changed

- **The assembly allowance is raised for focus mode**, where the browser only ever sees the pruned result. Assembly is plain dicts and stays well under a second at 5000 nodes.
- **The prune holds the render cap instead**, expanding ring by ring from the seeds and stopping when the budget is spent. The seeds alone can overflow it, since they default to every selected class.
- **The allowance is tied to the prune actually running**, not to the mode being on. With focus on and every seed cleared nothing prunes, and the browser would otherwise be handed the whole ontology.
- **The graph now says what it left out.** None of this was visible before: nodes dropped by the cap went missing silently, taking every edge that needed them, which reads as unrelated classes losing their connections. An empty focus now explains itself rather than looking broken.

The Visualization tab picker also seeds its selection in `session_state` rather than passing `default=`, matching the Classes, Relations and Restrictions pages.

## Testing

- `tests/test_viz_node_cap.py`: the regression itself (a class past the cap focuses and keeps its neighbours), the cap still holding without focus, a neighbourhood and a seed set larger than the cap being cut with no dangling edges, and a seed past the assembly cap explaining the empty graph.
- Full suite, ruff and mypy pass.
- Verified in the running app with the reported ontology: focusing on `trig` returns its neighbourhood, a plain render still stops at 500 nodes and now says "39 of 539 classes are not drawn", and a focus over every class is bounded to exactly 500 with a notice. Driving it live is what caught two holes in the first version of this fix.

## Not changed

Focus seeds default to *every* selected class, so ticking "Focus on one node" starts by focusing on all of them. That is worth revisiting, but it affects every node equally and is not what made specific ones fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)