### PR TITLE
feat: ring a selected node's neighbours in the graph (#224)

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -111,6 +111,103 @@ function applyHeight(h) {
     sendToStreamlit("streamlit:setFrameHeight", {height: h});
 }
 
+// --- Neighbour highlight (issue #224) ---------------------------------------
+// Selecting a node rings the nodes at the other end of its edges. vis already
+// styles the clicked node and thickens its connected edges, but leaves those
+// neighbours looking like every other node, so "what does this class actually
+// link to?" stays hard to answer on a large ontology — which is what the focus
+// mode was being over-used for.
+//
+// Direction is carried by the border *dash*, not by a colour: the fills already
+// spend the palette on entity type (green class, purple object property, orange
+// individual, brown annotation, teal data property, two blue-greys), and a red
+// ring at width 3 already means "has validation issues". The ring colour is the
+// theme's text colour, which is maximum-contrast against its own background by
+// construction and reads against every mid-luminance fill in that palette, so it
+// works in light and dark without the node colours having to change.
+var HL_WIDTH = 2;             // 3 stays reserved for the validation-issue ring
+var HL_DASH = [6, 4];         // incoming; outgoing stays solid
+var hlSource = null;          // node whose neighbourhood is currently ringed
+var hlSaved = null;           // id -> styling we overwrote, for an exact restore
+var hlJustSelected = false;   // this tap changed the selection (see the click handler)
+
+// Restore every ringed node to exactly what it looked like before.
+//
+// The saved values are written back explicitly rather than by passing the
+// originals straight through: a DataSet update ignores an undefined field, so a
+// node that never carried `borderWidth` or `shapeProperties` (only classes and
+// individuals set the former, and Python never sets the latter) would silently
+// keep the ring. The fallbacks are vis's own defaults for those two options.
+function clearNeighbourHighlight() {
+    var ds = network && network.body && network.body.data && network.body.data.nodes;
+    if (ds && hlSaved) {
+        var undo = [];
+        for (var id in hlSaved) {
+            if (!Object.prototype.hasOwnProperty.call(hlSaved, id)) continue;
+            if (!ds.get(id)) continue;  // node has since left the graph
+            var s = hlSaved[id];
+            undo.push({
+                id: id,
+                color: s.color,
+                borderWidth: s.borderWidth === undefined ? 1 : s.borderWidth,
+                shapeProperties: s.shapeProperties === undefined
+                    ? {borderDashes: false} : s.shapeProperties
+            });
+        }
+        if (undo.length) { try { ds.update(undo); } catch (e) {} }
+    }
+    hlSource = null;
+    hlSaved = null;
+}
+
+// Ring `id`'s neighbours: dashed for the ones pointing at it, solid for the ones
+// it points at. A node on both sides of the relation ends up solid, because the
+// outgoing pass is applied second.
+function applyNeighbourHighlight(id) {
+    clearNeighbourHighlight();
+    var ds = network && network.body && network.body.data && network.body.data.nodes;
+    if (!ds || id === null || id === undefined || !ds.get(id)) return;
+    var incoming = [], outgoing = [];
+    try {
+        incoming = network.getConnectedNodes(id, 'from') || [];
+        outgoing = network.getConnectedNodes(id, 'to') || [];
+    } catch (e) { return; }
+
+    var ring = (currentTheme && currentTheme.text) || '#333333';
+    hlSource = id;
+    hlSaved = {};
+    var updates = [];
+
+    function ringNode(nid, dashed) {
+        if (nid === id) return;                 // self-loop: the source is not its own neighbour
+        var nd = ds.get(nid);
+        if (!nd) return;
+        if (!Object.prototype.hasOwnProperty.call(hlSaved, nid)) {
+            hlSaved[nid] = {
+                color: nd.color,
+                borderWidth: nd.borderWidth,
+                shapeProperties: nd.shapeProperties
+            };
+        }
+        // Keep the fill (it encodes the entity type) and override only the
+        // border, for the selected and unselected states alike — the neighbour
+        // itself is not selected, but a restore-selection rebuild can make it so.
+        var base = (nd.color && typeof nd.color === 'object') ? nd.color : {};
+        var color = Object.assign({}, base, {border: ring});
+        color.highlight = Object.assign({}, base.highlight, {border: ring});
+        updates.push({
+            id: nid,
+            color: color,
+            borderWidth: HL_WIDTH,
+            shapeProperties: {borderDashes: dashed ? HL_DASH : false}
+        });
+    }
+
+    incoming.forEach(function(nid) { ringNode(nid, true); });
+    outgoing.forEach(function(nid) { ringNode(nid, false); });
+    if (updates.length) { try { ds.update(updates); } catch (e) {} }
+}
+
 // Apply theme colours without rebuilding the graph, so a theme change (or the
 // first-render theme settling) doesn't reset the user's zoom/pan. Node colours
 // encode type, not theme, so only the background, overlays and edge labels change.
@@ -137,6 +234,9 @@ function applyTheme(theme) {
     if (network) {
         network.setOptions({edges: {font: {color: theme.text, strokeColor: theme.bg, strokeWidth: 4}}});
     }
+    // The neighbour ring is drawn in the theme's text colour, so a theme change
+    // under a live selection has to redraw it or it keeps the old theme's colour.
+    if (hlSource !== null && hlSource !== undefined) applyNeighbourHighlight(hlSource);
 }
 
 function autofitApply() {
@@ -520,6 +620,7 @@ function renderGraph(args) {
             var _spin = (args.focus_node && _sds && _sds.get(args.focus_node)) ? args.focus_node : null;
             if (_spin) {
                 try { network.selectNodes([_spin]); } catch (e) {}
+                applyNeighbourHighlight(_spin);
                 try { network.focus(_spin, {scale: 1.1, animation: {duration: 700, easingFunction: 'easeInOutQuad'}}); } catch (e) {}
                 sendFindSelection(_spin);
             }
@@ -655,6 +756,11 @@ function renderGraph(args) {
     }
     var nodes = new vis.DataSet(nodeArr);
     network = new vis.Network(el, {nodes: nodes, edges: edges}, options);
+    // Fresh DataSet: whatever the previous network had ringed is gone with it,
+    // so drop the bookkeeping rather than letting it undo styling on new nodes.
+    hlSource = null;
+    hlSaved = null;
+    hlJustSelected = false;
     document.getElementById('download-btn').style.display = 'flex';
     // Only offer fullscreen where the API works — hidden in the desktop webview.
     if (fullscreenSupported()) {
@@ -674,6 +780,7 @@ function renderGraph(args) {
     }
     if (restoreNode !== null && restoreNode !== undefined) {
         try { network.selectNodes([restoreNode]); } catch (e) {}
+        applyNeighbourHighlight(restoreNode);
     }
     // --- Find & centre (issue #144) ---------------------------------------
     // Python sends focus_node (the entity picked in "Find entity", present on
@@ -695,6 +802,7 @@ function renderGraph(args) {
     if (_pin) {
         var _findFresh = !_find.centred;
         try { network.selectNodes([_pin]); } catch (e) {}
+        applyNeighbourHighlight(_pin);
         // Centre now only when the layout is already final. When physics still
         // has to run, the node is still moving, so centring on its current
         // position would land in the wrong place — the stabilization handler
@@ -855,15 +963,21 @@ function renderGraph(args) {
 
     network.on('selectNode', function(params) {
         var nd = nodes.get(params.nodes[0]);
+        hlJustSelected = true;
+        applyNeighbourHighlight(params.nodes[0]);
         sendSelection({nodeId: params.nodes[0], ntype: nd.ntype || null, ename: nd.ename || null, label: nd.label, title: nd.title || '', selected: true});
     });
     network.on('selectEdge', function(params) {
         if (params.nodes.length === 0 && params.edges.length > 0) {
+            // An edge-only selection means no node is selected, and vis does not
+            // fire deselectNode on the way there.
+            clearNeighbourHighlight();
             var ed = edges.get(params.edges[0]);
             sendSelection({ntype: ed.ntype || null, ename: ed.ename || null, label: ed.label || '', title: ed.title || '', selected: true, isEdge: true});
         }
     });
     network.on('deselectNode', function() {
+        clearNeighbourHighlight();
         sendSelection({selected: false});
     });
     network.on('deselectEdge', function() {
@@ -876,12 +990,28 @@ function renderGraph(args) {
     // the Python side applies it once. Sent after the normal selectNode value,
     // so this is the value Streamlit keeps for this interaction.
     network.on('click', function(params) {
+        var wasFresh = hlJustSelected;
+        hlJustSelected = false;
         if (!params.nodes.length) return;
         var ev = params.event && params.event.srcEvent;
-        if (!ev || !(ev.ctrlKey || ev.metaKey)) return;
-        sendToStreamlit("streamlit:setComponentValue", {
-            value: {focusRequest: true, reqId: Date.now(), nodeId: params.nodes[0]}
-        });
+        if (ev && (ev.ctrlKey || ev.metaKey)) {
+            sendToStreamlit("streamlit:setComponentValue", {
+                value: {focusRequest: true, reqId: Date.now(), nodeId: params.nodes[0]}
+            });
+            return;
+        }
+        // Clicking the already-selected node again clears it, so the ring can be
+        // dismissed on the node that raised it instead of having to find empty
+        // canvas to click. vis emits selectNode only when the selection actually
+        // changes, so no event fires on that second click — hlJustSelected tells
+        // the two clicks apart, and vis's own unselectAll() is silent too, so the
+        // deselect has to be published here.
+        if (!wasFresh && params.nodes[0] === hlSource) {
+            clearNeighbourHighlight();
+            try { network.unselectAll(); } catch (e) {}
+            try { network.redraw(); } catch (e) {}
+            sendSelection({selected: false});
+        }
     });
 }
 

--- a/tests/test_viz_neighbour_highlight.py
+++ b/tests/test_viz_neighbour_highlight.py
@@ -1,0 +1,116 @@
+"""Guards for the graph viewer's neighbour highlight (issue #224).
+
+Selecting a node rings the nodes at the other end of its edges, dashed for
+incoming and solid for outgoing. All of it is canvas behaviour, so none of it is
+observable from Python; the invariants that silently break it are pinned at the
+source level instead, the way the fullscreen ones are in test_viz_fullscreen.py.
+"""
+
+import re
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+_VIEWER = _PKG / "lib" / "graph_viewer" / "index.html"
+
+
+def _viewer():
+    return _VIEWER.read_text(encoding="utf-8")
+
+
+def test_programmatic_selection_also_rings_the_neighbours():
+    """Every ``selectNodes()`` call must ring the neighbourhood itself.
+
+    ``selectNodes()`` does not fire ``selectNode``, so the paths that restore a
+    selection without a click — a re-mount rebuild and both Find & centre paths —
+    would leave the node selected but its neighbours unringed.
+    """
+    src = _viewer()
+    sites = list(re.finditer(r"network\.selectNodes\(", src))
+    assert len(sites) == 3, (
+        f"expected 3 programmatic selectNodes() sites, found {len(sites)} — "
+        "a new one must ring the neighbourhood too"
+    )
+    for site in sites:
+        following = src[site.end() : site.end() + 200]
+        assert "applyNeighbourHighlight(" in following, (
+            "every selectNodes() must be followed by applyNeighbourHighlight(), "
+            "since selectNodes() does not fire selectNode (issue #224)"
+        )
+
+
+def test_losing_the_node_selection_clears_the_ring():
+    """Deselecting a node, or selecting an edge instead, drops the ring.
+
+    An edge-only selection means no node is selected, and vis does not fire
+    ``deselectNode`` on the way there — so that handler has to clear it too or
+    the ring outlives the selection that raised it.
+    """
+    src = _viewer()
+    for event in ("deselectNode", "selectEdge"):
+        handler = src.split(f"network.on('{event}'", 1)[1].split("\n    });", 1)[0]
+        assert "clearNeighbourHighlight()" in handler, (
+            f"{event} must clear the neighbour ring (issue #224)"
+        )
+
+
+def test_the_ring_colour_is_the_theme_colour():
+    """The ring is drawn in the theme's text colour, never a fixed one.
+
+    Node fills encode entity type and stay the same in both themes, so a
+    hard-coded ring would have to contrast with white *and* #0e1117. Reusing
+    ``theme.text`` is contrast-correct in both by construction.
+    """
+    src = _viewer()
+    body = src.split("function applyNeighbourHighlight(", 1)[1].split("\n}\n", 1)[0]
+    assert "currentTheme.text" in body, (
+        "the ring must take its colour from the theme, so it reads in light and "
+        "dark alike (issue #224)"
+    )
+    rung = body.split("var ring =", 1)[1].split(";", 1)[0]
+    assert not re.search(r"#[0-9A-Fa-f]{6}", rung.replace("#333333", "")), (
+        "no fixed ring colour beyond the light-theme fallback"
+    )
+
+
+def test_a_theme_change_redraws_a_live_ring():
+    """applyTheme runs without a rebuild, so it has to recolour a live ring."""
+    src = _viewer()
+    body = src.split("function applyTheme(", 1)[1].split("\n}\n", 1)[0]
+    assert "applyNeighbourHighlight(hlSource)" in body, (
+        "a theme change under a live selection must redraw the ring, or it keeps "
+        "the previous theme's colour (issue #224)"
+    )
+
+
+def test_the_ring_does_not_impersonate_the_validation_ring():
+    """Width 3 means "has validation issues" — the ring must not reuse it.
+
+    A red border at width 3 is what the "Highlight issues" mode marks broken
+    entities with, so a neighbour ring at the same weight would read as a
+    validation warning.
+    """
+    app_src = (_PKG / "app.py").read_text(encoding="utf-8")
+    issue_widths = set(re.findall(r"border_width = (\d+) if has_issue", app_src))
+    assert issue_widths == {"3"}, (
+        f"expected the validation ring at width 3, found {issue_widths}"
+    )
+
+    src = _viewer()
+    width = src.split("var HL_WIDTH =", 1)[1].split(";", 1)[0].strip()
+    assert width not in issue_widths, (
+        f"the neighbour ring must not use width {width} — that is the "
+        "validation-issue ring (issue #224)"
+    )
+
+
+def test_the_restore_writes_every_field_back_explicitly():
+    """The undo must not rely on a DataSet update ignoring undefined fields.
+
+    Only classes and individuals carry ``borderWidth``, and nothing carries
+    ``shapeProperties``, so writing an undefined value back would leave those
+    nodes ringed forever. The fallbacks are vis's own defaults.
+    """
+    src = _viewer()
+    body = src.split("function clearNeighbourHighlight(", 1)[1].split("\n}\n", 1)[0]
+    assert "s.borderWidth === undefined ? 1 :" in body
+    assert "borderDashes: false" in body


### PR DESCRIPTION
Addresses the second half of #224: "a way to preview entering and exiting nodes of a selected node".

Selecting a node now outlines the nodes at the other end of its edges: dashed for the ones pointing at it, solid for the ones it points at.

vis-network already styled the clicked node and thickened its connected edges (its `selectConnectedEdges` default, never overridden here), but it left the neighbours themselves looking like every other node. So "what does this class actually link to?" stayed hard to answer on a large ontology, which is what the reporter had been over-using focus mode for.

### Why a dash and not a colour

Node fills already spend the palette on entity type (green class, purple object property, orange individual, brown annotation, teal data property, two blue-greys), and a red border at width 3 already means "has validation issues". A new hue would compete with both, and it would have to survive a white *and* a `#0e1117` background.

So direction is carried by the border dash instead, and the ring takes its colour from `theme.text` (`#333333` light, `#fafafa` dark). That value is already plumbed into the viewer, it is maximum-contrast against its own background by construction, and every fill in the palette is mid-luminance so it reads against all of them. Width 2 keeps clear of the width-3 validation ring.

### Behaviour

* Selecting a node rings its neighbours; deselecting, or selecting an edge instead, clears them.
* Clicking the already-selected node again clears the selection, so the ring can be dismissed on the node that raised it rather than by finding empty canvas. vis emits `selectNode` only when the selection actually changes, so a flag tells the two clicks apart, and `unselectAll()` is silent too, so the deselect is published explicitly.
* A node on both sides of a relation renders solid, since the outgoing pass is applied second.
* No new toolbar control: the row is already crowded, and this is cheap enough to be always on.

### Implementation notes

* All three programmatic `selectNodes()` paths (re-mount restore, both Find and centre paths) ring the neighbourhood explicitly, because `selectNodes()` does not fire `selectNode`.
* The undo writes `borderWidth` and `shapeProperties` back explicitly rather than passing the originals through: a DataSet update ignores an undefined field, and only classes and individuals carry `borderWidth` while nothing carries `shapeProperties`, so those nodes would otherwise stay ringed.
* Updates carry only `color`, `borderWidth` and `shapeProperties`. vis's `Node.setOptions` returns true only for `hidden` or `physics`, so these take the `_dataUpdated` redraw path and the layout never re-stabilizes.
* A theme change arrives without a rebuild, so `applyTheme` redraws a live ring in the new colour.

### Verification

Driven live against the Organization template, clicking through the real handler chain in both themes:

* Light: incoming neighbour dashed `#333333`, the both-directions neighbour solid, fills preserved.
* Dark: the same rings at `#fafafa` on `#0e1117`.
* Second click restores every node exactly (border `#388E3C`, width 1, dashes off).
* Flipping the theme under a live selection recolours the ring without a rebuild.

768 tests pass, ruff and mypy clean. `tests/test_viz_neighbour_highlight.py` adds six source-level guards, following the pattern in `test_viz_fullscreen.py`, since none of this is observable from Python.

### Not included

The other reading of #224, limiting "Focus on one node" to a single item, is untouched. Enabling focus mode currently seeds itself from every selected class, which is a separate defect against that control's own label and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)