### PR TITLE
fix: don't seed focus mode with every class (#224)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -912,10 +912,29 @@ def viz_filter_changed(kind_key, uri_by_display):
     ]
 
 
+def focus_seeds_from_selection(selected_classes, class_count):
+    """The focus seeds a fresh switch into focus mode should start from (#224).
+
+    A class selection that is a genuine narrowing carries intent — the user
+    filtered down to what they care about — so the neighbourhood grows from all
+    of it. "Everything selected" is the default state and carries no intent at
+    all, and seeding from *that* opened "Focus on one node" on every class at
+    once: the post-build prune had nothing to narrow, so the mode did least on
+    exactly the large ontologies it exists for. Start from a single class there
+    instead, which is what the control is named after; the multiselect is right
+    there to add more.
+    """
+    labels = [f"Class: {c}" for c in selected_classes]
+    if class_count and len(labels) >= class_count:
+        return labels[:1]
+    return labels
+
+
 def viz_focus_toggle():
     """Persist the focus toggle and, when it turns on, seed the focus nodes from
     the classes selected in the multiselect — so the neighbourhood grows from
-    exactly what the user had picked (one class or several). An empty selection
+    exactly what the user had narrowed to, or from one class when they had
+    narrowed to nothing (see focus_seeds_from_selection). An empty selection
     falls back to the first node."""
     if _viz_widget_missing("viz_focus_mode"):
         return
@@ -923,8 +942,10 @@ def viz_focus_toggle():
     st.session_state["_viz_cfg_focus_mode"] = on
     st.session_state["_viz_settings_dirty"] = True
     if on:
-        sel = st.session_state.get("_viz_cfg_selected_classes") or []
-        st.session_state["_viz_cfg_focus_seeds"] = [f"Class: {c}" for c in sel]
+        st.session_state["_viz_cfg_focus_seeds"] = focus_seeds_from_selection(
+            st.session_state.get("_viz_cfg_selected_classes") or [],
+            st.session_state.get("_viz_cfg_class_count") or 0,
+        )
 
 
 def viz_find_changed():
@@ -7848,8 +7869,11 @@ def render_visualization():
         selected_ind_uris = set(filters["ind"]["selected_uris"])
         # Display mirror of the class selection, refreshed here on every render
         # and never written to elsewhere. The focus-mode controls below read it
-        # to seed themselves from the current selection.
+        # to seed themselves from the current selection. The total rides along so
+        # they can tell a real narrowing from the everything-selected default
+        # (see focus_seeds_from_selection); neither is a persisted setting.
         st.session_state["_viz_cfg_selected_classes"] = selected_classes_list
+        st.session_state["_viz_cfg_class_count"] = len(all_class_names)
 
         # Focus mode: centre the view on one node (class, individual or SKOS
         # concept) and show only its neighbourhood within N hops. The pruning
@@ -7975,16 +7999,14 @@ def render_visualization():
                 label_set = set(focus_labels)
                 # Default the focus seeds to the classes selected in the
                 # multiselect, so the neighbourhood grows from exactly what the
-                # user had picked (one class or several).
+                # user had narrowed to — or from one class when they had narrowed
+                # to nothing (see focus_seeds_from_selection).
                 saved_seeds = st.session_state.get("_viz_cfg_focus_seeds")
                 if saved_seeds is None:
-                    saved_seeds = [
-                        f"Class: {c}"
-                        for c in (
-                            st.session_state.get("_viz_cfg_selected_classes") or []
-                        )
-                        if f"Class: {c}" in label_set
-                    ]
+                    saved_seeds = focus_seeds_from_selection(
+                        st.session_state.get("_viz_cfg_selected_classes") or [],
+                        len(all_class_names),
+                    )
                 saved_seeds = [s for s in saved_seeds if s in label_set]
                 if not saved_seeds:
                     saved_seeds = [focus_labels[0]]
@@ -8005,8 +8027,10 @@ def render_visualization():
                         on_change=viz_sync,
                         args=("_viz_cfg_focus_seeds", "viz_focus_seeds"),
                         help="Classes, individuals or SKOS concepts to centre on. "
-                        "The neighbourhood grows from all of them. Toggle the "
-                        "entity-type checkboxes above to list more.",
+                        "The neighbourhood grows from all of them. Starts from "
+                        "the classes you had filtered down to, or from one when "
+                        "you hadn't filtered. Toggle the entity-type checkboxes "
+                        "above to list more.",
                     )
                 with fcol2:
                     focus_depth = st.slider(

--- a/tests/test_viz_callbacks.py
+++ b/tests/test_viz_callbacks.py
@@ -58,6 +58,12 @@ def _script():
         app.viz_focus_toggle()
     elif scenario == "focus_turned_on":
         st.session_state["_viz_cfg_selected_classes"] = ["Person"]
+        st.session_state["_viz_cfg_class_count"] = 3
+        st.session_state["viz_focus_mode"] = True
+        app.viz_focus_toggle()
+    elif scenario == "focus_turned_on_unfiltered":
+        st.session_state["_viz_cfg_selected_classes"] = ["Person", "Org", "Role"]
+        st.session_state["_viz_cfg_class_count"] = 3
         st.session_state["viz_focus_mode"] = True
         app.viz_focus_toggle()
     elif scenario == "find_changed":
@@ -126,6 +132,14 @@ def test_turning_focus_on_persists_it_and_seeds_from_the_selection():
     assert state["_viz_cfg_focus_mode"] is True
     assert state["_viz_cfg_focus_seeds"] == ["Class: Person"]
     assert state["_viz_settings_dirty"] is True
+
+
+def test_turning_focus_on_with_nothing_filtered_seeds_one_class():
+    """Every class "selected" is the default state, not a choice, so focus opens
+    on one node rather than on the whole ontology (issue #224)."""
+    state = _run("focus_turned_on_unfiltered")
+    assert state["_viz_cfg_focus_mode"] is True
+    assert state["_viz_cfg_focus_seeds"] == ["Class: Person"]
 
 
 def test_the_find_sequence_bumps():

--- a/tests/test_viz_focus_seeding.py
+++ b/tests/test_viz_focus_seeding.py
@@ -1,0 +1,47 @@
+"""What "Focus on one node" starts from when it is switched on (issue #224).
+
+Seeding from the class selection is right when that selection is a narrowing the
+user made. It is wrong when nothing has been filtered, because "everything
+selected" is just the default state: seeding from it opened focus mode on every
+class at once, leaving the post-build prune nothing to narrow.
+"""
+
+from orionbelt_ontology_builder.app import focus_seeds_from_selection
+
+
+def test_a_narrowed_selection_seeds_all_of_it():
+    """The narrowing is the intent, so the neighbourhood grows from all of it."""
+    assert focus_seeds_from_selection(["Person", "Org"], 10) == [
+        "Class: Person",
+        "Class: Org",
+    ]
+
+
+def test_selecting_everything_seeds_one_class():
+    """Nothing was filtered, so focus starts where the control's name says."""
+    assert focus_seeds_from_selection(["Person", "Org", "Role"], 3) == ["Class: Person"]
+
+
+def test_one_class_in_a_one_class_ontology_still_seeds_it():
+    """The only class is both "everything" and the single seed."""
+    assert focus_seeds_from_selection(["Person"], 1) == ["Class: Person"]
+
+
+def test_an_empty_selection_seeds_nothing():
+    """The caller falls back to the first available node, as it always did."""
+    assert focus_seeds_from_selection([], 4) == []
+
+
+def test_an_unknown_total_keeps_the_whole_selection():
+    """The count mirror is refreshed on render, so a callback can fire before it
+    exists. Seeding from the selection is the old behaviour, and the render pass
+    that follows re-derives it with the real count."""
+    assert focus_seeds_from_selection(["Person", "Org"], 0) == [
+        "Class: Person",
+        "Class: Org",
+    ]
+
+
+def test_a_stale_count_below_the_selection_still_seeds_one():
+    """A count that lags the selection must not read as a narrowing."""
+    assert focus_seeds_from_selection(["Person", "Org", "Role"], 2) == ["Class: Person"]


### PR DESCRIPTION
Addresses the other half of #224: "I have found the `Focus on one node` function to be useful for a *specific* class at a time."

Follows #227, which handled the reporter's alternative suggestion.

### The problem

Switching on "Focus on one node" seeded the focus with every currently selected class. Nothing is filtered by default, so in practice that meant every class in the ontology. The post-build prune then had the whole graph to work with and narrowed nothing, so the mode did least on exactly the large ontologies it exists for, under a control named for one node.

### The fix

Seed from the class selection only when that selection is a genuine narrowing. That case carries intent, the user filtered down to what they care about, so the neighbourhood still grows from all of it. "Everything selected" is the default resting state and carries no intent at all, so focus starts from a single class there and the multiselect is right there to add more.

No arbitrary cap. A "seed at most N" rule would have to answer which N, and N neighbourhoods at depth 2 is still most of a large graph, so it would not deliver the one-class-at-a-time the reporter asked for.

Worth noting the app already draws this same distinction elsewhere: "Select all" is `disabled` once everything is selected, because at that point there is nothing to restore. The everything-selected state is already treated as the neutral resting state rather than as a choice, and this applies the same reading to the focus seeds. "Select all" itself is unaffected, and is not even rendered in focus mode, which swaps the filter controls out.

### Implementation

* `focus_seeds_from_selection()` holds the rule, and both seeding sites use it: the toggle callback and the render-time default.
* The class total rides along with the existing selected-classes display mirror so the callback can tell the two cases apart. Neither is a persisted setting; `_VIZ_PERSIST_KEYS` is an explicit tuple, so the new mirror stays out of it.
* An absent total keeps the whole selection, which is the old behaviour. That covers a callback firing before the first render has mirrored the count, and the render pass that follows re-derives the seeds with the real value.
* The "Focus node(s)" help text now states where the seeds come from.

### Tests

775 pass, ruff and mypy clean.

* `tests/test_viz_focus_seeding.py` covers the rule directly, including the one-class ontology, the empty selection, an unknown total and a stale total below the selection.
* `tests/test_viz_callbacks.py` gains an unfiltered scenario alongside the existing narrowed one, so the wiring through session state is covered at the callback level too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)