### PR TITLE
fix: say how many "Select all" would restore you to

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -8127,8 +8127,14 @@ def render_visualization():
                     # An empty (or narrowed) filter hides nodes and there is no
                     # native way back — offer a one-click restore (issue B3).
                     with _bcol1:
+                        # The count says what the button would restore you to, so
+                        # its greyed-out state reads as "you already have all 4"
+                        # rather than as an arbitrary disable. Its only other
+                        # signal is the shown/total on the segmented control
+                        # above, which is easy to miss and sits on a different
+                        # widget.
                         if st.button(
-                            "Select all",
+                            f"Select all ({len(_entries)})",
                             key=f"viz_select_all_{_key}",
                             disabled=not _narrowed,
                             use_container_width=True,

--- a/tests/test_viz_select_all_label.py
+++ b/tests/test_viz_select_all_label.py
@@ -1,0 +1,49 @@
+"""The "Select all" button states how many it would restore you to.
+
+Whether the button is live is decided by ``disabled=not _narrowed``, and its only
+other signal is the shown/total on the segmented control above — a different
+widget, easy to miss. Without a count in its own label the greyed-out state reads
+as an arbitrary disable rather than as "you already have all of them", so the
+count is the point of the control and is pinned here.
+"""
+
+import ast
+from pathlib import Path
+
+_APP = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder" / "app.py"
+
+
+def _select_all_button():
+    """The ``st.button`` call that restores a node filter, as an AST node."""
+    tree = ast.parse(_APP.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "button"):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "key" and "viz_select_all" in ast.dump(kw.value):
+                return node
+    raise AssertionError("no st.button keyed viz_select_all found in app.py")
+
+
+def test_the_label_carries_a_count():
+    """A plain "Select all" cannot explain its own greyed-out state."""
+    label = _select_all_button().args[0]
+    assert isinstance(label, ast.JoinedStr), (
+        "the button label must interpolate a count, not be a fixed string"
+    )
+    counted = [p for p in label.values if isinstance(p, ast.FormattedValue)]
+    assert counted, "the button label must interpolate a count"
+    assert any("_entries" in ast.dump(p) for p in counted), (
+        "the count must be the kind's total, so the label says what the button "
+        "would restore you to"
+    )
+
+
+def test_the_button_still_greys_out_when_nothing_is_hidden():
+    """The count is only meaningful next to the enabled/disabled state."""
+    disabled = [kw for kw in _select_all_button().keywords if kw.arg == "disabled"]
+    assert disabled, "the button must stay gated on whether anything is hidden"
+    assert "_narrowed" in ast.dump(disabled[0].value)


### PR DESCRIPTION
### The problem

"Select all" is `disabled` whenever nothing is hidden, which is most of the time. So it mostly reads as a greyed-out button with no stated reason.

Its only other signal is the shown/total on the segmented control above ("Classes" versus "Classes 3/4"), which is a different widget a few inches away, and nothing links the two. Its explanation lives in `help="Show every <noun> in the graph again."`, which sits on a disabled control where hovering generally will not surface a tooltip at all, so the explanation is hidden exactly when you would want it.

### The change

Put the kind's total in the label: `Select all (4)`.

Next to four visible chips, the greyed-out state now explains itself as "you already have all 4" rather than reading as an arbitrary disable. Next to "Classes 3/4" it says exactly what clicking would get you back to. One label, no new control, and the button row stays two wide.

### Verified live

| state | chips | segment | button |
| --- | --- | --- | --- |
| nothing hidden | 4 | `Classes` | `Select all (4)`, greyed |
| one class hidden | 3 | `Classes 3/4` | `Select all (4)`, active |

### Tests

777 pass, ruff and mypy clean. `tests/test_viz_select_all_label.py` pins the count in the label and the enabled/disabled gating that makes it meaningful, following the source-level pattern already used for viewer invariants in `test_viz_fullscreen.py`.

The button is rendered once per filterable kind, so individuals get the same treatment from the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)