### PR TITLE
fix: keep the chosen focus nodes across a mode switch (#235)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -931,17 +931,25 @@ def focus_seeds_from_selection(selected_classes, class_count):
 
 
 def viz_focus_toggle():
-    """Persist the focus toggle and, when it turns on, seed the focus nodes from
-    the classes selected in the multiselect — so the neighbourhood grows from
-    exactly what the user had narrowed to, or from one class when they had
-    narrowed to nothing (see focus_seeds_from_selection). An empty selection
-    falls back to the first node."""
+    """Persist the focus toggle, seeding the focus nodes on first use.
+
+    Turning focus on derives seeds from the class selection only when there are
+    none to restore (see focus_seeds_from_selection). Deriving them on *every*
+    switch-on threw away whatever you had picked the moment you toggled the mode
+    off and on again, so narrowing "Focus node(s)" to the one class you wanted
+    never survived (issue #235). The derived seeding is a starting point for the
+    first use, not something reapplied over a choice you have already made.
+
+    That also decouples the two controls: after you have expressed a preference,
+    the focus seeds are their own list rather than a function of Filter Nodes.
+    An empty selection still falls back to the first node, downstream.
+    """
     if _viz_widget_missing("viz_focus_mode"):
         return
     on = st.session_state["viz_focus_mode"]
     st.session_state["_viz_cfg_focus_mode"] = on
     st.session_state["_viz_settings_dirty"] = True
-    if on:
+    if on and not st.session_state.get("_viz_cfg_focus_seeds"):
         st.session_state["_viz_cfg_focus_seeds"] = focus_seeds_from_selection(
             st.session_state.get("_viz_cfg_selected_classes") or [],
             st.session_state.get("_viz_cfg_class_count") or 0,

--- a/tests/test_viz_callbacks.py
+++ b/tests/test_viz_callbacks.py
@@ -66,6 +66,21 @@ def _script():
         st.session_state["_viz_cfg_class_count"] = 3
         st.session_state["viz_focus_mode"] = True
         app.viz_focus_toggle()
+    elif scenario == "focus_turned_on_again":
+        # The user narrowed the focus to one class, then toggled the mode off
+        # and on again. Their pick must survive the round trip (issue #235).
+        st.session_state["_viz_cfg_selected_classes"] = ["Person", "Org", "Role"]
+        st.session_state["_viz_cfg_class_count"] = 3
+        st.session_state["_viz_cfg_focus_seeds"] = ["Class: Org"]
+        st.session_state["viz_focus_mode"] = True
+        app.viz_focus_toggle()
+    elif scenario == "focus_turned_on_after_clearing":
+        # Nothing left to restore, so the derived seeding still applies.
+        st.session_state["_viz_cfg_selected_classes"] = ["Person"]
+        st.session_state["_viz_cfg_class_count"] = 3
+        st.session_state["_viz_cfg_focus_seeds"] = []
+        st.session_state["viz_focus_mode"] = True
+        app.viz_focus_toggle()
     elif scenario == "find_changed":
         app.viz_find_changed()
 
@@ -139,6 +154,23 @@ def test_turning_focus_on_with_nothing_filtered_seeds_one_class():
     on one node rather than on the whole ontology (issue #224)."""
     state = _run("focus_turned_on_unfiltered")
     assert state["_viz_cfg_focus_mode"] is True
+    assert state["_viz_cfg_focus_seeds"] == ["Class: Person"]
+
+
+def test_switching_focus_off_and_on_keeps_the_chosen_nodes():
+    """Re-deriving the seeds on every switch-on threw away the user's pick.
+
+    Narrowing "Focus node(s)" to the one class you want never survived toggling
+    the mode off and on again (issue #235). The derived seeding is a first-use
+    starting point, not something reapplied over a choice already made.
+    """
+    state = _run("focus_turned_on_again")
+    assert state["_viz_cfg_focus_seeds"] == ["Class: Org"]
+
+
+def test_turning_focus_on_with_no_seeds_left_still_derives_them():
+    """The first-use seeding must still happen when there is nothing to keep."""
+    state = _run("focus_turned_on_after_clearing")
     assert state["_viz_cfg_focus_seeds"] == ["Class: Person"]
 
 


### PR DESCRIPTION
Closes #235.

### The bug

Turning "Focus on one node" on re-derived the focus seeds from the class selection **every single time**, overwriting whatever had been picked:

```python
if on:
    st.session_state["_viz_cfg_focus_seeds"] = focus_seeds_from_selection(...)
```

So the cycle the issue describes was:

1. Enable focus, seeds are derived from the filter
2. Narrow "Focus node(s)" down to the one class you actually want
3. Disable focus, your pick survives (the toggle only wrote on the way on)
4. **Re-enable focus, and the derived list silently replaces it**

### The fix

Derive the seeds only when there are none to restore. The derived seeding is a starting point for first use, not something reapplied over a choice already made.

That also gives the decoupling the issue asks for: once you have expressed a preference, the focus seeds are their own list rather than a function of Filter Nodes.

Both existing behaviours are kept:

* clearing the seeds entirely still falls back to the derived seeding, so the control is never left with nothing
* switching ontology still drops them (`_clear_viz_file_session_state`), so nothing stale carries into a file whose entities those labels do not name

### On the persistence request

The issue also asks for the selection to persist into the next session, in a config file. That already happens where it can be done safely: focus seeds are saved **per linked file** (#164). They are deliberately kept out of the global settings, because a seed names a specific entity and restoring `Class: Person` into a different ontology means nothing. So this PR changes the within-session behaviour only, which is the part that was actually losing work.

### Relation to #224 and #228

#228 fixed the first half of the complaint (opening focus mode no longer seeds every class when nothing is narrowed). This is the half that survived it: the overwrite on re-enable, which happened regardless of how the seeds were derived.

The reporter notes that #235 is what #224 "collapsed into", so this also settles the part of #224 whose text was truncated.

### Tests

792 pass, ruff and mypy clean. The new callback test was checked against the old code first and fails there, so it pins the actual regression rather than passing vacuously.

Also verified live: enable focus (seeds `Class: Department`), change the pick to `Class: Role`, toggle off and back on, and `Class: Role` is still there. Before the fix that reverted to `Class: Department`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)