### PR TITLE
feat: add a restriction by clicking the two classes it relates (#221)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -2484,7 +2484,7 @@ def _render_panel_add_restriction_button(classes, ntype, ename):
         st.rerun()
 
 
-def _render_panel_add_restriction_form(ont, classes, properties, ntype, ename):
+def _render_panel_add_restriction_form(ont, classes, object_props, ntype, ename):
     """Add a restriction by clicking the two classes it relates (issue #221).
 
     Same arm-then-pick as the relation form: the selected class is the one the
@@ -2493,15 +2493,26 @@ def _render_panel_add_restriction_form(ont, classes, properties, ntype, ename):
     value restrictions and the three qualified cardinalities. hasValue and the
     plain cardinalities say something about one class on its own, so the graph
     has no second end to offer and they stay on the Restrictions page.
+
+    ``object_props`` only, deliberately. Everything this flow can produce fills a
+    class slot: the value of someValuesFrom/allValuesFrom, or the owl:onClass of
+    a qualified cardinality. On a data property those slots take a data range
+    instead, so offering one here would write ``owl:someValuesFrom :SomeClass``
+    against an ``owl:DatatypeProperty`` — an axiom no reasoner accepts. Data
+    properties stay on the Restrictions page until this flow can offer a
+    datatype for them.
     """
     by_id = {_uid(c["uri"]): c for c in classes}
     subject = by_id.get(st.session_state.get("_viz_crel_subject"))
     if subject is None:
         _panel_close_add()
         st.rerun()
-    if not properties:
+    if not object_props:
         st.markdown("**New restriction**")
-        st.info("Add a property first: a restriction is always on one.")
+        st.info(
+            "Add an object property first. Restrictions built here point at a "
+            "class, which a data property cannot do."
+        )
         if st.button("Cancel", key="panel_add_rest_nocancel", use_container_width=True):
             _panel_close_add()
             st.rerun()
@@ -2532,7 +2543,7 @@ def _render_panel_add_restriction_form(ont, classes, properties, ntype, ename):
 
     st.markdown("**New restriction**")
     cls_options, cls_lookup = build_class_options(classes)
-    prop_options, prop_lookup = build_uri_options(properties)
+    prop_options, prop_lookup = build_uri_options(object_props)
     display_by_uri = {u: d for d, u in cls_lookup.items()}
     types = [t for t in ont.RESTRICTION_TYPES if restriction_references_class(t)]
     # Outside the form on purpose: a form batches until submit and does not rerun
@@ -5024,7 +5035,7 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
             "cardinality, or a literal for hasValue. A full URI is kept as it is.",
         )
         new_on_class = None
-        if "Qualified" in new_type:
+        if restriction_takes_on_class(new_type):
             new_on_class = st.selectbox(
                 "Qualified on Class",
                 on_options,
@@ -9715,12 +9726,10 @@ def render_visualization():
                             ont, classes, _sel_ntype, _sel_ename
                         )
                     elif _add_kind == "rest":
+                        # Object properties only: every restriction this flow can
+                        # build points at a class, which a data property cannot.
                         _render_panel_add_restriction_form(
-                            ont,
-                            classes,
-                            object_props + data_props,
-                            _sel_ntype,
-                            _sel_ename,
+                            ont, classes, object_props, _sel_ntype, _sel_ename
                         )
                     elif not has_selection:
                         st.caption(

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1998,6 +1998,57 @@ def _apply_class_edit(
     return True
 
 
+def restriction_takes_on_class(restriction_type: str) -> bool:
+    """Does this restriction type carry an ``owl:onClass``?
+
+    The qualified cardinalities do: OWL 2 requires one to name the class being
+    counted, and a qualified cardinality written without it is an axiom no
+    reasoner accepts.
+
+    Matched case-insensitively on purpose. The exact-cardinality type is spelled
+    ``qualifiedCardinality`` with a lower-case q, so a ``"Qualified" in ...``
+    test matched its min and max siblings but silently missed it: that type
+    never got an onClass selector and wrote a bare ``owl:qualifiedCardinality``.
+    """
+    return "qualified" in restriction_type.lower()
+
+
+def restriction_value_is_class(restriction_type: str) -> bool:
+    """Is this restriction's *value* another class, rather than a literal,
+    an individual or a number?"""
+    return restriction_type in ("someValuesFrom", "allValuesFrom")
+
+
+def restriction_references_class(restriction_type: str) -> bool:
+    """Does this restriction point at a second class at all? (issue #221)
+
+    These are the types worth building by clicking two nodes on the graph. The
+    rest (hasValue, the plain cardinalities) say something about one class on
+    its own, so the graph has no second end to offer and they stay on the
+    Restrictions page.
+    """
+    return restriction_value_is_class(restriction_type) or restriction_takes_on_class(
+        restriction_type
+    )
+
+
+def _apply_restriction_add(ont, target_uri, prop_uri, rtype, value, on_class=None):
+    """Write one restriction. Returns True on success.
+
+    Shared by the Restrictions page and the Visualization panel (issue #221).
+    The engine rejects a bad cardinality or an empty value by raising, and that
+    has to reach the user as a message rather than a traceback.
+    """
+    try:
+        ont.add_restriction(target_uri, prop_uri, rtype, value, on_class=on_class)
+    except Exception as e:  # noqa: BLE001 - a rejected axiom must show as a message
+        show_message(f"Error adding restriction: {e!s}", "error")
+        return False
+    save_checkpoint("Add restriction")
+    show_message("Restriction added!", "success")
+    return True
+
+
 def _apply_class_relation_add(ont, subj_uri, rel_type, obj_uri, subj_show, obj_show):
     """Write one class relation. Returns True on success.
 
@@ -2416,6 +2467,126 @@ def _render_panel_add_relation_form(ont, classes, ntype, ename):
     ):
         _panel_close_add()
         st.rerun()
+
+
+def _render_panel_add_restriction_button(classes, ntype, ename):
+    """The button that arms a restriction add, at the foot of the panel (#221)."""
+    if _panel_add_parent(classes, ntype, ename) is None:
+        return
+    if st.button(
+        "Add restriction",
+        key="panel_add_rest_open",
+        use_container_width=True,
+        help="Then click the class it restricts to.",
+    ):
+        st.session_state["_viz_add_kind"] = "rest"
+        st.session_state["_viz_crel_subject"] = ename
+        st.rerun()
+
+
+def _render_panel_add_restriction_form(ont, classes, properties, ntype, ename):
+    """Add a restriction by clicking the two classes it relates (issue #221).
+
+    Same arm-then-pick as the relation form: the selected class is the one the
+    restriction is applied to, and the next class you click is the one it points
+    at. Only the types that *have* a second class are offered here — the two
+    value restrictions and the three qualified cardinalities. hasValue and the
+    plain cardinalities say something about one class on its own, so the graph
+    has no second end to offer and they stay on the Restrictions page.
+    """
+    by_id = {_uid(c["uri"]): c for c in classes}
+    subject = by_id.get(st.session_state.get("_viz_crel_subject"))
+    if subject is None:
+        _panel_close_add()
+        st.rerun()
+    if not properties:
+        st.markdown("**New restriction**")
+        st.info("Add a property first: a restriction is always on one.")
+        if st.button("Cancel", key="panel_add_rest_nocancel", use_container_width=True):
+            _panel_close_add()
+            st.rerun()
+        return
+
+    obj_id = st.session_state.get("_viz_crel_object")
+    if not obj_id:
+        st.markdown(f"**Restriction on {subject['name']}**")
+        st.info("Now click the class it restricts to.")
+        action, picked = resolve_picked_object(
+            st.session_state["_viz_crel_subject"], ntype, ename
+        )
+        if action == "pick":
+            st.session_state["_viz_crel_object"] = picked
+            st.rerun()
+        if action == "cancel":
+            _panel_close_add()
+            st.rerun()
+        if st.button("Cancel", key="panel_add_rest_cancel", use_container_width=True):
+            _panel_close_add()
+            st.rerun()
+        return
+
+    other = by_id.get(obj_id)
+    if other is None:
+        st.session_state.pop("_viz_crel_object", None)
+        st.rerun()
+
+    st.markdown("**New restriction**")
+    cls_options, cls_lookup = build_class_options(classes)
+    prop_options, prop_lookup = build_uri_options(properties)
+    display_by_uri = {u: d for d, u in cls_lookup.items()}
+    types = [t for t in ont.RESTRICTION_TYPES if restriction_references_class(t)]
+    # Outside the form on purpose: a form batches until submit and does not rerun
+    # when a widget inside it changes, so the fields that depend on the type
+    # (which slot the picked class fills, and whether a count is needed) would
+    # still be showing the previous type's shape when you pressed Add.
+    rtype = st.selectbox("Restriction Type", options=types, key="panel_rest_type")
+    qualified = restriction_takes_on_class(rtype)
+    with st.form("panel_add_rest_form"):
+        target_disp = st.selectbox(
+            "Apply to Class",
+            options=cls_options,
+            index=cls_options.index(display_by_uri[subject["uri"]]),
+            format_func=_pad_option,
+        )
+        prop_disp = st.selectbox(
+            "On Property", options=prop_options, format_func=_pad_option
+        )
+        # The picked class is the value for someValuesFrom / allValuesFrom, and
+        # the owl:onClass for the qualified cardinalities. Same click, different
+        # slot in the axiom, so the label says which one it is filling.
+        klass_disp = st.selectbox(
+            "Qualified on Class" if qualified else "Value (Class)",
+            options=cls_options,
+            index=cls_options.index(display_by_uri[other["uri"]]),
+            format_func=_pad_option,
+        )
+        cardinality = None
+        if qualified:
+            cardinality = st.number_input("Cardinality", min_value=0, value=1)
+        add_col, cancel_col = st.columns(2)
+        with add_col:
+            submitted = st.form_submit_button(
+                "Add restriction", use_container_width=True
+            )
+        with cancel_col:
+            cancelled = st.form_submit_button("Cancel", use_container_width=True)
+    if cancelled:
+        _panel_close_add()
+        st.rerun()
+    if submitted:
+        picked_uri = cls_lookup.get(klass_disp)
+        on_class = picked_uri if restriction_takes_on_class(rtype) else None
+        value = cardinality if restriction_takes_on_class(rtype) else picked_uri
+        if _apply_restriction_add(
+            ont,
+            cls_lookup.get(target_disp),
+            prop_lookup.get(prop_disp),
+            rtype,
+            value,
+            on_class=on_class,
+        ):
+            _panel_close_add()
+            st.rerun()
 
 
 def _render_panel_entity_editor(
@@ -4986,7 +5157,7 @@ def render_add_restriction(ont, classes, properties):
             value = st.number_input("Cardinality", min_value=0, value=1)
 
         on_class = None
-        if "Qualified" in restriction_type:
+        if restriction_takes_on_class(restriction_type):
             on_class = cls_lookup[
                 st.selectbox(
                     "Qualified on Class",
@@ -4997,20 +5168,15 @@ def render_add_restriction(ont, classes, properties):
             ]
 
         submitted = st.form_submit_button("Add Restriction")
-        if submitted:
-            try:
-                ont.add_restriction(
-                    cls_lookup[target_disp],
-                    prop_lookup[property_disp],
-                    restriction_type,
-                    value,
-                    on_class=on_class,
-                )
-                save_checkpoint("Add restriction")
-                show_message("Restriction added!", "success")
-                st.rerun()
-            except Exception as e:  # noqa: BLE001 - a rejected edit must show as a message, not a traceback
-                show_message(f"Error adding restriction: {e!s}", "error")
+        if submitted and _apply_restriction_add(
+            ont,
+            cls_lookup[target_disp],
+            prop_lookup[property_disp],
+            restriction_type,
+            value,
+            on_class=on_class,
+        ):
+            st.rerun()
 
 
 def render_restrictions():
@@ -9548,6 +9714,14 @@ def render_visualization():
                         _render_panel_add_relation_form(
                             ont, classes, _sel_ntype, _sel_ename
                         )
+                    elif _add_kind == "rest":
+                        _render_panel_add_restriction_form(
+                            ont,
+                            classes,
+                            object_props + data_props,
+                            _sel_ntype,
+                            _sel_ename,
+                        )
                     elif not has_selection:
                         st.caption(
                             "Click a node to see details. Ctrl/Cmd-click focuses on it."
@@ -9579,6 +9753,7 @@ def render_visualization():
                             _open_full_editor(ntype, ename)
                         _render_panel_add_class_button(classes, ntype, ename)
                         _render_panel_add_relation_button(classes, ntype, ename)
+                        _render_panel_add_restriction_button(classes, ntype, ename)
             else:
                 # Status bar under the graph (shown when the panel is hidden).
                 if has_selection:

--- a/tests/test_viz_add_restriction.py
+++ b/tests/test_viz_add_restriction.py
@@ -5,6 +5,9 @@ the second click fills, are the decisions worth pinning: get them wrong and the
 app writes an axiom no reasoner will accept.
 """
 
+import ast
+from pathlib import Path
+
 import pytest
 
 from orionbelt_ontology_builder.app import (
@@ -21,6 +24,8 @@ QUALIFIED = (
 )
 VALUE_CLASS = ("someValuesFrom", "allValuesFrom")
 NO_SECOND_CLASS = ("hasValue", "minCardinality", "maxCardinality", "exactCardinality")
+
+_APP = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder" / "app.py"
 
 
 @pytest.mark.parametrize("rtype", QUALIFIED)
@@ -67,6 +72,70 @@ def test_the_classifiers_cover_every_type_the_engine_knows():
     assert set(OntologyManager.RESTRICTION_TYPES) == set(
         QUALIFIED + VALUE_CLASS + NO_SECOND_CLASS
     )
+
+
+def test_no_form_decides_qualified_by_case_sensitive_substring():
+    """Both the add *and* the edit form must use the shared classifier.
+
+    ``"Qualified" in rtype`` misses ``qualifiedCardinality``. In the add form
+    that wrote a bare cardinality; in the edit form it was worse, since saving an
+    untouched row sent ``on_class=None`` and stripped ``owl:onClass`` off an
+    axiom that was already valid.
+    """
+    tree = ast.parse(_APP.read_text(encoding="utf-8"))
+    offenders = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Compare)
+        and any(isinstance(op, ast.In) for op in node.ops)
+        and isinstance(node.left, ast.Constant)
+        and node.left.value == "Qualified"
+    ]
+    assert not offenders, (
+        f"case-sensitive 'Qualified' membership test at line(s) {offenders}; "
+        "use restriction_takes_on_class(), which also matches "
+        "qualifiedCardinality"
+    )
+
+
+def test_editing_a_qualified_cardinality_keeps_its_on_class():
+    """The regression the edit form caused: a valid axiom losing its onClass."""
+    ont = OntologyManager("http://ex.org/o#")
+    ont.add_class("Person")
+    ont.add_class("Role")
+    ont.add_object_property("hasRole")
+    ont.add_restriction("Person", "hasRole", "qualifiedCardinality", 2, on_class="Role")
+    rest = ont.get_restrictions()[0]
+    assert rest["on_class"] == "Role"
+
+    # Re-save the row exactly as it stands, the way the edit form does when the
+    # onClass selector is rendered and its current value is submitted back.
+    ident = {
+        "class_name": rest["applied_to_uris"][0],
+        "property_name": rest.get("property_uri") or rest["property"],
+        "restriction_type": rest["type"],
+        "value": rest.get("value_uri") or rest.get("value"),
+        "on_class": rest.get("on_class_uri") or rest.get("on_class"),
+    }
+    ont.update_restriction(ident, dict(ident))
+
+    assert ont.get_restrictions()[0]["on_class"] == "Role"
+    assert "owl:onClass" in ont.graph.serialize(format="turtle")
+
+
+def test_the_graph_flow_is_handed_object_properties_only():
+    """A class-valued restriction on a data property is not valid OWL.
+
+    Every restriction this flow builds fills a class slot, so a data property
+    would produce ``owl:someValuesFrom :SomeClass`` against an
+    ``owl:DatatypeProperty``.
+    """
+    src = _APP.read_text(encoding="utf-8")
+    call = src.split("_render_panel_add_restriction_form(\n", 1)[1].split(")", 1)[0]
+    assert "data_props" not in call, (
+        "the graph restriction flow must not be offered data properties"
+    )
+    assert "object_props" in call
 
 
 def test_a_qualified_cardinality_writes_its_on_class():

--- a/tests/test_viz_add_restriction.py
+++ b/tests/test_viz_add_restriction.py
@@ -1,0 +1,81 @@
+"""Adding a restriction by clicking the two classes it relates (issue #221).
+
+Which restriction types belong in the graph flow, and which slot of the axiom
+the second click fills, are the decisions worth pinning: get them wrong and the
+app writes an axiom no reasoner will accept.
+"""
+
+import pytest
+
+from orionbelt_ontology_builder.app import (
+    restriction_references_class,
+    restriction_takes_on_class,
+    restriction_value_is_class,
+)
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+QUALIFIED = (
+    "minQualifiedCardinality",
+    "maxQualifiedCardinality",
+    "qualifiedCardinality",
+)
+VALUE_CLASS = ("someValuesFrom", "allValuesFrom")
+NO_SECOND_CLASS = ("hasValue", "minCardinality", "maxCardinality", "exactCardinality")
+
+
+@pytest.mark.parametrize("rtype", QUALIFIED)
+def test_every_qualified_cardinality_takes_an_on_class(rtype):
+    """Including ``qualifiedCardinality``, whose lower-case q used to hide it.
+
+    A ``"Qualified" in rtype`` test matched the min and max siblings but missed
+    the exact one, so that type never got an onClass selector on the
+    Restrictions page and wrote a bare cardinality.
+    """
+    assert restriction_takes_on_class(rtype)
+
+
+@pytest.mark.parametrize("rtype", VALUE_CLASS + NO_SECOND_CLASS)
+def test_nothing_else_takes_an_on_class(rtype):
+    assert not restriction_takes_on_class(rtype)
+
+
+@pytest.mark.parametrize("rtype", VALUE_CLASS)
+def test_the_value_restrictions_take_a_class_as_their_value(rtype):
+    assert restriction_value_is_class(rtype)
+
+
+@pytest.mark.parametrize("rtype", QUALIFIED + NO_SECOND_CLASS)
+def test_nothing_else_takes_a_class_as_its_value(rtype):
+    """The qualified ones count with a number; the class rides in onClass."""
+    assert not restriction_value_is_class(rtype)
+
+
+@pytest.mark.parametrize("rtype", VALUE_CLASS + QUALIFIED)
+def test_the_graph_flow_offers_every_type_with_a_second_class(rtype):
+    assert restriction_references_class(rtype)
+
+
+@pytest.mark.parametrize("rtype", NO_SECOND_CLASS)
+def test_the_graph_flow_leaves_out_types_with_no_second_class(rtype):
+    """hasValue and the plain cardinalities describe one class on its own, so
+    there is no second node to click and they stay on the Restrictions page."""
+    assert not restriction_references_class(rtype)
+
+
+def test_the_classifiers_cover_every_type_the_engine_knows():
+    """A type added to the engine must be classified here, not silently skipped."""
+    assert set(OntologyManager.RESTRICTION_TYPES) == set(
+        QUALIFIED + VALUE_CLASS + NO_SECOND_CLASS
+    )
+
+
+def test_a_qualified_cardinality_writes_its_on_class():
+    """The axiom the fix protects: qualified cardinality names the class counted."""
+    ont = OntologyManager("http://ex.org/o#")
+    ont.add_class("Person")
+    ont.add_class("Role")
+    ont.add_object_property("hasRole")
+    ont.add_restriction("Person", "hasRole", "qualifiedCardinality", 2, on_class="Role")
+    turtle = ont.graph.serialize(format="turtle")
+    assert "owl:onClass" in turtle
+    assert "owl:qualifiedCardinality" in turtle


### PR DESCRIPTION
Third step of #221, after #230 (classes) and #231 (relations). Completes the set the reporter named as daily use.

Same arm-then-pick as the relation form, reusing `resolve_picked_object`: press **Add restriction** with a class selected and it becomes the class the restriction applies to; the next class you click is the one it points at.

### Which types are offered

Only the ones that actually have a second class:

| type | what the picked class fills |
| --- | --- |
| `someValuesFrom`, `allValuesFrom` | the value |
| `minQualifiedCardinality`, `maxQualifiedCardinality`, `qualifiedCardinality` | the `owl:onClass`, plus a count |

`hasValue` and the plain cardinalities describe one class on its own, so the graph has no second end to offer and they stay on the Restrictions page. The field label changes to say which slot the picked class is filling, and the count appears only for the qualified ones.

### A pre-existing bug, fixed by sharing the classification

The page decided whether a type was qualified with:

```python
if "Qualified" in restriction_type:
```

That matches `minQualifiedCardinality` and `maxQualifiedCardinality`, but **not** `qualifiedCardinality`, whose q is lower case. So that one type never got an onClass selector, and the page wrote:

```turtle
:Person rdfs:subClassOf [ a owl:Restriction ;
        owl:onProperty :hasRole ;
        owl:qualifiedCardinality "2"^^xsd:nonNegativeInteger ] .
```

A qualified cardinality with no `owl:onClass`, which is not valid OWL 2 and which no reasoner will accept. I needed this classification for the panel anyway, so it is now one case-insensitive helper used by both callers, which fixes the page as a consequence. A test asserts the classifiers cover every type the engine knows, so a new type cannot be silently skipped.

### Why the type selector is outside the form

A Streamlit form batches until submit and does not rerun when a widget inside it changes. With the type inside, switching to a qualified type left the label reading "Value (Class)" and never rendered the count field, so pressing Add submitted the new type against the old type's shape. Verified that failing, then moved the selector out.

Worth noting the **Restrictions page has the same shape** for its own value fields, so the value widget there can lag the chosen type by one submit. That is pre-existing and untouched here; happy to fix separately if you want it.

### Verified live

| step | result |
| --- | --- |
| select `Person`, press Add restriction | holds at "Restriction on Person / Now click the class it restricts to" |
| click `Role` | form opens, Apply to = Person, Value (Class) = Role, no count field |
| switch type to `qualifiedCardinality` | label becomes "Qualified on Class", a Cardinality field appears |
| submit | writes `owl:onClass :Role` with `owl:qualifiedCardinality "1"`, confirmed in Source |
| Restrictions page, add a `someValuesFrom` | still works, listed alongside |

821 tests pass, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)