### PR TITLE
feat: introduce the app to someone with nothing loaded yet

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -9919,6 +9919,22 @@ def main():
         st.sidebar.write(f"🏷️ SKOS Concepts: {stats['concepts']}")
     st.sidebar.write(f"📊 Triples: {stats['content_triples']}")
 
+    # Say what the app is, but only to someone who has nothing loaded yet. The
+    # name otherwise lives in the sidebar and the tab title, and a permanent
+    # banner would push every page's real content down for the whole session.
+    # It sits above the page dispatch rather than on the Dashboard because a
+    # fresh session lands on Import / Export, so a Dashboard-only intro would be
+    # seen by returning users and missed by the newcomers it is written for.
+    if _ontology_is_empty(st.session_state.ontology):
+        # ® to match the trademark notice in the README; this is the one place
+        # in the UI that prints the full product name.
+        st.title("OrionBelt® Ontology Builder")
+        st.markdown(
+            "### Build and explore OWL ontologies in your browser\n\n"
+            "Create, visualize and validate ontologies without installing "
+            "Protégé."
+        )
+
     # Show ontology name in main area
     ont = st.session_state.ontology
     meta = ont.get_ontology_metadata()

--- a/tests/test_empty_state_hero.py
+++ b/tests/test_empty_state_hero.py
@@ -1,0 +1,64 @@
+"""The intro shown to someone with nothing loaded yet.
+
+It says what the app is on a first visit and then gets out of the way. Both
+halves matter: a banner that outlived the empty ontology would push every page's
+real content down for the rest of the session, on all thirteen pages.
+"""
+
+import ast
+from pathlib import Path
+
+from orionbelt_ontology_builder.app import _ontology_is_empty
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+_APP = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder" / "app.py"
+
+
+HERO_TITLE = "OrionBelt® Ontology Builder"
+
+
+def _hero_guards():
+    """Every ``if`` whose body prints the hero title, as AST nodes."""
+    tree = ast.parse(_APP.read_text(encoding="utf-8"))
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and any(HERO_TITLE in ast.dump(stmt) for stmt in node.body)
+    ]
+
+
+def test_the_hero_is_gated_on_an_empty_ontology():
+    """It must sit inside a condition, not be emitted unconditionally."""
+    guards = _hero_guards()
+    assert guards, f"the hero title {HERO_TITLE!r} is not inside any `if`"
+    assert all("_ontology_is_empty" in ast.dump(g.test) for g in guards), (
+        "the hero must be gated on _ontology_is_empty, so it disappears as soon "
+        "as there is something to work on"
+    )
+
+
+def test_the_product_name_carries_the_trademark():
+    """The README registers OrionBelt®, and this is the one place in the UI that
+    prints the full product name."""
+    assert HERO_TITLE in _APP.read_text(encoding="utf-8")
+    readme = (_APP.parent.parent / "README.md").read_text(encoding="utf-8")
+    assert "OrionBelt®" in readme
+
+
+def test_an_untouched_ontology_counts_as_empty():
+    """A fresh session: metadata only, so the hero shows."""
+    assert _ontology_is_empty(OntologyManager("http://example.org/o#"))
+
+
+def test_one_class_is_enough_to_retire_the_hero():
+    ont = OntologyManager("http://example.org/o#")
+    ont.add_class("Person")
+    assert not _ontology_is_empty(ont)
+
+
+def test_metadata_alone_does_not_retire_the_hero():
+    """Naming an ontology is not the same as having built anything in it."""
+    ont = OntologyManager("http://example.org/o#")
+    ont.set_ontology_metadata(label="My ontology", comment="Notes")
+    assert _ontology_is_empty(ont)


### PR DESCRIPTION
The main content area had no title. The product name lived only in the sidebar and the browser tab, so a first-time visitor landed on a form with no statement of what any of it is for.

```
OrionBelt® Ontology Builder

Build and explore OWL ontologies in your browser

Create, visualize and validate ontologies without installing Protégé.
```

### Shown while empty, then retired

The hero is gated on `_ontology_is_empty`, so it disappears the moment there is something to work on. A permanent banner would push real content down on all thirteen pages for the rest of the session, which is a poor trade for a tool people keep open all day.

It sits **above the page dispatch** rather than on the Dashboard. A fresh session with an empty ontology lands on **Import / Export**, not Dashboard, so a Dashboard-only intro would be seen by returning users and missed by exactly the newcomers it is written for. Above the dispatch it appears wherever the visitor happens to land.

Metadata alone does not retire it: naming an ontology is not the same as having built anything in it.

### The trademark

`OrionBelt®`, matching the notice already in the README ("OrionBelt® is a registered trademark of RALFORION d.o.o."). This is the only place in the UI that prints the full product name.

### Verified live

| state | hero |
| --- | --- |
| 5 classes restored from autosave | absent |
| after Discard saved session, 0 classes | present, on both Dashboard and Import / Export |
| after applying a template, 4 classes | absent again |

The ® superscripts correctly at title size.

### Tests

797 pass, ruff 0.16.1 and mypy clean. `tests/test_empty_state_hero.py` pins the gating with an AST check that the title only ever appears inside an `_ontology_is_empty` guard, so it cannot quietly become unconditional, plus the empty/non-empty boundary cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)