### PR TITLE
docs: lead the README with what the workbench does, and what it does not

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 <p align="center"><strong>A browser-based ontology workbench built with Streamlit and rdflib</strong></p>
 
+<p align="center">
+  Build and explore OWL ontologies directly in your browser.
+</p>
+
+<p align="center">
+  ✔ Visual graph editor<br>
+  ✔ OWL RL reasoning &amp; consistency checks<br>
+  ✔ OWL + SKOS in one workbench<br>
+  ✔ RDF/OWL import &amp; export<br>
+  ✔ Pure Python
+</p>
+
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
 [![PyPI](https://img.shields.io/pypi/v/orionbelt-ontology-builder?logo=pypi&logoColor=white&label=PyPI&color=purple)](https://pypi.org/project/orionbelt-ontology-builder/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
@@ -369,6 +381,15 @@ orionbelt-ontology-builder/
 ```
 
 Dependencies: streamlit, rdflib, owlrl, networkx, pyvis.
+
+---
+
+## Roadmap
+
+Not implemented yet, listed here so it is clear what the workbench does *not* do today:
+
+- **SHACL validation.** Validation is currently structural (orphan classes, duplicate labels, domain/range mismatches, SKOS cycles) plus OWL RL reasoning. Shape-based validation against SHACL constraints is not supported.
+- **SPARQL queries.** There is no query console; exploration is through search, usage/backlink views and the graph.
 
 ---
 


### PR DESCRIPTION
Adds a benefit line and a feature checklist under the existing tagline. Logo, badges and screenshot stay exactly where they were.

```
✔ Visual graph editor
✔ OWL RL reasoning & consistency checks
✔ OWL + SKOS in one workbench
✔ RDF/OWL import & export
✔ Pure Python
```

### Two claims deliberately left out

The list started as *SHACL validation* and *SPARQL queries*. Neither is in this codebase:

* **SHACL**: zero occurrences anywhere in the repo. Validation is structural (`validate()`, `validate_skos()`: orphan classes, duplicate labels, domain/range mismatches, SKOS cycles) plus **OWL RL reasoning** through `owlrl`. The page is even headed "Validation & Reasoning". Real, and already carried by the OWL-RL badge, but not SHACL, which is a specific standard people will check.
* **SPARQL**: zero occurrences, and no `.query()` against the graph anywhere. There is no query console.

Both now live in a new **Roadmap** section that says plainly they are not supported, rather than leaving it to be discovered. That felt worth being explicit about because `README.md` is synced to the Docker Hub overview on push, so a claim here reaches further than the repo page.

The two entries that took their place are things the app does deliver: OWL RL reasoning and consistency checks, and OWL plus SKOS in one workbench (SKOS has its own page and its own validator, and it is a differentiator most Protégé alternatives do not lead with).

### Note

The header now carries two centred lines: the existing *"A browser-based ontology workbench built with Streamlit and rdflib"* and the new *"Build and explore OWL ontologies directly in your browser."* Both say "browser". Happy to merge them into one if you would rather; I kept both since the first is positioning and the second is the benefit line, and removing existing copy was not part of the ask.

792 tests pass, including the version-consistency check that reads the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)