### PR TITLE
feat: edit annotations from the Visualization graph (#223)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1734,7 +1734,11 @@ def annotation_ename(subject_uri: str, ann: dict) -> str:
         ann.get("predicate_uri") or ann["predicate"],
         ann["value"],
         ann.get("language") or "",
-        ann.get("datatype") or "",
+        # The full datatype URI, not the local name: two datatypes in different
+        # namespaces share a local name, and a non-XSD one does not resolve back
+        # from it. "uri" marks a resource-valued annotation, which is a different
+        # triple from a literal that happens to spell the same IRI.
+        "uri" if ann.get("is_uri") else (ann.get("datatype_uri") or ""),
     )
 
 
@@ -2083,9 +2087,14 @@ def _apply_annotation_edit(ont, subject_uri, ann, new_pred, new_value, new_lang)
     The datatype rides along unchanged. Without it the re-add would store a
     plain string and quietly drop a ``^^xsd:date`` that the user never touched.
     """
-    datatype = ann.get("datatype")
+    # The full datatype URI, never the display local name: a non-XSD local name
+    # does not resolve back, so deleting by it matches nothing and re-adding
+    # mints a relative ``^^<Thing>`` beside the untouched original.
+    datatype = ann.get("datatype_uri") or ann.get("datatype")
+    is_uri = bool(ann.get("is_uri"))
+    old_pred = ann.get("predicate_uri") or ann["predicate"]
     if (
-        new_pred == (ann.get("predicate_uri") or ann["predicate"])
+        new_pred == old_pred
         and new_value == ann["value"]
         and (new_lang or None) == (ann.get("language") or None)
     ):
@@ -2093,26 +2102,29 @@ def _apply_annotation_edit(ont, subject_uri, ann, new_pred, new_value, new_lang)
 
     ont.delete_annotation(
         subject_uri,
-        ann.get("predicate_uri") or ann["predicate"],
+        old_pred,
         ann["value"],
         lang=ann.get("language"),
         datatype=datatype,
+        value_is_uri=is_uri,
     )
     try:
         ont.add_annotation(
             subject_uri,
             new_pred,
             new_value,
-            lang=new_lang or None,
-            datatype=None if new_lang else datatype,
+            lang=None if is_uri else (new_lang or None),
+            datatype=None if (is_uri or new_lang) else datatype,
+            value_is_uri=is_uri,
         )
     except Exception as e:  # noqa: BLE001 - a rejected predicate must not eat the annotation
         ont.add_annotation(
             subject_uri,
-            ann.get("predicate_uri") or ann["predicate"],
+            old_pred,
             ann["value"],
             lang=ann.get("language"),
             datatype=datatype,
+            value_is_uri=is_uri,
         )
         show_message(f"Annotation unchanged: {e!s}", "error")
         return False
@@ -2339,13 +2351,21 @@ def _render_panel_annotation_editor(ont, ename):
             help="A full URI, a prefixed name (dcterms:created), or a common "
             "name like label.",
         )
-        new_value = st.text_input("Value", value=ann["value"])
-        new_lang = st.text_input(
-            "Language",
-            value=ann.get("language") or "",
-            help="Optional BCP 47 tag such as en or de. Leave empty for none.",
+        new_value = st.text_input(
+            "Value" if not ann.get("is_uri") else "Value (IRI)", value=ann["value"]
         )
-        if ann.get("datatype"):
+        new_lang = ""
+        if ann.get("is_uri"):
+            # A resource-valued annotation has no language or datatype to carry;
+            # it stays a resource through the rewrite.
+            st.caption("Points at a resource, not a literal.")
+        else:
+            new_lang = st.text_input(
+                "Language",
+                value=ann.get("language") or "",
+                help="Optional BCP 47 tag such as en or de. Leave empty for none.",
+            )
+        if ann.get("datatype") and not ann.get("is_uri"):
             # Not editable here, but say it is there: it is carried through the
             # rewrite untouched, and a silent one would look like data loss.
             st.caption(f"Datatype: {ann['datatype']} (kept)")
@@ -2361,7 +2381,11 @@ def _render_panel_annotation_editor(ont, ename):
             ann.get("predicate_uri") or ann["predicate"],
             ann["value"],
             lang=ann.get("language"),
-            datatype=ann.get("datatype"),
+            # Same two reasons as the rewrite: the display local name does not
+            # resolve back, and a literal match never finds a resource, so
+            # either would report a delete that removed nothing.
+            datatype=ann.get("datatype_uri") or ann.get("datatype"),
+            value_is_uri=bool(ann.get("is_uri")),
         )
         save_checkpoint("Delete annotation")
         show_message("Annotation deleted!", "success")
@@ -6294,7 +6318,14 @@ def render_annotations():
                                         ann.get("predicate_uri", ann["predicate"]),
                                         ann["value"],
                                         lang=ann.get("language"),
-                                        datatype=ann.get("datatype"),
+                                        # Full URI, and the resource/literal
+                                        # distinction: passing the display local
+                                        # name or treating an IRI object as a
+                                        # literal deletes nothing while
+                                        # reporting success (issue #223 review).
+                                        datatype=ann.get("datatype_uri")
+                                        or ann.get("datatype"),
+                                        value_is_uri=bool(ann.get("is_uri")),
                                     )
                                     save_checkpoint("Delete annotation")
                                     show_message("Annotation deleted!", "success")
@@ -8828,7 +8859,11 @@ def render_visualization():
         selected_inds_key = (
             "_".join(sorted(selected_ind_uris)) if selected_ind_uris else "none"
         )
-        _graph_ver = 18  # Bump to invalidate cached graph data after code changes
+        # Bump to invalidate cached graph data after code changes. 19: annotation
+        # nodes gained a stable id, ntype and ename (issue #223), and a session
+        # holding a pre-#223 payload would otherwise keep serving nodes a click
+        # cannot resolve until some unrelated change happened to evict it.
+        _graph_ver = 19
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -1704,6 +1704,45 @@ def _edge_id_parts(ename: str, count: int) -> tuple | None:
     return parts if len(parts) == count else None
 
 
+#: How many parts an annotation's identity has (see :func:`annotation_ename`).
+_ANN_ID_PARTS = 5
+
+
+def _uri_local_name(uri: str) -> str:
+    """The local part of a URI, for naming the resource something hangs off."""
+    if not uri:
+        return ""
+    return uri.rsplit("#", 1)[-1].rsplit("/", 1)[-1] or uri
+
+
+def annotation_ename(subject_uri: str, ann: dict) -> str:
+    """Name the annotation a graph node stands for (issue #223).
+
+    An annotation has no URI of its own — it *is* a triple — so like the
+    relations and restrictions drawn as edges it is identified by its parts:
+    subject, predicate, value, and the language or datatype that tells two
+    otherwise identical literals apart. That is exactly the key
+    ``delete_annotation`` matches on, so a node resolves back to the one triple
+    it was drawn from.
+
+    Derived from content rather than counted, so the id survives a rebuild. The
+    nodes used to be numbered in iteration order, which meant a node id changed
+    whenever anything before it did, and a click could not be resolved at all.
+    """
+    return _edge_id(
+        subject_uri,
+        ann.get("predicate_uri") or ann["predicate"],
+        ann["value"],
+        ann.get("language") or "",
+        ann.get("datatype") or "",
+    )
+
+
+def annotation_matches_ename(subject_uri: str, ann: dict, parts: tuple) -> bool:
+    """Whether ``ann`` on ``subject_uri`` is the annotation ``parts`` names."""
+    return annotation_ename(subject_uri, ann) == _edge_id(*parts)
+
+
 def _restriction_matches_edge(rest: dict, parts: tuple) -> bool:
     """Whether ``rest`` is the restriction a graph edge stands for (issue #152).
 
@@ -2032,6 +2071,54 @@ def restriction_references_class(restriction_type: str) -> bool:
     )
 
 
+def _apply_annotation_edit(ont, subject_uri, ann, new_pred, new_value, new_lang):
+    """Rewrite one annotation. Returns True when the graph changed (issue #223).
+
+    An annotation is a triple, and the engine has no update for one, so an edit
+    is a delete followed by an add. That order can fail halfway: ``add`` rejects
+    an unusable predicate (an unbound prefix above all), and by then the original
+    is already gone. So a failed add puts the original back before reporting,
+    rather than leaving the user with neither.
+
+    The datatype rides along unchanged. Without it the re-add would store a
+    plain string and quietly drop a ``^^xsd:date`` that the user never touched.
+    """
+    datatype = ann.get("datatype")
+    if (
+        new_pred == (ann.get("predicate_uri") or ann["predicate"])
+        and new_value == ann["value"]
+        and (new_lang or None) == (ann.get("language") or None)
+    ):
+        return False
+
+    ont.delete_annotation(
+        subject_uri,
+        ann.get("predicate_uri") or ann["predicate"],
+        ann["value"],
+        lang=ann.get("language"),
+        datatype=datatype,
+    )
+    try:
+        ont.add_annotation(
+            subject_uri,
+            new_pred,
+            new_value,
+            lang=new_lang or None,
+            datatype=None if new_lang else datatype,
+        )
+    except Exception as e:  # noqa: BLE001 - a rejected predicate must not eat the annotation
+        ont.add_annotation(
+            subject_uri,
+            ann.get("predicate_uri") or ann["predicate"],
+            ann["value"],
+            lang=ann.get("language"),
+            datatype=datatype,
+        )
+        show_message(f"Annotation unchanged: {e!s}", "error")
+        return False
+    return True
+
+
 def _apply_restriction_add(ont, target_uri, prop_uri, rtype, value, on_class=None):
     """Write one restriction. Returns True on success.
 
@@ -2212,6 +2299,82 @@ def _apply_individual_edit(
         remove_class=remove_class if remove_class and remove_class != "None" else None,
     )
     return True
+
+
+def _render_panel_annotation_editor(ont, ename):
+    """Edit the annotation behind a graph node, in the Details panel (#223).
+
+    The node names the whole triple, which is looked up in the live ontology for
+    the same reason the relation and restriction editors do it: a selection can
+    outlive what it points at, and an annotation that has changed is a different
+    annotation, so this has to say so rather than rewrite whatever is at hand.
+    """
+    parts = _edge_id_parts(ename, _ANN_ID_PARTS)
+    ann = None
+    subject_uri = ""
+    if parts:
+        subject_uri = parts[0]
+        try:
+            ann = next(
+                (
+                    a
+                    for a in ont.get_annotations(subject_uri)
+                    if annotation_matches_ename(subject_uri, a, parts)
+                ),
+                None,
+            )
+        except Exception:  # noqa: BLE001 - a subject that has gone reads as "gone"
+            ann = None
+    if ann is None:
+        st.caption(
+            "This annotation was edited or removed. Click a node to pick one up."
+        )
+        return
+
+    st.caption(f"On {_uri_local_name(subject_uri)}")
+    with st.form(f"panel_edit_ann_{_uid(ename)}"):
+        new_pred = st.text_input(
+            "Predicate",
+            value=ann.get("predicate_uri") or ann["predicate"],
+            help="A full URI, a prefixed name (dcterms:created), or a common "
+            "name like label.",
+        )
+        new_value = st.text_input("Value", value=ann["value"])
+        new_lang = st.text_input(
+            "Language",
+            value=ann.get("language") or "",
+            help="Optional BCP 47 tag such as en or de. Leave empty for none.",
+        )
+        if ann.get("datatype"):
+            # Not editable here, but say it is there: it is carried through the
+            # rewrite untouched, and a silent one would look like data loss.
+            st.caption(f"Datatype: {ann['datatype']} (kept)")
+        save_col, del_col = st.columns(2)
+        with save_col:
+            saved = st.form_submit_button("Save", use_container_width=True)
+        with del_col:
+            deleted = st.form_submit_button("Delete", use_container_width=True)
+
+    if deleted:
+        ont.delete_annotation(
+            subject_uri,
+            ann.get("predicate_uri") or ann["predicate"],
+            ann["value"],
+            lang=ann.get("language"),
+            datatype=ann.get("datatype"),
+        )
+        save_checkpoint("Delete annotation")
+        show_message("Annotation deleted!", "success")
+        st.rerun()
+    if saved:
+        if not new_value.strip():
+            show_message("Annotation value is required!", "error")
+        elif _apply_annotation_edit(
+            ont, subject_uri, ann, new_pred, new_value, new_lang
+        ):
+            save_checkpoint("Update annotation")
+            show_message("Annotation updated!", "success")
+            st.rerun()
 
 
 def _render_panel_relation_editor(ont, ename, classes):
@@ -2617,6 +2780,11 @@ def _render_panel_entity_editor(
         return None
     if ntype == "Restriction":
         _render_panel_restriction_editor(ont, ename, classes, object_props + data_props)
+        return None
+    if ntype == "Annotation":
+        # Like the two above, an annotation has no URI of its own: it resolves
+        # from the identity its node carries, not from an entity pool (#223).
+        _render_panel_annotation_editor(ont, ename)
         return None
 
     # Object properties are drawn as edges (so selecting one is a selectEdge with
@@ -9100,7 +9268,6 @@ def render_visualization():
 
             # Add annotations for classes and individuals
             if show_annotations and node_count < max_nodes:
-                annotation_counter = 0
                 # Annotations for classes
                 if show_classes and classes:
                     for cls in classes:
@@ -9120,8 +9287,8 @@ def render_visualization():
                                 # Skip label and comment as they're already shown in tooltip
                                 if ann["predicate"] in ["label", "comment"]:
                                     continue
-                                annotation_counter += 1
-                                ann_id = f"ann_{annotation_counter}"
+                                ann_ename = annotation_ename(cls["uri"], ann)
+                                ann_id = f"ann_{_uid(ann_ename)}"
                                 # Use prefixed predicate name
                                 pred_display = ann.get(
                                     "predicate_prefixed", ann["predicate"]
@@ -9143,6 +9310,8 @@ def render_visualization():
                                     shape="box",
                                     size=8,
                                     font={"size": 10, "color": "#f0f0f0"},
+                                    ntype="Annotation",
+                                    ename=ann_ename,
                                 )
                                 node_count += 1
                                 net.add_edge(
@@ -9173,8 +9342,8 @@ def render_visualization():
                                     break
                                 if ann["predicate"] in ["label", "comment"]:
                                     continue
-                                annotation_counter += 1
-                                ann_id = f"ann_{annotation_counter}"
+                                ann_ename = annotation_ename(ind["uri"], ann)
+                                ann_id = f"ann_{_uid(ann_ename)}"
                                 pred_display = ann.get(
                                     "predicate_prefixed", ann["predicate"]
                                 )
@@ -9194,6 +9363,8 @@ def render_visualization():
                                     shape="box",
                                     size=8,
                                     font={"size": 10, "color": "#f0f0f0"},
+                                    ntype="Annotation",
+                                    ename=ann_ename,
                                 )
                                 node_count += 1
                                 net.add_edge(

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -392,6 +392,24 @@ class OntologyManager:
     _INVALID_URI_CHARS = frozenset('<>"{}|\\^`')
 
     @classmethod
+    def invalid_uri_reason(cls, uri: str) -> str | None:
+        """Why ``uri`` cannot be stored as a resource, or None if it can.
+
+        rdflib takes any string as a ``URIRef`` and only objects when asked to
+        serialize, so an unusable one is accepted silently and then breaks every
+        export of the whole ontology. Callers writing a resource-valued object
+        check here first, while there is still something to refuse.
+        """
+        if uri is None or not uri.strip():
+            return "A resource value cannot be empty."
+        if any(c.isspace() or c in cls._INVALID_URI_CHARS for c in uri):
+            return (
+                "A resource value must be a URI: no spaces, and none of the "
+                'characters < > " { } | \\ ^ `.'
+            )
+        return None
+
+    @classmethod
     def invalid_name_reason(cls, name: str) -> str | None:
         """Return a human-readable reason ``name`` is not a valid entity name,
         or ``None`` if it is valid.
@@ -2179,6 +2197,13 @@ class OntologyManager:
             # Keep a resource-valued annotation a resource. Writing it back as a
             # literal would leave the original triple in place beside a string
             # copy of the same IRI.
+            #
+            # Checked before it is stored, because rdflib accepts any string as a
+            # URIRef and only refuses at serialization: one bad edit would make
+            # the whole ontology unexportable, long after the edit that did it.
+            # Raising instead lets the caller's rollback put the original back.
+            if reason := self.invalid_uri_reason(value):
+                raise ValueError(reason)
             obj: Node = URIRef(value)
         elif lang:
             obj = Literal(value, lang=lang)
@@ -2364,10 +2389,15 @@ class OntologyManager:
             self.graph.remove((subj_uri, pred_uri, Literal(value, datatype=dt_uri)))
             return
 
-        # No lang/datatype specified: remove any literal whose string value matches
+        # Nothing said about the object: remove any whose string value matches,
+        # resource or literal alike. Matching only literals here meant a caller
+        # that did not know the difference — the bulk editor, whose table has no
+        # column for it — deleted nothing and reported success (issue #223
+        # review). An exact object kind is still available through
+        # ``value_is_uri``.
         to_remove = []
         for obj in self.graph.objects(subj_uri, pred_uri):
-            if isinstance(obj, Literal) and str(obj) == value:
+            if isinstance(obj, (Literal, URIRef)) and str(obj) == value:
                 to_remove.append(obj)
         for obj in to_remove:
             self.graph.remove((subj_uri, pred_uri, obj))

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2124,6 +2124,7 @@ class OntologyManager:
         value: str,
         lang: str | None = None,
         datatype: str | None = None,
+        value_is_uri: bool = False,
     ):
         """Add an annotation to any resource.
 
@@ -2150,10 +2151,14 @@ class OntologyManager:
             datatype: Optional datatype, as the local name of an XSD type or a
                 full URI, resolved the same way :meth:`delete_annotation`
                 resolves it so an annotation can be removed and re-added without
-                changing. Ignored when ``lang`` is given, since RDF literals
-                carry a language tag or a datatype, never both. Without it an
-                edit that rewrote a value would silently drop its ``^^xsd:date``
-                and store a plain string (issue #223).
+                changing. Prefer the full URI: a local name that is not an XSD
+                type does not resolve back and would mint a relative
+                ``^^<Thing>``. Ignored when ``lang`` is given, since RDF
+                literals carry a language tag or a datatype, never both, and
+                when ``value_is_uri`` is set. Without it an edit that rewrote a
+                value would silently drop its ``^^xsd:date`` (issue #223).
+            value_is_uri: Write the object as a resource rather than a literal,
+                for annotations like ``rdfs:seeAlso`` whose value is an IRI.
         """
         self._require_valid_annotation_predicate(predicate)
         subj_uri = self._uri(subject)
@@ -2170,21 +2175,26 @@ class OntologyManager:
         ):
             self.graph.add((pred_uri, RDF.type, OWL.AnnotationProperty))
 
-        if lang:
-            literal = Literal(value, lang=lang)
+        if value_is_uri:
+            # Keep a resource-valued annotation a resource. Writing it back as a
+            # literal would leave the original triple in place beside a string
+            # copy of the same IRI.
+            obj: Node = URIRef(value)
+        elif lang:
+            obj = Literal(value, lang=lang)
         elif datatype:
-            literal = Literal(
+            obj = Literal(
                 value, datatype=self.XSD_DATATYPES.get(datatype, URIRef(datatype))
             )
         else:
-            literal = Literal(value)
+            obj = Literal(value)
 
-        self.graph.add((subj_uri, pred_uri, literal))
+        self.graph.add((subj_uri, pred_uri, obj))
 
-    def get_annotations(self, subject: str) -> list[dict[str, str]]:
+    def get_annotations(self, subject: str) -> list[dict[str, Any]]:
         """Get all annotations/predicates for a resource (like Protege shows)."""
         subj_uri = self._uri(subject)
-        annotations = []
+        annotations: list[dict[str, Any]] = []
 
         # Get all predicates for this subject, excluding rdf:type, rdfs:subClassOf,
         # rdfs:domain, rdfs:range, and other structural predicates
@@ -2224,7 +2234,7 @@ class OntologyManager:
             pred_uri = str(pred)
             prefix = self._get_prefix_for_uri(pred_uri)
             local_name = self._local_name(pred)
-            ann = {
+            ann: dict[str, Any] = {
                 "predicate": local_name,
                 "predicate_uri": pred_uri,
                 "predicate_prefixed": f"{prefix}:{local_name}"
@@ -2235,7 +2245,19 @@ class OntologyManager:
             if hasattr(obj, "language") and obj.language:
                 ann["language"] = obj.language
             if hasattr(obj, "datatype") and obj.datatype:
+                # Local name for display, full URI to act on. Two datatypes in
+                # different namespaces can share a local name, and one that is
+                # not an XSD type does not resolve back from the local name at
+                # all — deleting by it removes nothing and re-adding mints a
+                # relative ``^^<Thing>`` (issue #223 review).
                 ann["datatype"] = self._local_name(obj.datatype)
+                ann["datatype_uri"] = str(obj.datatype)
+            if isinstance(obj, URIRef):
+                # The object is a resource, not a literal. Callers that rewrite
+                # an annotation have to know: a literal delete does not match a
+                # URIRef, and re-adding one as a literal leaves the original in
+                # place next to a string copy of it.
+                ann["is_uri"] = True
             annotations.append(ann)
 
         # Sort by predicate name
@@ -2306,18 +2328,31 @@ class OntologyManager:
         value: str | None = None,
         lang: str | None = None,
         datatype: str | None = None,
+        value_is_uri: bool = False,
     ):
         """Delete an annotation from a resource.
 
         Matches language-tagged and datatype-qualified literals when lang/datatype
         are provided. When they are not provided but a value is given, searches
         for any literal with a matching string value regardless of tag.
+
+        ``datatype`` may be an XSD local name or a full URI; a full one is what
+        callers should pass, since a non-XSD local name does not resolve back.
+        ``value_is_uri`` says the object is a resource rather than a literal,
+        which no literal match can find.
         """
         subj_uri = self._uri(subject)
         pred_uri = self._resolve_predicate_uri(predicate)
 
         if value is None:
             self.graph.remove((subj_uri, pred_uri, None))
+            return
+
+        if value_is_uri:
+            # A resource-valued annotation (rdfs:seeAlso, owl:sameAs). The
+            # literal branches below cannot match one, so without this the
+            # delete silently removes nothing and reports success.
+            self.graph.remove((subj_uri, pred_uri, URIRef(value)))
             return
 
         # Build exact literal if lang or datatype is known

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2118,7 +2118,12 @@ class OntologyManager:
             raise ValueError(reason)
 
     def add_annotation(
-        self, subject: str, predicate: str, value: str, lang: str | None = None
+        self,
+        subject: str,
+        predicate: str,
+        value: str,
+        lang: str | None = None,
+        datatype: str | None = None,
     ):
         """Add an annotation to any resource.
 
@@ -2142,6 +2147,13 @@ class OntologyManager:
             predicate: Either a full URI, a common name (label, comment, etc.), or a local name
             value: The annotation value
             lang: Optional language tag
+            datatype: Optional datatype, as the local name of an XSD type or a
+                full URI, resolved the same way :meth:`delete_annotation`
+                resolves it so an annotation can be removed and re-added without
+                changing. Ignored when ``lang`` is given, since RDF literals
+                carry a language tag or a datatype, never both. Without it an
+                edit that rewrote a value would silently drop its ``^^xsd:date``
+                and store a plain string (issue #223).
         """
         self._require_valid_annotation_predicate(predicate)
         subj_uri = self._uri(subject)
@@ -2160,6 +2172,10 @@ class OntologyManager:
 
         if lang:
             literal = Literal(value, lang=lang)
+        elif datatype:
+            literal = Literal(
+                value, datatype=self.XSD_DATATYPES.get(datatype, URIRef(datatype))
+            )
         else:
             literal = Literal(value)
 

--- a/tests/test_mutation_checkpoints.py
+++ b/tests/test_mutation_checkpoints.py
@@ -37,6 +37,11 @@ CHECKPOINTED_BY_CALLER = {
     "_apply_class_edit",
     "_apply_property_edit",
     "_apply_individual_edit",
+    # Rewrites an annotation as a delete plus an add, and puts the original back
+    # when the add is rejected. The panel checkpoints on the True return; the
+    # rollback path returns False having restored the graph, so there is nothing
+    # to checkpoint there either (issue #223).
+    "_apply_annotation_edit",
 }
 
 # Either of these moves the revision: the checkpoint helper, or a direct bump

--- a/tests/test_viz_annotation_edit.py
+++ b/tests/test_viz_annotation_edit.py
@@ -277,3 +277,95 @@ def test_a_resource_and_a_literal_spelling_the_same_iri_are_different_annotation
         a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "seeAlso"
     ]
     assert len({annotation_ename(NS + "Person", a) for a in anns}) == 2
+
+
+# --- an IRI object has to be storable ---------------------------------------
+
+
+def test_an_unusable_iri_is_refused_rather_than_stored():
+    """rdflib takes any string as a URIRef and only objects at serialization, so
+    one bad edit would break every export of the whole ontology, long after the
+    edit that caused it."""
+    from rdflib import URIRef
+
+    ont = _ont()
+    _resource(ont, "http://docs.example/person")
+    ann = next(
+        a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "seeAlso"
+    )
+
+    assert not _apply_annotation_edit(
+        ont, NS + "Person", ann, SEE_ALSO, "not a uri with spaces", ""
+    )
+    objs = list(ont.graph.objects(ont._uri("Person"), URIRef(SEE_ALSO)))
+    assert [str(o) for o in objs] == ["http://docs.example/person"]
+
+
+def test_the_ontology_still_serializes_after_a_refused_iri_edit():
+    ont = _ont()
+    _resource(ont, "http://docs.example/person")
+    ann = next(
+        a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "seeAlso"
+    )
+    _apply_annotation_edit(ont, NS + "Person", ann, SEE_ALSO, "has spaces", "")
+    assert "docs.example/person" in ont.export_to_string("turtle")
+
+
+@pytest.mark.parametrize(
+    "bad", ["has spaces", "angle<brackets>", 'quote"mark', "brace{s}", "", "   "]
+)
+def test_add_annotation_rejects_an_unserializable_resource_value(bad):
+    ont = _ont()
+    with pytest.raises(ValueError):
+        ont.add_annotation(NS + "Person", SEE_ALSO, bad, value_is_uri=True)
+
+
+@pytest.mark.parametrize(
+    "good", ["http://a.example/x", "urn:isbn:0451450523", "mailto:a@b.example"]
+)
+def test_a_usable_iri_is_still_accepted(good):
+    ont = _ont()
+    ont.add_annotation(NS + "Person", SEE_ALSO, good, value_is_uri=True)
+    assert ont.export_to_string("turtle")
+
+
+# --- deleting without knowing the object kind -------------------------------
+
+
+def test_a_delete_that_does_not_say_the_kind_matches_a_resource_too():
+    """The bulk editor's table has no column for it, so it deleted nothing and
+    reported success."""
+    from rdflib import URIRef
+
+    ont = _ont()
+    _resource(ont, "http://docs.example/person")
+    ont.delete_annotation(NS + "Person", SEE_ALSO, "http://docs.example/person")
+    assert not list(ont.graph.objects(ont._uri("Person"), URIRef(SEE_ALSO)))
+
+
+def test_bulk_delete_removes_a_resource_valued_annotation():
+    from rdflib import URIRef
+
+    ont = _ont()
+    _resource(ont, "http://docs.example/person")
+    result = ont.bulk_update_annotations(
+        [
+            {
+                "resource": "Person",
+                "predicate": SEE_ALSO,
+                "value": "http://docs.example/person",
+                "action": "delete",
+            }
+        ]
+    )
+    assert result == {"applied": 1, "errors": []}
+    assert not list(ont.graph.objects(ont._uri("Person"), URIRef(SEE_ALSO)))
+
+
+def test_a_literal_delete_is_unaffected_by_the_widened_match():
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "source", "plain")
+    ont.delete_annotation(NS + "Person", DCT + "source", "plain")
+    assert not [
+        a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "source"
+    ]

--- a/tests/test_viz_annotation_edit.py
+++ b/tests/test_viz_annotation_edit.py
@@ -169,3 +169,111 @@ def test_a_language_tag_wins_over_a_datatype():
     ann = _ann(ont, DCT + "y")
     assert ann.get("language") == "en"
     assert not ann.get("datatype")
+
+
+# --- review follow-ups: what the identity and the rewrite must not lose ------
+
+
+CUSTOM_DT = "http://types.example/a#Thing"
+SEE_ALSO = "http://www.w3.org/2000/01/rdf-schema#seeAlso"
+
+
+def _typed(ont, value, datatype):
+    from rdflib import Literal, URIRef
+
+    ont.graph.add(
+        (
+            ont._uri("Person"),
+            URIRef(DCT + "x"),
+            Literal(value, datatype=URIRef(datatype)),
+        )
+    )
+
+
+def _resource(ont, value):
+    from rdflib import URIRef
+
+    ont.graph.add((ont._uri("Person"), URIRef(SEE_ALSO), URIRef(value)))
+
+
+def test_a_non_xsd_datatype_is_exposed_as_a_full_uri():
+    """The display local name does not resolve back, so acting on it is wrong."""
+    ont = _ont()
+    _typed(ont, "v", CUSTOM_DT)
+    ann = _ann(ont, DCT + "x")
+    assert ann["datatype"] == "Thing"
+    assert ann["datatype_uri"] == CUSTOM_DT
+
+
+def test_editing_a_custom_datatype_does_not_orphan_the_original():
+    """Deleting by the local name matched nothing and re-adding minted a
+    relative ``^^<Thing>``, leaving two triples where there was one."""
+    ont = _ont()
+    _typed(ont, "v", CUSTOM_DT)
+    assert _apply_annotation_edit(
+        ont, NS + "Person", _ann(ont, DCT + "x"), DCT + "x", "v2", ""
+    )
+    objs = list(
+        ont.graph.objects(ont._uri("Person"), __import__("rdflib").URIRef(DCT + "x"))
+    )
+    assert len(objs) == 1
+    assert str(objs[0]) == "v2"
+    assert str(objs[0].datatype) == CUSTOM_DT
+
+
+def test_a_resource_valued_annotation_is_flagged():
+    ont = _ont()
+    _resource(ont, "http://docs.example/person")
+    ann = next(
+        a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "seeAlso"
+    )
+    assert ann["is_uri"] is True
+
+
+def test_editing_a_resource_valued_annotation_keeps_it_a_resource():
+    """A literal delete never matched the IRI object, and the replacement was
+    written as a string, so the original survived beside a copy of itself."""
+    from rdflib import URIRef
+
+    ont = _ont()
+    _resource(ont, "http://docs.example/person")
+    ann = next(
+        a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "seeAlso"
+    )
+    assert _apply_annotation_edit(
+        ont, NS + "Person", ann, SEE_ALSO, "http://docs.example/other", ""
+    )
+    objs = list(ont.graph.objects(ont._uri("Person"), URIRef(SEE_ALSO)))
+    assert [(type(o).__name__, str(o)) for o in objs] == [
+        ("URIRef", "http://docs.example/other")
+    ]
+
+
+def test_deleting_a_resource_valued_annotation_actually_removes_it():
+    """It used to report success having removed nothing."""
+    from rdflib import URIRef
+
+    ont = _ont()
+    _resource(ont, "http://docs.example/person")
+    ann = next(
+        a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "seeAlso"
+    )
+    ont.delete_annotation(
+        NS + "Person", ann["predicate_uri"], ann["value"], value_is_uri=True
+    )
+    assert not list(ont.graph.objects(ont._uri("Person"), URIRef(SEE_ALSO)))
+
+
+def test_a_resource_and_a_literal_spelling_the_same_iri_are_different_annotations():
+    """So a click on one cannot resolve to the other."""
+    from rdflib import Literal, URIRef
+
+    ont = _ont()
+    _resource(ont, "http://docs.example/person")
+    ont.graph.add(
+        (ont._uri("Person"), URIRef(SEE_ALSO), Literal("http://docs.example/person"))
+    )
+    anns = [
+        a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "seeAlso"
+    ]
+    assert len({annotation_ename(NS + "Person", a) for a in anns}) == 2

--- a/tests/test_viz_annotation_edit.py
+++ b/tests/test_viz_annotation_edit.py
@@ -1,0 +1,171 @@
+"""Editing an annotation from the Visualization graph (issue #223).
+
+An annotation has no URI of its own, so a graph node can only point back at it
+by naming its parts. Two things decide whether that works: the identity has to
+survive a rebuild, and rewriting the triple must not lose anything the user did
+not touch.
+"""
+
+import pytest
+
+from orionbelt_ontology_builder.app import (
+    _apply_annotation_edit,
+    annotation_ename,
+    annotation_matches_ename,
+)
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+NS = "http://ex.org/o#"
+DCT = "http://purl.org/dc/terms/"
+
+
+def _ont():
+    ont = OntologyManager(NS)
+    ont.add_class("Person")
+    return ont
+
+
+def _ann(ont, predicate):
+    return next(
+        a for a in ont.get_annotations(NS + "Person") if a["predicate_uri"] == predicate
+    )
+
+
+# --- identity ---------------------------------------------------------------
+
+
+def test_the_identity_is_content_derived_not_positional():
+    """Node ids used to be numbered in iteration order, so adding an annotation
+    renamed the ones after it and a click could not be resolved."""
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "source", "second")
+    first = annotation_ename(NS + "Person", _ann(ont, DCT + "source"))
+
+    ont.add_annotation(NS + "Person", DCT + "creator", "aaa-sorts-first")
+    assert annotation_ename(NS + "Person", _ann(ont, DCT + "source")) == first
+
+
+def test_two_values_of_one_predicate_are_told_apart():
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "source", "one")
+    ont.add_annotation(NS + "Person", DCT + "source", "two")
+    names = {
+        annotation_ename(NS + "Person", a) for a in ont.get_annotations(NS + "Person")
+    }
+    assert len(names) == len(ont.get_annotations(NS + "Person"))
+
+
+def test_the_language_tag_is_part_of_the_identity():
+    """Same predicate and same string, different tag: different annotations."""
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "title", "Bank", lang="en")
+    ont.add_annotation(NS + "Person", DCT + "title", "Bank", lang="de")
+    anns = [a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "title"]
+    assert len({annotation_ename(NS + "Person", a) for a in anns}) == 2
+
+
+def test_an_annotation_matches_only_its_own_name():
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "source", "one")
+    ont.add_annotation(NS + "Person", DCT + "source", "two")
+    a, b = (a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "source")
+    parts = tuple(annotation_ename(NS + "Person", a).split("\x1f"))
+    assert annotation_matches_ename(NS + "Person", a, parts)
+    assert not annotation_matches_ename(NS + "Person", b, parts)
+
+
+# --- rewriting --------------------------------------------------------------
+
+
+def test_editing_the_value_rewrites_the_triple():
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "source", "old")
+    assert _apply_annotation_edit(
+        ont, NS + "Person", _ann(ont, DCT + "source"), DCT + "source", "new", ""
+    )
+    assert _ann(ont, DCT + "source")["value"] == "new"
+
+
+def test_an_unchanged_edit_reports_no_change():
+    """So the caller does not take an undo checkpoint for a no-op."""
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "source", "same")
+    ann = _ann(ont, DCT + "source")
+    assert not _apply_annotation_edit(
+        ont, NS + "Person", ann, DCT + "source", "same", ""
+    )
+
+
+def test_a_datatype_survives_an_edit_of_the_value():
+    """The engine had no way to re-add a typed literal, so a rewrite used to
+    drop ``^^xsd:date`` the user never touched."""
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "created", "2024-01-01", datatype="date")
+    ann = _ann(ont, DCT + "created")
+    assert ann["datatype"] == "date"
+
+    assert _apply_annotation_edit(
+        ont, NS + "Person", ann, DCT + "created", "2025-02-02", ""
+    )
+    after = _ann(ont, DCT + "created")
+    assert after["value"] == "2025-02-02"
+    assert after["datatype"] == "date"
+
+
+def test_a_language_tag_survives_an_edit_of_the_value():
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "title", "Hello", lang="en")
+    ann = _ann(ont, DCT + "title")
+    assert _apply_annotation_edit(ont, NS + "Person", ann, DCT + "title", "Hallo", "de")
+    after = _ann(ont, DCT + "title")
+    assert (after["value"], after["language"]) == ("Hallo", "de")
+
+
+def test_a_rejected_predicate_puts_the_original_back():
+    """The rewrite is a delete then an add, so a rejected add must not leave the
+    user with neither."""
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "source", "keepme")
+    ann = _ann(ont, DCT + "source")
+
+    assert not _apply_annotation_edit(
+        ont, NS + "Person", ann, "nosuchprefix:thing", "changed", ""
+    )
+    survived = _ann(ont, DCT + "source")
+    assert survived["value"] == "keepme"
+
+
+def test_a_rejected_predicate_does_not_duplicate_the_original():
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "source", "keepme")
+    ann = _ann(ont, DCT + "source")
+    _apply_annotation_edit(ont, NS + "Person", ann, "nosuchprefix:thing", "changed", "")
+    assert (
+        len(
+            [
+                a
+                for a in ont.get_annotations(NS + "Person")
+                if a["predicate"] == "source"
+            ]
+        )
+        == 1
+    )
+
+
+# --- the engine gap this needed ---------------------------------------------
+
+
+@pytest.mark.parametrize("dt", ["date", "integer", "boolean"])
+def test_add_annotation_can_now_write_a_typed_literal(dt):
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "x", "1", datatype=dt)
+    assert _ann(ont, DCT + "x")["datatype"] == dt
+
+
+def test_a_language_tag_wins_over_a_datatype():
+    """RDF literals carry one or the other, never both."""
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "y", "v", lang="en", datatype="date")
+    ann = _ann(ont, DCT + "y")
+    assert ann.get("language") == "en"
+    assert not ann.get("datatype")


### PR DESCRIPTION
Closes #223.

Annotations were the one thing on the graph you could not edit, and the reason turned out to be structural rather than a decision anyone made: **annotation values were drawn as anonymous nodes.** Unlike classes, individuals, data properties and SKOS concepts, they carried no type and no identity, so clicking one gave the details panel nothing to resolve and it fell through to printing the tooltip text.

## Giving an annotation an identity

Their node ids were also *counted in iteration order* (`ann_1`, `ann_2`, …), so a node was renamed whenever anything before it changed.

An annotation has no URI of its own, it **is** a triple. So it is now named by its parts, exactly as the relations and restrictions drawn as edges already are: subject, predicate, value, and the language or datatype that tells two otherwise identical literals apart. That is the same key `delete_annotation` matches on, and being content-derived it survives a rebuild.

The panel then resolves the node and offers predicate, value and language, plus delete, alongside the editors for the other kinds. This is the plumbing you predicted in the issue, and it is the same plumbing "add an annotation from the graph" will need in #221.

## An engine gap this exposed

`add_annotation` could not write a typed literal: it only ever produced `Literal(value)` or `Literal(value, lang=...)`. Since an edit is a **delete plus an add**, rewriting a value would have silently dropped a `^^xsd:date` the user never touched.

It now takes an optional `datatype`, resolved exactly as `delete_annotation` already resolved one, so a typed annotation round-trips. A language tag still wins over a datatype, since RDF literals carry one or the other, never both. The panel shows `Datatype: date (kept)` rather than leaving that invisible.

## Failing halfway

Delete-then-add can fail in the middle: `add` rejects an unusable predicate (an unbound prefix above all), and by then the original is gone. A rejected add **puts the original back** and reports the reason, so an edit that cannot be applied does not cost you the annotation.

`_apply_annotation_edit` is in the checkpoint test's `CHECKPOINTED_BY_CALLER` set for the documented reason: the panel checkpoints on the True return, and the rollback path returns False having already restored the graph.

## Verified live

Imported a class with `dcterms:source "Wikidata Q5"` and `dcterms:created "2024-01-01"^^xsd:date`:

| step | result |
| --- | --- |
| inspect the graph payload | both annotation nodes now carry `ntype="Annotation"` and a full identity including the `date` datatype |
| click the typed one | panel shows the editor: On Person, Predicate, Value, Language, `Datatype: date (kept)`, Save, Delete |
| change the value, Save | Source shows `dcterms:created "2025-06-15"^^xsd:date`, datatype intact |

843 tests pass, ruff 0.16.1 and mypy clean. `tests/test_viz_annotation_edit.py` covers the identity (content-derived not positional, two values of one predicate, language as part of the key) and the rewrite (datatype and language survive, no-op reports no change, a rejected predicate restores the original without duplicating it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)