### PR TITLE
chore: bump version to 1.19.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.19.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.19.1` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -17,7 +17,7 @@ import streamlit as st
 from . import local_store
 
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.19.0"
+APP_VERSION = "1.19.1"
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.19.0"
+version = "1.19.1"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.19.0"
+version = "1.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Release bump for v1.19.1, covering #241 and #242.

Updated in all four places: `pyproject.toml`, `APP_VERSION`, the Docker pin example in `README.md`, and `uv.lock`. The PyPI badge is dynamic.

**Lockfile check:** extracting every `name`/`version` pair before and after shows exactly one difference, this package's own. No dependency was upgraded as a side effect.

875 tests pass, ruff 0.16.1 and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)