### PR TITLE
fix: draw the Find target even when a later filter change hid it (#234)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -9054,7 +9054,21 @@ def render_visualization():
                 ):
                     if node_count >= max_nodes:
                         break
-                    if cls["uri"] not in visible_class_uris:
+                    # The entity picked in Find is drawn even when the node
+                    # filter hides it: you asked to see it, and a graph that
+                    # silently omits it looks broken rather than filtered.
+                    #
+                    # Checked here, against the live filter, rather than by
+                    # un-hiding it in the filter when the pick happens. That
+                    # un-hiding ran once per pick, so an entity that was visible
+                    # when picked and hidden by a *later* filter change was never
+                    # revealed again: the pick had not changed, so nothing
+                    # re-ran, and the app went on telling the viewer to centre on
+                    # a node it had not sent (issue #234).
+                    if (
+                        cls["uri"] not in visible_class_uris
+                        and _uid(cls["uri"]) != _find_id
+                    ):
                         continue
                     cls_node_id = _uid(cls["uri"])
                     disp_cls_name = _disambiguated_name(cls, cls_collisions)
@@ -9257,7 +9271,11 @@ def render_visualization():
                     # Individuals filter (issue #196). Focus mode builds the full
                     # graph and prunes afterwards, so it ignores the filter the
                     # same way the class one does.
-                    if not focus_mode and ind["uri"] not in selected_ind_uris:
+                    if (
+                        not focus_mode
+                        and ind["uri"] not in selected_ind_uris
+                        and f"ind_{_uid(ind['uri'])}" != _find_id
+                    ):
                         continue
                     ind_node_id = f"ind_{_uid(ind['uri'])}"
                     disp_ind_name = _disambiguated_name(ind, ind_collisions)

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -8592,6 +8592,11 @@ def render_visualization():
         # sits beside the Filter Classes expander so it doesn't cost the graph a
         # whole row; the empty state is a placeholder (clearable), not a "—" row.
         _find_id: str | None = None
+        # Whether that target is a class. Class node ids carry no prefix, so the
+        # kind cannot be read back off the id the way the others can, and the
+        # class loop's own guard needs it: an emptied filter would otherwise skip
+        # the loop before the per-node bypass could run (issue #234 review).
+        _find_is_class = False
         focus_seed_ids: list = []
         focus_depth = 0
         _find_col, _filter_col = st.columns([1, 3])
@@ -8610,6 +8615,9 @@ def render_visualization():
                 )
                 if _find_choice:
                     _find_id = focus_targets.get(_find_choice)
+                    _find_is_class = bool(_find_id) and _find_choice.startswith(
+                        "Class: "
+                    )
                     # The target may currently be hidden — by one of the display
                     # filters, or pruned away in focus mode — in which case its
                     # node isn't in the graph and the JS focus() would silently
@@ -8620,24 +8628,12 @@ def render_visualization():
                     _cur_seq = st.session_state.get("_viz_find_seq", 0)
                     if st.session_state.get("_viz_find_revealed_seq") != _cur_seq:
                         st.session_state["_viz_find_revealed_seq"] = _cur_seq
-                        _label, _, _name = _find_choice.partition(": ")
                         _reveal_rerun = False
-                        # Every filterable kind can hide its entity, so look the
-                        # picked label up across them rather than only classes.
-                        for _fk in _FILTER_KINDS:
-                            if _label != _fk["singular"]:
-                                continue
-                            _key = _fk["key"]
-                            _uri = filters[_key]["uri_by_display"].get(_name)
-                            _sel = list(
-                                st.session_state.get(f"_viz_cfg_selected_{_key}_uris")
-                                or []
-                            )
-                            if _uri and _uri not in _sel:
-                                st.session_state[f"_viz_cfg_selected_{_key}_uris"] = (
-                                    _sel + [_uri]
-                                )
-                                _reveal_rerun = True
+                        # A node filter hiding the target is handled where the
+                        # graph is built, against the live filter, so nothing is
+                        # written back here. Un-hiding it once per pick both
+                        # rewrote a filter the user had set and went stale the
+                        # moment a later filter change hid it again (issue #234).
                         if st.session_state.get("_viz_cfg_focus_mode"):
                             _seeds = list(
                                 st.session_state.get("_viz_cfg_focus_seeds") or []
@@ -9048,7 +9044,7 @@ def render_visualization():
             skos_node_ids: set = set()
 
             # Add classes as nodes (only selected classes)
-            if show_classes and selected_classes:
+            if show_classes and (selected_classes or _find_is_class):
                 for cls in prioritise_find_target(
                     classes, lambda c: _uid(c["uri"]), _find_id
                 ):

--- a/tests/test_viz_node_cap.py
+++ b/tests/test_viz_node_cap.py
@@ -86,11 +86,25 @@ def _script():
         if os.environ.get("FIND"):
             # What picking an entity in "Find and centre" leaves behind.
             st.session_state["viz_find_entity"] = os.environ["FIND"]
+        if os.environ.get("HIDE"):
+            # A narrowed node filter that does *not* include the Find target,
+            # and a find-seq already marked as revealed: the state left behind
+            # when an entity was visible at the moment it was picked and a later
+            # filter change hid it (issue #234).
+            keep = set(os.environ["HIDE"].split())
+            st.session_state["_viz_cfg_selected_class_uris"] = [
+                c["uri"] for c in om.get_classes() if c["name"] in keep
+            ]
+            st.session_state["_viz_cfg_known_class_uris"] = {
+                c["uri"] for c in om.get_classes()
+            }
+            st.session_state["_viz_find_seq"] = 1
+            st.session_state["_viz_find_revealed_seq"] = 1
 
     app.render_visualization()
 
 
-def _graph(n_classes, seed="", shape="chain", depth=1, find="", extra=""):
+def _graph(n_classes, seed="", shape="chain", depth=1, find="", extra="", hide=""):
     """Render once and return ``(nodes, edges, notice)``. An empty seed means
     focus mode off; ``find`` is an entity picked in "Find and centre"."""
     os.environ["N_CLASSES"] = str(n_classes)
@@ -99,6 +113,7 @@ def _graph(n_classes, seed="", shape="chain", depth=1, find="", extra=""):
     os.environ["DEPTH"] = str(depth)
     os.environ["FIND"] = find
     os.environ["EXTRA"] = extra
+    os.environ["HIDE"] = hide
     at = AppTest.from_function(_script)
     at.run(timeout=300)
     assert not at.exception, at.exception
@@ -307,3 +322,23 @@ def test_a_data_property_find_target_is_drawn_even_if_its_domain_was_capped_out(
         over, find="Data Property: findMe", extra="dprop_capped_domain"
     )
     assert "findMe" in {n.get("label") for n in nodes}
+
+
+def test_a_find_target_hidden_by_a_later_filter_change_is_still_drawn():
+    """The state the reporter was in: the entity was visible when they picked
+    it, so nothing needed revealing and the find-seq was marked done; a later
+    filter change then hid it. The pick had not changed, so the once-per-pick
+    reveal never ran again and the graph never got the node, while the app went
+    on telling the viewer to centre on it (issue #234)."""
+    keep = "C0001 C0002 C0003"
+    nodes, _, _ = _graph(40, find="Class: C0007", hide=keep)
+    labels = {n.get("label") for n in nodes}
+    assert "C0007" in labels, "the entity asked for is missing from the graph"
+
+
+def test_the_node_filter_still_hides_everything_else():
+    """Only the entity you asked for is exempt; the filter is otherwise honoured."""
+    keep = "C0001 C0002 C0003"
+    nodes, _, _ = _graph(40, find="Class: C0007", hide=keep)
+    labels = {n.get("label") for n in nodes}
+    assert labels == {"C0001", "C0002", "C0003", "C0007"}

--- a/tests/test_viz_node_cap.py
+++ b/tests/test_viz_node_cap.py
@@ -100,11 +100,28 @@ def _script():
             }
             st.session_state["_viz_find_seq"] = 1
             st.session_state["_viz_find_revealed_seq"] = 1
+        if os.environ.get("HIDE_ALL"):
+            # The filter emptied completely, with the reveal already marked done.
+            st.session_state["_viz_cfg_selected_class_uris"] = []
+            st.session_state["_viz_cfg_known_class_uris"] = {
+                c["uri"] for c in om.get_classes()
+            }
+            st.session_state["_viz_find_seq"] = 1
+            st.session_state["_viz_find_revealed_seq"] = 1
 
     app.render_visualization()
 
 
-def _graph(n_classes, seed="", shape="chain", depth=1, find="", extra="", hide=""):
+def _graph(
+    n_classes,
+    seed="",
+    shape="chain",
+    depth=1,
+    find="",
+    extra="",
+    hide="",
+    hide_all=False,
+):
     """Render once and return ``(nodes, edges, notice)``. An empty seed means
     focus mode off; ``find`` is an entity picked in "Find and centre"."""
     os.environ["N_CLASSES"] = str(n_classes)
@@ -114,6 +131,7 @@ def _graph(n_classes, seed="", shape="chain", depth=1, find="", extra="", hide="
     os.environ["FIND"] = find
     os.environ["EXTRA"] = extra
     os.environ["HIDE"] = hide
+    os.environ["HIDE_ALL"] = "1" if hide_all else ""
     at = AppTest.from_function(_script)
     at.run(timeout=300)
     assert not at.exception, at.exception
@@ -342,3 +360,41 @@ def test_the_node_filter_still_hides_everything_else():
     nodes, _, _ = _graph(40, find="Class: C0007", hide=keep)
     labels = {n.get("label") for n in nodes}
     assert labels == {"C0001", "C0002", "C0003", "C0007"}
+
+
+def test_a_find_target_survives_an_emptied_class_filter():
+    """Clearing the filter entirely skips the class loop before the per-node
+    bypass can run, so the entity asked for disappeared with everything else."""
+    nodes, _, _ = _graph(40, find="Class: C0007", hide_all=True)
+    assert {n.get("label") for n in nodes} == {"C0007"}
+
+
+def test_find_does_not_rewrite_the_users_node_filter():
+    """Picking an entity used to un-hide it by editing the filter, which both
+    changed a setting the user had chosen and went stale as soon as a later
+    filter change hid it again. The graph exempts it at build time instead, so
+    the filter is left exactly as it was found."""
+    import ast
+    import pathlib
+
+    src = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "orionbelt_ontology_builder/app.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    handlers = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If) and "_viz_find_revealed_seq" in ast.dump(node.test)
+    ]
+    assert handlers, "the Find reveal handler was not found"
+    for handler in handlers:
+        for node in ast.walk(handler):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                dumped = ast.dump(target)
+                assert not ("_viz_cfg_selected_" in dumped and "_uris" in dumped), (
+                    f"line {node.lineno}: Find must not write the node filter; "
+                    "the graph exempts the target at build time instead"
+                )


### PR DESCRIPTION
Closes #234, properly this time. @SuperCowProducts supplied their ontology and their exact class list, which is what made this findable.

### Why the previous fix was not enough

#242 fixed the render cap, and their ontology genuinely has 629 classes, so the cap was in play. But with their 25 classes selected the graph draws only **47 nodes**, nowhere near the cap. What they were still hitting is a different mechanism.

### Root cause

The picked entity was un-hidden by **rewriting the node filter, once per pick**, guarded by the find sequence. But whether that entity is visible depends on the **filter**, which changes independently and afterwards, while the sequence only moves when the **pick** changes.

Instrumenting the live interaction showed it exactly:

```
DBG find choice='Class: sin' cur_seq=1 revealed_seq=None      <- picked while visible
DBG reveal kind=class name='sin' uri='...#sin' in_sel=True    <- nothing to reveal
DBG find choice='Class: sin' cur_seq=1 revealed_seq=1         <- filter narrowed, sin now hidden
DBG find choice='Class: sin' cur_seq=1 revealed_seq=1         <- never runs again
```

So the failing order is: pick an entity while it is visible, so nothing needs revealing and the sequence is marked done; then narrow the filter so it is hidden. The pick has not changed, the sequence has not moved, and the reveal never runs again. The graph never gets the node, while the app goes on telling the viewer to centre on it, which throws `Node: 5ec7fc41cbb4 cannot be found` in the console and refits the whole graph: **movement, with nothing in view**.

Both of their observations follow from this:

* **"It works after clicking Clear value"** — clearing and re-picking is two selection changes, so the sequence moves and the reveal runs.
* **"more classes makes it likelier"** — more filter churn after a pick means more chances for the picked entity to end up outside it.

### The fix

Draw the target **regardless of the filter**, checked against the live filter on every render so it cannot go stale, the same way the render cap already exempts it.

That also stops the app silently rewriting the user's filter behind their back. Nothing else is exempt: the filter is otherwise honoured exactly as before, and there is a test asserting only the picked entity gets through.

### Verified against the reporter's own data

Their ontology, their 25-class list, picking `Class: sin` through the real widget:

| | before | after |
| --- | --- | --- |
| nodes drawn | 47 | **48** |
| `sin` in the graph | no | **yes** |
| selected / camera | none | **selected, scale 1.1** |
| console | `Node ... cannot be found` | clean |

### Tests

877 pass, ruff 0.16.1 and mypy clean. Two new tests, both failing without the fix: the target hidden by a later filter change is drawn, and the filter still hides everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)