### PR TITLE
fix: bow opposite-running parallel edges apart, not on top of each other (#245)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -9874,18 +9874,29 @@ def render_visualization():
             for edge in net.edges:
                 key = tuple(sorted((edge["from"], edge["to"])))
                 _edge_groups[key].append(edge)
-            for group in _edge_groups.values():
+            for (_first, _second), group in _edge_groups.items():
                 if len(group) < 2:
                     continue
                 # Alternate sides, widening every second edge, so each edge of a
-                # pair gets a distinct (side, roundness). The old arithmetic gave
-                # index 2 the same curve as index 0 — `(i + 1) // 2` is 1 for
-                # both i=1 and i=2 — so from three parallel edges upwards the
-                # third lay exactly on top of the first (issue #245).
+                # pair gets a distinct curve. Two things this has to get right:
+                #
+                # The step. `(i + 1) // 2` was 1 for both i=1 and i=2, so from
+                # three parallel edges upwards the third lay exactly on top of
+                # the first.
+                #
+                # The direction. curvedCW is clockwise *along the edge's own*
+                # from-to, so two edges pointing opposite ways cancel out: give
+                # one CW and the other CCW, as plain alternation does, and they
+                # land on the same side of the pair rather than either side of
+                # it. Flipping the label for an edge that runs against the
+                # group's canonical order makes the side absolute, so
+                # `A disjointWith B` and `B nextItem A` bow apart (issue #245).
                 for i, edge in enumerate(group):
+                    _runs_backwards = edge["from"] != _first
+                    _clockwise = (i % 2 == 0) != _runs_backwards
                     edge["smooth"] = {
                         "enabled": True,
-                        "type": "curvedCW" if i % 2 == 0 else "curvedCCW",
+                        "type": "curvedCW" if _clockwise else "curvedCCW",
                         "roundness": 0.2 * (i // 2 + 1),
                     }
 

--- a/tests/test_viz_parallel_edges.py
+++ b/tests/test_viz_parallel_edges.py
@@ -32,17 +32,31 @@ def _script():
         om.add_class("B")
         # As many relations between the same pair as asked for. Three is the
         # count the old arithmetic broke on: the third repeated the first.
-        for rel in list(om.CLASS_RELATIONS)[: int(os.environ["N_RELS"])]:
-            om.add_class_relation("A", rel, "B")
+        rels = list(om.CLASS_RELATIONS)[: int(os.environ["N_RELS"])]
+        for n, rel in enumerate(rels):
+            # MIXED points every second relation the other way, which is the
+            # case the reporter hit: "A disjointWith B" alongside
+            # "B nextItem A" (issue #245).
+            if os.environ.get("MIXED") and n % 2:
+                om.add_class_relation("B", rel, "A")
+            else:
+                om.add_class_relation("A", rel, "B")
         st.session_state.ontology = om
         st.session_state["_autosave_restored"] = True
         st.session_state["_viz_settings_restored"] = True
     app.render_visualization()
 
 
-def _curves(n_rels):
-    """Render and return the (type, roundness) of every A-to-B edge."""
+def _curves(n_rels, mixed=False):
+    """Render and return each A-B edge's curve as an *absolute* side.
+
+    ``curvedCW`` is clockwise along the edge's own from-to, so the raw label
+    says nothing on its own: two edges pointing opposite ways with opposite
+    labels sit on the same side of the pair. Normalising to the group's
+    canonical order is what the eye actually sees.
+    """
     os.environ["N_RELS"] = str(n_rels)
+    os.environ["MIXED"] = "1" if mixed else ""
     at = AppTest.from_function(_script)
     at.run(timeout=300)
     assert not at.exception, at.exception
@@ -51,11 +65,15 @@ def _curves(n_rels):
     groups = defaultdict(list)
     for edge in edges:
         groups[tuple(sorted((edge["from"], edge["to"])))].append(edge)
-    biggest = max(groups.values(), key=len)
-    return [
-        (e.get("smooth", {}).get("type"), e.get("smooth", {}).get("roundness"))
-        for e in biggest
-    ]
+    key, biggest = max(groups.items(), key=lambda kv: len(kv[1]))
+    out = []
+    for edge in biggest:
+        smooth = edge.get("smooth") or {}
+        side = smooth.get("type")
+        if side and edge["from"] != key[0]:
+            side = "curvedCCW" if side == "curvedCW" else "curvedCW"
+        out.append((side, smooth.get("roundness")))
+    return out
 
 
 @pytest.mark.parametrize("n_rels", [2, 3])
@@ -87,3 +105,19 @@ def test_a_single_edge_is_left_alone():
     edges = json.loads(at.session_state["last_graph_data"]["edges"])
     assert edges, "no edge was drawn"
     assert all("smooth" not in e for e in edges)
+
+
+@pytest.mark.parametrize("n_rels", [2, 3])
+def test_edges_pointing_opposite_ways_still_bow_apart(n_rels):
+    """The reported case: `A disjointWith B` next to `B nextItem A`.
+
+    Alternating the label alone puts these on the *same* side, because the
+    label is relative to each edge's own direction and the two flips cancel.
+    """
+    curves = _curves(n_rels, mixed=True)
+    assert len(set(curves)) == n_rels, f"overlapping curves in {curves}"
+
+
+def test_a_reversed_pair_lands_on_opposite_sides():
+    sides = [side for side, _ in _curves(2, mixed=True)]
+    assert set(sides) == {"curvedCW", "curvedCCW"}


### PR DESCRIPTION
Closes #245. Follow-up to #248, which fixed the arithmetic and left the harder half — the half that was actually being reported.

### I read the first report wrong

I concluded `sine` and `cosine` had only one edge between them and that the crowding was two edges sharing an endpoint. That was an artefact of the class selection I happened to use. With the reporter's own selection they have exactly two, and they are the two named in the report:

```
cosine -> sine    nextItem      smooth=curvedCW  0.2
sine   -> cosine  disjointWith  smooth=curvedCCW 0.2
```

### Root cause

`curvedCW` is clockwise along the edge's **own** from-to, so the label alone says nothing about which side of the pair an edge ends up on. Alternating CW/CCW by index separates edges that point the same way. For edges pointing **opposite** ways it does the reverse: the two flips cancel, and the pair lands on the same side, labels and all.

That is why one pair in the screenshot looked neat and the other did not, with no difference in the code. The neat one happened to have both edges running the same direction.

### The fix

Flip the label for any edge running against the group's canonical (sorted) order, so the side is absolute rather than relative to each edge. Same-direction groups come out exactly as before.

The reporter's pair now emits `curvedCCW` for both, which on opposite-running edges is opposite sides — confirmed in the browser, where the red `disjointWith` and blue `nextItem` bow apart with their labels clear of each other.

### Tests

901 pass, ruff 0.16.1 and mypy clean.

The tests in #248 could not have caught this: they built every relation in the same direction, so the case never arose. They now assert the **absolute** side, normalised to the group's canonical order, rather than the raw label — the raw label is exactly the thing that misled me — and there is a mixed-direction case for 2 and 3 edges. All three new assertions fail against #248 as merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)