### PR TITLE
feat: move an annotation to another resource from the graph (#251)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -2075,7 +2075,9 @@ def restriction_references_class(restriction_type: str) -> bool:
     )
 
 
-def _apply_annotation_edit(ont, subject_uri, ann, new_pred, new_value, new_lang):
+def _apply_annotation_edit(
+    ont, subject_uri, ann, new_pred, new_value, new_lang, new_subject_uri=None
+):
     """Rewrite one annotation. Returns True when the graph changed (issue #223).
 
     An annotation is a triple, and the engine has no update for one, so an edit
@@ -2093,10 +2095,14 @@ def _apply_annotation_edit(ont, subject_uri, ann, new_pred, new_value, new_lang)
     datatype = ann.get("datatype_uri") or ann.get("datatype")
     is_uri = bool(ann.get("is_uri"))
     old_pred = ann.get("predicate_uri") or ann["predicate"]
+    # Moving an annotation to another resource is the same delete-then-add, just
+    # landing somewhere else, so it rides the same guards and rollback (#251).
+    target_uri = new_subject_uri or subject_uri
     if (
         new_pred == old_pred
         and new_value == ann["value"]
         and (new_lang or None) == (ann.get("language") or None)
+        and target_uri == subject_uri
     ):
         return False
 
@@ -2110,7 +2116,7 @@ def _apply_annotation_edit(ont, subject_uri, ann, new_pred, new_value, new_lang)
     )
     try:
         ont.add_annotation(
-            subject_uri,
+            target_uri,
             new_pred,
             new_value,
             lang=None if is_uri else (new_lang or None),
@@ -2313,7 +2319,34 @@ def _apply_individual_edit(
     return True
 
 
-def _render_panel_annotation_editor(ont, ename):
+def annotation_subject_options(classes, object_props, data_props, individuals):
+    """Everything an annotation can hang off, as ``(options, display -> URI)``.
+
+    Built per kind and tagged with it, so a class and an individual sharing a
+    name stay apart, and keyed by URI throughout: local names collide across
+    namespaces, and moving an annotation onto the wrong same-named resource
+    would be silent (issue #251).
+    """
+    options: list[str] = []
+    lookup: dict[str, str] = {}
+    for kind, items in (
+        ("Class", classes),
+        ("Object Property", object_props),
+        ("Data Property", data_props),
+        ("Individual", individuals),
+    ):
+        kind_options, kind_lookup = build_uri_options(items)
+        for display in kind_options:
+            tagged = f"{display} [{kind}]"
+            options.append(tagged)
+            lookup[tagged] = kind_lookup[display]
+    options.sort(key=str.lower)
+    return options, lookup
+
+
+def _render_panel_annotation_editor(
+    ont, ename, classes, object_props, data_props, individuals
+):
     """Edit the annotation behind a graph node, in the Details panel (#223).
 
     The node names the whole triple, which is looked up in the live ontology for
@@ -2343,8 +2376,28 @@ def _render_panel_annotation_editor(ont, ename):
         )
         return
 
-    st.caption(f"On {_uri_local_name(subject_uri)}")
+    subject_options, subject_lookup = annotation_subject_options(
+        classes, object_props, data_props, individuals
+    )
+    # An annotation can sit on something the picker does not list — the ontology
+    # itself, a SKOS concept — and an unlisted subject would otherwise select the
+    # first entry, so saving an untouched annotation would quietly move it. Offer
+    # the current subject as its own option instead, the way the relation editor
+    # offers an external URI (issue #251).
+    if subject_uri not in set(subject_lookup.values()):
+        _own = f"{_uri_local_name(subject_uri)} [current]"
+        subject_options = [_own, *subject_options]
+        subject_lookup[_own] = subject_uri
     with st.form(f"panel_edit_ann_{_uid(ename)}"):
+        # Which resource it hangs off is editable, so an annotation can be moved
+        # the way a relation or restriction can be re-pointed from here (#251).
+        new_subject = st.selectbox(
+            "On",
+            options=subject_options,
+            index=_uri_option_index(subject_options, subject_lookup, subject_uri),
+            format_func=_pad_option,
+            help="Move the annotation by choosing a different resource.",
+        )
         new_pred = st.text_input(
             "Predicate",
             value=ann.get("predicate_uri") or ann["predicate"],
@@ -2394,7 +2447,13 @@ def _render_panel_annotation_editor(ont, ename):
         if not new_value.strip():
             show_message("Annotation value is required!", "error")
         elif _apply_annotation_edit(
-            ont, subject_uri, ann, new_pred, new_value, new_lang
+            ont,
+            subject_uri,
+            ann,
+            new_pred,
+            new_value,
+            new_lang,
+            new_subject_uri=subject_lookup.get(new_subject),
         ):
             save_checkpoint("Update annotation")
             show_message("Annotation updated!", "success")
@@ -2935,7 +2994,9 @@ def _render_panel_entity_editor(
     if ntype == "Annotation":
         # Like the two above, an annotation has no URI of its own: it resolves
         # from the identity its node carries, not from an entity pool (#223).
-        _render_panel_annotation_editor(ont, ename)
+        _render_panel_annotation_editor(
+            ont, ename, classes, object_props, data_props, individuals
+        )
         return None
 
     # Object properties are drawn as edges (so selecting one is a selectEdge with

--- a/tests/test_viz_annotation_edit.py
+++ b/tests/test_viz_annotation_edit.py
@@ -369,3 +369,181 @@ def test_a_literal_delete_is_unaffected_by_the_widened_match():
     assert not [
         a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "source"
     ]
+
+
+# --- moving an annotation to another resource (issue #251) -------------------
+
+
+def _subject_options(ont):
+    from orionbelt_ontology_builder.app import annotation_subject_options
+
+    return annotation_subject_options(
+        ont.get_classes(),
+        ont.get_object_properties(),
+        ont.get_data_properties(),
+        ont.get_individuals(),
+    )
+
+
+def test_an_annotation_moves_to_another_resource():
+    ont = _ont()
+    ont.add_class("Org")
+    ont.add_annotation(NS + "Person", DCT + "source", "Wikidata Q5")
+    ann = _ann(ont, DCT + "source")
+
+    assert _apply_annotation_edit(
+        ont,
+        NS + "Person",
+        ann,
+        DCT + "source",
+        "Wikidata Q5",
+        "",
+        new_subject_uri=NS + "Org",
+    )
+    assert not [
+        a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "source"
+    ]
+    moved = [a for a in ont.get_annotations(NS + "Org") if a["predicate"] == "source"]
+    assert [a["value"] for a in moved] == ["Wikidata Q5"]
+
+
+def test_a_move_carries_the_datatype():
+    """The move is the same delete-then-add, so it must not drop what an edit
+    in place already preserves."""
+    ont = _ont()
+    ont.add_class("Org")
+    ont.add_annotation(NS + "Person", DCT + "created", "2024-01-01", datatype="date")
+    ann = _ann(ont, DCT + "created")
+    assert _apply_annotation_edit(
+        ont,
+        NS + "Person",
+        ann,
+        DCT + "created",
+        "2024-01-01",
+        "",
+        new_subject_uri=NS + "Org",
+    )
+    moved = next(
+        a for a in ont.get_annotations(NS + "Org") if a["predicate"] == "created"
+    )
+    assert moved["datatype"] == "date"
+
+
+def test_a_move_keeps_a_resource_value_a_resource():
+    from rdflib import URIRef
+
+    ont = _ont()
+    ont.add_class("Org")
+    _resource(ont, "http://docs.example/person")
+    ann = next(
+        a for a in ont.get_annotations(NS + "Person") if a["predicate"] == "seeAlso"
+    )
+    assert _apply_annotation_edit(
+        ont,
+        NS + "Person",
+        ann,
+        SEE_ALSO,
+        "http://docs.example/person",
+        "",
+        new_subject_uri=NS + "Org",
+    )
+    objs = list(ont.graph.objects(ont._uri("Org"), URIRef(SEE_ALSO)))
+    assert [(type(o).__name__, str(o)) for o in objs] == [
+        ("URIRef", "http://docs.example/person")
+    ]
+    assert not list(ont.graph.objects(ont._uri("Person"), URIRef(SEE_ALSO)))
+
+
+def test_a_move_to_the_same_resource_is_not_a_change():
+    ont = _ont()
+    ont.add_annotation(NS + "Person", DCT + "source", "same")
+    ann = _ann(ont, DCT + "source")
+    assert not _apply_annotation_edit(
+        ont,
+        NS + "Person",
+        ann,
+        DCT + "source",
+        "same",
+        "",
+        new_subject_uri=NS + "Person",
+    )
+
+
+def test_a_failed_move_leaves_the_annotation_where_it_was():
+    """The add can be rejected after the delete, and the original subject is
+    where it has to go back to."""
+    ont = _ont()
+    ont.add_class("Org")
+    ont.add_annotation(NS + "Person", DCT + "source", "keepme")
+    ann = _ann(ont, DCT + "source")
+    assert not _apply_annotation_edit(
+        ont,
+        NS + "Person",
+        ann,
+        "nosuchprefix:thing",
+        "keepme",
+        "",
+        new_subject_uri=NS + "Org",
+    )
+    assert [
+        a["value"]
+        for a in ont.get_annotations(NS + "Person")
+        if a["predicate"] == "source"
+    ] == ["keepme"]
+    assert not [
+        a for a in ont.get_annotations(NS + "Org") if a["predicate"] == "source"
+    ]
+
+
+def test_the_subject_picker_offers_every_annotatable_kind():
+    ont = _ont()
+    ont.add_object_property("knows")
+    ont.add_data_property("age")
+    ont.add_individual("alice", "Person")
+    options, lookup = _subject_options(ont)
+    assert {lookup[o] for o in options} == {
+        NS + "Person",
+        NS + "knows",
+        NS + "age",
+        NS + "alice",
+    }
+
+
+def test_the_picker_says_what_kind_each_resource_is():
+    """A property and a class read alike otherwise, and moving an annotation
+    onto the wrong one is silent."""
+    ont = _ont()
+    ont.add_data_property("age")
+    options, _ = _subject_options(ont)
+    assert {o[o.rindex("[") :] for o in options} == {"[Class]", "[Data Property]"}
+
+
+def test_the_picker_keys_by_uri_across_namespaces():
+    """Two resources sharing a local name are different subjects, and the
+    picker has to be able to name both."""
+    from rdflib import OWL, RDF, URIRef
+
+    ont = _ont()
+    other = URIRef("http://elsewhere.example/o#Person")
+    ont.graph.add((other, RDF.type, OWL.Class))
+    options, lookup = _subject_options(ont)
+    for_person = [o for o in options if o.startswith("Person")]
+    assert len(for_person) == 2
+    assert len({lookup[o] for o in for_person}) == 2
+
+
+def test_an_unlisted_subject_is_offered_rather_than_silently_replaced():
+    """The picker covers classes, properties and individuals. An annotation on
+    anything else would otherwise select the first entry, so saving without
+    touching the subject would move the annotation to it."""
+    from orionbelt_ontology_builder.app import _uri_option_index
+
+    ont = _ont()
+    options, lookup = _subject_options(ont)
+    outsider = "http://example.org/ontology#"
+    assert outsider not in set(lookup.values())
+    # What the editor does when the current subject is not among the options.
+    own = f"{outsider} [current]"
+    options = [own, *options]
+    lookup[own] = outsider
+    assert lookup[options[_uri_option_index(options, lookup, outsider)]] == outsider


### PR DESCRIPTION
Closes #251.

Relations and restrictions can already be re-pointed from the details panel. Annotations could be edited there since #241 but not moved, because the panel *printed* the resource they hang off instead of offering it. It is a picker now.

### It reuses the rewrite rather than adding a second path

Moving is the same delete-then-add the edit already performs, just landing somewhere else, so it inherits every guard that came with it:

* the **datatype** and **language** survive the move
* a **resource-valued** annotation stays a resource rather than becoming a string
* a rejected predicate **rolls back to the original subject**, not the new one
* moving to where it already is reports **no change**, so no undo checkpoint is taken for a no-op

### Two things worth calling out

**Subjects are keyed by URI and tagged with their kind.** Local names collide across namespaces, and a picker keyed by name would move an annotation onto the wrong same-named resource silently. The tag distinguishes a class from a property that reads the same.

**An unlisted subject is offered as its own option.** The picker covers classes, properties and individuals. An annotation can sit on something else — the ontology itself, a SKOS concept — and an unlisted subject would have selected the first entry, so saving an *untouched* annotation would have moved it somewhere. I caught this because a comment I had written claimed the opposite of what the code did.

### Tests

910 pass, ruff 0.16.1 and mypy clean. Eight new tests cover the move, the datatype and resource-value cases, the rollback landing back on the original subject, the no-op, the kind tagging, URI keying across namespaces, and the unlisted subject.

### Verification note

The move logic is covered by unit tests, but I did **not** confirm the panel UI live this round: browser setup for this scenario failed repeatedly and I stopped rather than keep retrying. The change to the panel is thin — one caption replaced by a selectbox in a form that already existed and was verified live in #241 — but it is untested end to end, and I would rather say so than imply otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)