### PR TITLE
feat: pick the class for a restriction value instead of typing it (#250)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -5394,10 +5394,13 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
     )
     on_options, on_lookup = _slot_options(classes, rest.get("on_class_uri"))
 
-    # The value stays free text: it can be a class, a cardinality or a literal,
-    # and a form cannot swap the widget when the type picker changes. It is
-    # pre-filled as a full URI in the two cases where a bare local name would
-    # not round-trip (review P2):
+    # The value is a class, a cardinality or a literal depending on the type, so
+    # the type picker sits *outside* the form below: a form batches until submit
+    # and does not rerun when a widget inside it changes, so the value field
+    # could not follow the type and had to stay free text for every type
+    # (issue #250). Outside, changing the type reruns and the right widget
+    # appears. It is pre-filled as a full URI in the two cases where a bare local
+    # name would not round-trip (review P2):
     #   * an imported entity, since a local name resolves into the base
     #     namespace and would point at a different thing;
     #   * any resource-valued hasValue, since add_restriction stores a
@@ -5410,6 +5413,14 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
         rest["type"] == "hasValue" or not str(_value_uri).startswith(str(ont.namespace))
     ):
         value_default = str(_value_uri)
+
+    new_type = st.selectbox(
+        "Restriction Type",
+        types,
+        index=types.index(rest["type"]) if rest["type"] in types else 0,
+        key=f"er_type_{form_key}",
+    )
+    value_options, value_lookup = _slot_options(classes, rest.get("value_uri"))
 
     with st.form(f"edit_rest_form_{form_key}"):
         new_class = st.selectbox(
@@ -5428,19 +5439,33 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
             key=f"er_prop_{form_key}",
             format_func=_pad_option,
         )
-        new_type = st.selectbox(
-            "Restriction Type",
-            types,
-            index=types.index(rest["type"]) if rest["type"] in types else 0,
-            key=f"er_type_{form_key}",
-        )
-        new_value = st.text_input(
-            "Value",
-            value=value_default,
-            key=f"er_val_{form_key}",
-            help="A class name for someValuesFrom/allValuesFrom, a number for a "
-            "cardinality, or a literal for hasValue. A full URI is kept as it is.",
-        )
+        if restriction_value_is_class(new_type):
+            # someValuesFrom / allValuesFrom point at a class, so offer the
+            # classes rather than asking for the name to be typed (issue #250).
+            # A value the list does not hold — an imported class, an external
+            # URI — is offered as itself, so an unchanged row round-trips.
+            new_value = value_lookup.get(
+                st.selectbox(
+                    "Value (Class)",
+                    value_options,
+                    index=_uri_option_index(
+                        value_options, value_lookup, rest.get("value_uri")
+                    ),
+                    key=f"er_valcls_{form_key}",
+                    format_func=_pad_option,
+                )
+            )
+        else:
+            # Cardinalities and hasValue keep the free-text field: a number and a
+            # literal are what they are, and the engine already reports a bad
+            # one. Only the class-valued types gained a picker (issue #250).
+            new_value = st.text_input(
+                "Value",
+                value=value_default,
+                key=f"er_val_{form_key}",
+                help="A number for a cardinality, or a literal for hasValue. A "
+                "full URI is kept as it is.",
+            )
         new_on_class = None
         if restriction_takes_on_class(new_type):
             new_on_class = st.selectbox(

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -5420,7 +5420,14 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
         index=types.index(rest["type"]) if rest["type"] in types else 0,
         key=f"er_type_{form_key}",
     )
-    value_options, value_lookup = _slot_options(classes, rest.get("value_uri"))
+    # Carry the row's own value into the class picker only when it already names
+    # a class. A hasValue value is an individual or a literal, and offering it
+    # here let a switch to someValuesFrom write owl:someValuesFrom :alice, naming
+    # an individual where a class belongs (#250 review).
+    value_options, value_lookup = _slot_options(
+        classes,
+        rest.get("value_uri") if restriction_value_is_class(rest["type"]) else None,
+    )
 
     with st.form(f"edit_rest_form_{form_key}"):
         new_class = st.selectbox(

--- a/tests/test_restriction_edit_ui.py
+++ b/tests/test_restriction_edit_ui.py
@@ -40,6 +40,16 @@ def _click(at, label):
     next(b for b in at.button if b.label == label).click().run(timeout=120)
 
 
+def _pick_class(at, key, name):
+    """Choose a class in a value selectbox. Options are padded for search
+    ranking (see app.SEARCH_PAD_WIDTH), so match on the stripped label."""
+    box = at.selectbox(key=key)
+    option = next(
+        o for o in box.options if o.strip() == name or o.strip().startswith(name + " ")
+    )
+    box.set_value(option)
+
+
 def _open_row(at, index):
     at.session_state["active_rest"] = (str(index), "edit")
     at.run(timeout=120)
@@ -56,7 +66,7 @@ def test_editor_opens_with_the_rows_own_values():
 
     assert not at.exception, at.exception
     assert at.selectbox(key="er_type_0").value == "someValuesFrom"
-    assert at.text_input(key="er_val_0").value == "Engine"
+    assert at.selectbox(key="er_valcls_0").value.strip() == "Engine"
 
 
 def test_saving_edits_the_row_it_was_opened_for():
@@ -65,7 +75,7 @@ def test_saving_edits_the_row_it_was_opened_for():
     at.run(timeout=120)
     _open_row(at, 0)
 
-    at.text_input(key="er_val_0").set_value("Frame")
+    _pick_class(at, "er_valcls_0", "Frame")
     _click(at, "💾 Save")
 
     assert not at.exception, at.exception
@@ -94,7 +104,7 @@ def test_cancel_leaves_the_restriction_alone():
     at.run(timeout=120)
     _open_row(at, 0)
 
-    at.text_input(key="er_val_0").set_value("Frame")
+    _pick_class(at, "er_valcls_0", "Frame")
     _click(at, "Cancel")
 
     assert _rows(at.session_state["ontology"]) == [
@@ -109,7 +119,7 @@ def test_a_bad_cardinality_is_reported_and_changes_nothing():
     at.run(timeout=120)
     _open_row(at, 0)
 
-    at.selectbox(key="er_type_0").set_value("exactCardinality")
+    at.selectbox(key="er_type_0").set_value("exactCardinality").run(timeout=120)
     at.text_input(key="er_val_0").set_value("two")
     _click(at, "💾 Save")
 
@@ -127,7 +137,7 @@ def test_a_negative_cardinality_is_reported_and_changes_nothing():
     at.run(timeout=120)
     _open_row(at, 0)
 
-    at.selectbox(key="er_type_0").set_value("maxCardinality")
+    at.selectbox(key="er_type_0").set_value("maxCardinality").run(timeout=120)
     at.text_input(key="er_val_0").set_value("-1")
     _click(at, "💾 Save")
 
@@ -182,8 +192,10 @@ def test_an_imported_restriction_keeps_its_namespace_through_an_edit():
     _open_row(at, 0)
 
     assert not at.exception, at.exception
-    # The value is offered as its URI, so saving round-trips it.
-    assert at.text_input(key="er_val_0").value == "http://other.example/vocab#Bar"
+    # The imported class is a proper option now rather than a raw URI, and it
+    # maps back to its own URI, so saving round-trips it (issue #250). The
+    # assertions after the save are what prove that.
+    assert at.selectbox(key="er_valcls_0").value.strip() == "Bar"
 
     at.selectbox(key="er_type_0").set_value("allValuesFrom")
     _click(at, "💾 Save")
@@ -197,8 +209,13 @@ def test_an_imported_restriction_keeps_its_namespace_through_an_edit():
 
 
 def test_an_empty_value_is_reported_and_changes_nothing():
-    """It used to write owl:someValuesFrom : and destroy the original."""
-    at = AppTest.from_function(_script)
+    """It used to write owl:someValuesFrom : and destroy the original.
+
+    Driven through hasValue, which is still a free-text field. A class-valued
+    type cannot reach this any more: its picker has no empty option, which is
+    the point of #250 and is asserted below.
+    """
+    at = AppTest.from_function(_has_value_script)
     at.run(timeout=120)
     _open_row(at, 0)
 
@@ -207,10 +224,17 @@ def test_an_empty_value_is_reported_and_changes_nothing():
 
     assert not at.exception, at.exception
     assert any("needs a value" in e.value for e in at.error)
-    assert _rows(at.session_state["ontology"]) == [
-        ("hasPart", "someValuesFrom", "Engine"),
-        ("hasPart", "someValuesFrom", "Wheel"),
-    ]
+    assert at.session_state["ontology"].get_restrictions()[0]["value"] is not None
+
+
+def test_a_class_valued_restriction_cannot_be_emptied():
+    """The picker offers classes only, so there is no empty value to submit."""
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    options = at.selectbox(key="er_valcls_0").options
+    assert options and all(o.strip() for o in options)
 
 
 def _has_value_script():

--- a/tests/test_restriction_edit_ui.py
+++ b/tests/test_restriction_edit_ui.py
@@ -299,3 +299,18 @@ def test_a_hasvalue_literal_stays_a_literal():
     assert not at.exception, at.exception
     row = at.session_state["ontology"].get_restrictions()[0]
     assert row["value"] == "42" and row["value_uri"] is None
+
+
+def test_switching_a_hasvalue_row_to_a_class_type_offers_only_classes():
+    """A hasValue row's value is an individual or a literal. Carrying it into
+    the class picker let a type change write owl:someValuesFrom :alice, which
+    names an individual where a class belongs (#250 review)."""
+    at = AppTest.from_function(_has_value_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    at.selectbox(key="er_type_0").set_value("someValuesFrom").run(timeout=120)
+
+    options = [o.strip() for o in at.selectbox(key="er_valcls_0").options]
+    assert options == ["Person"], options
+    assert "alice" not in " ".join(options)

--- a/tests/test_viz_relation_restriction_edit.py
+++ b/tests/test_viz_relation_restriction_edit.py
@@ -190,8 +190,11 @@ def test_panel_edits_the_restriction_the_edge_stands_for(graph):
     )
     at = _run("panel", "Restriction", ename)
 
-    assert at.text_input(key=_panel_key(ename, "er_val")).value == "Wheel"
-    at.text_input(key=_panel_key(ename, "er_val")).set_value("Vehicle")
+    # someValuesFrom points at a class, so the value is a picker now (#250).
+    assert at.selectbox(key=_panel_key(ename, "er_valcls")).value.strip() == "Wheel"
+    _box = at.selectbox(key=_panel_key(ename, "er_valcls"))
+    # Options are padded for search ranking, so match on the stripped label.
+    _box.set_value(next(o for o in _box.options if o.strip() == "Vehicle"))
     _click(at, "💾 Save")
 
     assert not at.exception, at.exception
@@ -261,7 +264,11 @@ def test_open_full_editor_opens_the_restrictions_row(graph):
     at = _run("restrictions", ename=ename)
 
     # One editor, on the Wheel restriction rather than its Engine sibling.
-    values = [i.value for i in at.text_input if i.key and i.key.startswith("er_val_")]
+    values = [
+        s.value.strip()
+        for s in at.selectbox
+        if s.key and s.key.startswith("er_valcls_")
+    ]
     assert values == ["Wheel"]
     assert "_rest_open_edge" not in at.session_state
 


### PR DESCRIPTION
Closes #250.

`someValuesFrom` and `allValuesFrom` point at a class, but the value was free text while everywhere else offered a picker, so the class name had to be typed in full with no autocomplete and nothing to catch a typo.

### Why it was free text

The old comment on the field said it outright: *"a form cannot swap the widget when the type picker changes"*. A form batches until submit and does not rerun when a widget inside it changes, so the value field could not follow the type and had to stay free text for every type.

The type picker now sits **outside** the form, so changing it reruns and the right widget appears:

| type | value field |
| --- | --- |
| `someValuesFrom`, `allValuesFrom` | class picker |
| the cardinalities | free text |
| `hasValue` | free text |

Cardinalities and `hasValue` are a number and a literal, and were never the complaint, so they are untouched.

A value the class list does not hold — an imported class, an external URI — is offered as itself, so an unchanged row still round-trips.

### Verified live

* the edit form shows **Value (Class)** as a dropdown with no free-text Value field
* switching the type to `exactCardinality` swaps it to free text, and back to `someValuesFrom` swaps it to the picker: the thing the old comment said could not be done
* all three dropdowns filter as you type: `Per` narrows to `Person`, `o` narrows the property list to three

### Tests

911 pass, ruff 0.16.1 and mypy clean.

The existing tests drove a text input that class-valued rows no longer have, so they now drive the picker and let the extra rerun happen when they change the type. The empty-value guard moves to `hasValue`, where free text remains, since a picker cannot submit an empty class — with a new test asserting exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)