### PR TITLE
feat: clearable dropdowns, and an error when a required one is left empty

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -2211,17 +2211,20 @@ def render_add_class_form(ont, classes, form_key, parent_uri=None, on_close=None
         )
         label = st.text_input("Label", help="Human-readable label")
         comment = st.text_area("Comment", help="Description of the class")
-        parent_display = st.selectbox(
+        parent_display = clearable_selectbox(
             "Parent Class",
-            options=parent_options,
-            index=parent_index,
+            parent_options,
+            key=f"add_cls_parent_{form_key}",
+            current_display=parent_options[parent_index],
             help="Select a parent class for hierarchy",
             format_func=_pad_option,
         )
         ns_options, ns_lookup = build_namespace_options(ont)
-        ns_display = st.selectbox(
+        ns_display = clearable_selectbox(
             "Namespace",
-            options=ns_options,
+            ns_options,
+            key=f"add_cls_ns_{form_key}",
+            current_display=ns_options[0] if ns_options else None,
             help="Namespace the class is created in (default is the base URI)",
         )
 
@@ -2611,9 +2614,11 @@ def _render_panel_add_individual_form(ont, classes, individuals, ntype, ename):
         label = st.text_input("Label")
         comment = st.text_area("Comment")
         ns_options, ns_lookup = build_namespace_options(ont)
-        ns_display = st.selectbox(
+        ns_display = clearable_selectbox(
             "Namespace",
-            options=ns_options,
+            ns_options,
+            key="panel_add_ind_ns",
+            current_display=ns_options[0] if ns_options else None,
             help="Namespace the individual is created in (default is the base URI)",
         )
         add_col, cancel_col = st.columns(2)
@@ -2662,11 +2667,12 @@ def _render_panel_add_annotation_form(ont, subject_uri, subject_label):
     st.markdown(f"**Annotate {subject_label}**")
     options, lookup = annotation_predicate_options(ont)
     with st.form("panel_add_ann_form"):
-        predicate_display = st.selectbox(
+        predicate_display = required_selectbox(
             "Annotation Type",
-            options=options,
-            accept_new_options=True,
+            options,
             key="panel_ann_predicate",
+            current_display=options[0] if options else None,
+            accept_new_options=True,
             help=(
                 "Pick a type, or type your own to create it: a name like "
                 "`wikidataId`, a bound prefix like `wdt:P31`, or a full URI."
@@ -2690,6 +2696,9 @@ def _render_panel_add_annotation_form(ont, subject_uri, subject_label):
         _panel_close_add()
         st.rerun()
     if submitted:
+        if _missing := missing_required(**{"Annotation Type": predicate_display}):
+            show_message(_missing, "error")
+            return
         if not value.strip():
             show_message("Annotation value is required!", "error")
             return
@@ -3055,10 +3064,11 @@ def _render_panel_entity_editor(
             comment = st.text_area("Comment", value=entity["comment"])
             others = [c["name"] for c in classes if c["name"] != entity["name"]]
             cur = entity["parents"][0] if entity["parents"] else "None"
-            parent = st.selectbox(
+            parent = clearable_selectbox(
                 "Parent",
                 ["None"] + others,
-                index=others.index(cur) + 1 if cur in others else 0,
+                key=f"panel_edit_cls_parent_{_uid(entity['uri'])}",
+                current_display=cur if cur in others else "None",
             )
             if st.form_submit_button("Save", use_container_width=True):
                 if _apply_class_edit(ont, entity, name, label, comment, parent):
@@ -3075,10 +3085,11 @@ def _render_panel_entity_editor(
                 (d for d, u in cls_lookup.items() if u == entity.get("domain_uri", "")),
                 "None",
             )
-            dom = st.selectbox(
+            dom = clearable_selectbox(
                 "Domain",
                 cls_opts,
-                index=cls_opts.index(cur_dom) if cur_dom in cls_opts else 0,
+                key=f"panel_edit_prop_dom_{_uid(entity['uri'])}",
+                current_display=cur_dom if cur_dom in cls_opts else None,
                 format_func=_pad_option,
             )
             if ntype == "Object Property":
@@ -3090,10 +3101,11 @@ def _render_panel_entity_editor(
                     ),
                     "None",
                 )
-                rng = st.selectbox(
+                rng = clearable_selectbox(
                     "Range",
                     cls_opts,
-                    index=cls_opts.index(cur_rng) if cur_rng in cls_opts else 0,
+                    key=f"panel_edit_prop_rng_{_uid(entity['uri'])}",
+                    current_display=cur_rng if cur_rng in cls_opts else None,
                     format_func=_pad_option,
                 )
                 # Only apply when changed, so a range/domain that can't be shown
@@ -3110,20 +3122,31 @@ def _render_panel_entity_editor(
                     if entity["range"] in dts
                     else (dts[0] if dts else None)
                 )
-                rng = st.selectbox(
+                rng = required_selectbox(
                     "Range (datatype)",
                     dts,
-                    index=dts.index(default_rng) if default_rng in dts else 0,
+                    key=f"panel_edit_prop_dtrng_{_uid(entity['uri'])}",
+                    current_display=default_rng,
                 )
                 new_range = rng if rng != default_rng else None
             new_domain = (cls_lookup.get(dom) or "") if dom != cur_dom else None
             if st.form_submit_button("Save", use_container_width=True):
-                if _apply_property_edit(
-                    ont, entity, name, label, comment, new_domain, new_range
+                # A data property's range has no "no datatype" state to fall
+                # back on: cleared, it would read as "leave as-is" and the save
+                # would quietly do nothing to it.
+                if ntype == "Data Property" and (
+                    _missing := missing_required(**{"Range (datatype)": rng})
                 ):
-                    save_checkpoint("Update property")
-                    show_message("Property updated!", "success")
-                st.rerun()
+                    # No rerun: show_message draws inline, so rerunning here
+                    # would wipe the error before it was ever seen.
+                    show_message(_missing, "error")
+                else:
+                    if _apply_property_edit(
+                        ont, entity, name, label, comment, new_domain, new_range
+                    ):
+                        save_checkpoint("Update property")
+                        show_message("Property updated!", "success")
+                    st.rerun()
     elif ntype == "Individual":
         with st.form("panel_edit_ind"):
             name = st.text_input("Name", value=entity["name"])
@@ -3131,8 +3154,18 @@ def _render_panel_entity_editor(
             comment = st.text_area("Comment", value=entity["comment"])
             cur_classes = entity["classes"]
             avail = [c["name"] for c in classes if c["name"] not in cur_classes]
-            add_cls = st.selectbox("Add to class", ["None"] + avail)
-            rem_cls = st.selectbox("Remove from class", ["None"] + cur_classes)
+            add_cls = clearable_selectbox(
+                "Add to class",
+                ["None"] + avail,
+                key=f"panel_edit_ind_add_{_uid(entity['uri'])}",
+                current_display="None",
+            )
+            rem_cls = clearable_selectbox(
+                "Remove from class",
+                ["None"] + cur_classes,
+                key=f"panel_edit_ind_rem_{_uid(entity['uri'])}",
+                current_display="None",
+            )
             if st.form_submit_button("Save", use_container_width=True):
                 if _apply_individual_edit(
                     ont, entity, name, label, comment, add_cls, rem_cls
@@ -3784,17 +3817,13 @@ def render_classes():
                             current_parent = (
                                 cls["parents"][0] if cls["parents"] else "None"
                             )
-                            new_parent = st.selectbox(
+                            new_parent = clearable_selectbox(
                                 "Parent Class",
-                                options=["None"] + other_classes,
-                                index=0
-                                if current_parent == "None"
-                                else (
-                                    other_classes.index(current_parent) + 1
-                                    if current_parent in other_classes
-                                    else 0
-                                ),
+                                ["None"] + other_classes,
                                 key=f"par_{cls_uid}",
+                                current_display=current_parent
+                                if current_parent in other_classes
+                                else "None",
                             )
 
                             if st.form_submit_button("Save Changes"):
@@ -3867,10 +3896,11 @@ def render_classes():
         else:
             # Build options with disambiguated name · Label format; lookup is by URI
             class_options, class_lookup = build_class_options(classes)
-            selected_display = st.selectbox(
+            selected_display = clearable_selectbox(
                 "Select Class",
-                options=class_options,
+                class_options,
                 key="edit_class_select",
+                current_display=class_options[0] if class_options else None,
                 format_func=_pad_option,
             )
             selected_uri = class_lookup.get(selected_display)
@@ -3898,10 +3928,11 @@ def render_classes():
                     ns_index = _namespace_option_index(
                         ont, ns_options, ns_lookup, class_info["uri"]
                     )
-                    new_ns_display = st.selectbox(
+                    new_ns_display = required_selectbox(
                         "Namespace",
-                        options=ns_options,
-                        index=ns_index,
+                        ns_options,
+                        key=f"edit_cls_ns_{selected_uid}",
+                        current_display=ns_options[ns_index] if ns_options else None,
                         help="Moving to another namespace re-points every "
                         "reference to this class.",
                     )
@@ -3918,16 +3949,13 @@ def render_classes():
                     current_parent = (
                         class_info["parents"][0] if class_info["parents"] else "None"
                     )
-                    new_parent = st.selectbox(
+                    new_parent = clearable_selectbox(
                         "Parent Class",
-                        options=["None"] + other_classes,
-                        index=0
-                        if current_parent == "None"
-                        else (
-                            other_classes.index(current_parent) + 1
-                            if current_parent in other_classes
-                            else 0
-                        ),
+                        ["None"] + other_classes,
+                        key=f"edit_cls_parent_{selected_uid}",
+                        current_display=current_parent
+                        if current_parent in other_classes
+                        else "None",
                     )
 
                     col1, col2 = st.columns(2)
@@ -3938,7 +3966,14 @@ def render_classes():
                             "Delete Class", type="secondary"
                         )
 
-                    if update_btn:
+                    if update_btn and (
+                        _missing := missing_required(Namespace=new_ns_display)
+                    ):
+                        # An empty namespace reads as the base URI, so a cleared
+                        # one would move the class there and re-point every
+                        # reference, silently.
+                        show_message(_missing, "error")
+                    elif update_btn:
                         if _apply_class_edit(
                             ont,
                             class_info,
@@ -4251,18 +4286,21 @@ def render_properties():
                                 "no links are lost.",
                             )
                             ns_opts, ns_lookup = build_namespace_options(ont)
-                            new_namespace = ns_lookup.get(
-                                st.selectbox(
-                                    "Namespace",
-                                    options=ns_opts,
-                                    index=_namespace_option_index(
+                            ns_disp = required_selectbox(
+                                "Namespace",
+                                ns_opts,
+                                key=f"objp_ns_{prop_uid}",
+                                current_display=ns_opts[
+                                    _namespace_option_index(
                                         ont, ns_opts, ns_lookup, prop["uri"]
-                                    ),
-                                    key=f"objp_ns_{prop_uid}",
-                                    help="Moving to another namespace re-points "
-                                    "every reference to this property.",
-                                )
+                                    )
+                                ]
+                                if ns_opts
+                                else None,
+                                help="Moving to another namespace re-points "
+                                "every reference to this property.",
                             )
+                            new_namespace = ns_lookup.get(ns_disp)
                             new_name = _custom_uri_field(
                                 prop["uri"],
                                 new_name,
@@ -4294,27 +4332,35 @@ def render_properties():
                             )
                             col1, col2 = st.columns(2)
                             with col1:
-                                dom_disp = st.selectbox(
+                                dom_disp = clearable_selectbox(
                                     "Domain",
-                                    options=cls_opts,
-                                    index=cls_opts.index(cur_dom_disp)
-                                    if cur_dom_disp in cls_opts
-                                    else 0,
+                                    cls_opts,
                                     key=f"objp_dom_{prop_uid}",
+                                    current_display=cur_dom_disp
+                                    if cur_dom_disp in cls_opts
+                                    else None,
                                     format_func=_pad_option,
                                 )
                             with col2:
-                                rng_disp = st.selectbox(
+                                rng_disp = clearable_selectbox(
                                     "Range",
-                                    options=cls_opts,
-                                    index=cls_opts.index(cur_rng_disp)
-                                    if cur_rng_disp in cls_opts
-                                    else 0,
+                                    cls_opts,
                                     key=f"objp_rng_{prop_uid}",
+                                    current_display=cur_rng_disp
+                                    if cur_rng_disp in cls_opts
+                                    else None,
                                     format_func=_pad_option,
                                 )
 
                             if st.form_submit_button("Save Changes"):
+                                # An empty namespace reads as the base URI, so a
+                                # cleared one would move the property there and
+                                # re-point every reference to it. Flashed rather
+                                # than shown, since the rerun below would wipe
+                                # anything drawn inline here.
+                                if _missing := missing_required(Namespace=ns_disp):
+                                    set_flash_message(_missing, "error")
+                                    st.rerun()
                                 if (
                                     new_name
                                     and new_name != prop["name"]
@@ -4464,18 +4510,21 @@ def render_properties():
                                 "no links are lost.",
                             )
                             ns_opts, ns_lookup = build_namespace_options(ont)
-                            new_namespace = ns_lookup.get(
-                                st.selectbox(
-                                    "Namespace",
-                                    options=ns_opts,
-                                    index=_namespace_option_index(
+                            ns_disp = required_selectbox(
+                                "Namespace",
+                                ns_opts,
+                                key=f"dp_ns_{prop_uid}",
+                                current_display=ns_opts[
+                                    _namespace_option_index(
                                         ont, ns_opts, ns_lookup, prop["uri"]
-                                    ),
-                                    key=f"dp_ns_{prop_uid}",
-                                    help="Moving to another namespace re-points "
-                                    "every reference to this property.",
-                                )
+                                    )
+                                ]
+                                if ns_opts
+                                else None,
+                                help="Moving to another namespace re-points "
+                                "every reference to this property.",
                             )
+                            new_namespace = ns_lookup.get(ns_disp)
                             new_name = _custom_uri_field(
                                 prop["uri"],
                                 new_name,
@@ -4499,13 +4548,13 @@ def render_properties():
                             )
                             col1, col2 = st.columns(2)
                             with col1:
-                                dom_disp = st.selectbox(
+                                dom_disp = clearable_selectbox(
                                     "Domain",
-                                    options=cls_opts,
-                                    index=cls_opts.index(cur_dom_disp)
-                                    if cur_dom_disp in cls_opts
-                                    else 0,
+                                    cls_opts,
                                     key=f"dp_dom_{prop_uid}",
+                                    current_display=cur_dom_disp
+                                    if cur_dom_disp in cls_opts
+                                    else None,
                                     format_func=_pad_option,
                                 )
                             with col2:
@@ -4514,16 +4563,27 @@ def render_properties():
                                     if prop["range"] in datatypes
                                     else "string"
                                 )
-                                new_range = st.selectbox(
+                                new_range = required_selectbox(
                                     "Range (Datatype)",
-                                    options=datatypes,
-                                    index=datatypes.index(current_range)
-                                    if current_range in datatypes
-                                    else 0,
+                                    datatypes,
                                     key=f"dp_rng_{prop_uid}",
+                                    current_display=current_range,
                                 )
 
                             if st.form_submit_button("Save Changes"):
+                                # An empty namespace reads as the base URI, so a
+                                # cleared one would move the property there and
+                                # re-point every reference to it. Flashed rather
+                                # than shown, since the rerun below would wipe
+                                # anything drawn inline here.
+                                if _missing := missing_required(
+                                    **{
+                                        "Namespace": ns_disp,
+                                        "Range (Datatype)": new_range,
+                                    }
+                                ):
+                                    set_flash_message(_missing, "error")
+                                    st.rerun()
                                 if (
                                     new_name
                                     and new_name != prop["name"]
@@ -4595,21 +4655,31 @@ def render_properties():
                 )
                 with st.form("reuse_obj_prop_form"):
                     reuse_opts, reuse_lookup = build_uri_options(object_props)
-                    prop_disp = st.selectbox(
+                    prop_disp = required_selectbox(
                         "Existing property *",
-                        options=reuse_opts,
+                        reuse_opts,
+                        key="reuse_prop_existing",
+                        current_display=reuse_opts[0] if reuse_opts else None,
                         format_func=_pad_option,
                     )
 
                     cls_opts, cls_lookup = build_class_options(classes)
                     col1, col2 = st.columns(2)
                     with col1:
-                        source_disp = st.selectbox(
-                            "Source class *", options=cls_opts, format_func=_pad_option
+                        source_disp = required_selectbox(
+                            "Source class *",
+                            cls_opts,
+                            key="reuse_prop_source",
+                            current_display=cls_opts[0] if cls_opts else None,
+                            format_func=_pad_option,
                         )
                     with col2:
-                        target_disp = st.selectbox(
-                            "Target class *", options=cls_opts, format_func=_pad_option
+                        target_disp = required_selectbox(
+                            "Target class *",
+                            cls_opts,
+                            key="reuse_prop_target",
+                            current_display=cls_opts[0] if cls_opts else None,
+                            format_func=_pad_option,
                         )
 
                     link_disp = st.radio(
@@ -4629,7 +4699,15 @@ def render_properties():
                         prop_name = reuse_lookup.get(prop_disp)
                         source = cls_lookup.get(source_disp)
                         target = cls_lookup.get(target_disp)
-                        if not (prop_name and source and target):
+                        if _missing := missing_required(
+                            **{
+                                "Existing property": prop_disp,
+                                "Source class": source_disp,
+                                "Target class": target_disp,
+                            }
+                        ):
+                            show_message(_missing, "error")
+                        elif not (prop_name and source and target):
                             show_message(
                                 "Property, source and target are required!", "error"
                             )
@@ -4666,12 +4744,20 @@ def render_properties():
                 )
                 col1, col2 = st.columns(2)
                 with col1:
-                    domain_disp = st.selectbox(
-                        "Domain (Class)", options=cls_opts, format_func=_pad_option
+                    domain_disp = clearable_selectbox(
+                        "Domain (Class)",
+                        cls_opts,
+                        key="add_objprop_domain",
+                        current_display=cls_opts[0] if cls_opts else None,
+                        format_func=_pad_option,
                     )
                 with col2:
-                    range_disp = st.selectbox(
-                        "Range (Class)", options=cls_opts, format_func=_pad_option
+                    range_disp = clearable_selectbox(
+                        "Range (Class)",
+                        cls_opts,
+                        key="add_objprop_range",
+                        current_display=cls_opts[0] if cls_opts else None,
+                        format_func=_pad_option,
                     )
 
                 st.write("**Property Characteristics:**")
@@ -4688,13 +4774,19 @@ def render_properties():
                 with col4:
                     symmetric = st.checkbox("Symmetric")
 
-                inverse_disp = st.selectbox(
-                    "Inverse Of", options=obj_prop_opts, format_func=_pad_option
+                inverse_disp = clearable_selectbox(
+                    "Inverse Of",
+                    obj_prop_opts,
+                    key="add_objprop_inverse",
+                    current_display=obj_prop_opts[0] if obj_prop_opts else None,
+                    format_func=_pad_option,
                 )
                 ns_options, ns_lookup = build_namespace_options(ont)
-                ns_display = st.selectbox(
+                ns_display = clearable_selectbox(
                     "Namespace",
-                    options=ns_options,
+                    ns_options,
+                    key="add_objprop_ns",
+                    current_display=ns_options[0] if ns_options else None,
                     help="Namespace the property is created in (default is the base URI)",
                 )
 
@@ -4742,29 +4834,38 @@ def render_properties():
             cls_opts, cls_lookup = build_class_options(classes, include_none=True)
             col1, col2 = st.columns(2)
             with col1:
-                domain_disp = st.selectbox(
+                domain_disp = clearable_selectbox(
                     "Domain (Class)",
-                    options=cls_opts,
+                    cls_opts,
                     key="data_prop_domain",
+                    current_display=cls_opts[0] if cls_opts else None,
                     format_func=_pad_option,
                 )
             with col2:
                 datatypes = list(get_ontology_manager_class().XSD_DATATYPES.keys())
-                range_ = st.selectbox(
-                    "Range (Datatype)", options=datatypes, key="data_prop_range"
+                range_ = required_selectbox(
+                    "Range (Datatype)",
+                    datatypes,
+                    key="data_prop_range",
+                    current_display=datatypes[0] if datatypes else None,
                 )
 
             functional = st.checkbox("Functional", key="data_prop_functional")
             ns_options, ns_lookup = build_namespace_options(ont)
-            ns_display = st.selectbox(
+            ns_display = clearable_selectbox(
                 "Namespace",
-                options=ns_options,
-                help="Namespace the property is created in (default is the base URI)",
+                ns_options,
                 key="data_prop_namespace",
+                current_display=ns_options[0] if ns_options else None,
+                help="Namespace the property is created in (default is the base URI)",
             )
 
             submitted = st.form_submit_button("Add Data Property")
-            if submitted:
+            if submitted and (
+                _missing := missing_required(**{"Range (Datatype)": range_})
+            ):
+                show_message(_missing, "error")
+            elif submitted:
                 ns_val = ns_lookup.get(ns_display)
                 prop_uris = {p["uri"] for p in object_props} | {
                     p["uri"] for p in data_props
@@ -5039,18 +5140,21 @@ def render_individuals():
                                 "delete-and-recreate.",
                             )
                             ns_opts, ns_lookup = build_namespace_options(ont)
-                            new_namespace = ns_lookup.get(
-                                st.selectbox(
-                                    "Namespace",
-                                    options=ns_opts,
-                                    index=_namespace_option_index(
+                            ns_disp = required_selectbox(
+                                "Namespace",
+                                ns_opts,
+                                key=f"ind_ns_{_ik}",
+                                current_display=ns_opts[
+                                    _namespace_option_index(
                                         ont, ns_opts, ns_lookup, ind["uri"]
-                                    ),
-                                    key=f"ind_ns_{_ik}",
-                                    help="Moving to another namespace re-points "
-                                    "every reference to this individual.",
-                                )
+                                    )
+                                ]
+                                if ns_opts
+                                else None,
+                                help="Moving to another namespace re-points "
+                                "every reference to this individual.",
                             )
+                            new_namespace = ns_lookup.get(ns_disp)
                             new_name = _custom_uri_field(
                                 ind["uri"], new_name, key=f"custom_uri_ind_{_ik}"
                             )
@@ -5069,19 +5173,27 @@ def render_individuals():
 
                             col1, col2 = st.columns(2)
                             with col1:
-                                add_class = st.selectbox(
+                                add_class = clearable_selectbox(
                                     "Add to Class",
-                                    options=["None"] + available_classes,
+                                    ["None"] + available_classes,
                                     key=f"ind_add_cls_{_ik}",
+                                    current_display="None",
                                 )
                             with col2:
-                                remove_class = st.selectbox(
+                                remove_class = clearable_selectbox(
                                     "Remove from Class",
-                                    options=["None"] + current_classes,
+                                    ["None"] + current_classes,
                                     key=f"ind_rem_cls_{_ik}",
+                                    current_display="None",
                                 )
 
                             if st.form_submit_button("Save Changes"):
+                                # An empty namespace reads as the base URI, so a
+                                # cleared one would move the individual there
+                                # and re-point every reference to it.
+                                if _missing := missing_required(Namespace=ns_disp):
+                                    set_flash_message(_missing, "error")
+                                    st.rerun()
                                 if (
                                     new_name
                                     and new_name != ind["name"]
@@ -5131,18 +5243,27 @@ def render_individuals():
                 name = st.text_input("Individual Name *")
                 label = st.text_input("Label")
                 comment = st.text_area("Comment")
-                class_type = st.selectbox("Class Type *", options=class_names)
+                class_type = required_selectbox(
+                    "Class Type *",
+                    class_names,
+                    key="add_ind_class_type",
+                    current_display=class_names[0] if class_names else None,
+                )
                 ns_options, ns_lookup = build_namespace_options(ont)
-                ns_display = st.selectbox(
+                ns_display = clearable_selectbox(
                     "Namespace",
-                    options=ns_options,
+                    ns_options,
+                    key="add_ind_ns",
+                    current_display=ns_options[0] if ns_options else None,
                     help="Namespace the individual is created in (default is the base URI)",
                 )
 
                 submitted = st.form_submit_button("Add Individual")
                 if submitted:
                     ns_val = ns_lookup.get(ns_display)
-                    if not name:
+                    if _missing := missing_required(**{"Class Type": class_type}):
+                        show_message(_missing, "error")
+                    elif not name:
                         show_message("Individual name is required!", "error")
                     elif reason := ont.invalid_name_reason(name):
                         show_message(reason, "error")
@@ -5169,7 +5290,12 @@ def render_individuals():
             st.warning("Please create at least one property first.")
         else:
             with st.form("add_prop_value_form"):
-                individual = st.selectbox("Select Individual", options=ind_names)
+                individual = required_selectbox(
+                    "Select Individual",
+                    ind_names,
+                    key="add_pv_individual",
+                    current_display=ind_names[0] if ind_names else None,
+                )
 
                 prop_type = st.radio(
                     "Property Type", ["Object Property", "Data Property"]
@@ -5177,24 +5303,37 @@ def render_individuals():
 
                 if prop_type == "Object Property":
                     prop_options = [p["name"] for p in object_props]
-                    property_name = st.selectbox(
+                    property_name = required_selectbox(
                         "Property",
-                        options=prop_options if prop_options else ["No properties"],
+                        prop_options if prop_options else ["No properties"],
+                        key="add_pv_obj_prop",
+                        current_display=(prop_options or ["No properties"])[0],
                     )
-                    value = st.selectbox("Value (Individual)", options=ind_names)
+                    value = required_selectbox(
+                        "Value (Individual)",
+                        ind_names,
+                        key="add_pv_obj_value",
+                        current_display=ind_names[0] if ind_names else None,
+                    )
                     is_object = True
                 else:
                     prop_options = [p["name"] for p in data_props]
-                    property_name = st.selectbox(
+                    property_name = required_selectbox(
                         "Property",
-                        options=prop_options if prop_options else ["No properties"],
+                        prop_options if prop_options else ["No properties"],
+                        key="add_pv_data_prop",
+                        current_display=(prop_options or ["No properties"])[0],
                     )
                     value = st.text_input("Value")
                     is_object = False
 
                 submitted = st.form_submit_button("Add Property Value")
                 if submitted:
-                    if not property_name or property_name == "No properties":
+                    if _missing := missing_required(
+                        **{"Select Individual": individual, "Property": property_name}
+                    ):
+                        show_message(_missing, "error")
+                    elif property_name == "No properties":
                         show_message("Please select a property!", "error")
                     elif not value:
                         show_message("Please provide a value!", "error")
@@ -5313,26 +5452,37 @@ def render_individuals():
                         st.rerun()
 
 
-def required_selectbox(label, options, key, current_display=None, **kwargs):
-    """A dropdown that can be cleared, for a field that still must be filled.
+def clearable_selectbox(label, options, key, current_display=None, **kwargs):
+    """A dropdown carrying the clear cross, returning None once cleared.
 
-    Streamlit only draws the clear cross when a selectbox may hold nothing,
-    which means ``index=None`` and therefore no preselection — so the current
-    value is seeded into the widget's own state instead. That is done once per
-    value rather than once per render: re-seeding every run would undo a clear
-    the moment it happened, and seeding only on first sight would show a stale
-    value when the row underneath changes.
+    Streamlit only draws that cross when a selectbox may hold nothing, which
+    means ``index=None`` and therefore no preselection — so the current value is
+    seeded into the widget's own state instead. That is done once per value
+    rather than once per render: re-seeding every run would undo a clear the
+    moment it happened, and seeding only on first sight would show a stale value
+    when the row underneath changes.
 
-    Returns the chosen option, or ``None`` when the field has been cleared. Every
-    caller has to say so rather than carrying on: clearing a required dropdown
-    used to fall back to whatever was selected before, so the write landed on a
-    resource the user had explicitly cleared, with nothing said either way.
+    Use this where empty is a legitimate answer: a picker that chooses what to
+    show, or a field whose absence simply means "not set".
     """
     seeded_for = f"{key}__seeded_for"
     if st.session_state.get(seeded_for) != current_display:
         st.session_state[seeded_for] = current_display
         st.session_state[key] = current_display if current_display in options else None
     return st.selectbox(label, options, index=None, key=key, **kwargs)
+
+
+def required_selectbox(label, options, key, current_display=None, **kwargs):
+    """A clearable dropdown for a field that still must be filled.
+
+    Identical to :func:`clearable_selectbox` on screen; the difference is the
+    obligation it puts on the caller, which has to check the result with
+    :func:`missing_required` and refuse the write. Clearing a required dropdown
+    used to fall back to whatever was selected before, so the write landed on a
+    resource the user had explicitly cleared, with nothing said either way. A
+    test pins the two together so a new form cannot offer one without the other.
+    """
+    return clearable_selectbox(label, options, key, current_display, **kwargs)
 
 
 def missing_required(**fields) -> str | None:
@@ -5544,15 +5694,17 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
             )
         new_on_class = None
         if restriction_takes_on_class(new_type):
-            new_on_class = st.selectbox(
+            new_on_class = required_selectbox(
                 "Qualified on Class",
                 on_options,
-                index=(
+                key=f"er_onclass_{form_key}",
+                current_display=on_options[
                     _uri_option_index(on_options, on_lookup, rest["on_class_uri"])
                     if rest.get("on_class_uri")
                     else 0
-                ),
-                key=f"er_onclass_{form_key}",
+                ]
+                if on_options
+                else None,
                 format_func=_pad_option,
             )
 
@@ -5579,6 +5731,13 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
                     **(
                         {"Value (Class)": new_value}
                         if restriction_value_is_class(new_type)
+                        else {}
+                    ),
+                    # A qualified cardinality without its onClass is an axiom
+                    # no reasoner accepts, so it cannot be left empty either.
+                    **(
+                        {"Qualified on Class": new_on_class}
+                        if restriction_takes_on_class(new_type)
                         else {}
                     ),
                 }
@@ -5652,11 +5811,19 @@ def render_add_restriction(ont, classes, properties):
         # was silently created on a base-namespace twin instead.
         cls_opts, cls_lookup = build_uri_options(classes)
         prop_opts, prop_lookup = build_uri_options(properties)
-        target_disp = st.selectbox(
-            "Apply to Class", options=cls_opts, format_func=_pad_option
+        target_disp = required_selectbox(
+            "Apply to Class",
+            cls_opts,
+            key="add_rest_target",
+            current_display=cls_opts[0] if cls_opts else None,
+            format_func=_pad_option,
         )
-        property_disp = st.selectbox(
-            "On Property", options=prop_opts, format_func=_pad_option
+        property_disp = required_selectbox(
+            "On Property",
+            prop_opts,
+            key="add_rest_property",
+            current_display=prop_opts[0] if prop_opts else None,
+            format_func=_pad_option,
         )
 
         # Straight from the engine, so a type can never be offered here
@@ -5667,26 +5834,33 @@ def render_add_restriction(ont, classes, properties):
 
         st.write("**Restriction Value:**")
         value = None
+        value_disp = None
+        value_label = None
         if restriction_type in ["someValuesFrom", "allValuesFrom"]:
-            value = cls_lookup[
-                st.selectbox(
-                    "Value (Class)",
-                    options=cls_opts,
-                    key="rest_class_value",
-                    format_func=_pad_option,
-                )
-            ]
+            value_label = "Value (Class)"
+            value_disp = required_selectbox(
+                "Value (Class)",
+                cls_opts,
+                key="rest_class_value",
+                current_display=cls_opts[0] if cls_opts else None,
+                format_func=_pad_option,
+            )
+            value = cls_lookup.get(value_disp)
         elif restriction_type == "hasValue":
             ind_opts, ind_lookup = build_uri_options(ont.get_individuals())
             value_type = st.radio("Value Type", ["Literal", "Individual"])
             if value_type == "Literal":
                 value = st.text_input("Literal Value")
             elif ind_opts:
-                value = ind_lookup[
-                    st.selectbox(
-                        "Individual", options=ind_opts, format_func=_pad_option
-                    )
-                ]
+                value_label = "Individual"
+                value_disp = required_selectbox(
+                    "Individual",
+                    ind_opts,
+                    key="rest_individual_value",
+                    current_display=ind_opts[0],
+                    format_func=_pad_option,
+                )
+                value = ind_lookup.get(value_disp)
             else:
                 # Offering a "No individuals" placeholder let that string
                 # be stored as the value.
@@ -5695,18 +5869,34 @@ def render_add_restriction(ont, classes, properties):
             value = st.number_input("Cardinality", min_value=0, value=1)
 
         on_class = None
+        on_class_disp = None
         if restriction_takes_on_class(restriction_type):
-            on_class = cls_lookup[
-                st.selectbox(
-                    "Qualified on Class",
-                    options=cls_opts,
-                    key="qualified_class",
-                    format_func=_pad_option,
-                )
-            ]
+            on_class_disp = required_selectbox(
+                "Qualified on Class",
+                cls_opts,
+                key="qualified_class",
+                current_display=cls_opts[0] if cls_opts else None,
+                format_func=_pad_option,
+            )
+            on_class = cls_lookup.get(on_class_disp)
 
         submitted = st.form_submit_button("Add Restriction")
-        if submitted and _apply_restriction_add(
+        if submitted and (
+            _missing := missing_required(
+                **{
+                    "Apply to Class": target_disp,
+                    "On Property": property_disp,
+                    **({value_label: value_disp} if value_label else {}),
+                    **(
+                        {"Qualified on Class": on_class_disp}
+                        if restriction_takes_on_class(restriction_type)
+                        else {}
+                    ),
+                }
+            )
+        ):
+            show_message(_missing, "error")
+        elif submitted and _apply_restriction_add(
             ont,
             cls_lookup[target_disp],
             prop_lookup[property_disp],
@@ -5936,10 +6126,11 @@ def render_relations():
                 col1, col2, col3 = st.columns(3)
 
                 with col1:
-                    class1_disp = st.selectbox(
+                    class1_disp = required_selectbox(
                         "Class 1",
-                        options=cls_opts,
+                        cls_opts,
                         key="crel_class1",
+                        current_display=cls_opts[0] if cls_opts else None,
                         format_func=_pad_option,
                     )
                 with col2:
@@ -5949,10 +6140,11 @@ def render_relations():
                         key="crel_type",
                     )
                 with col3:
-                    class2_disp = st.selectbox(
+                    class2_disp = required_selectbox(
                         "Class 2",
-                        options=cls_opts,
+                        cls_opts,
                         key="crel_class2",
+                        current_display=cls_opts[0] if cls_opts else None,
                         format_func=_pad_option,
                     )
 
@@ -5975,7 +6167,13 @@ def render_relations():
                         if class2_uri == cls_lookup.get(class2_disp)
                         else class2_uri
                     )
-                    if ext_err:
+                    # Class 2 is checked as the resolved target, since an
+                    # external URI legitimately stands in for the pick.
+                    if _missing := missing_required(
+                        **{"Class 1": class1_disp, "Class 2": class2_uri}
+                    ):
+                        show_message(_missing, "error")
+                    elif ext_err:
                         show_message(ext_err, "error")
                     elif _apply_class_relation_add(
                         ont,
@@ -6002,10 +6200,11 @@ def render_relations():
                 col1, col2, col3 = st.columns(3)
 
                 with col1:
-                    prop1_disp = st.selectbox(
+                    prop1_disp = required_selectbox(
                         "Property 1",
-                        options=prop_opts,
+                        prop_opts,
                         key="prel_prop1",
+                        current_display=prop_opts[0] if prop_opts else None,
                         format_func=_pad_option,
                     )
                 with col2:
@@ -6015,10 +6214,11 @@ def render_relations():
                         key="prel_type",
                     )
                 with col3:
-                    prop2_disp = st.selectbox(
+                    prop2_disp = required_selectbox(
                         "Property 2",
-                        options=prop_opts,
+                        prop_opts,
                         key="prel_prop2",
+                        current_display=prop_opts[0] if prop_opts else None,
                         format_func=_pad_option,
                     )
 
@@ -6042,7 +6242,11 @@ def render_relations():
                         if prop2_uri == prop_lookup.get(prop2_disp)
                         else prop2_uri
                     )
-                    if ext_err:
+                    if _missing := missing_required(
+                        **{"Property 1": prop1_disp, "Property 2": prop2_uri}
+                    ):
+                        show_message(_missing, "error")
+                    elif ext_err:
                         show_message(ext_err, "error")
                     elif prop1_uri == prop2_uri:
                         show_message("Please select two different properties!", "error")
@@ -6069,10 +6273,11 @@ def render_relations():
                 col1, col2, col3 = st.columns(3)
 
                 with col1:
-                    ind1_disp = st.selectbox(
+                    ind1_disp = required_selectbox(
                         "Individual 1",
-                        options=ind_opts,
+                        ind_opts,
                         key="irel_ind1",
+                        current_display=ind_opts[0] if ind_opts else None,
                         format_func=_pad_option,
                     )
                 with col2:
@@ -6082,10 +6287,11 @@ def render_relations():
                         key="irel_type",
                     )
                 with col3:
-                    ind2_disp = st.selectbox(
+                    ind2_disp = required_selectbox(
                         "Individual 2",
-                        options=ind_opts,
+                        ind_opts,
                         key="irel_ind2",
+                        current_display=ind_opts[0] if ind_opts else None,
                         format_func=_pad_option,
                     )
 
@@ -6106,7 +6312,11 @@ def render_relations():
                     ind2_show = (
                         ind2_disp if ind2_uri == ind_lookup.get(ind2_disp) else ind2_uri
                     )
-                    if ext_err:
+                    if _missing := missing_required(
+                        **{"Individual 1": ind1_disp, "Individual 2": ind2_uri}
+                    ):
+                        show_message(_missing, "error")
+                    elif ext_err:
                         show_message(ext_err, "error")
                     elif ind1_uri == ind2_uri:
                         show_message(
@@ -6277,16 +6487,15 @@ def render_relation_form(ont, rel, form_key, spec, on_close=None):
         # The add forms can point an object at an entity in an ontology that
         # was never imported; without this the editor could keep such a
         # target but never set one.
-        # The external-URI field reads the object's URI, which a cleared
-        # object has not got, and has nothing to override without one.
-        ext_obj_uri, ext_err = (None, None)
-        if new_object is not None:
-            ext_obj_uri, ext_err = _external_uri_target(
-                ont,
-                row_lookup[new_object],
-                key=f"eo_ext_{form_key}",
-                label="the object",
-            )
+        # ``.get``, not ``[]``: a cleared object has no URI to default to, and
+        # the field is still offered because typing an external URI is how the
+        # object is set when no local entity holds it.
+        ext_obj_uri, ext_err = _external_uri_target(
+            ont,
+            row_lookup.get(new_object),
+            key=f"eo_ext_{form_key}",
+            label="the object",
+        )
         cancelled = False
         if on_close is None:
             saved = st.form_submit_button("💾 Save", use_container_width=True)
@@ -6300,8 +6509,11 @@ def render_relation_form(ont, rel, form_key, spec, on_close=None):
         if cancelled:
             on_close()
             st.rerun()
+        # Checked against the resolved target rather than the dropdown: an
+        # external URI legitimately replaces the pick, so an object typed there
+        # is an object, and only having neither is an error.
         if saved and (
-            _missing := missing_required(Subject=new_subject, Object=new_object)
+            _missing := missing_required(Subject=new_subject, Object=ext_obj_uri)
         ):
             # A cleared endpoint used to fall back to the one the row started
             # with, rewriting the triple against an entity the user had
@@ -6481,11 +6693,12 @@ def render_add_annotation(ont, all_resources):
             # puts its type into the used-predicate options — would change
             # the widget's identity and snap the selection back to the first
             # entry.
-            predicate_display = st.selectbox(
+            predicate_display = required_selectbox(
                 "Annotation Type",
-                options=predicate_options,
-                accept_new_options=True,
+                predicate_options,
                 key="ann_predicate",
+                current_display=predicate_options[0] if predicate_options else None,
+                accept_new_options=True,
                 help=(
                     "Pick a type, or type your own to create it: a name like "
                     "`wikidataId`, a bound prefix like `wdt:P31`, or a full "
@@ -6508,7 +6721,12 @@ def render_add_annotation(ont, all_resources):
                 predicate_uri, predicate_reason = resolve_annotation_predicate_choice(
                     ont, predicate_display, predicate_lookup
                 )
-                if _missing := missing_required(**{"Select Resource": selected}):
+                if _missing := missing_required(
+                    **{
+                        "Select Resource": selected,
+                        "Annotation Type": predicate_display,
+                    }
+                ):
                     # Clearing the resource used to leave the previous pick in
                     # place, so the annotation was written to a resource the
                     # user had cleared, with nothing said either way.
@@ -6626,10 +6844,12 @@ def render_annotations():
 
             with col2:
                 if filtered_resources:
-                    selected = st.selectbox(
+                    _view_opts = [r["display"] for r in filtered_resources]
+                    selected = clearable_selectbox(
                         "Select Resource",
-                        options=[r["display"] for r in filtered_resources],
+                        _view_opts,
                         key="view_annotations_select",
+                        current_display=_view_opts[0] if _view_opts else None,
                     )
                 else:
                     selected = None
@@ -7056,13 +7276,21 @@ def render_skos_vocabulary():
                             _rel_opts, _rel_lookup = build_uri_options(
                                 [c for c in concepts if c["uri"] != concept["uri"]]
                             )
-                            rel_target = st.selectbox(
+                            rel_target = required_selectbox(
                                 "Target Concept",
                                 _rel_opts,
                                 key=f"rel_target_{_ck}",
+                                current_display=_rel_opts[0] if _rel_opts else None,
                                 format_func=_pad_option,
                             )
-                            if st.button("Add", key=f"add_rel_{_ck}") and rel_target:
+                            _add_rel = st.button("Add", key=f"add_rel_{_ck}")
+                            if _add_rel and (
+                                _missing := missing_required(
+                                    **{"Target Concept": rel_target}
+                                )
+                            ):
+                                show_message(_missing, "error")
+                            elif _add_rel and rel_target:
                                 # Address both concepts by their actual URIs: a
                                 # concept moved to a non-base namespace (e.g. via a
                                 # custom URI) would not resolve through the base
@@ -7134,13 +7362,13 @@ def render_skos_vocabulary():
                                 "None",
                             )
                             broader_options = ["None"] + _broader_opts
-                            new_broader = st.selectbox(
+                            new_broader = clearable_selectbox(
                                 "Broader Concept",
                                 broader_options,
-                                index=broader_options.index(_cur_broader_disp)
-                                if _cur_broader_disp in broader_options
-                                else 0,
                                 key=f"broader_{_ck}",
+                                current_display=_cur_broader_disp
+                                if _cur_broader_disp in broader_options
+                                else "None",
                                 format_func=_pad_option,
                             )
 
@@ -7159,13 +7387,13 @@ def render_skos_vocabulary():
                                 "None",
                             )
                             scheme_options = ["None"] + scheme_opts
-                            new_scheme = st.selectbox(
+                            new_scheme = clearable_selectbox(
                                 "Scheme",
                                 scheme_options,
-                                index=scheme_options.index(_cur_scheme_disp)
-                                if _cur_scheme_disp in scheme_options
-                                else 0,
                                 key=f"scheme_{_ck}",
+                                current_display=_cur_scheme_disp
+                                if _cur_scheme_disp in scheme_options
+                                else "None",
                                 format_func=_pad_option,
                             )
                             new_name = _custom_uri_field(
@@ -7248,17 +7476,19 @@ def render_skos_vocabulary():
             c_name = st.text_input("Concept Name *")
             c_pref = st.text_input("Preferred Label")
             c_def = st.text_area("Definition")
-            c_scheme = st.selectbox(
+            c_scheme = clearable_selectbox(
                 "Scheme",
                 ["None"] + scheme_opts,
                 key="concept_scheme_select",
+                current_display="None",
                 format_func=_pad_option,
             )
             _add_broader_opts, _add_broader_lookup = build_uri_options(concepts)
-            c_broader = st.selectbox(
+            c_broader = clearable_selectbox(
                 "Broader Concept",
                 ["None"] + _add_broader_opts,
                 key="concept_broader_select",
+                current_display="None",
                 format_func=_pad_option,
             )
             c_lang = st.text_input("Language Tag (e.g., en, de)", key="concept_lang")
@@ -7777,8 +8007,11 @@ def render_import_export():
             st.success(st.session_state.pop("_template_msg"))
 
         template_names = get_template_names()
-        selected_template = st.selectbox(
-            "Select Template", template_names, key="template_select"
+        selected_template = clearable_selectbox(
+            "Select Template",
+            template_names,
+            key="template_select",
+            current_display=template_names[0] if template_names else None,
         )
 
         if selected_template:
@@ -7857,8 +8090,11 @@ def render_import_export():
             st.error(st.session_state.pop("_upper_onto_err"))
 
         upper_names = get_upper_ontology_names()
-        selected_upper = st.selectbox(
-            "Select Upper Ontology", upper_names, key="upper_ontology_select"
+        selected_upper = clearable_selectbox(
+            "Select Upper Ontology",
+            upper_names,
+            key="upper_ontology_select",
+            current_display=upper_names[0] if upper_names else None,
         )
 
         if selected_upper:
@@ -7952,8 +8188,11 @@ def render_import_export():
             st.error(st.session_state.pop("_ref_onto_err"))
 
         ref_names = get_reference_ontology_names()
-        selected_ref = st.selectbox(
-            "Select Reference Ontology", ref_names, key="reference_ontology_select"
+        selected_ref = clearable_selectbox(
+            "Select Reference Ontology",
+            ref_names,
+            key="reference_ontology_select",
+            current_display=ref_names[0] if ref_names else None,
         )
 
         if selected_ref:
@@ -8049,9 +8288,11 @@ def render_advanced():
             st.warning("Need at least 2 classes to create expressions.")
         else:
             with st.form("add_class_expression_form"):
-                target_class = st.selectbox(
+                target_class = required_selectbox(
                     "Target Class",
-                    options=class_names,
+                    class_names,
+                    key="adv_expr_target",
+                    current_display=class_names[0] if class_names else None,
                     help="The class to define with this expression",
                 )
 
@@ -8062,8 +8303,11 @@ def render_advanced():
 
                 st.write("**Select members:**")
                 if expr_type == "complementOf":
-                    complement_class = st.selectbox(
-                        "Complement of Class", options=class_names
+                    complement_class = required_selectbox(
+                        "Complement of Class",
+                        class_names,
+                        key="adv_expr_complement",
+                        current_display=class_names[0] if class_names else None,
                     )
                     selected_classes = [complement_class] if complement_class else []
                     selected_individuals = []
@@ -8078,7 +8322,9 @@ def render_advanced():
 
                 submitted = st.form_submit_button("Add Expression")
                 if submitted:
-                    if expr_type == "oneOf" and selected_individuals:
+                    if _missing := missing_required(**{"Target Class": target_class}):
+                        show_message(_missing, "error")
+                    elif expr_type == "oneOf" and selected_individuals:
                         ont.add_class_expression(
                             target_class, expr_type, individuals=selected_individuals
                         )
@@ -8117,9 +8363,11 @@ def render_advanced():
             st.warning("Need at least 2 object properties to create chains.")
         else:
             with st.form("add_property_chain_form"):
-                result_prop = st.selectbox(
+                result_prop = required_selectbox(
                     "Result Property",
-                    options=obj_prop_names,
+                    obj_prop_names,
+                    key="adv_chain_result",
+                    current_display=obj_prop_names[0] if obj_prop_names else None,
                     help="The property that results from following the chain",
                 )
 
@@ -8131,7 +8379,9 @@ def render_advanced():
 
                 submitted = st.form_submit_button("Add Property Chain")
                 if submitted:
-                    if len(chain_props) < 2:
+                    if _missing := missing_required(**{"Result Property": result_prop}):
+                        show_message(_missing, "error")
+                    elif len(chain_props) < 2:
                         show_message("Chain must have at least 2 properties!", "error")
                     else:
                         ont.add_property_chain(result_prop, chain_props)
@@ -8164,9 +8414,11 @@ def render_advanced():
             )
         else:
             with st.form("add_disjoint_union_form"):
-                parent_class = st.selectbox(
+                parent_class = required_selectbox(
                     "Parent Class",
-                    options=class_names,
+                    class_names,
+                    key="adv_union_parent",
+                    current_display=class_names[0] if class_names else None,
                     help="The class that is the disjoint union",
                 )
 
@@ -8178,7 +8430,9 @@ def render_advanced():
 
                 submitted = st.form_submit_button("Add Disjoint Union")
                 if submitted:
-                    if len(member_classes) < 2:
+                    if _missing := missing_required(**{"Parent Class": parent_class}):
+                        show_message(_missing, "error")
+                    elif len(member_classes) < 2:
                         show_message("Need at least 2 member classes!", "error")
                     elif parent_class in member_classes:
                         show_message("Parent class cannot be a member!", "error")
@@ -8246,7 +8500,12 @@ def render_advanced():
             st.warning("Need at least 1 property.")
         else:
             with st.form("add_has_key_form"):
-                target_class = st.selectbox("Class", options=class_names)
+                target_class = required_selectbox(
+                    "Class",
+                    class_names,
+                    key="adv_haskey_class",
+                    current_display=class_names[0] if class_names else None,
+                )
 
                 key_props = st.multiselect(
                     "Key Properties",
@@ -8256,7 +8515,9 @@ def render_advanced():
 
                 submitted = st.form_submit_button("Add hasKey")
                 if submitted:
-                    if not key_props:
+                    if _missing := missing_required(Class=target_class):
+                        show_message(_missing, "error")
+                    elif not key_props:
                         show_message("Select at least 1 property!", "error")
                     else:
                         ont.add_has_key(target_class, key_props)

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -5285,6 +5285,40 @@ def render_individuals():
                         st.rerun()
 
 
+def required_selectbox(label, options, key, current_display=None, **kwargs):
+    """A dropdown that can be cleared, for a field that still must be filled.
+
+    Streamlit only draws the clear cross when a selectbox may hold nothing,
+    which means ``index=None`` and therefore no preselection — so the current
+    value is seeded into the widget's own state instead. That is done once per
+    value rather than once per render: re-seeding every run would undo a clear
+    the moment it happened, and seeding only on first sight would show a stale
+    value when the row underneath changes (issue #252).
+
+    Returns the chosen option, or ``None`` when the field has been cleared. Every
+    caller has to say so rather than carrying on: clearing a required dropdown
+    used to fall back to whatever was selected before, so the write landed on a
+    resource the user had explicitly cleared, with nothing said either way.
+    """
+    seeded_for = f"{key}__seeded_for"
+    if st.session_state.get(seeded_for) != current_display:
+        st.session_state[seeded_for] = current_display
+        st.session_state[key] = current_display if current_display in options else None
+    return st.selectbox(label, options, index=None, key=key, **kwargs)
+
+
+def missing_required(**fields) -> str | None:
+    """The message for the first required field left empty, or None.
+
+    Named so the error says which field, since a form can have several and
+    "something is required" sends the user hunting.
+    """
+    for name, value in fields.items():
+        if value is None or (isinstance(value, str) and not value.strip()):
+            return f"{name} is required."
+    return None
+
+
 def _slot_options(entities: list, current_uri) -> tuple:
     """Build ``(options, lookup)`` for an editor slot, keeping ``current_uri``.
 
@@ -5430,20 +5464,26 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
     )
 
     with st.form(f"edit_rest_form_{form_key}"):
-        new_class = st.selectbox(
+        new_class = required_selectbox(
             "Applies to Class",
             cls_options,
-            index=_uri_option_index(cls_options, cls_lookup, applied_uris[0]),
             key=f"er_cls_{form_key}",
+            current_display=cls_options[
+                _uri_option_index(cls_options, cls_lookup, applied_uris[0])
+            ],
             format_func=_pad_option,
         )
-        new_property = st.selectbox(
+        new_property = required_selectbox(
             "Property",
             prop_options,
-            index=_uri_option_index(
-                prop_options, prop_lookup, rest.get("property_uri") or rest["property"]
-            ),
             key=f"er_prop_{form_key}",
+            current_display=prop_options[
+                _uri_option_index(
+                    prop_options,
+                    prop_lookup,
+                    rest.get("property_uri") or rest["property"],
+                )
+            ],
             format_func=_pad_option,
         )
         if restriction_value_is_class(new_type):
@@ -5451,17 +5491,18 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
             # classes rather than asking for the name to be typed (issue #250).
             # A value the list does not hold — an imported class, an external
             # URI — is offered as itself, so an unchanged row round-trips.
-            new_value = value_lookup.get(
-                st.selectbox(
-                    "Value (Class)",
-                    value_options,
-                    index=_uri_option_index(
+            _picked_value = required_selectbox(
+                "Value (Class)",
+                value_options,
+                key=f"er_valcls_{form_key}",
+                current_display=value_options[
+                    _uri_option_index(
                         value_options, value_lookup, rest.get("value_uri")
-                    ),
-                    key=f"er_valcls_{form_key}",
-                    format_func=_pad_option,
-                )
+                    )
+                ],
+                format_func=_pad_option,
             )
+            new_value = value_lookup.get(_picked_value) if _picked_value else None
         else:
             # Cardinalities and hasValue keep the free-text field: a number and a
             # literal are what they are, and the engine already reports a bad
@@ -5500,7 +5541,26 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
         if cancelled:
             on_close()
             st.rerun()
-        if saved:
+        if saved and (
+            _missing := missing_required(
+                **{
+                    "Applies to Class": new_class,
+                    "Property": new_property,
+                    # The value is a class only for the types that take one; the
+                    # others are free text and the engine already reports empty.
+                    **(
+                        {"Value (Class)": new_value}
+                        if restriction_value_is_class(new_type)
+                        else {}
+                    ),
+                }
+            )
+        ):
+            # A cleared dropdown used to fall back to the value it started with,
+            # so the axiom was rewritten against a class or property the user had
+            # explicitly cleared, and nothing was said either way (issue #252).
+            show_message(_missing, "error")
+        elif saved:
             try:
                 changed = ont.update_restriction(
                     {

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -5466,7 +5466,15 @@ def clearable_selectbox(label, options, key, current_display=None, **kwargs):
     show, or a field whose absence simply means "not set".
     """
     seeded_for = f"{key}__seeded_for"
-    if st.session_state.get(seeded_for) != current_display:
+    # ``key not in session_state`` is the second half of the condition, not a
+    # redundancy: Streamlit drops the state of a widget that wasn't rendered on
+    # a run, so leaving the page and coming back loses the value — while the
+    # marker below, not being a widget key, survives and would suppress the
+    # re-seed. The field then came back empty instead of showing what it holds.
+    if (
+        key not in st.session_state
+        or st.session_state.get(seeded_for) != current_display
+    ):
         st.session_state[seeded_for] = current_display
         st.session_state[key] = current_display if current_display in options else None
     return st.selectbox(label, options, index=None, key=key, **kwargs)

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -2391,10 +2391,13 @@ def _render_panel_annotation_editor(
     with st.form(f"panel_edit_ann_{_uid(ename)}"):
         # Which resource it hangs off is editable, so an annotation can be moved
         # the way a relation or restriction can be re-pointed from here (#251).
-        new_subject = st.selectbox(
+        new_subject = required_selectbox(
             "On",
-            options=subject_options,
-            index=_uri_option_index(subject_options, subject_lookup, subject_uri),
+            subject_options,
+            key=f"panel_ann_on_{_uid(ename)}",
+            current_display=subject_options[
+                _uri_option_index(subject_options, subject_lookup, subject_uri)
+            ],
             format_func=_pad_option,
             help="Move the annotation by choosing a different resource.",
         )
@@ -2444,7 +2447,12 @@ def _render_panel_annotation_editor(
         show_message("Annotation deleted!", "success")
         st.rerun()
     if saved:
-        if not new_value.strip():
+        if _missing := missing_required(On=new_subject):
+            # A cleared subject used to fall back to the one it came from, so
+            # the annotation was rewritten onto a resource the user had
+            # explicitly cleared.
+            show_message(_missing, "error")
+        elif not new_value.strip():
             show_message("Annotation value is required!", "error")
         elif _apply_annotation_edit(
             ont,
@@ -2823,17 +2831,19 @@ def _render_panel_add_relation_form(ont, classes, ntype, ename):
     # were just resolved out of `classes`, so both are present.
     display_by_uri = {u: d for d, u in lookup.items()}
     with st.form("panel_add_rel_form"):
-        subj_disp = st.selectbox(
+        subj_disp = required_selectbox(
             "Subject",
-            options=options,
-            index=options.index(display_by_uri[subject["uri"]]),
+            options,
+            key=f"panel_rel_subj_{_uid(ename or '')}",
+            current_display=display_by_uri[subject["uri"]],
             format_func=_pad_option,
         )
         rel_type = st.selectbox("Relation Type", options=list(ont.CLASS_RELATIONS))
-        obj_disp = st.selectbox(
+        obj_disp = required_selectbox(
             "Object",
-            options=options,
-            index=options.index(display_by_uri[obj["uri"]]),
+            options,
+            key=f"panel_rel_obj_{_uid(ename or '')}",
+            current_display=display_by_uri[obj["uri"]],
             format_func=_pad_option,
         )
         st.caption(f"Reads as: {subject['name']} → {obj['name']}")
@@ -2845,7 +2855,9 @@ def _render_panel_add_relation_form(ont, classes, ntype, ename):
     if cancelled:
         _panel_close_add()
         st.rerun()
-    if submitted and _apply_class_relation_add(
+    if submitted and (_missing := missing_required(Subject=subj_disp, Object=obj_disp)):
+        show_message(_missing, "error")
+    elif submitted and _apply_class_relation_add(
         ont,
         lookup.get(subj_disp),
         rel_type,
@@ -2926,22 +2938,28 @@ def _render_panel_add_restriction_form(ont, classes, object_props, ntype, ename)
     rtype = st.selectbox("Restriction Type", options=types, key="panel_rest_type")
     qualified = restriction_takes_on_class(rtype)
     with st.form("panel_add_rest_form"):
-        target_disp = st.selectbox(
+        target_disp = required_selectbox(
             "Apply to Class",
-            options=cls_options,
-            index=cls_options.index(display_by_uri[subject["uri"]]),
+            cls_options,
+            key=f"panel_rest_target_{_uid(ename or '')}",
+            current_display=display_by_uri[subject["uri"]],
             format_func=_pad_option,
         )
-        prop_disp = st.selectbox(
-            "On Property", options=prop_options, format_func=_pad_option
+        prop_disp = required_selectbox(
+            "On Property",
+            prop_options,
+            key=f"panel_rest_prop_{_uid(ename or '')}",
+            current_display=prop_options[0] if prop_options else None,
+            format_func=_pad_option,
         )
         # The picked class is the value for someValuesFrom / allValuesFrom, and
         # the owl:onClass for the qualified cardinalities. Same click, different
         # slot in the axiom, so the label says which one it is filling.
-        klass_disp = st.selectbox(
+        klass_disp = required_selectbox(
             "Qualified on Class" if qualified else "Value (Class)",
-            options=cls_options,
-            index=cls_options.index(display_by_uri[other["uri"]]),
+            cls_options,
+            key=f"panel_rest_cls_{_uid(ename or '')}",
+            current_display=display_by_uri[other["uri"]],
             format_func=_pad_option,
         )
         cardinality = None
@@ -2957,7 +2975,17 @@ def _render_panel_add_restriction_form(ont, classes, object_props, ntype, ename)
     if cancelled:
         _panel_close_add()
         st.rerun()
-    if submitted:
+    if submitted and (
+        _missing := missing_required(
+            **{
+                "Apply to Class": target_disp,
+                "On Property": prop_disp,
+                ("Qualified on Class" if qualified else "Value (Class)"): klass_disp,
+            }
+        )
+    ):
+        show_message(_missing, "error")
+    elif submitted:
         picked_uri = cls_lookup.get(klass_disp)
         on_class = picked_uri if restriction_takes_on_class(rtype) else None
         value = cardinality if restriction_takes_on_class(rtype) else picked_uri
@@ -5293,7 +5321,7 @@ def required_selectbox(label, options, key, current_display=None, **kwargs):
     value is seeded into the widget's own state instead. That is done once per
     value rather than once per render: re-seeding every run would undo a clear
     the moment it happened, and seeding only on first sight would show a stale
-    value when the row underneath changes (issue #252).
+    value when the row underneath changes.
 
     Returns the chosen option, or ``None`` when the field has been cleared. Every
     caller has to say so rather than carrying on: clearing a required dropdown
@@ -5558,7 +5586,7 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
         ):
             # A cleared dropdown used to fall back to the value it started with,
             # so the axiom was rewritten against a class or property the user had
-            # explicitly cleared, and nothing was said either way (issue #252).
+            # explicitly cleared, and nothing was said either way.
             show_message(_missing, "error")
         elif saved:
             try:
@@ -6226,11 +6254,11 @@ def render_relation_form(ont, rel, form_key, spec, on_close=None):
         subj_default = _uri_option_index(row_options, row_lookup, subj_uri)
         obj_default = _uri_option_index(row_options, row_lookup, obj_uri)
         types = list(spec["relation_types"])
-        new_subject = st.selectbox(
+        new_subject = required_selectbox(
             "Subject",
             row_options,
-            index=subj_default,
             key=f"es_{form_key}",
+            current_display=row_options[subj_default],
             format_func=_pad_option,
         )
         new_type = st.selectbox(
@@ -6239,22 +6267,26 @@ def render_relation_form(ont, rel, form_key, spec, on_close=None):
             index=types.index(rel["relation"]) if rel["relation"] in types else 0,
             key=f"et_{form_key}",
         )
-        new_object = st.selectbox(
+        new_object = required_selectbox(
             "Object",
             row_options,
-            index=obj_default,
             key=f"eo_{form_key}",
+            current_display=row_options[obj_default],
             format_func=_pad_option,
         )
         # The add forms can point an object at an entity in an ontology that
         # was never imported; without this the editor could keep such a
         # target but never set one.
-        ext_obj_uri, ext_err = _external_uri_target(
-            ont,
-            row_lookup[new_object],
-            key=f"eo_ext_{form_key}",
-            label="the object",
-        )
+        # The external-URI field reads the object's URI, which a cleared
+        # object has not got, and has nothing to override without one.
+        ext_obj_uri, ext_err = (None, None)
+        if new_object is not None:
+            ext_obj_uri, ext_err = _external_uri_target(
+                ont,
+                row_lookup[new_object],
+                key=f"eo_ext_{form_key}",
+                label="the object",
+            )
         cancelled = False
         if on_close is None:
             saved = st.form_submit_button("💾 Save", use_container_width=True)
@@ -6268,6 +6300,14 @@ def render_relation_form(ont, rel, form_key, spec, on_close=None):
         if cancelled:
             on_close()
             st.rerun()
+        if saved and (
+            _missing := missing_required(Subject=new_subject, Object=new_object)
+        ):
+            # A cleared endpoint used to fall back to the one the row started
+            # with, rewriting the triple against an entity the user had
+            # explicitly cleared.
+            show_message(_missing, "error")
+            return
         if saved:
             new_subj_uri = row_lookup[new_subject]
             new_obj_uri = ext_obj_uri
@@ -6425,10 +6465,11 @@ def render_add_annotation(ont, all_resources):
         with st.form("add_annotation_form"):
             # Use display format with label
             resource_options = [f"{r['display']} [{r['type']}]" for r in all_resources]
-            selected = st.selectbox(
+            selected = required_selectbox(
                 "Select Resource",
-                options=resource_options,
+                resource_options,
                 key="ann_resource",
+                current_display=resource_options[0] if resource_options else None,
                 format_func=_pad_option,
             )
 
@@ -6467,7 +6508,12 @@ def render_add_annotation(ont, all_resources):
                 predicate_uri, predicate_reason = resolve_annotation_predicate_choice(
                     ont, predicate_display, predicate_lookup
                 )
-                if not value:
+                if _missing := missing_required(**{"Select Resource": selected}):
+                    # Clearing the resource used to leave the previous pick in
+                    # place, so the annotation was written to a resource the
+                    # user had cleared, with nothing said either way.
+                    show_message(_missing, "error")
+                elif not value:
                     show_message("Value is required!", "error")
                 elif predicate_reason:
                     show_message(predicate_reason, "error")

--- a/tests/test_clearable_required_dropdowns.py
+++ b/tests/test_clearable_required_dropdowns.py
@@ -1,0 +1,92 @@
+"""Required dropdowns can be cleared, and say so when they are.
+
+Clearing one was already possible by selecting its text and deleting it, but
+there was no cross to do it with and clearing achieved nothing useful: the value
+fell back to whatever had been selected before, so the write landed on an entity
+the user had explicitly cleared, with neither an error nor a confirmation.
+
+The two halves have to stay together. A dropdown that can be cleared but is not
+checked writes the wrong thing; one that is checked but cannot be cleared just
+never fires. The last test here fails if they come apart.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+from orionbelt_ontology_builder.app import missing_required
+
+APP = pathlib.Path(__file__).resolve().parents[1] / "orionbelt_ontology_builder/app.py"
+
+
+# --- the message ------------------------------------------------------------
+
+
+def test_nothing_missing_reads_as_none():
+    assert missing_required(Subject="a", Object="b") is None
+
+
+@pytest.mark.parametrize("empty", [None, "", "   "])
+def test_an_empty_field_is_named(empty):
+    """Named, because a form has several and "something is required" sends the
+    user hunting for which."""
+    assert missing_required(Subject="a", Object=empty) == "Object is required."
+
+
+def test_the_first_empty_field_is_the_one_reported():
+    assert missing_required(Subject=None, Object=None) == "Subject is required."
+
+
+def test_a_label_with_spaces_survives():
+    assert (
+        missing_required(**{"Applies to Class": None})
+        == "Applies to Class is required."
+    )
+
+
+# --- the two halves stay together -------------------------------------------
+
+
+def _functions_calling(name):
+    tree = ast.parse(APP.read_text(encoding="utf-8"))
+    parents = {c: p for p in ast.walk(tree) for c in ast.iter_child_nodes(p)}
+
+    def enclosing(node):
+        while node in parents:
+            node = parents[node]
+            if isinstance(node, ast.FunctionDef):
+                return node.name
+        return "<module>"
+
+    return {
+        enclosing(node)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == name
+    }
+
+
+def test_every_form_with_a_clearable_dropdown_checks_it():
+    """A cleared field must be reported, not written past.
+
+    Both are function-scoped, so a form that grows a clearable dropdown without
+    a check — or loses its check — shows up here rather than in someone's
+    ontology.
+    """
+    clearable = _functions_calling("required_selectbox")
+    checked = _functions_calling("missing_required")
+    assert clearable, "no form uses required_selectbox"
+    unchecked = clearable - checked
+    assert not unchecked, (
+        f"these forms offer a clearable dropdown but never check it: {sorted(unchecked)}"
+    )
+
+
+def test_no_form_checks_without_offering_one():
+    """The mirror: a check with nothing clearable can never fire, which reads
+    as protection that is not there."""
+    clearable = _functions_calling("required_selectbox")
+    checked = _functions_calling("missing_required")
+    assert not (checked - clearable), sorted(checked - clearable)

--- a/tests/test_clearable_required_dropdowns.py
+++ b/tests/test_clearable_required_dropdowns.py
@@ -90,3 +90,90 @@ def test_no_form_checks_without_offering_one():
     clearable = _functions_calling("required_selectbox")
     checked = _functions_calling("missing_required")
     assert not (checked - clearable), sorted(checked - clearable)
+
+
+# --- nothing new slips back to a plain dropdown -----------------------------
+
+# The dropdowns the rule below cannot read off the call itself, because their
+# options were built a line earlier and passed by name: three fixed sets from
+# the engine (the restriction types, the relation types) and one "All" filter.
+ALLOWED_BY_NAME = {
+    ("render_restriction_form", "Restriction Type"),
+    ("_render_panel_add_restriction_form", "Restriction Type"),
+    ("render_relation_form", "Relation"),
+    ("render_annotations", "Filter by Type"),
+}
+
+
+def _plain_selectboxes():
+    """Every ``st.selectbox`` left in the app, as (function, label, node)."""
+    tree = ast.parse(APP.read_text(encoding="utf-8"))
+    parents = {c: p for p in ast.walk(tree) for c in ast.iter_child_nodes(p)}
+
+    def enclosing(node):
+        while node in parents:
+            node = parents[node]
+            if isinstance(node, ast.FunctionDef):
+                return node.name
+        return "<module>"
+
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            continue
+        if node.func.attr != "selectbox" or not node.args:
+            continue
+        label = node.args[0]
+        label = label.value if isinstance(label, ast.Constant) else None
+        yield enclosing(node), label, node
+
+
+def _options_of(node):
+    if len(node.args) > 1:
+        return node.args[1]
+    return next((k.value for k in node.keywords if k.arg == "options"), None)
+
+
+def _is_exempt(func, label, node):
+    """A plain dropdown is fine when clearing it would mean nothing.
+
+    Three shapes qualify: it already passes ``index=None`` (so it draws the
+    cross itself), its options carry an explicit "All" (empty already has a
+    name), or its options are a fixed enum — a list literal, or one built
+    straight from an engine constant.
+    """
+    if func == "clearable_selectbox":
+        return True
+    if any(k.arg == "index" and _is_none(k.value) for k in node.keywords):
+        return True
+    options = _options_of(node)
+    if options is None:
+        return True
+    if any(isinstance(c, ast.Constant) and c.value == "All" for c in ast.walk(options)):
+        return True
+    if isinstance(options, (ast.List, ast.Tuple)):
+        return True
+    if isinstance(options, ast.Call) and isinstance(options.func, ast.Name):
+        return options.func.id in ("list", "sorted")
+    return (func, label) in ALLOWED_BY_NAME
+
+
+def _is_none(node):
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+def test_no_dropdown_worth_clearing_is_left_plain():
+    """Every picker of an entity, a namespace or a datatype offers the cross.
+
+    Written as a rule rather than a list of labels so a new form is covered the
+    day it is added: only a fixed enum, an "All"-style filter or a dropdown that
+    is already clearable may stay a plain ``st.selectbox``.
+    """
+    offenders = [
+        f"app.py:{node.lineno} {func}() {label!r}"
+        for func, label, node in _plain_selectboxes()
+        if not _is_exempt(func, label, node)
+    ]
+    assert not offenders, (
+        "these dropdowns hold a value worth clearing but offer no way to:\n  "
+        + "\n  ".join(sorted(offenders))
+    )

--- a/tests/test_clearable_required_dropdowns.py
+++ b/tests/test_clearable_required_dropdowns.py
@@ -177,3 +177,55 @@ def test_no_dropdown_worth_clearing_is_left_plain():
         "these dropdowns hold a value worth clearing but offer no way to:\n  "
         + "\n  ".join(sorted(offenders))
     )
+
+
+# --- seeding ----------------------------------------------------------------
+
+
+def _seed(monkeypatch, key, options, current_display):
+    """Run the helper's seeding with a stubbed selectbox, returning what it
+    would have rendered with."""
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+
+    seen = {}
+
+    def fake_selectbox(label, opts, index=None, key=None, **kwargs):
+        seen["value"] = st.session_state.get(key)
+        return seen["value"]
+
+    monkeypatch.setattr(app.st, "selectbox", fake_selectbox)
+    app.clearable_selectbox("L", options, key=key, current_display=current_display)
+    return seen["value"]
+
+
+def test_a_clear_survives_the_next_render(monkeypatch):
+    """Re-seeding on every run would undo the clear the moment it happened."""
+    import streamlit as st
+
+    st.session_state.clear()
+    assert _seed(monkeypatch, "k", ["a", "b"], "a") == "a"
+    st.session_state["k"] = None  # the user clears it
+    assert _seed(monkeypatch, "k", ["a", "b"], "a") is None
+
+
+def test_the_value_comes_back_after_the_widget_is_dropped(monkeypatch):
+    """Streamlit discards the state of a widget that wasn't rendered on a run,
+    so leaving the page and returning must re-seed rather than show empty."""
+    import streamlit as st
+
+    st.session_state.clear()
+    assert _seed(monkeypatch, "k", ["a", "b"], "a") == "a"
+    del st.session_state["k"]  # what Streamlit does while the page is away
+    assert _seed(monkeypatch, "k", ["a", "b"], "a") == "a"
+
+
+def test_a_changed_row_underneath_reseeds(monkeypatch):
+    """Seeding only on first sight would leave the previous row's value on
+    screen when the editor is reopened for another row."""
+    import streamlit as st
+
+    st.session_state.clear()
+    assert _seed(monkeypatch, "k", ["a", "b"], "a") == "a"
+    assert _seed(monkeypatch, "k", ["a", "b"], "b") == "b"

--- a/tests/test_restriction_edit_ui.py
+++ b/tests/test_restriction_edit_ui.py
@@ -316,7 +316,7 @@ def test_switching_a_hasvalue_row_to_a_class_type_offers_only_classes():
     assert "alice" not in " ".join(options)
 
 
-# --- clearing a required dropdown (issue #252) -------------------------------
+# --- clearing a required dropdown --------------------------------------------
 
 
 def test_a_required_dropdown_can_be_cleared():

--- a/tests/test_restriction_edit_ui.py
+++ b/tests/test_restriction_edit_ui.py
@@ -314,3 +314,78 @@ def test_switching_a_hasvalue_row_to_a_class_type_offers_only_classes():
     options = [o.strip() for o in at.selectbox(key="er_valcls_0").options]
     assert options == ["Person"], options
     assert "alice" not in " ".join(options)
+
+
+# --- clearing a required dropdown (issue #252) -------------------------------
+
+
+def test_a_required_dropdown_can_be_cleared():
+    """The clear cross only exists when a selectbox may hold nothing, so the
+    current value is seeded into the widget rather than preselected."""
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    box = at.selectbox(key="er_cls_0")
+    assert box.value is not None and box.value.strip() == "Bicycle"
+    box.set_value(None).run(timeout=120)
+    assert at.selectbox(key="er_cls_0").value is None
+
+
+def test_clearing_the_class_and_saving_reports_it_and_changes_nothing():
+    """It used to fall back to the value the row started with, rewriting the
+    axiom against a class the user had explicitly cleared."""
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    at.selectbox(key="er_cls_0").set_value(None).run(timeout=120)
+    _click(at, "💾 Save")
+
+    assert not at.exception, at.exception
+    assert any("Applies to Class is required" in e.value for e in at.error)
+    assert _rows(at.session_state["ontology"]) == [
+        ("hasPart", "someValuesFrom", "Engine"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]
+
+
+def test_clearing_the_property_and_saving_reports_it():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    at.selectbox(key="er_prop_0").set_value(None).run(timeout=120)
+    _click(at, "💾 Save")
+
+    assert any("Property is required" in e.value for e in at.error)
+    assert _rows(at.session_state["ontology"]) == [
+        ("hasPart", "someValuesFrom", "Engine"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]
+
+
+def test_clearing_the_class_value_and_saving_reports_it():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    at.selectbox(key="er_valcls_0").set_value(None).run(timeout=120)
+    _click(at, "💾 Save")
+
+    assert any("Value (Class) is required" in e.value for e in at.error)
+    assert _rows(at.session_state["ontology"]) == [
+        ("hasPart", "someValuesFrom", "Engine"),
+        ("hasPart", "someValuesFrom", "Wheel"),
+    ]
+
+
+def test_an_untouched_row_still_saves():
+    """The seeding must not leave a required field looking empty."""
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_row(at, 0)
+
+    _click(at, "💾 Save")
+
+    assert not any("is required" in e.value for e in at.error)


### PR DESCRIPTION
Adds the small clear cross (x) to the dropdowns across the app, so a
field can be emptied with one click instead of selecting its text and
deleting it. Requested in chat, not from an issue.

Streamlit only draws that cross when a selectbox is allowed to hold
nothing, which means `index=None` and therefore no preselection. So the
current value is seeded into the widget's own state instead, once per
value rather than once per render.

## The bug this uncovered

Every one of these dropdowns could already be emptied by hand, and every
one of them then silently fell back to whatever the row started with.
Verified live before the fix: clearing `Select Resource` on the
Annotations page and submitting wrote the annotation to the previously
selected class, with no error and no success message.

`missing_required()` now names the first empty field ("Class 1 is
required.") and the save is skipped.

## Two helpers

`clearable_selectbox()` is for fields where empty is a legitimate answer:
a picker that chooses what to show, or a value whose absence means "not
set". `required_selectbox()` is the same widget with an obligation on the
caller, which must check the result and refuse the write.

## Covered

Annotation Type (page and graph panel), the namespace pickers, Parent
Class, Select Class, Domain, Range, Range (Datatype), Class Type, Select
Individual, Property, Value (Individual), Apply to Class, On Property,
Value (Class), Individual, Qualified on Class, Subject/Object and the six
relation endpoints, Existing property, Source and Target class, Inverse
Of, On, Select Resource, Target Concept, Broader Concept, Scheme, Target
Class, Complement of Class, Result Property, and the template and
ontology pickers.

Left plain, by request and by rule: fixed enums (Restriction Type,
Relation Type, Relation, Expression Type, Format, Export Format,
Reasoning Profile) and the "All"-style filters, where empty already has a
name.

## Three cases that needed more than a widget swap

* A namespace that reads as empty means the base URI, so clearing one in
  an edit form would move the entity there and re-point every reference
  to it. Those are required, and flash the error rather than drawing it
  inline, since the rerun that follows would wipe anything inline.
* A relation's second endpoint can be replaced by an external URI, so
  requiring the dropdown would have blocked that flow. The check runs
  against the resolved target instead. Verified live: Class 2 cleared
  plus an external URI still creates the relation.
* Streamlit discards the state of a widget that wasn't rendered on a run,
  and the marker recording what a field was seeded for is not a widget
  key, so it survived and suppressed the re-seed. The dropdown came back
  empty after leaving the page and returning. Found in the running app,
  fixed, and pinned.

## Tests

`tests/test_clearable_required_dropdowns.py` covers `missing_required()`,
the three seeding cases, and two drift guards: a form offering a
clearable dropdown must check it, and no dropdown worth clearing may stay
a plain `st.selectbox`. The second is written as a rule on the options,
not a list of labels, so a form added later is covered the day it is
written. Confirmed the first guard bites by deleting one check, which
named the offending form.

929 passed, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
