### PR TITLE
feat: edit annotations from the Annotations page

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -2379,6 +2379,38 @@ def _render_panel_annotation_editor(
         )
         return
 
+    render_annotation_form(
+        ont,
+        subject_uri,
+        ann,
+        _uid(ename),
+        classes,
+        object_props,
+        data_props,
+        individuals,
+    )
+
+
+def render_annotation_form(
+    ont,
+    subject_uri,
+    ann,
+    form_key,
+    classes,
+    object_props,
+    data_props,
+    individuals,
+    on_close=None,
+):
+    """Render the edit form for one annotation (issue #257).
+
+    Shared by the Annotations page rows and the Visualization details panel, so
+    both rewrite the triple through the same guards and rollback. ``form_key``
+    makes the widget keys unique — the page passes the row's position, the panel
+    the selected node's id. ``on_close`` is what dismissing the editor means; the
+    panel has no such thing (it follows the graph selection), so it passes None
+    and gets no Cancel button.
+    """
     subject_options, subject_lookup = annotation_subject_options(
         classes, object_props, data_props, individuals
     )
@@ -2391,13 +2423,13 @@ def _render_panel_annotation_editor(
         _own = f"{_uri_local_name(subject_uri)} [current]"
         subject_options = [_own, *subject_options]
         subject_lookup[_own] = subject_uri
-    with st.form(f"panel_edit_ann_{_uid(ename)}"):
+    with st.form(f"edit_ann_{form_key}"):
         # Which resource it hangs off is editable, so an annotation can be moved
         # the way a relation or restriction can be re-pointed from here (#251).
         new_subject = required_selectbox(
             "On",
             subject_options,
-            key=f"panel_ann_on_{_uid(ename)}",
+            key=f"ann_on_{form_key}",
             current_display=subject_options[
                 _uri_option_index(subject_options, subject_lookup, subject_uri)
             ],
@@ -2428,12 +2460,22 @@ def _render_panel_annotation_editor(
             # Not editable here, but say it is there: it is carried through the
             # rewrite untouched, and a silent one would look like data loss.
             st.caption(f"Datatype: {ann['datatype']} (kept)")
-        save_col, del_col = st.columns(2)
+        cancelled = False
+        if on_close is None:
+            save_col, del_col = st.columns(2)
+        else:
+            save_col, del_col, cancel_col = st.columns(3)
         with save_col:
             saved = st.form_submit_button("Save", use_container_width=True)
         with del_col:
             deleted = st.form_submit_button("Delete", use_container_width=True)
+        if on_close is not None:
+            with cancel_col:
+                cancelled = st.form_submit_button("Cancel", use_container_width=True)
 
+    if cancelled:
+        on_close()
+        st.rerun()
     if deleted:
         ont.delete_annotation(
             subject_uri,
@@ -2447,7 +2489,9 @@ def _render_panel_annotation_editor(
             value_is_uri=bool(ann.get("is_uri")),
         )
         save_checkpoint("Delete annotation")
-        show_message("Annotation deleted!", "success")
+        if on_close is not None:
+            on_close()
+        set_flash_message("Annotation deleted!", "success")
         st.rerun()
     if saved:
         if _missing := missing_required(On=new_subject):
@@ -2467,7 +2511,9 @@ def _render_panel_annotation_editor(
             new_subject_uri=subject_lookup.get(new_subject),
         ):
             save_checkpoint("Update annotation")
-            show_message("Annotation updated!", "success")
+            if on_close is not None:
+                on_close()
+            set_flash_message("Annotation updated!", "success")
             st.rerun()
 
 
@@ -6779,6 +6825,7 @@ def render_annotations():
         all_resources.append(
             {
                 "name": c["name"],
+                "uri": c["uri"],
                 "label": c.get("label"),
                 "type": "Class",
                 "display": display,
@@ -6789,6 +6836,7 @@ def render_annotations():
         all_resources.append(
             {
                 "name": p["name"],
+                "uri": p["uri"],
                 "label": p.get("label"),
                 "type": "Object Property",
                 "display": display,
@@ -6799,6 +6847,7 @@ def render_annotations():
         all_resources.append(
             {
                 "name": p["name"],
+                "uri": p["uri"],
                 "label": p.get("label"),
                 "type": "Data Property",
                 "display": display,
@@ -6809,6 +6858,7 @@ def render_annotations():
         all_resources.append(
             {
                 "name": i["name"],
+                "uri": i["uri"],
                 "label": i.get("label"),
                 "type": "Individual",
                 "display": display,
@@ -6876,8 +6926,14 @@ def render_annotations():
                         st.info(f"No annotations found for '{resource_name}'")
                     else:
                         st.subheader(f"Annotations for {selected}")
-                        for ann in annotations:
-                            col1, col2, col3 = st.columns([2, 4, 1])
+                        resource_uri = resource.get("uri") or resource_name
+                        for _ai, ann in enumerate(annotations):
+                            # By position, the way the restriction rows are
+                            # keyed: a resource can carry two annotations that
+                            # differ only in language, and they would otherwise
+                            # share a key and open each other's editor.
+                            row_key = f"{_uid(resource_uri)}_{_ai}"
+                            col1, col2, col3, col4 = st.columns([2, 4, 0.7, 0.7])
                             with col1:
                                 # Show prefixed predicate (e.g., rdfs:label, skos:prefLabel)
                                 predicate_display = ann.get(
@@ -6897,9 +6953,18 @@ def render_annotations():
                                 )
                                 st.write(f"{ann['value']}{lang_str}{dtype_str}")
                             with col3:
+                                st.button(
+                                    "✏️",
+                                    key=f"edit_ann_{row_key}",
+                                    help="Edit this annotation",
+                                    on_click=_cb_toggle_edit,
+                                    args=("ann", row_key),
+                                )
+                            with col4:
                                 if st.button(
                                     "🗑️",
-                                    key=f"del_ann_{resource_name}_{ann['predicate']}_{hash(ann['value'])}",
+                                    key=f"del_ann_{row_key}",
+                                    help="Delete this annotation",
                                 ):
                                     ont.delete_annotation(
                                         resource_name,
@@ -6916,8 +6981,21 @@ def render_annotations():
                                         value_is_uri=bool(ann.get("is_uri")),
                                     )
                                     save_checkpoint("Delete annotation")
-                                    show_message("Annotation deleted!", "success")
+                                    set_flash_message("Annotation deleted!", "success")
                                     st.rerun()
+
+                            if _is_open("ann", row_key, "edit"):
+                                render_annotation_form(
+                                    ont,
+                                    resource_uri,
+                                    ann,
+                                    row_key,
+                                    classes,
+                                    object_props,
+                                    data_props,
+                                    individuals,
+                                    on_close=lambda: _close_entity("ann"),
+                                )
 
     if _ann_tab == "Add Annotation":
         render_add_annotation(ont, all_resources)

--- a/tests/test_annotations_edit_ui.py
+++ b/tests/test_annotations_edit_ui.py
@@ -1,0 +1,128 @@
+"""An annotation can be edited from the Annotations page (issue #257).
+
+The page's list offered only a delete, so fixing a typo in a value meant
+deleting the annotation and adding it back — losing the language tag and the
+datatype unless they were retyped exactly. The editor already existed for the
+graph's details panel; the form is now shared, so both routes rewrite the triple
+through the same guards and the same rollback.
+
+Driven through ``render_annotation_form`` rather than the page: the page's tab
+picker is a ``segmented_control``, which AppTest mis-serializes, so the row's
+pencil cannot be clicked from a page run (the same reason the restriction tests
+call the form directly).
+"""
+
+from streamlit.testing.v1 import AppTest
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Animal")
+        om.add_class("Plant")
+        om.add_annotation("Animal", "rdfs:comment", "a beast", lang="en")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    classes = ont.get_classes()
+    subject = next(c for c in classes if c["name"] == "Animal")
+    anns = ont.get_annotations("Animal")
+    if not anns:
+        # Moved away or deleted: the page stops listing the row, so there is
+        # nothing left to render an editor for.
+        st.caption("gone")
+        return
+    ann = anns[0]
+    app.render_annotation_form(
+        ont,
+        subject["uri"],
+        ann,
+        "row0",
+        classes,
+        ont.get_object_properties(),
+        ont.get_data_properties(),
+        ont.get_individuals(),
+        on_close=lambda: app._close_entity("ann"),
+    )
+
+
+def _run():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    return at
+
+
+def _save(at):
+    at.button(key="FormSubmitter:edit_ann_row0-Save").click().run(timeout=120)
+    assert not at.exception, at.exception
+    return at
+
+
+def test_the_form_opens_on_the_annotation_it_was_given():
+    at = _run()
+    assert at.text_input[0].value == "http://www.w3.org/2000/01/rdf-schema#comment"
+    assert at.text_input[1].value == "a beast"
+    assert at.selectbox(key="ann_on_row0").value == "Animal [Class]"
+
+
+def test_editing_the_value_rewrites_it_in_place():
+    at = _run()
+    at.text_input[1].set_value("a large beast")
+    _save(at)
+
+    anns = at.session_state["ontology"].get_annotations("Animal")
+    assert [a["value"] for a in anns] == ["a large beast"]
+    # The tag rides along: a delete-and-retype loses it, which is what made the
+    # missing editor worth having.
+    assert anns[0]["language"] == "en"
+
+
+def test_the_editor_moves_an_annotation_like_the_panel_does():
+    at = _run()
+    at.selectbox(key="ann_on_row0").set_value("Plant [Class]")
+    _save(at)
+
+    ont = at.session_state["ontology"]
+    assert ont.get_annotations("Animal") == []
+    assert [a["value"] for a in ont.get_annotations("Plant")] == ["a beast"]
+
+
+def test_an_empty_value_is_refused_rather_than_written():
+    at = _run()
+    at.text_input[1].set_value("   ")
+    _save(at)
+
+    assert "required" in at.error[0].value
+    assert [a["value"] for a in at.session_state["ontology"].get_annotations("Animal")]
+
+
+def test_cancel_closes_the_row_without_touching_it():
+    """The page owns the closing, so the form offers a Cancel; the panel, which
+    follows the graph selection, passes no on_close and gets none."""
+    at = _run()
+    at.session_state["active_ann"] = ("row0", "edit")
+    at.text_input[1].set_value("not saved")
+    at.button(key="FormSubmitter:edit_ann_row0-Cancel").click().run(timeout=120)
+    assert not at.exception, at.exception
+
+    assert "active_ann" not in at.session_state
+    anns = at.session_state["ontology"].get_annotations("Animal")
+    assert [a["value"] for a in anns] == ["a beast"]
+
+
+def test_delete_removes_it_and_closes_the_row():
+    at = _run()
+    at.session_state["active_ann"] = ("row0", "edit")
+    at.button(key="FormSubmitter:edit_ann_row0-Delete").click().run(timeout=120)
+    assert not at.exception, at.exception
+
+    assert at.session_state["ontology"].get_annotations("Animal") == []
+    assert "active_ann" not in at.session_state


### PR DESCRIPTION
Closes #257.

Each row in View Annotations gains a pencil, opening the editor
underneath the row it belongs to, the way the Relations and Restrictions
rows already do. Before this, the list offered only a delete: fixing a
typo in a value meant deleting the annotation and adding it back, which
lost the language tag and the datatype unless both were retyped exactly.

## One form, two routes

The editor built for the graph's details panel in #223 is extracted as
`render_annotation_form` and shared. Both routes now rewrite the triple
through the same guards and the same rollback, and moving an annotation
to another resource (#251) works from the page too.

The page owns the closing, so it passes `on_close` and gets a Cancel
button; the panel follows the graph selection, passes None, and gets
none. Same arrangement as `render_relation_form` and
`render_restriction_form`.

## Two details worth flagging

* Rows are keyed by position, like the restriction rows. A resource can
  carry two annotations that differ only in language; keyed by predicate
  and value they would share a key and open each other's editor.
* The subject is addressed by URI rather than by local name, which
  collides across namespaces. The page's resource list now carries the
  URI for that.
* Both editors flash their result instead of drawing it inline. The rerun
  that follows a save wiped the message before it could be seen, so a
  successful edit looked like nothing had happened.

## Verified in the running app

Opened the editor on a row, changed the value, saved (flash: "Annotation
updated!", row updated, editor closed), then deleted through the form
(flash: "Annotation deleted!", row gone).

## Tests

`tests/test_annotations_edit_ui.py` drives the form through AppTest:
opens on the annotation it was given, rewrites a value in place while
keeping the language tag, moves an annotation to another resource,
refuses an empty value, and covers Cancel and Delete closing the row.
Driven through the form rather than the page because the page's tab
picker is a `segmented_control`, which AppTest mis-serializes.

935 passed, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
