### PR TITLE
fix: recover the sidebar space that pushed Quick Stats out of view

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -131,6 +131,32 @@ _CUSTOM_CSS = """
     [data-testid="stCustomComponentV1"] {
         margin-bottom: -1rem !important;
     }
+    /* Sidebar density. Streamlit's defaults put 16px between every element,
+       64px around each divider and 96px of padding under the last one, which
+       together pushed Quick Stats off the bottom of a 1080p screen. Measured
+       in the browser: this recovers ~270px, enough for the whole sidebar to
+       fit without scrolling.
+       NOTE: internal DOM again — re-verify on a Streamlit bump. */
+    [data-testid="stSidebarHeader"] [data-testid="stLogoSpacer"] {
+        /* Reserves room for a st.logo() this app doesn't set: the mark is
+           rendered as an image in the sidebar body instead. */
+        display: none !important;
+    }
+    [data-testid="stSidebarUserContent"] {
+        padding-bottom: 1.5rem !important;
+    }
+    [data-testid="stSidebarUserContent"] [data-testid="stVerticalBlock"] {
+        gap: 0.5rem !important;
+    }
+    [data-testid="stSidebar"] hr {
+        margin-top: 0.4rem !important;
+        margin-bottom: 0.4rem !important;
+    }
+    [data-testid="stSidebar"] h1 {
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+        margin-bottom: 0.2rem !important;
+    }
 </style>
 """
 
@@ -11103,13 +11129,19 @@ def main():
     # Quick stats in sidebar
     stats = st.session_state.ontology.get_statistics()
     st.sidebar.caption("Quick Stats")
-    st.sidebar.write(f"📦 Classes: {stats['classes']}")
-    st.sidebar.write(f"🔗 Object Props: {stats['object_properties']}")
-    st.sidebar.write(f"📝 Data Props: {stats['data_properties']}")
-    st.sidebar.write(f"👤 Individuals: {stats['individuals']}")
+    # One block rather than a write() per line: each was its own element, and
+    # the gap between elements cost more than the lines themselves. Two trailing
+    # spaces are markdown for a line break.
+    _stat_lines = [
+        f"📦 Classes: {stats['classes']}",
+        f"🔗 Object Props: {stats['object_properties']}",
+        f"📝 Data Props: {stats['data_properties']}",
+        f"👤 Individuals: {stats['individuals']}",
+    ]
     if stats.get("concepts", 0) > 0:
-        st.sidebar.write(f"🏷️ SKOS Concepts: {stats['concepts']}")
-    st.sidebar.write(f"📊 Triples: {stats['content_triples']}")
+        _stat_lines.append(f"🏷️ SKOS Concepts: {stats['concepts']}")
+    _stat_lines.append(f"📊 Triples: {stats['content_triples']}")
+    st.sidebar.markdown("  \n".join(_stat_lines))
 
     # Say what the app is, but only to someone who has nothing loaded yet. The
     # name otherwise lives in the sidebar and the tab title, and a permanent

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -142,6 +142,16 @@ _CUSTOM_CSS = """
            rendered as an image in the sidebar body instead. */
         display: none !important;
     }
+    [data-testid="stSidebarHeader"] {
+        /* 60px tall plus a 16px margin, to hold a 28px collapse button, all
+           of it above the logo. Sized to the button instead, which keeps it
+           clear of the logo underneath. */
+        height: 2.5rem !important;
+        min-height: 2.5rem !important;
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+        margin-bottom: 0 !important;
+    }
     [data-testid="stSidebarUserContent"] {
         padding-bottom: 1.5rem !important;
     }


### PR DESCRIPTION
Reported in chat with a screenshot: the sidebar spends so much vertical
space on gaps that Quick Stats falls below the fold.

## Where it was going

Measured in the running app rather than guessed at:

| Source | Cost |
| --- | --- |
| 16px gap between every element (18 of them) | ~272px |
| 64px of margin around each divider | ~190px |
| 96px of padding under the last element | 96px |
| A header band 60px tall plus a 16px margin, above the logo, holding a 28px collapse button | 48px |
| A 32px logo slot reserved for a `st.logo()` this app doesn't set | 32px |

The mark is rendered as an image in the sidebar body, so that last one
was empty space held for a logo already on screen.

## What changed

CSS tightens the element gap to 8px, the divider margins to 6px, the
trailing padding to 1.5rem, sizes the header band to the collapse button
it holds, and hides the unused logo slot. Quick Stats is also rendered as
one markdown block instead of six separate elements, since the gap
between elements cost more than the lines themselves.

The selectors reach into Streamlit's internal DOM, like the brand-colour
rules directly above them, so they carry the same re-verify-on-a-bump
note.

## Before and after

Sidebar content height at 1440x1142: 1416px (scrolled) to 1086px (fits).
About 330px recovered, and the logo starts 36px higher.

| Viewport height | Before | After |
| --- | --- | --- |
| 1142 | overflows, Quick Stats below the fold | fits, nothing scrolls |
| 900 | overflows by ~290px, Quick Stats hidden | overflows by 91px, Quick Stats visible |
| 768 | Quick Stats far below the fold | overflows by 223px, reachable in one short scroll |

Verified in the browser at all three heights, and the collapse chevron
stays clear of the logo with collapse and expand both still working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
