### PR TITLE
feat: collapsible Visualization display options, and a graph that fills the window

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -55,6 +55,7 @@ _VIZ_PERSIST_KEYS = (
     "details_panel",
     "focus_mode",
     "focus_depth",
+    "options_open",
 )
 # Clamp restored integer settings so a stale/tampered value can't crash a slider
 # whose value must lie within its min/max.
@@ -9032,6 +9033,7 @@ def render_visualization():
             "highlight_issues": False,
             "focus_mode": False,
             "focus_depth": 1,
+            "options_open": True,
         }
         # Bring back settings saved in a previous session before applying
         # defaults, so a returning user opens with their own preferences (#142).
@@ -9044,130 +9046,24 @@ def render_visualization():
             # Restore widget key from persisted config
             st.session_state[wid_key] = st.session_state[cfg_key]
 
-        _cols = (
-            st.columns([1, 1, 1, 1, 1, 1, 1, 1])
-            if _has_skos
-            else st.columns([1, 1, 1, 1, 1, 1, 1])
-        )
-        with _cols[0]:
-            show_classes = st.checkbox(
-                "Classes",
-                key="viz_show_classes",
+        # The display options are a band of controls above the canvas that is
+        # set once and then left alone, so it collapses to give the graph the
+        # room. A toggle rather than an expander: an expander's open state is
+        # client-side only and resets on reload, while this rides the same
+        # persisted viz settings, so a band you collapsed stays collapsed.
+        # Render sits outside it, since redrawing is the one thing still worth
+        # doing while the rest is out of the way.
+        _opt_col, _render_col = st.columns([5, 1])
+        with _opt_col:
+            options_open = st.toggle(
+                "Display options",
+                key="viz_options_open",
                 on_change=viz_sync,
-                args=("_viz_cfg_show_classes", "viz_show_classes"),
+                args=("_viz_cfg_options_open", "viz_options_open"),
+                help="Which node types to draw, the graph height and the "
+                "layout spacing.",
             )
-        with _cols[1]:
-            show_properties = st.checkbox(
-                "Obj Props",
-                key="viz_show_obj_props",
-                on_change=viz_sync,
-                args=("_viz_cfg_show_obj_props", "viz_show_obj_props"),
-            )
-        with _cols[2]:
-            show_data_props = st.checkbox(
-                "Data Props",
-                key="viz_show_data_props",
-                on_change=viz_sync,
-                args=("_viz_cfg_show_data_props", "viz_show_data_props"),
-            )
-        with _cols[3]:
-            show_annotations = st.checkbox(
-                "Annotations",
-                key="viz_show_annotations",
-                on_change=viz_sync,
-                args=("_viz_cfg_show_annotations", "viz_show_annotations"),
-            )
-        with _cols[4]:
-            show_individuals = st.checkbox(
-                "Individuals",
-                key="viz_show_individuals",
-                on_change=viz_sync,
-                args=("_viz_cfg_show_individuals", "viz_show_individuals"),
-            )
-        if _has_skos:
-            with _cols[5]:
-                show_skos = st.checkbox(
-                    "SKOS",
-                    key="viz_show_skos",
-                    on_change=viz_sync,
-                    args=("_viz_cfg_show_skos", "viz_show_skos"),
-                )
-            with _cols[6]:
-                show_ind_edges = st.checkbox(
-                    "Ind. Edges",
-                    key="viz_show_ind_edges",
-                    on_change=viz_sync,
-                    args=("_viz_cfg_show_ind_edges", "viz_show_ind_edges"),
-                    help="Show property edges between individuals",
-                )
-            with _cols[7]:
-                show_triples = st.checkbox(
-                    "Triples",
-                    key="viz_show_triples",
-                    on_change=viz_sync,
-                    args=("_viz_cfg_show_triples", "viz_show_triples"),
-                    help="Show all RDF triples for visible nodes",
-                )
-        else:
-            show_skos = False
-            with _cols[5]:
-                show_ind_edges = st.checkbox(
-                    "Ind. Edges",
-                    key="viz_show_ind_edges",
-                    on_change=viz_sync,
-                    args=("_viz_cfg_show_ind_edges", "viz_show_ind_edges"),
-                    help="Show property edges between individuals",
-                )
-            with _cols[6]:
-                show_triples = st.checkbox(
-                    "Triples",
-                    key="viz_show_triples",
-                    on_change=viz_sync,
-                    args=("_viz_cfg_show_triples", "viz_show_triples"),
-                    help="Show all RDF triples for visible nodes",
-                )
-
-        # Row 2: sliders + fit-to-window + highlight issues + render button
-        col1, col2, col3, col4, col5 = st.columns([2, 2, 1, 1, 1])
-        with col1:
-            height = st.slider(
-                "Graph Height",
-                300,
-                1200,
-                step=10,
-                key="viz_graph_height",
-                on_change=viz_sync,
-                args=("_viz_cfg_graph_height", "viz_graph_height"),
-                disabled=st.session_state.get("_viz_cfg_fit", True),
-                help="Used when 'Fit to window' is off.",
-            )
-        with col2:
-            node_spacing = st.slider(
-                "Node Spacing",
-                50,
-                300,
-                help="Distance between nodes. Increase for less overlap.",
-                key="viz_node_spacing",
-                on_change=viz_sync,
-                args=("_viz_cfg_node_spacing", "viz_node_spacing"),
-            )
-        with col3:
-            fit = st.checkbox(
-                "Fit to window",
-                help="Resize the graph to fill the window height. "
-                "Turn off to use the Graph Height slider.",
-                key="viz_fit",
-                on_change=viz_sync,
-                args=("_viz_cfg_fit", "viz_fit"),
-            )
-        with col4:
-            highlight_issues = st.checkbox(
-                "Highlight Issues",
-                key="viz_highlight_issues",
-                on_change=viz_sync,
-                args=("_viz_cfg_highlight_issues", "viz_highlight_issues"),
-            )
-        with col5:
+        with _render_col:
             render_graph = st.button(
                 "Render",
                 type="primary",
@@ -9175,6 +9071,135 @@ def render_visualization():
                 help="Redraw the graph and re-run the layout. Also re-centres on "
                 "the current Find selection.",
             )
+
+        if options_open:
+            _cols = (
+                st.columns([1, 1, 1, 1, 1, 1, 1, 1])
+                if _has_skos
+                else st.columns([1, 1, 1, 1, 1, 1, 1])
+            )
+            with _cols[0]:
+                st.checkbox(
+                    "Classes",
+                    key="viz_show_classes",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_show_classes", "viz_show_classes"),
+                )
+            with _cols[1]:
+                st.checkbox(
+                    "Obj Props",
+                    key="viz_show_obj_props",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_show_obj_props", "viz_show_obj_props"),
+                )
+            with _cols[2]:
+                st.checkbox(
+                    "Data Props",
+                    key="viz_show_data_props",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_show_data_props", "viz_show_data_props"),
+                )
+            with _cols[3]:
+                st.checkbox(
+                    "Annotations",
+                    key="viz_show_annotations",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_show_annotations", "viz_show_annotations"),
+                )
+            with _cols[4]:
+                st.checkbox(
+                    "Individuals",
+                    key="viz_show_individuals",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_show_individuals", "viz_show_individuals"),
+                )
+            _ind_edge_col, _triple_col = (
+                (_cols[6], _cols[7]) if _has_skos else (_cols[5], _cols[6])
+            )
+            if _has_skos:
+                with _cols[5]:
+                    st.checkbox(
+                        "SKOS",
+                        key="viz_show_skos",
+                        on_change=viz_sync,
+                        args=("_viz_cfg_show_skos", "viz_show_skos"),
+                    )
+            with _ind_edge_col:
+                st.checkbox(
+                    "Ind. Edges",
+                    key="viz_show_ind_edges",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_show_ind_edges", "viz_show_ind_edges"),
+                    help="Show property edges between individuals",
+                )
+            with _triple_col:
+                st.checkbox(
+                    "Triples",
+                    key="viz_show_triples",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_show_triples", "viz_show_triples"),
+                    help="Show all RDF triples for visible nodes",
+                )
+
+            # Row 2: sliders + fit-to-window + highlight issues
+            col1, col2, col3, col4 = st.columns([2, 2, 1, 1])
+            with col1:
+                st.slider(
+                    "Graph Height",
+                    300,
+                    1200,
+                    step=10,
+                    key="viz_graph_height",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_graph_height", "viz_graph_height"),
+                    disabled=st.session_state.get("_viz_cfg_fit", True),
+                    help="Used when 'Fit to window' is off.",
+                )
+            with col2:
+                st.slider(
+                    "Node Spacing",
+                    50,
+                    300,
+                    help="Distance between nodes. Increase for less overlap.",
+                    key="viz_node_spacing",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_node_spacing", "viz_node_spacing"),
+                )
+            with col3:
+                st.checkbox(
+                    "Fit to window",
+                    help="Resize the graph to fill the window height. "
+                    "Turn off to use the Graph Height slider.",
+                    key="viz_fit",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_fit", "viz_fit"),
+                )
+            with col4:
+                st.checkbox(
+                    "Highlight Issues",
+                    key="viz_highlight_issues",
+                    on_change=viz_sync,
+                    args=("_viz_cfg_highlight_issues", "viz_highlight_issues"),
+                )
+
+        # Read the settings from the persisted config rather than from the
+        # widgets' return values: collapsed, the widgets do not render at all,
+        # and the config is what they write into either way.
+        _cfg = st.session_state
+        show_classes = _cfg["_viz_cfg_show_classes"]
+        show_properties = _cfg["_viz_cfg_show_obj_props"]
+        show_data_props = _cfg["_viz_cfg_show_data_props"]
+        show_annotations = _cfg["_viz_cfg_show_annotations"]
+        show_individuals = _cfg["_viz_cfg_show_individuals"]
+        # SKOS has no toggle without concepts to draw, so it stays off rather
+        # than reading a stale True from a previous ontology.
+        show_skos = _has_skos and _cfg["_viz_cfg_show_skos"]
+        show_ind_edges = _cfg["_viz_cfg_show_ind_edges"]
+        show_triples = _cfg["_viz_cfg_show_triples"]
+        height = _cfg["_viz_cfg_graph_height"]
+        node_spacing = _cfg["_viz_cfg_node_spacing"]
+        fit = _cfg["_viz_cfg_fit"]
+        highlight_issues = _cfg["_viz_cfg_highlight_issues"]
 
         validation_subjects = set()
         if highlight_issues:

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -115,11 +115,15 @@ _CUSTOM_CSS = """
         border-radius: 4px;
         color: #721c24;
     }
-    /* Reduce margin/padding */
+    /* Reduce margin/padding. The side gutters are Streamlit's own 80px, which
+       on a wide screen is 160px the graph could be using; 2rem still keeps text
+       pages off the window edge. */
     .block-container, .stMainBlockContainer,
     [data-testid="stAppViewBlockContainer"] {
         padding-top: 2.5rem !important;
         padding-bottom: 0 !important;
+        padding-left: 2rem !important;
+        padding-right: 2rem !important;
     }
     footer, [data-testid="stBottom"] {
         display: none !important;

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -108,22 +108,45 @@ var fsDetachTimer = null;   // timer that detaches fsResizeHandler
 // not change when the graph is resized, so the two cannot chase each other.
 var AUTOFIT_MAX_RESERVE = 220;
 
-function autofitReserve(rect) {
-    var host = window.frameElement;
-    while (host && host.getAttribute
-           && host.getAttribute('data-testid') !== 'stElementContainer') {
-        host = host.parentElement;
+function autofitReserve() {
+    var node = window.frameElement;
+    while (node && node.getAttribute
+           && node.getAttribute('data-testid') !== 'stElementContainer') {
+        node = node.parentElement;
     }
-    if (!host || !host.parentElement) return 90;
-    var gap = parseFloat(
-        window.parent.getComputedStyle(host.parentElement).rowGap
-    ) || 0;
-    var below = 0;
-    for (var sib = host.nextElementSibling; sib; sib = sib.nextElementSibling) {
-        var h = sib.getBoundingClientRect().height;
-        if (h > 0) below += h + gap;
+    if (!node || !node.parentElement) return 90;
+    // The lowest edge of anything below, not the sum of their heights: that way
+    // the gaps and padding between them are included without having to know
+    // which of Streamlit's blocks contributes what.
+    var bottom = window.frameElement.getBoundingClientRect().bottom;
+    var lowest = bottom;
+    while (node && node.parentElement) {
+        var parent = node.parentElement;
+        var ptid = parent.getAttribute && parent.getAttribute('data-testid');
+        // Climb, because the status bar is not the graph's sibling: it sits a
+        // level up, after the whole row of columns. Skip the row itself, where
+        // the following sibling is the details panel *beside* the graph — taking
+        // that for "below" collapsed the canvas to its floor.
+        if (ptid !== 'stHorizontalBlock') {
+            for (var sib = node.nextElementSibling; sib; sib = sib.nextElementSibling) {
+                var r = sib.getBoundingClientRect();
+                if (r.height > 0 && r.bottom > lowest) lowest = r.bottom;
+                // Descendants too: the status bar is a fixed-height div inside a
+                // shorter markdown container, so the container's own edge sits
+                // 16px above the bar it holds and the bar hung off the window.
+                var kids = sib.querySelectorAll('*');
+                if (kids.length && kids.length < 60) {
+                    for (var i = 0; i < kids.length; i++) {
+                        var kr = kids[i].getBoundingClientRect();
+                        if (kr.height > 0 && kr.bottom > lowest) lowest = kr.bottom;
+                    }
+                }
+            }
+        }
+        if (ptid === 'stMainBlockContainer') break;
+        node = parent;
     }
-    return Math.min(below, AUTOFIT_MAX_RESERVE);
+    return Math.min(lowest - bottom, AUTOFIT_MAX_RESERVE);
 }
 
 function autofitHeight() {
@@ -131,7 +154,7 @@ function autofitHeight() {
         var fe = window.frameElement;
         if (!fe) return null;
         var rect = fe.getBoundingClientRect();
-        var avail = window.parent.innerHeight - rect.top - autofitReserve(rect) - 8;
+        var avail = window.parent.innerHeight - rect.top - autofitReserve() - 8;
         return Math.max(Math.round(avail), 300);
     } catch (e) {
         return null;  // cross-origin or unavailable: fall back to fixed height
@@ -287,14 +310,27 @@ window.addEventListener('resize', autofitApply);
 // closing) — layout changes that don't fire a 'resize' event. Poll for a
 // position change and re-fit, so the graph grows back after such a shift
 // instead of staying stuck at a height computed for the old position (bug B2).
+//
+// The reserve below is watched as well as the top. Hiding the details panel puts
+// the status bar back under the graph without moving the graph's top edge, so
+// watching the top alone kept a height computed for no bar at all and pushed the
+// bar off the bottom of the window.
 var _lastFitTop = null;
+var _lastFitReserve = null;
 setInterval(function() {
     if (!autofitOn || !network) return;
-    var t;
+    var t, res;
     try {
-        t = window.frameElement ? Math.round(window.frameElement.getBoundingClientRect().top) : 0;
+        var fe = window.frameElement;
+        if (!fe) return;
+        t = Math.round(fe.getBoundingClientRect().top);
+        res = Math.round(autofitReserve());
     } catch (e) { return; }
-    if (t !== _lastFitTop) { _lastFitTop = t; autofitApply(); }
+    if (t !== _lastFitTop || res !== _lastFitReserve) {
+        _lastFitTop = t;
+        _lastFitReserve = res;
+        autofitApply();
+    }
 }, 400);
 
 function downloadGraph() {

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -94,12 +94,28 @@ var fsDetachTimer = null;   // timer that detaches fsResizeHandler
 
 // When "Fit to window" is on, fill the available window height instead of using
 // the fixed Graph Height. Reads the parent window's height and this iframe's
-// position in it (same-origin), reserving room for the status bar below.
+// position in it (same-origin), reserving room for whatever sits below.
+//
+// That reserve used to be a flat 90px, which is what the status bar takes when
+// something is selected. With nothing selected the bar is a single line, so the
+// graph stopped ~80px short of the bottom for no reason. It is measured instead:
+// the distance from this iframe's bottom edge to the bottom of the page's
+// content block is exactly the status bar plus the block's own padding. Measured
+// from the iframe's *bottom*, so it does not change when the graph is resized
+// and the two cannot chase each other.
 function autofitHeight() {
     try {
         var fe = window.frameElement;
-        var top = fe ? fe.getBoundingClientRect().top : 0;
-        var avail = window.parent.innerHeight - top - 90;
+        if (!fe) return null;
+        var rect = fe.getBoundingClientRect();
+        var doc = window.parent.document;
+        var block = doc.querySelector('[data-testid="stMainBlockContainer"]')
+            || doc.querySelector('.block-container');
+        var below = 90;
+        if (block) {
+            below = Math.max(block.getBoundingClientRect().bottom - rect.bottom, 0);
+        }
+        var avail = window.parent.innerHeight - rect.top - below - 8;
         return Math.max(Math.round(avail), 300);
     } catch (e) {
         return null;  // cross-origin or unavailable: fall back to fixed height

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -98,24 +98,40 @@ var fsDetachTimer = null;   // timer that detaches fsResizeHandler
 //
 // That reserve used to be a flat 90px, which is what the status bar takes when
 // something is selected. With nothing selected the bar is a single line, so the
-// graph stopped ~80px short of the bottom for no reason. It is measured instead:
-// the distance from this iframe's bottom edge to the bottom of the page's
-// content block is exactly the status bar plus the block's own padding. Measured
-// from the iframe's *bottom*, so it does not change when the graph is resized
-// and the two cannot chase each other.
+// graph stopped ~80px short of the bottom for no reason. It is measured instead,
+// by adding up what actually follows the graph.
+//
+// Only the graph's *own* column counts. Measuring to the bottom of the whole
+// page block took the details panel beside the graph with it — a tall panel then
+// read as "space below the graph", and the canvas collapsed to its 300px floor
+// with the panel's height of emptiness underneath it. The siblings' heights do
+// not change when the graph is resized, so the two cannot chase each other.
+var AUTOFIT_MAX_RESERVE = 220;
+
+function autofitReserve(rect) {
+    var host = window.frameElement;
+    while (host && host.getAttribute
+           && host.getAttribute('data-testid') !== 'stElementContainer') {
+        host = host.parentElement;
+    }
+    if (!host || !host.parentElement) return 90;
+    var gap = parseFloat(
+        window.parent.getComputedStyle(host.parentElement).rowGap
+    ) || 0;
+    var below = 0;
+    for (var sib = host.nextElementSibling; sib; sib = sib.nextElementSibling) {
+        var h = sib.getBoundingClientRect().height;
+        if (h > 0) below += h + gap;
+    }
+    return Math.min(below, AUTOFIT_MAX_RESERVE);
+}
+
 function autofitHeight() {
     try {
         var fe = window.frameElement;
         if (!fe) return null;
         var rect = fe.getBoundingClientRect();
-        var doc = window.parent.document;
-        var block = doc.querySelector('[data-testid="stMainBlockContainer"]')
-            || doc.querySelector('.block-container');
-        var below = 90;
-        if (block) {
-            below = Math.max(block.getBoundingClientRect().bottom - rect.bottom, 0);
-        }
-        var avail = window.parent.innerHeight - rect.top - below - 8;
+        var avail = window.parent.innerHeight - rect.top - autofitReserve(rect) - 8;
         return Math.max(Math.round(avail), 300);
     } catch (e) {
         return null;  // cross-origin or unavailable: fall back to fixed height


### PR DESCRIPTION
Requests from chat: make the band of display options above the graph
collapsible, and stop the canvas falling short of the bottom and the
sides.

## Collapsible options

The band is set once and then left alone, so it now sits behind a
"Display options" switch. Render stays outside it, since redrawing is the
one thing still worth doing while the rest is out of the way.

A toggle rather than an `st.expander`: an expander's open state is
client-side only and resets on every reload, so it would not actually buy
the space back tomorrow. This rides the same persisted viz settings as
the rest of the page.

The settings are read from the persisted `_viz_cfg_*` config rather than
from the widgets' return values, because collapsed the widgets do not
render at all and the config is what they write into either way.

## A graph that fills the space

Fit-to-window reserved a flat 90px below the canvas, which is what the
status bar takes when something is selected. The reserve is measured now.
Getting that right took three passes, each found by driving the page:

* Measuring to the bottom of the page block took the details panel
  *beside* the graph with it, so a tall panel read as space below and the
  canvas collapsed to its 300px floor. The walk skips the columns row.
* The status bar is not the graph's sibling; it sits a level up, after
  the whole row of columns, so a walk over the graph's own siblings found
  nothing and the canvas took the bar's space. The walk climbs.
* The bar is a fixed-height div inside a shorter markdown container, so
  the container's edge sits 16px above the bar it holds. The reserve
  measures the lowest edge in the subtree, not the container's own.

The re-fit poll also watches the reserve now, not only the iframe's top:
hiding the details panel puts the bar back under the graph without moving
the graph's top edge.

The page's side gutters drop from Streamlit's 80px to 32px, so a wide
window stops spending 160px on empty margin.

## Measured in the browser, at 1920x1080 and 2056x1198

| | Before | After |
| --- | --- | --- |
| Graph height, options open | 528px | 646px |
| Graph height, options collapsed | n/a | 742px |
| Graph width at 1920 | 1120px | 1192px |
| Dead space below the graph | 90px | 8px |
| Status bar with the panel hidden | pushed below the fold | fully visible, page does not scroll |
| Graph with the details panel open | collapsed to 300px | 686px |

935 passed, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
