### PR TITLE
fix: import reported a different triple count than Quick Stats

### DIFF
--- a/orionbelt_ontology_builder/pages/import_export.py
+++ b/orionbelt_ontology_builder/pages/import_export.py
@@ -89,8 +89,15 @@ def render_import_export():
                 st.session_state.ontology = ont
                 save_checkpoint("Import ontology")
                 request_autosave_flush()
+                # The same count the sidebar shows, which is what the user
+                # checks it against. len(graph) includes the ontology header,
+                # so an import of a file carrying one announced more triples
+                # than Quick Stats then displayed, and the difference read as
+                # data lost on the way in (issue #263). The template and
+                # upper/reference loaders below already report it this way.
                 set_flash_message(
-                    f"Ontology imported successfully! ({len(ont.graph)} triples)",
+                    "Ontology imported successfully! "
+                    f"({ont.get_statistics()['content_triples']} triples)",
                     "success",
                 )
                 # Clear file uploader by incrementing its key
@@ -253,7 +260,7 @@ def render_import_export():
                         st.session_state.import_preview = None
                         st.session_state.import_content = None
                         st.session_state.import_format = None
-                        triples = len(ont.graph)
+                        triples = ont.get_statistics()["content_triples"]
                         set_flash_message(
                             f"Ontology imported successfully! ({triples} triples)",
                             "success",

--- a/tests/test_triple_count_consistency.py
+++ b/tests/test_triple_count_consistency.py
@@ -1,0 +1,76 @@
+"""One number for "triples" wherever the app reports it (issue #263).
+
+Importing a file flashed "(14 triples)" while Quick Stats read "Triples: 12"
+for the same ontology at the same moment. Neither was wrong: the message counted
+``len(graph)`` and the sidebar counts ``content_triples``, which excludes the
+triples hanging off the ontology URI. Shown side by side, the gap reads as data
+lost on the way in.
+
+The template and upper/reference loaders already reported the sidebar's number,
+so the two import paths were the outliers rather than the rule.
+"""
+
+import ast
+
+import sources
+
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+WITH_HEADER = """
+@prefix : <http://example.org/imported#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+<http://example.org/imported> a owl:Ontology ; rdfs:label "Imported" .
+:Vehicle a owl:Class ; rdfs:label "Vehicle" .
+:Bicycle a owl:Class ; rdfs:subClassOf :Vehicle .
+"""
+
+
+def test_the_two_counts_really_do_differ():
+    """The premise: without a header they agree, which is why this went unseen."""
+    om = OntologyManager()
+    om.load_from_string(WITH_HEADER, format="turtle")
+    stats = om.get_statistics()
+
+    assert stats["total_triples"] - stats["content_triples"] == 2
+    assert stats["content_triples"] < len(om.graph)
+
+
+def _triple_messages() -> list[str]:
+    """Every user-facing string that reports a count of "triples"."""
+    found = []
+    for path in sources.ui_sources():
+        for node in ast.walk(ast.parse(path.read_text("utf-8"))):
+            if not isinstance(node, ast.JoinedStr):
+                continue
+            text = "".join(
+                str(v.value) for v in node.values if isinstance(v, ast.Constant)
+            )
+            if "triples" in text.lower():
+                found.append(f"{path.name}:{node.lineno} {ast.unparse(node)}")
+    return found
+
+
+def test_no_reported_count_is_the_raw_graph_length():
+    """``len(graph)`` counts the ontology header, which the sidebar does not.
+
+    A metric explicitly labelled "Total Triples" may use it — the import
+    preview compares whole files — so this looks at the counts presented as
+    plain "triples" alongside everything else.
+    """
+    offenders = [
+        message
+        for message in _triple_messages()
+        if "len(" in message and ".graph)" in message and "Total" not in message
+    ]
+    assert not offenders, (
+        "these report len(graph) where the sidebar reports content triples:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_scan_finds_the_messages_it_is_guarding():
+    """Otherwise the test above passes by looking at nothing."""
+    messages = _triple_messages()
+    assert any("imported successfully" in m for m in messages), messages
+    assert len(messages) >= 4, messages


### PR DESCRIPTION
Closes #263.

Importing a file flashed "Ontology imported successfully! (14 triples)"
while Quick Stats read "Triples: 12" for the same ontology at the same
moment.

Neither number was wrong. The message counted `len(ont.graph)`; the
sidebar counts `get_statistics()["content_triples"]`, which excludes the
triples hanging off the ontology URI. With a file whose header is
`<...> a owl:Ontology ; rdfs:label "..."`, that is exactly the two-triple
difference. Shown side by side, the gap reads as data lost on the way in.

## Why the two import paths and nothing else

Everything else in the same file already reported the sidebar's number:

| Reported by | Counted as |
| --- | --- |
| Apply Template | `content_triples` |
| Load Upper Ontology | `content_triples` |
| Load Reference Ontology | `content_triples` |
| **Import (direct)** | ~~`len(graph)`~~ → `content_triples` |
| **Import (after preview)** | ~~`len(graph)`~~ → `content_triples` |

That is visible in the reporter's own screenshots: loading gist announced
3419 triples and the sidebar agreed, because that loader was already
using the right one.

It also explains why this survived so long. A file with no ontology
header makes the two counts identical, and fixtures rarely carry one.

The "Total Triples" metrics in the import preview keep `len(graph)` on
purpose: they compare whole incoming files, and they are labelled Total.

## Tests

`tests/test_triple_count_consistency.py` states the premise (the two
counts differ by exactly the header) and guards the rule: no string
reporting a plain count of "triples" may be built from `len(graph)`. It
fails with the old line restored, and a third test asserts the scan finds
the messages it is guarding, so it cannot pass by looking at nothing.

## Verified in the browser

Same file that produced the report: the flash now reads
"imported successfully! (12 triples)" and the sidebar "Triples: 12".

1018 passed, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
