### PR TITLE
chore: bump to v1.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.20.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.21.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -31,7 +31,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.20.0"
+APP_VERSION = "1.21.0"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.20.0"
+version = "1.21.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.20.0"
+version = "1.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Version bump for the v1.21.0 release.

`pyproject.toml`, `APP_VERSION` in `ui.py`, the Docker pin example in the
README, and `uv.lock`. The README badges read from PyPI, so they follow
on their own.

Ten PRs since v1.20.0: the clearable dropdowns and their required-field
errors, editing and deleting entities from the graph, annotation editing
on its own page, the collapsible Visualization options with a graph that
fills the window, the sidebar and gutter space recovered, and the split
of app.py from 11.5k lines into ui, pages and the shell.

1018 passed, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
