### PR TITLE
fix: Filter Nodes panel closes on every filter edit (#267)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -207,6 +207,7 @@ from .ui import (  # noqa: F401
     viz_find_changed,
     viz_focus_toggle,
     viz_hidden_caption,
+    viz_hidden_note_style,
     viz_mark_ontology_seen,
     viz_ontology_was_replaced,
     viz_sync,

--- a/orionbelt_ontology_builder/pages/visualization.py
+++ b/orionbelt_ontology_builder/pages/visualization.py
@@ -50,6 +50,7 @@ from ..ui import (
     viz_find_changed,
     viz_focus_toggle,
     viz_hidden_caption,
+    viz_hidden_note_style,
     viz_mark_ontology_seen,
     viz_ontology_was_replaced,
     viz_sync,
@@ -478,16 +479,19 @@ def render_visualization():
         # no vertical space there, and it sits on the control that causes it.
         # Written by the run that built the graph (below), because the numbers
         # come from the focus controls inside this very expander and from the
-        # prune, neither of which has happened yet. Italic, which the CSS hides
-        # while the expander is open — the controls then say it in full.
+        # prune, neither of which has happened yet. The CSS hides it while the
+        # expander is open — the controls then say it in full.
+        #
+        # It reaches the label as generated content, not as part of the label
+        # string: Streamlit's expander snaps back to `expanded` whenever its
+        # label changes, so a note that moves with the filter closed the panel
+        # under the user on every edit (issue #267).
         _hidden_note = st.session_state.get("_viz_hidden_note") or ""
-        _filter_label = "Filter Nodes"
-        if _hidden_note:
-            _filter_label += f" &nbsp; *{_hidden_note}*"
         with (
             _filter_col.container(key="viz_filter_nodes"),
-            st.expander(_filter_label, expanded=False),
+            st.expander("Filter Nodes", expanded=False),
         ):
+            st.html(viz_hidden_note_style(_hidden_note))
             focus_mode = st.checkbox(
                 "Focus on one node",
                 key="viz_focus_mode",

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -128,17 +128,22 @@ _CUSTOM_CSS = """
        in the browser: this recovers ~270px, enough for the whole sidebar to
        fit without scrolling.
        NOTE: internal DOM again — re-verify on a Streamlit bump. */
-    /* The "what is hidden" note, which rides on the Filter Nodes label as its
-       only italic run. Quieter than the label it follows, and gone once the
-       expander is open: the controls inside then say the same thing in full.
-       Scoped by the container key so no other expander's label is touched. */
-    .st-key-viz_filter_nodes summary em {
-        font-style: normal;
+    /* The "what is hidden" note, which rides on the Filter Nodes label as
+       generated content — not as part of the label text, which would force the
+       expander shut on every filter edit (see viz_hidden_note_style, #267).
+       Quieter than the label it follows, and gone once the expander is open:
+       the controls inside then say the same thing in full. Scoped by the
+       container key so no other expander's label is touched.
+       The text itself comes from --viz-hidden-note, set per render. */
+    .st-key-viz_filter_nodes summary p::after {
+        content: var(--viz-hidden-note, "");
+        margin-left: 0.75rem;
         font-size: 0.8rem;
         opacity: 0.55;
     }
-    .st-key-viz_filter_nodes details[open] summary em {
-        display: none;
+    .st-key-viz_filter_nodes details[open] summary p::after {
+        content: "";
+        margin-left: 0;
     }
     [data-testid="stSidebarHeader"] [data-testid="stLogoSpacer"] {
         /* Reserves room for a st.logo() this app doesn't set: the mark is
@@ -4307,6 +4312,44 @@ def viz_hidden_caption(
     if hidden_by_filter:
         parts.append(f"{hidden_by_filter} hidden by the node filter")
     return " · ".join(parts)
+
+
+def viz_hidden_note_style(note: str) -> str:
+    """A ``<style>`` block that writes ``note`` onto the Filter Nodes label.
+
+    The note cannot simply be appended to the expander's label text: Streamlit's
+    expander resets its open/closed state to the ``expanded`` argument whenever
+    its label changes, and this note changes on every filter edit — so the panel
+    snapped shut after each class you added (issue #267). Carrying the note as
+    generated content keeps the label string constant: only this stylesheet
+    changes, and the expander never notices.
+
+    Everything but the text lives in the app's static CSS; this sets one custom
+    property, and ``""`` for no note renders nothing.
+    """
+    return (
+        "<style>.st-key-viz_filter_nodes "
+        f"{{ --viz-hidden-note: {css_string(note)}; }}</style>"
+    )
+
+
+def css_string(text: str) -> str:
+    """Quote ``text`` as a CSS string literal, safe inside a ``<style>`` block.
+
+    Entity names reach this (the note lists the focus seeds), so quotes and
+    backslashes are escaped as CSS demands, and ``<`` — the one character that
+    could end the style element early — as a six-digit hex escape, which needs
+    no trailing separator.
+    """
+    out = []
+    for ch in text:
+        if ch in '\\"':
+            out.append("\\" + ch)
+        elif ch == "<" or ord(ch) < 0x20:
+            out.append(f"\\{ord(ch):06x}")
+        else:
+            out.append(ch)
+    return '"' + "".join(out) + '"'
 
 
 def reconcile_filter_selection(all_uris, selected, known, replaced=False):

--- a/tests/test_viz_filter_expander.py
+++ b/tests/test_viz_filter_expander.py
@@ -1,0 +1,74 @@
+"""The Filter Nodes panel must stay open while you edit the filter (issue #267).
+
+Streamlit's expander resets its open/closed state to the ``expanded`` argument
+whenever its *label* changes, so the "what is hidden" note used to snap the
+panel shut after every class you added or removed. The note now reaches the
+label as generated content and the label string never moves.
+"""
+
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import app
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Shown")
+        om.add_class("Hidden")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["_viz_settings_restored"] = True
+        # Start from a narrowed filter — one class hidden — which is what puts a
+        # note on the label. `known` carries both, so the deselected one reads
+        # as deliberately hidden rather than newly created.
+        uris = [c["uri"] for c in om.get_classes()]
+        shown = [u for u in uris if u.endswith("Shown")]
+        st.session_state["_viz_cfg_selected_class_uris"] = shown
+        st.session_state["_viz_cfg_known_class_uris"] = set(uris)
+    app.render_visualization()
+
+
+def _rendered():
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    return at
+
+
+def test_the_hidden_note_never_reaches_the_expander_label():
+    at = _rendered()
+    labels = [e.label for e in at.expander]
+    assert "Filter Nodes" in labels
+    assert not [
+        label for label in labels if "hidden" in label or label != label.strip()
+    ], labels
+
+
+def test_the_note_is_written_as_generated_content_instead():
+    at = _rendered()
+    assert at.session_state["_viz_hidden_note"] == "1 hidden by the node filter"
+    styles = [
+        e.proto.body for e in at.get("html") if "--viz-hidden-note" in e.proto.body
+    ]
+    assert styles, "no stylesheet carries the note"
+    assert '--viz-hidden-note: "1 hidden by the node filter"' in styles[0]
+
+
+def test_no_note_renders_nothing():
+    assert app.viz_hidden_note_style("") == (
+        '<style>.st-key-viz_filter_nodes { --viz-hidden-note: ""; }</style>'
+    )
+
+
+def test_entity_names_cannot_break_out_of_the_stylesheet():
+    """Seed names reach the note, so the CSS string has to survive quotes,
+    backslashes and anything that could end the style element early."""
+    style = app.viz_hidden_note_style('Focused on <"a\\b">')
+    assert "</style>" not in style[: -len("</style>")]
+    assert '--viz-hidden-note: "Focused on \\00003c\\"a\\\\b\\">"' in style


### PR DESCRIPTION
Closes #267

## The bug

Adding or removing a class in `Filter Nodes` closed the panel, so adding several classes one by one meant reopening it every time. Toggling `Focus on one node` did the same.

## Cause

Streamlit's expander resets its open/closed state to the `expanded` argument whenever its **label** changes - the frontend's effect that syncs `open` is keyed on `[label, expanded]`. The "what is hidden" note (`1 hidden by the node filter`, `Focused on ... 2 hops ...`) is part of that label, and it changes with every filter edit, so each edit forced the panel back to `expanded=False`.

## Fix

The note now reaches the label as generated content instead of label text:

- the expander label is the constant string `Filter Nodes`;
- a per-render `<style>` sets `--viz-hidden-note` on the panel's container, and the existing static CSS renders it in `summary p::after` with the same quiet styling as before (and still hides it while the panel is open);
- entity names reach the note via the focus seeds, so the value is escaped as a CSS string literal (quotes, backslashes, and `<` as a hex escape so it cannot end the style element).

## Verification

- New `tests/test_viz_filter_expander.py`: the note never appears in the expander label, it is carried by the stylesheet instead, and the escaping holds.
- Full suite, ruff and mypy pass.
- Checked live in the running app on a 100-class ontology: removing a class, typing a class name + Enter, and toggling `Focus on one node` all leave the panel open, and the collapsed label still shows the note exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)