### PR TITLE
chore: bump to v1.21.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.21.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.21.1` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -31,7 +31,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.21.0"
+APP_VERSION = "1.21.1"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.21.0"
+version = "1.21.1"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.21.0"
+version = "1.21.1"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Patch release for #269: the console launcher and the desktop app rendered a second, non-functional list of pages in the sidebar, because Streamlit reads a `pages` directory next to the entry script as a legacy multipage app. Fixed in #273 by renaming the package to `views`.

Streamlit Cloud runs the top-level `app.py` and was never affected, so this is a desktop/console-only fix.

Bumped in `pyproject.toml`, `orionbelt_ontology_builder/ui.py`, the README Docker pin hint, and `uv.lock`. `tests/test_version_consistency.py` covers the first three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)