### PR TITLE
fix: refuse a name already used by another kind of entity (#279)

### DIFF
--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -538,8 +538,13 @@ class OntologyManager:
         prefix); when omitted the base namespace is used.
         """
         self._require_valid_name(name)
+        self._require_free_name(name, "class", namespace)
         if parent:
             self._require_valid_name(parent)
+            # The parent becomes a class by being one (and is declared as one by
+            # bulk_add_classes), so a parent owned by another kind of entity is
+            # the same collision one link removed.
+            self._require_free_name(parent, "class")
         class_uri = self._uri(name, namespace)
         self.graph.add((class_uri, RDF.type, OWL.Class))
 
@@ -640,17 +645,51 @@ class OntologyManager:
         kinds = self.entity_kinds(name, namespace)
         if not kinds:
             return None
-        same_kind = self.RESOURCE_TYPE_KINDS.get(resource_type, frozenset())
-        if any(kind in same_kind for kind in kinds):
+        if any(kind in self._kinds_of(resource_type) for kind in kinds):
             return f"{resource_type.capitalize()} '{name}' already exists!"
-        kind = kinds[0]
+        return self._cross_kind_message(name, kinds[0], resource_type)
+
+    def _kinds_of(self, resource_type: str) -> frozenset[str]:
+        """The entity kinds ``resource_type`` names. An engine kind ("object
+        property") stands for itself; the app's wider words are mapped."""
+        return self.RESOURCE_TYPE_KINDS.get(resource_type, frozenset({resource_type}))
+
+    def _cross_kind_message(self, name: str, other: str, resource_type: str) -> str:
         return (
-            f"'{name}' is already {_with_article(kind)} in this ontology. "
+            f"'{name}' is already {_with_article(other)} in this ontology. "
             "Classes, properties, individuals and SKOS concepts share one set "
-            f"of names, so this would make that {kind} "
+            f"of names, so this would make that {other} "
             f"{_with_article(resource_type)} as well instead of creating a new "
             "one. Choose a different name."
         )
+
+    def cross_kind_conflict(
+        self, name: str, resource_type: str, namespace: str | None = None
+    ) -> str | None:
+        """Why ``name`` cannot be used for a ``resource_type``, when *only* other
+        kinds of entity own it. None when the name is free, and None when it
+        already is this kind as well: re-adding an existing class is how
+        templates and bulk rows top one up, and an ontology that arrived punned
+        (PROV-O's EmptyCollection is a class and an individual) must stay usable
+        as the kind it is. Neither adds a type the name did not already carry.
+        """
+        kinds = self.entity_kinds(name, namespace)
+        if not kinds or any(kind in self._kinds_of(resource_type) for kind in kinds):
+            return None
+        return self._cross_kind_message(name, kinds[0], resource_type)
+
+    def _require_free_name(
+        self, name: str, resource_type: str, namespace: str | None = None
+    ) -> None:
+        """Raise ``ValueError`` if another kind of entity owns ``name``.
+
+        Every ``add_*`` runs this, so the guard holds for programmatic callers
+        too and not only for the app's create forms (issue #279). Loading and
+        merging graphs go around it: an ontology that arrives with a punned name
+        (PROV-O has one) is still read as it stands, and validation reports it.
+        """
+        if reason := self.cross_kind_conflict(name, resource_type, namespace):
+            raise ValueError(reason)
 
     def rename_class(self, old_name: str, new_name: str) -> bool:
         """Rename a class, updating all references.
@@ -1040,6 +1079,16 @@ class OntologyManager:
             namespace = entry.get("namespace", "").strip() or None
             parent = entry.get("parent", "").strip() or None
             uri = str(self._uri(name, namespace))
+            # Both halves of the row are checked before anything is written: a
+            # parent owned by another kind of entity would otherwise be linked
+            # to (and then declared a class by the backfill), leaving the class
+            # listed under an individual (issue #279).
+            conflict = self.cross_kind_conflict(name, "class", namespace)
+            if not conflict and parent:
+                conflict = self.cross_kind_conflict(parent, "class")
+            if conflict:
+                result["errors"].append({"name": name, "error": conflict})
+                continue
             if uri in existing:
                 # Existing class: add a newly named parent as an extra
                 # subClassOf rather than silently dropping the whole row (#157).
@@ -1061,12 +1110,6 @@ class OntologyManager:
                     result["updated"].append(name)
                     referenced_parents.add(str(parent_ref))
                 continue
-            if conflict := self.name_conflict_reason(name, "class", namespace):
-                # Not an existing class (that is handled above), so the name is
-                # taken by an individual, property or concept: creating it would
-                # type that one resource twice over (issue #279).
-                result["errors"].append({"name": name, "error": conflict})
-                continue
             try:
                 self.add_class(
                     name,
@@ -1083,12 +1126,9 @@ class OntologyManager:
 
         # Backfill: any referenced parent that no successful row declared as a
         # class becomes a bare owl:Class, so the hierarchy has no dangling target.
-        # A parent whose name is taken by another kind of entity is left alone:
-        # declaring it would pun that entity into a class (issue #279).
+        # Only parents from rows that got this far are here, so none of them is
+        # owned by another kind of entity; add_class refuses one anyway.
         for parent_uri in sorted(referenced_parents - existing):
-            if conflict := self.name_conflict_reason(parent_uri, "class"):
-                result["errors"].append({"name": parent_uri, "error": conflict})
-                continue
             try:
                 created_uri = self.add_class(parent_uri)
                 existing.add(parent_uri)
@@ -1123,11 +1163,9 @@ class OntologyManager:
             if uri in existing:
                 result["skipped"].append(name)
                 continue
-            if conflict := self.name_conflict_reason(name, "property", namespace):
-                # Taken by a class, individual, concept, or the other flavour of
-                # property: one name is one resource (issue #279).
-                result["errors"].append({"name": name, "error": conflict})
-                continue
+            # add_object_property/add_data_property refuse a name another kind
+            # of entity owns (including the other flavour of property), so a
+            # clashing row lands in errors (issue #279).
             try:
                 domain = entry.get("domain", "").strip() or None
                 range_ = entry.get("range", "").strip() or None
@@ -1179,11 +1217,8 @@ class OntologyManager:
             if uri in existing:
                 result["skipped"].append(name)
                 continue
-            if conflict := self.name_conflict_reason(name, "individual", namespace):
-                # Taken by a class, property or concept: naming an individual
-                # after one makes them the same resource (issue #279).
-                result["errors"].append({"name": name, "error": conflict})
-                continue
+            # add_individual refuses a name a class, property or concept
+            # already owns, so a clashing row lands in errors (issue #279).
             try:
                 self.add_individual(
                     name,
@@ -1307,6 +1342,7 @@ class OntologyManager:
         prefix); when omitted the base namespace is used.
         """
         self._require_valid_name(name)
+        self._require_free_name(name, "object property", namespace)
         for ref in (domain, range_, inverse_of):
             if ref:
                 self._require_valid_name(ref)
@@ -1358,6 +1394,7 @@ class OntologyManager:
         prefix); when omitted the base namespace is used.
         """
         self._require_valid_name(name)
+        self._require_free_name(name, "data property", namespace)
         if domain:
             self._require_valid_name(domain)
         prop_uri = self._uri(name, namespace)
@@ -1628,6 +1665,7 @@ class OntologyManager:
         namespace than its type.
         """
         self._require_valid_name(name)
+        self._require_free_name(name, "individual", namespace)
         self._require_valid_name(class_name)
         ind_uri = self._uri(name, namespace)
         class_uri = self._uri(class_name)
@@ -2526,6 +2564,7 @@ class OntologyManager:
     ) -> URIRef:
         """Add a new SKOS ConceptScheme."""
         self._require_valid_name(name)
+        self._require_free_name(name, "SKOS concept scheme")
         scheme_uri = self._uri(name)
         self.graph.add((scheme_uri, RDF.type, SKOS.ConceptScheme))
         if label:
@@ -2634,6 +2673,7 @@ class OntologyManager:
     ) -> URIRef:
         """Add a SKOS Concept with optional scheme/broader links."""
         self._require_valid_name(name)
+        self._require_free_name(name, "SKOS concept")
         for ref in (scheme, broader):
             if ref:
                 self._require_valid_name(ref)

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -39,6 +39,12 @@ def rdf_format_for_path(path, default: str = "turtle") -> str:
 
 _UNSET: Any = object()  # sentinel: "parameter not provided"
 
+
+def _with_article(noun: str) -> str:
+    """'class' -> 'a class', 'individual' -> 'an individual'."""
+    return f"{'an' if noun[:1].lower() in 'aeiou' else 'a'} {noun}"
+
+
 # A triple and a list of (old_triple, new_triple) rename operations.
 _Triple = tuple[Node, Node, Node]
 _TripleUpdates = list[tuple[_Triple, _Triple]]
@@ -577,21 +583,74 @@ class OntologyManager:
         if new_parent:
             self.graph.add((class_uri, RDFS.subClassOf, self._uri(new_parent)))
 
-    # Entity types that share the local-name space; a rename target must not
-    # already be any of these, since they would collide on the same URI.
-    _ENTITY_TYPES = (
-        OWL.Class,
-        OWL.ObjectProperty,
-        OWL.DatatypeProperty,
-        OWL.NamedIndividual,
-        SKOS.Concept,
-        SKOS.ConceptScheme,
-    )
+    # Entity types that share the local-name space, each with the word the app
+    # calls it by; a rename or creation target must not already be any of these,
+    # since they would collide on the same URI.
+    ENTITY_TYPE_NAMES: ClassVar[dict[URIRef, str]] = {
+        OWL.Class: "class",
+        OWL.ObjectProperty: "object property",
+        OWL.DatatypeProperty: "data property",
+        OWL.NamedIndividual: "individual",
+        SKOS.Concept: "SKOS concept",
+        SKOS.ConceptScheme: "SKOS concept scheme",
+    }
+    _ENTITY_TYPES = tuple(ENTITY_TYPE_NAMES)
+
+    # The entity kinds each resource type the app talks about covers, so a
+    # collision can be told apart from a clash with a different kind. "property"
+    # covers both flavours: they are one namespace of property names.
+    RESOURCE_TYPE_KINDS: ClassVar[dict[str, frozenset[str]]] = {
+        "class": frozenset({"class"}),
+        "property": frozenset({"object property", "data property"}),
+        "individual": frozenset({"individual"}),
+        "concept": frozenset({"SKOS concept"}),
+        "scheme": frozenset({"SKOS concept scheme"}),
+    }
 
     def _name_in_use(self, uri: URIRef) -> bool:
         """True if `uri` is already defined as any class, property, individual,
         SKOS concept or scheme. Guards renames against cross-type collisions."""
         return any((uri, RDF.type, t) in self.graph for t in self._ENTITY_TYPES)
+
+    def entity_kinds(self, name: str, namespace: str | None = None) -> list[str]:
+        """The kinds of entity the URI ``name`` resolves to is already defined as.
+
+        Empty when the name is free. More than one entry means the URI already
+        carries several types (OWL punning), which is legal RDF but is what makes
+        one entity show up on two pages of the app.
+        """
+        uri = self._uri(name, namespace)
+        return [
+            kind
+            for etype, kind in self.ENTITY_TYPE_NAMES.items()
+            if (uri, RDF.type, etype) in self.graph
+        ]
+
+    def name_conflict_reason(
+        self, name: str, resource_type: str, namespace: str | None = None
+    ) -> str | None:
+        """Why ``name`` cannot be created as ``resource_type``, or None if it can.
+
+        The name is checked against every entity kind, not only its own: classes,
+        properties, individuals and SKOS concepts all live in the same URI space,
+        so naming a class after an existing individual does not create a second
+        entity. It adds ``owl:Class`` to the individual, which the app then lists
+        as both, and deleting either one takes the whole thing (issue #279).
+        """
+        kinds = self.entity_kinds(name, namespace)
+        if not kinds:
+            return None
+        same_kind = self.RESOURCE_TYPE_KINDS.get(resource_type, frozenset())
+        if any(kind in same_kind for kind in kinds):
+            return f"{resource_type.capitalize()} '{name}' already exists!"
+        kind = kinds[0]
+        return (
+            f"'{name}' is already {_with_article(kind)} in this ontology. "
+            "Classes, properties, individuals and SKOS concepts share one set "
+            f"of names, so this would make that {kind} "
+            f"{_with_article(resource_type)} as well instead of creating a new "
+            "one. Choose a different name."
+        )
 
     def rename_class(self, old_name: str, new_name: str) -> bool:
         """Rename a class, updating all references.
@@ -652,6 +711,14 @@ class OntologyManager:
             "annotations": 0,
             "relations": [],
             "property_assertions": [],
+            # Other kinds the same URI is typed as. Deletion removes every
+            # triple about it, so a punned name loses both definitions at once
+            # and the preview has to say so (issue #279).
+            "also_typed_as": [
+                kind
+                for kind in self.entity_kinds(name)
+                if kind not in self.RESOURCE_TYPE_KINDS.get(resource_type, frozenset())
+            ],
         }
 
         if resource_type == "class":
@@ -744,6 +811,12 @@ class OntologyManager:
             f"Deleting {rt} **{impact['resource']}** will remove {impact['total_triples']} triple(s)."
         )
 
+        if impact["also_typed_as"]:
+            kinds = ", ".join(_with_article(k) for k in impact["also_typed_as"])
+            parts.append(
+                f"- **This name is also {kinds}**: it is one resource, so "
+                f"deleting the {rt} deletes that too"
+            )
         if impact["subclasses"]:
             parts.append(
                 f"- {len(impact['subclasses'])} subclass link(s) lost: {', '.join(impact['subclasses'])}"
@@ -988,6 +1061,12 @@ class OntologyManager:
                     result["updated"].append(name)
                     referenced_parents.add(str(parent_ref))
                 continue
+            if conflict := self.name_conflict_reason(name, "class", namespace):
+                # Not an existing class (that is handled above), so the name is
+                # taken by an individual, property or concept: creating it would
+                # type that one resource twice over (issue #279).
+                result["errors"].append({"name": name, "error": conflict})
+                continue
             try:
                 self.add_class(
                     name,
@@ -1004,7 +1083,12 @@ class OntologyManager:
 
         # Backfill: any referenced parent that no successful row declared as a
         # class becomes a bare owl:Class, so the hierarchy has no dangling target.
+        # A parent whose name is taken by another kind of entity is left alone:
+        # declaring it would pun that entity into a class (issue #279).
         for parent_uri in sorted(referenced_parents - existing):
+            if conflict := self.name_conflict_reason(parent_uri, "class"):
+                result["errors"].append({"name": parent_uri, "error": conflict})
+                continue
             try:
                 created_uri = self.add_class(parent_uri)
                 existing.add(parent_uri)
@@ -1038,6 +1122,11 @@ class OntologyManager:
             uri = str(self._uri(name, namespace))
             if uri in existing:
                 result["skipped"].append(name)
+                continue
+            if conflict := self.name_conflict_reason(name, "property", namespace):
+                # Taken by a class, individual, concept, or the other flavour of
+                # property: one name is one resource (issue #279).
+                result["errors"].append({"name": name, "error": conflict})
                 continue
             try:
                 domain = entry.get("domain", "").strip() or None
@@ -1089,6 +1178,11 @@ class OntologyManager:
             uri = str(self._uri(name, namespace))
             if uri in existing:
                 result["skipped"].append(name)
+                continue
+            if conflict := self.name_conflict_reason(name, "individual", namespace):
+                # Taken by a class, property or concept: naming an individual
+                # after one makes them the same resource (issue #279).
+                result["errors"].append({"name": name, "error": conflict})
                 continue
             try:
                 self.add_individual(
@@ -4279,6 +4373,27 @@ class OntologyManager:
                                 "message": f"Individual '{ind_name}' uses data property '{self._local_name(pred)}' but is not typed as '{self._local_name(domain)}'",
                             }
                         )
+
+        # Names carrying more than one entity type (issue #279). Legal OWL 2
+        # punning, but in this app that one resource is listed as, say, both a
+        # class and an individual, and deleting either listing deletes the whole
+        # resource. The create flows refuse to make this; a loaded ontology can
+        # still arrive with it, so say so instead of letting it look like two
+        # entities that happen to share a name.
+        for subj in set(self.graph.subjects(RDF.type, None)):
+            if not isinstance(subj, URIRef):
+                continue
+            kinds = self.entity_kinds(str(subj))
+            if len(kinds) > 1:
+                name = self._local_name(subj)
+                issues.append(
+                    {
+                        "severity": "warning",
+                        "type": "punned_name",
+                        "subject": name,
+                        "message": f"'{name}' is defined as {' and '.join(_with_article(k) for k in kinds)} at once: one resource listed in both places, so deleting either listing deletes all of it",
+                    }
+                )
 
         # Check for duplicate rdfs:label values across resources
         from collections import defaultdict

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -734,7 +734,11 @@ class OntologyManager:
 
         Args:
             name: local name or full URI of the resource
-            resource_type: one of "class", "property", "individual"
+            resource_type: one of the keys of ``RESOURCE_TYPE_KINDS`` — "class",
+                "property", "individual", "concept" or "scheme". It selects both
+                the impact detail collected and which types count as the
+                resource's own, so passing the wrong one reports the resource as
+                punned with itself.
 
         Returns a dict with categorised impact counts and details.
         """
@@ -756,7 +760,7 @@ class OntologyManager:
             "also_typed_as": [
                 kind
                 for kind in self.entity_kinds(name)
-                if kind not in self.RESOURCE_TYPE_KINDS.get(resource_type, frozenset())
+                if kind not in self._kinds_of(resource_type)
             ],
         }
 
@@ -800,8 +804,9 @@ class OntologyManager:
                         f"{self._local_name(s)} {self._local_name(p)}"
                     )
 
-        elif resource_type == "concept":
-            # SKOS relations referencing this concept
+        elif resource_type in ("concept", "scheme"):
+            # SKOS links pointing here: broader/narrower/related for a concept,
+            # the inScheme of every concept in it for a scheme.
             for s, p in self.graph.subject_predicates(uri):
                 if isinstance(s, URIRef) and p not in (RDF.type,):
                     impact["relations"].append(

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1850,8 +1850,8 @@ def render_add_class_form(ont, classes, form_key, parent_uri=None, on_close=None
                 show_message("Class name is required!", "error")
             elif reason := ont.invalid_name_reason(name):
                 show_message(reason, "error")
-            elif str(ont._uri(name, ns_val)) in {c["uri"] for c in classes}:
-                show_message(f"Class '{name}' already exists!", "error")
+            elif taken := ont.name_conflict_reason(name, "class", ns_val):
+                show_message(taken, "error")
             else:
                 ont.add_class(
                     name,
@@ -2272,7 +2272,7 @@ def panel_subject_uri(ntype, ename, classes, object_props, data_props, individua
     return next((e["uri"] for e in pool if _uid(e["uri"]) == ename), None)
 
 
-def _render_panel_add_individual_form(ont, classes, individuals, ntype, ename):
+def _render_panel_add_individual_form(ont, classes, ntype, ename):
     """Add an individual of the selected class, from the graph (issue #221).
 
     The class is the point of adding from here: an individual is always an
@@ -2314,8 +2314,8 @@ def _render_panel_add_individual_form(ont, classes, individuals, ntype, ename):
             show_message("Individual name is required!", "error")
         elif reason := ont.invalid_name_reason(name):
             show_message(reason, "error")
-        elif str(ont._uri(name, ns_val)) in {i["uri"] for i in individuals}:
-            show_message(f"Individual '{name}' already exists!", "error")
+        elif taken := ont.name_conflict_reason(name, "individual", ns_val):
+            show_message(taken, "error")
         else:
             # By URI, not by name: the class may live in another namespace, and
             # its local name alone would resolve into this ontology's own.

--- a/orionbelt_ontology_builder/views/individuals.py
+++ b/orionbelt_ontology_builder/views/individuals.py
@@ -292,8 +292,8 @@ def render_individuals():
                         show_message("Individual name is required!", "error")
                     elif reason := ont.invalid_name_reason(name):
                         show_message(reason, "error")
-                    elif str(ont._uri(name, ns_val)) in {i["uri"] for i in individuals}:
-                        show_message(f"Individual '{name}' already exists!", "error")
+                    elif taken := ont.name_conflict_reason(name, "individual", ns_val):
+                        show_message(taken, "error")
                     else:
                         ont.add_individual(
                             name,

--- a/orionbelt_ontology_builder/views/properties.py
+++ b/orionbelt_ontology_builder/views/properties.py
@@ -677,15 +677,12 @@ def render_properties():
                 submitted = st.form_submit_button("Add Object Property")
                 if submitted:
                     ns_val = ns_lookup.get(ns_display)
-                    prop_uris = {p["uri"] for p in object_props} | {
-                        p["uri"] for p in data_props
-                    }
                     if not name:
                         show_message("Property name is required!", "error")
                     elif reason := ont.invalid_name_reason(name):
                         show_message(reason, "error")
-                    elif str(ont._uri(name, ns_val)) in prop_uris:
-                        show_message(f"Property '{name}' already exists!", "error")
+                    elif taken := ont.name_conflict_reason(name, "property", ns_val):
+                        show_message(taken, "error")
                     else:
                         ont.add_object_property(
                             name,
@@ -751,15 +748,12 @@ def render_properties():
                 show_message(_missing, "error")
             elif submitted:
                 ns_val = ns_lookup.get(ns_display)
-                prop_uris = {p["uri"] for p in object_props} | {
-                    p["uri"] for p in data_props
-                }
                 if not name:
                     show_message("Property name is required!", "error")
                 elif reason := ont.invalid_name_reason(name):
                     show_message(reason, "error")
-                elif str(ont._uri(name, ns_val)) in prop_uris:
-                    show_message(f"Property '{name}' already exists!", "error")
+                elif taken := ont.name_conflict_reason(name, "property", ns_val):
+                    show_message(taken, "error")
                 else:
                     ont.add_data_property(
                         name,

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -191,12 +191,13 @@ def render_skos_vocabulary():
                     show_message("Scheme name is required!", "error")
                 elif reason := ont.invalid_name_reason(s_name):
                     show_message(reason, "error")
-                elif str(ont._uri(s_name)) in {s["uri"] for s in schemes}:
-                    # Reject by target URI, not local name, so a base scheme can
-                    # be recreated after an existing one is moved to a custom URI
-                    # (issue #87 part B), mirroring the class/property/individual
-                    # add flows.
-                    show_message(f"Scheme '{s_name}' already exists!", "error")
+                # Rejected by target URI, not local name, so a base scheme can
+                # be recreated after an existing one is moved to a custom URI
+                # (issue #87 part B), and across every entity kind, since one
+                # URI cannot be two things (issue #279). Mirrors the
+                # class/property/individual add flows.
+                elif taken := ont.name_conflict_reason(s_name, "scheme"):
+                    show_message(taken, "error")
                 else:
                     ont.add_concept_scheme(
                         s_name, label=s_label or None, comment=s_comment or None
@@ -533,11 +534,10 @@ def render_skos_vocabulary():
                     show_message("Concept name is required!", "error")
                 elif reason := ont.invalid_name_reason(c_name):
                     show_message(reason, "error")
-                elif str(ont._uri(c_name)) in {c["uri"] for c in concepts}:
-                    # Reject by target URI, not local name, so a base concept can
-                    # be recreated after an existing one is moved to a custom URI
-                    # (issue #87 part B).
-                    show_message(f"Concept '{c_name}' already exists!", "error")
+                # Rejected by target URI, not local name (issue #87 part B), and
+                # across every entity kind (issue #279), as for schemes above.
+                elif taken := ont.name_conflict_reason(c_name, "concept"):
+                    show_message(taken, "error")
                 else:
                     ont.add_concept(
                         c_name,

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -108,7 +108,7 @@ def render_skos_vocabulary():
                         st.write(f"**Comment:** {scheme['comment'] or '—'}")
                         st.write(f"**Concepts:** {scheme['concept_count']}")
 
-                    if confirm_delete(scheme["uri"], "concept", f"scheme_{_sk}"):
+                    if confirm_delete(scheme["uri"], "scheme", f"scheme_{_sk}"):
                         ont.delete_concept_scheme(scheme["uri"])
                         save_checkpoint("Delete concept scheme")
                         set_flash_message(

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -1909,7 +1909,7 @@ def render_visualization():
                         )
                     elif _add_kind == "ind":
                         _render_panel_add_individual_form(
-                            ont, classes, individuals, _sel_ntype, _sel_ename
+                            ont, classes, _sel_ntype, _sel_ename
                         )
                     elif _add_kind == "ann":
                         _render_panel_add_annotation_form(

--- a/tests/test_delete_impact.py
+++ b/tests/test_delete_impact.py
@@ -50,6 +50,22 @@ def test_format_delete_impact(populated_om):
     assert "triple" in text
 
 
+def test_scheme_impact_shows_its_concepts_links(skos_om):
+    """A scheme is deleted as a "scheme", not a "concept": the resource type
+    also decides which types count as its own, so the wrong one made an ordinary
+    scheme look punned with itself (issue #279 review)."""
+    impact = skos_om.get_delete_impact("MyScheme", "scheme")
+    assert impact["also_typed_as"] == []
+    assert len(impact["relations"]) >= 1  # the inScheme of each concept in it
+    assert "also" not in skos_om.format_delete_impact(impact)
+
+
+def test_concept_impact_is_unaffected(skos_om):
+    impact = skos_om.get_delete_impact("Animal", "concept")
+    assert impact["also_typed_as"] == []
+    assert len(impact["relations"]) >= 1  # Dog and Cat are broader: Animal
+
+
 def test_isolated_class_has_minimal_impact(populated_om):
     populated_om.add_class("Isolated")
     impact = populated_om.get_delete_impact("Isolated", "class")

--- a/tests/test_name_collisions.py
+++ b/tests/test_name_collisions.py
@@ -242,6 +242,41 @@ def test_validation_reports_a_name_that_is_two_things(populated_om):
     assert "a class and an individual" in punned[0]["message"]
 
 
+def _scheme_delete_script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_concept_scheme("MyScheme")
+        om.add_concept("Dog", scheme="MyScheme")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["skos_active_tab"] = "Concept Schemes"
+        # The delete confirmation the 🗑️ button opens, keyed the way the page
+        # keys it (by a hash of the scheme URI, issue #87 part B). Seeded rather
+        # than clicked so the page renders the preview in a single run.
+        _sk = str(abs(hash(om.get_concept_schemes()[0]["uri"])))[:8]
+        st.session_state[f"confirm_delete_scheme_{_sk}"] = True
+
+    from orionbelt_ontology_builder import app
+
+    app.render_skos_vocabulary()
+
+
+def test_deleting_a_scheme_does_not_claim_it_is_two_things():
+    """The page asked for the impact of deleting a "concept", which made an
+    ordinary scheme read as punned with itself."""
+    at = AppTest.from_function(_scheme_delete_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+
+    preview = next(w.value for w in at.warning if "Deleting" in w.value)
+    assert preview.startswith("Deleting scheme")
+    assert "also" not in preview
+
+
 # --- the add form in front of it --------------------------------------------
 
 

--- a/tests/test_name_collisions.py
+++ b/tests/test_name_collisions.py
@@ -1,0 +1,182 @@
+"""Names are unique across entity kinds, not just within one (issue #279).
+
+A class, a property, an individual and a SKOS concept of the same name are one
+URI carrying several rdf:types. The app then lists that single resource as both
+a class and an individual, and deleting either one removes the whole thing, so
+the create flows refuse the collision instead of quietly making it.
+"""
+
+import pytest
+from rdflib import OWL, RDF
+from streamlit.testing.v1 import AppTest
+
+NS = "http://test.org/ont#"
+
+
+# --- what the engine reports ------------------------------------------------
+
+
+def test_a_free_name_has_no_kinds(populated_om):
+    assert populated_om.entity_kinds("Nothing") == []
+    assert populated_om.name_conflict_reason("Nothing", "class") is None
+
+
+@pytest.mark.parametrize(
+    ("name", "kinds"),
+    [
+        ("Person", ["class"]),
+        ("worksFor", ["object property"]),
+        ("hasName", ["data property"]),
+        ("alice", ["individual"]),
+    ],
+)
+def test_entity_kinds_names_what_is_there(populated_om, name, kinds):
+    assert populated_om.entity_kinds(name) == kinds
+
+
+def test_a_class_named_after_an_individual_is_refused(populated_om):
+    reason = populated_om.name_conflict_reason("alice", "class")
+    assert reason and "already an individual" in reason
+
+
+def test_an_individual_named_after_a_class_is_refused(populated_om):
+    reason = populated_om.name_conflict_reason("Person", "individual")
+    assert reason and "already a class" in reason
+
+
+def test_the_same_kind_keeps_the_plain_message(populated_om):
+    assert (
+        populated_om.name_conflict_reason("Person", "class")
+        == "Class 'Person' already exists!"
+    )
+    # Both flavours of property share one name space, so either one clashes.
+    assert (
+        populated_om.name_conflict_reason("hasName", "property")
+        == "Property 'hasName' already exists!"
+    )
+
+
+def test_skos_names_are_in_the_same_space(skos_om):
+    assert skos_om.name_conflict_reason("Dog", "class").startswith(
+        "'Dog' is already a SKOS concept"
+    )
+    assert skos_om.name_conflict_reason("MyScheme", "individual").startswith(
+        "'MyScheme' is already a SKOS concept scheme"
+    )
+    assert (
+        skos_om.name_conflict_reason("Dog", "concept")
+        == "Concept 'Dog' already exists!"
+    )
+
+
+def test_another_namespace_is_another_name(populated_om):
+    """The clash is over the URI, so the same local name elsewhere is free."""
+    assert (
+        populated_om.name_conflict_reason(
+            "alice", "class", namespace="http://other.example/vocab#"
+        )
+        is None
+    )
+
+
+# --- bulk add ---------------------------------------------------------------
+
+
+def test_bulk_classes_reject_an_individuals_name(populated_om):
+    result = populated_om.bulk_add_classes([{"name": "alice"}, {"name": "Product"}])
+    assert result["created"] == ["Product"]
+    assert [e["name"] for e in result["errors"]] == ["alice"]
+    assert populated_om.entity_kinds("alice") == ["individual"]
+
+
+def test_bulk_individuals_reject_a_class_name(populated_om):
+    result = populated_om.bulk_add_individuals([{"name": "Person", "class": "Person"}])
+    assert result["created"] == []
+    assert [e["name"] for e in result["errors"]] == ["Person"]
+    assert populated_om.entity_kinds("Person") == ["class"]
+
+
+def test_bulk_properties_reject_the_other_flavours_name(populated_om):
+    """hasName is a data property; the same name as an object property would be
+    one resource typed as both."""
+    result = populated_om.bulk_add_properties([{"name": "hasName"}], "object")
+    assert result["created"] == []
+    assert [e["name"] for e in result["errors"]] == ["hasName"]
+    assert populated_om.entity_kinds("hasName") == ["data property"]
+
+
+def test_a_backfilled_parent_never_pins_a_type_on_an_individual(populated_om):
+    """A parent nobody declared is normally backfilled as a bare owl:Class; one
+    whose name is an individual's must not be."""
+    result = populated_om.bulk_add_classes([{"name": "Robot", "parent": "alice"}])
+    assert result["created"] == ["Robot"]
+    assert populated_om.entity_kinds("alice") == ["individual"]
+    assert any(e["name"].endswith("alice") for e in result["errors"])
+
+
+# --- deleting a name that is already punned ---------------------------------
+
+
+def _pun_alice_as_a_class(om):
+    """The state an imported ontology can arrive in: one URI, two types."""
+    om.graph.add((om._uri("alice"), RDF.type, OWL.Class))
+
+
+def test_delete_impact_warns_that_the_name_is_also_something_else(populated_om):
+    _pun_alice_as_a_class(populated_om)
+    impact = populated_om.get_delete_impact("alice", "class")
+    assert impact["also_typed_as"] == ["individual"]
+    text = populated_om.format_delete_impact(impact)
+    assert "also an individual" in text
+
+
+def test_an_ordinary_delete_says_nothing_about_other_kinds(populated_om):
+    impact = populated_om.get_delete_impact("Person", "class")
+    assert impact["also_typed_as"] == []
+    assert "also" not in populated_om.format_delete_impact(impact)
+
+
+def test_validation_reports_a_name_that_is_two_things(populated_om):
+    """A loaded ontology can already hold one; nothing else in the app says so."""
+    assert not [i for i in populated_om.validate() if i["type"] == "punned_name"]
+    _pun_alice_as_a_class(populated_om)
+    punned = [i for i in populated_om.validate() if i["type"] == "punned_name"]
+    assert len(punned) == 1
+    assert punned[0]["subject"] == "alice"
+    assert "a class and an individual" in punned[0]["message"]
+
+
+# --- the add form in front of it --------------------------------------------
+
+
+def _add_class_script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Person")
+        om.add_individual("alice", "Person")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    app.render_add_class_form(ont, ont.get_classes(), "add_cls_test")
+
+
+def test_the_add_class_form_refuses_an_individuals_name():
+    at = AppTest.from_function(_add_class_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+
+    at.text_input[0].set_value("alice")
+    at.button[0].click().run(timeout=120)
+    assert not at.exception, at.exception
+
+    om = at.session_state["ontology"]
+    assert om.entity_kinds("alice") == ["individual"]
+    assert [c["name"] for c in om.get_classes()] == ["Person"]
+    assert any("already an individual" in e.value for e in at.error)

--- a/tests/test_name_collisions.py
+++ b/tests/test_name_collisions.py
@@ -7,7 +7,7 @@ the create flows refuse the collision instead of quietly making it.
 """
 
 import pytest
-from rdflib import OWL, RDF
+from rdflib import OWL, RDF, RDFS
 from streamlit.testing.v1 import AppTest
 
 NS = "http://test.org/ont#"
@@ -79,6 +79,84 @@ def test_another_namespace_is_another_name(populated_om):
     )
 
 
+# --- the engine refuses it too, not only the forms --------------------------
+
+
+@pytest.mark.parametrize(
+    ("call", "args"),
+    [
+        ("add_class", ("alice",)),
+        ("add_object_property", ("alice",)),
+        ("add_data_property", ("alice",)),
+        ("add_concept", ("alice",)),
+        ("add_concept_scheme", ("alice",)),
+        ("add_individual", ("Person", "Person")),
+    ],
+)
+def test_add_refuses_a_name_another_kind_owns(populated_om, call, args):
+    with pytest.raises(ValueError, match="already a"):
+        getattr(populated_om, call)(*args)
+    assert populated_om.entity_kinds("alice") == ["individual"]
+    assert populated_om.entity_kinds("Person") == ["class"]
+
+
+def test_the_two_property_flavours_are_one_name_space(populated_om):
+    """worksFor is an object property; the same name as a data property would be
+    one resource on both property lists."""
+    with pytest.raises(ValueError, match="already an object property"):
+        populated_om.add_data_property("worksFor")
+    assert populated_om.entity_kinds("worksFor") == ["object property"]
+
+
+def test_a_parent_of_another_kind_is_refused_and_nothing_is_written(populated_om):
+    with pytest.raises(ValueError, match="already an individual"):
+        populated_om.add_class("Robot", parent="alice")
+    assert populated_om.entity_kinds("Robot") == []
+    assert populated_om.entity_kinds("alice") == ["individual"]
+
+
+def test_adding_the_same_kind_again_still_works(populated_om):
+    """Not a conflict: re-adding is how templates and bulk rows top up an
+    existing entity, and the guard must not break that."""
+    populated_om.add_class("Person", comment="Again")
+    assert populated_om.entity_kinds("Person") == ["class"]
+
+
+def _loaded_with_a_punned_name():
+    """PROV-O declares prov:EmptyCollection as both a class and an individual."""
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    om = OntologyManager(base_uri=NS)
+    om.load_from_string(
+        """
+        @prefix : <http://test.org/ont#> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        :Both a owl:Class, owl:NamedIndividual .
+        """,
+        format="turtle",
+    )
+    return om
+
+
+def test_loading_an_ontology_that_puns_is_left_alone():
+    """Reading a file is not creating an entity, so it must not be rejected."""
+    assert _loaded_with_a_punned_name().entity_kinds("Both") == ["class", "individual"]
+
+
+def test_a_name_that_arrived_punned_stays_usable_as_what_it_is():
+    """The guard stops a *new* type going onto a name. Subclassing the punned
+    class, or editing it, adds none, so it must keep working."""
+    om = _loaded_with_a_punned_name()
+    om.add_class("Sub", parent="Both")
+    om.add_class("Both", comment="topped up")
+    assert om.entity_kinds("Both") == ["class", "individual"]
+    sub = next(c for c in om.get_classes() if c["name"] == "Sub")
+    assert sub["parents"] == ["Both"]
+    # A third type is still refused.
+    with pytest.raises(ValueError, match="already a class"):
+        om.add_object_property("Both")
+
+
 # --- bulk add ---------------------------------------------------------------
 
 
@@ -105,13 +183,31 @@ def test_bulk_properties_reject_the_other_flavours_name(populated_om):
     assert populated_om.entity_kinds("hasName") == ["data property"]
 
 
-def test_a_backfilled_parent_never_pins_a_type_on_an_individual(populated_om):
-    """A parent nobody declared is normally backfilled as a bare owl:Class; one
-    whose name is an individual's must not be."""
+def test_a_row_whose_parent_is_an_individual_writes_nothing(populated_om):
+    """An undeclared parent is normally backfilled as a bare owl:Class, so a
+    parent naming an individual would pun it. The row fails before any of it is
+    written: no class, and above all no subClassOf pointing at the individual,
+    which would list it as a parent on the Classes page."""
     result = populated_om.bulk_add_classes([{"name": "Robot", "parent": "alice"}])
-    assert result["created"] == ["Robot"]
+    assert result["created"] == []
+    assert [e["name"] for e in result["errors"]] == ["Robot"]
     assert populated_om.entity_kinds("alice") == ["individual"]
-    assert any(e["name"].endswith("alice") for e in result["errors"])
+    assert populated_om.entity_kinds("Robot") == []
+    assert (populated_om._uri("Robot"), RDFS.subClassOf, None) not in populated_om.graph
+
+
+def test_an_existing_class_is_not_linked_to_a_parent_of_another_kind(populated_om):
+    """The same guard on the other half of bulk_add_classes: the row that adds a
+    parent to a class that is already there (issue #157)."""
+    result = populated_om.bulk_add_classes([{"name": "Employee", "parent": "acme"}])
+    assert result["updated"] == []
+    assert [e["name"] for e in result["errors"]] == ["Employee"]
+    assert "acme" not in populated_om.get_classes()[0]["parents"]
+    assert (
+        populated_om._uri("Employee"),
+        RDFS.subClassOf,
+        populated_om._uri("acme"),
+    ) not in populated_om.graph
 
 
 # --- deleting a name that is already punned ---------------------------------


### PR DESCRIPTION
Closes #279.

## The bug

Naming a class the same as an existing individual did not create a second entity. Local names all resolve into one URI, so the `owl:Class` declaration landed on the individual, which the app then listed on both the Classes page and the Individuals page. Deleting what looked like the class deleted the individual, because it was one resource all along.

The add forms each compared the target URI against their own kind's list only (classes against classes, individuals against individuals), so nothing caught the cross-kind case. Renames were already guarded; creation was not.

## The fix

- `OntologyManager.entity_kinds()` reports every kind a name is already defined as; `cross_kind_conflict()` and `name_conflict_reason()` turn that into an explanation.
- Every `add_*` enforces it: `add_class` (name and parent), `add_object_property`, `add_data_property`, `add_individual`, `add_concept`, `add_concept_scheme` raise `ValueError` when another kind of entity owns the name. The guard therefore holds for programmatic callers, not only for the app's forms.
- All seven create flows call `name_conflict_reason` up front so the user gets the message instead of an exception: Add Class (page and graph panel), Add Individual (page and graph panel), Add Object Property, Add Data Property, Add Concept, Add Concept Scheme. A same-kind clash keeps the familiar "Class 'X' already exists!" wording, so nothing regresses for the common case.
- `bulk_add_classes` checks both halves of a row before writing anything. It used to write `rdfs:subClassOf` to the parent first, which left a class parented onto an individual once the backfill declined to declare that parent a class.

## What is deliberately still allowed

Punning is legal OWL 2 and a loaded file can arrive with it (PROV-O declares `prov:EmptyCollection` as both a class and an individual), so:

- loading and merging do not go through `add_*`: a file is read as it stands;
- a name that is already the kind being added is not a conflict, so re-adding an existing class still tops it up and a punned import stays usable as the kind it is. Neither case adds a type the name did not already carry.

Two places now name a pun instead of showing it as two entities: the delete preview adds a line saying what else the name is defined as and that deleting takes both, and validation reports punned names as a warning.

## Testing

- `tests/test_name_collisions.py`: the engine guard per `add_*`, the two property flavours, a parent of another kind, same-kind re-add, a punned import staying usable, namespace scoping, the three bulk paths and both halves of a `bulk_add_classes` row, the delete preview, the validation warning, plus an AppTest run of the real Add Class form refusing an individual's name.
- Full suite (1054 tests), ruff check/format and mypy pass. All five bundled templates and every bundled sample still load clean; only PROV-O reports its one known pun.
- Verified live in the running app: adding an individual named after an existing class shows the explanation and creates nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)