### PR TITLE
chore: bump to v1.21.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.21.1` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.21.2` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -31,7 +31,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.21.1"
+APP_VERSION = "1.21.2"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.21.1"
+version = "1.21.2"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.21.1"
+version = "1.21.2"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Patch release for the name collision fix in #280 (issue #279).

Naming a class the same as an existing individual did not create a second entity: local names all resolve into one URI, so the app listed one resource on both pages and deleting either listing deleted all of it. Every create path now refuses a name another kind of entity owns, the delete preview says what else a name is defined as, and validation reports names that arrived punned.

The hosted app already has the fix (it rebuilds from main), so this release is what carries it to PyPI and the Docker image.

Version bumped in pyproject.toml, ui.py APP_VERSION, uv.lock and the README Docker pin example; nothing else in the repo mentions 1.21.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)