### PR TITLE
fix: keep the focus on an entity you rename (#275)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -153,6 +153,7 @@ from .ui import (  # noqa: F401
     display_flash_message,
     filter_entry_token,
     focus_seeds_from_selection,
+    follow_focus_seed_renames,
     format_label_name,
     get_ontology_manager_class,
     graph_node_cap,
@@ -195,6 +196,8 @@ from .ui import (  # noqa: F401
     viz_hidden_caption,
     viz_hidden_note_style,
     viz_mark_ontology_seen,
+    viz_node_id,
+    viz_note_rename,
     viz_ontology_was_replaced,
     viz_sync,
 )

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -154,6 +154,7 @@ from .ui import (  # noqa: F401
     filter_entry_token,
     focus_seeds_from_selection,
     follow_focus_seed_renames,
+    follow_renamed_node_ids,
     format_label_name,
     get_ontology_manager_class,
     graph_node_cap,

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -778,6 +778,20 @@ def _renamed_node_id(node_id, renames):
     return node_id
 
 
+def follow_renamed_node_ids(node_ids, renames):
+    """Where ``node_ids`` ended up after the recorded renames (issue #275).
+
+    The seeds saved against a linked file are node ids rather than labels
+    (#164), and one saved before a rename made this session resolves to nothing
+    when it is read back. Same notes and same chain-following as
+    :func:`follow_focus_seed_renames`, one level down: that works in the labels
+    the seeds are shown under, this in the ids they are stored as.
+    """
+    if not renames:
+        return list(node_ids or [])
+    return [_renamed_node_id(i, renames) for i in node_ids or []]
+
+
 def follow_focus_seed_renames(seeds, seen_ids_by_label, focus_targets, renames):
     """Re-point focus seeds at entities that were renamed (issue #275).
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -613,6 +613,9 @@ def viz_drop_focus_seeds() -> None:
     """Forget the focus seeds so they re-derive from the current selection."""
     st.session_state.pop("_viz_cfg_focus_seeds", None)
     st.session_state.pop("_viz_cfg_focus_seed_ids_by_label", None)
+    # Notes about entities the seeds were meant to follow; with no seeds left
+    # there is nothing to re-point (see viz_note_rename).
+    st.session_state.pop("_viz_pending_renames", None)
 
 
 def _viz_widget_missing(wid_key: str) -> bool:
@@ -726,6 +729,84 @@ def prune_reused_focus_seeds(seeds, seen_ids_by_label, focus_targets):
         for s in seeds
         if s not in seen_ids_by_label or seen_ids_by_label[s] == focus_targets.get(s)
     ]
+
+
+_VIZ_NODE_ID_PREFIX = {"class": "", "individual": "ind_", "property": "dprop_"}
+
+
+def viz_node_id(kind: str, ref: str) -> str:
+    """The graph node id an entity of ``kind`` gets, as the builder assigns it.
+
+    ``ref`` is the entity's URI, except for SKOS concepts, whose nodes are keyed
+    by name. The focus-target map and the rename notes below both go through
+    here because they have to agree on the id: a rename that computed it any
+    other way would re-point nothing.
+    """
+    if kind == "concept":
+        return f"skos_{ref}"
+    return f"{_VIZ_NODE_ID_PREFIX[kind]}{_uid(ref)}"
+
+
+def viz_note_rename(kind: str, old_ref: str, new_ref: str) -> None:
+    """Record a rename so the focus seeds can follow the entity (issue #275).
+
+    Seeds are held as the labels the multiselect shows, and a rename mints a new
+    URI: on the next render the old label names nothing, so the seed was pruned
+    and focus mode fell back to an arbitrary first node. Renaming the very class
+    you were focused on therefore dropped it out of the graph.
+
+    Nothing in the rebuilt state ties the two names together — the label changed
+    and ``_uid`` hashes the URI, so the node id changed with it — which is why
+    the rename itself has to leave the note. It is consumed by the next
+    Visualization render (see :func:`follow_focus_seed_renames`).
+    """
+    if old_ref == new_ref:
+        return
+    renames = st.session_state.setdefault("_viz_pending_renames", {})
+    renames[viz_node_id(kind, old_ref)] = viz_node_id(kind, new_ref)
+
+
+def _renamed_node_id(node_id, renames):
+    """Where ``node_id`` ended up after the recorded renames, following a chain
+    of them (the seeds are only re-pointed on a Visualization render, so an
+    entity can be renamed more than once in between). Guarded against a cycle,
+    which a rename back to an earlier name produces."""
+    seen = set()
+    while node_id in renames and node_id not in seen:
+        seen.add(node_id)
+        node_id = renames[node_id]
+    return node_id
+
+
+def follow_focus_seed_renames(seeds, seen_ids_by_label, focus_targets, renames):
+    """Re-point focus seeds at entities that were renamed (issue #275).
+
+    Returns ``(seeds, seen_ids_by_label)`` with every seed whose entity now
+    answers to a new label swapped for that label, and its recorded id brought
+    up to date so the reuse prune that follows still recognises it.
+
+    A seed is only moved when the renamed entity is actually in ``focus_targets``
+    — if its type has been toggled off it is not focusable, and leaving the seed
+    alone lets the existing prune drop it as it always did.
+    """
+    if not seeds or not renames or not seen_ids_by_label:
+        return list(seeds or []), dict(seen_ids_by_label or {})
+    label_by_id = {node_id: label for label, node_id in focus_targets.items()}
+    out_seeds: list = []
+    out_ids = dict(seen_ids_by_label)
+    for s in seeds:
+        old_id = seen_ids_by_label.get(s)
+        new_id = _renamed_node_id(old_id, renames) if old_id else None
+        label = label_by_id.get(new_id) if new_id and new_id != old_id else None
+        if label is None:
+            if s not in out_seeds:
+                out_seeds.append(s)
+            continue
+        out_ids.pop(s, None)
+        out_ids[label] = new_id
+        if label not in out_seeds:
+            out_seeds.append(label)
+    return out_seeds, out_ids
 
 
 def _clear_viz_file_session_state() -> None:
@@ -1503,7 +1584,7 @@ def _namespace_option_index(ont, ns_options, ns_lookup, uri):
 _KEEP_NAMESPACE = object()  # sentinel: leave a resource in its current namespace
 
 
-def _rename_or_move(ont, rename_fn, old_uri, old_local, new_name, new_namespace):
+def _rename_or_move(ont, kind, rename_fn, old_uri, old_local, new_name, new_namespace):
     """Resolve the target URI from the (possibly changed) local name and
     namespace and rename via ``rename_fn`` if it differs from ``old_uri``.
 
@@ -1512,7 +1593,8 @@ def _rename_or_move(ont, rename_fn, old_uri, old_local, new_name, new_namespace)
     ``(ok, current_ref)``: ``ok`` is False only when ``rename_fn`` refuses
     because the target URI already exists. ``new_namespace`` is ``None`` (base),
     a namespace URI, or the ``_KEEP_NAMESPACE`` sentinel to keep the current
-    namespace.
+    namespace. ``kind`` is what the entity is to the graph ("class",
+    "individual", "property"), so the move can be noted for the focus seeds.
     """
     target_ns = (
         ont._namespace_of(old_uri)
@@ -1523,6 +1605,7 @@ def _rename_or_move(ont, rename_fn, old_uri, old_local, new_name, new_namespace)
     if target_uri == old_uri:
         return True, old_uri
     if rename_fn(old_uri, target_uri):
+        viz_note_rename(kind, old_uri, target_uri)
         return True, target_uri
     return False, old_uri
 
@@ -1621,6 +1704,7 @@ def _apply_class_edit(
         return False
     ok, current_ref = _rename_or_move(
         ont,
+        "class",
         ont.rename_class,
         class_info["uri"],
         class_info["name"],
@@ -1884,6 +1968,7 @@ def _apply_property_edit(
             return False
         if ont.rename_property(prop["uri"], new_name):
             current_ref = _renamed_ref(ont, prop["uri"], new_name)
+            viz_note_rename("property", prop["uri"], current_ref)
         else:
             show_message(f"Cannot rename: '{new_name}' already exists!", "error")
             return False
@@ -1912,6 +1997,7 @@ def _apply_individual_edit(
             return False
         if ont.rename_individual(ind["uri"], new_name):
             current_ref = _renamed_ref(ont, ind["uri"], new_name)
+            viz_note_rename("individual", ind["uri"], current_ref)
         else:
             show_message(f"Cannot rename: '{new_name}' already exists!", "error")
             return False

--- a/orionbelt_ontology_builder/views/classes.py
+++ b/orionbelt_ontology_builder/views/classes.py
@@ -29,6 +29,7 @@ from ..ui import (
     save_checkpoint,
     set_flash_message,
     show_message,
+    viz_note_rename,
 )
 
 
@@ -187,6 +188,9 @@ def render_classes():
                                         # Rename preserves the class's namespace.
                                         current_ref = _renamed_ref(
                                             ont, cls["uri"], new_name
+                                        )
+                                        viz_note_rename(
+                                            "class", cls["uri"], current_ref
                                         )
                                         save_checkpoint("Rename class")
                                         show_message(

--- a/orionbelt_ontology_builder/views/individuals.py
+++ b/orionbelt_ontology_builder/views/individuals.py
@@ -229,6 +229,7 @@ def render_individuals():
                                 # Rename/move first so later updates hit the new URI.
                                 ok, current_ref = _rename_or_move(
                                     ont,
+                                    "individual",
                                     ont.rename_individual,
                                     ind["uri"],
                                     ind["name"],

--- a/orionbelt_ontology_builder/views/properties.py
+++ b/orionbelt_ontology_builder/views/properties.py
@@ -255,6 +255,7 @@ def render_properties():
                                 # Rename/move first so later updates hit the new URI.
                                 ok, current_ref = _rename_or_move(
                                     ont,
+                                    "property",
                                     ont.rename_property,
                                     prop["uri"],
                                     prop["name"],
@@ -478,6 +479,7 @@ def render_properties():
                                 # Rename/move first so later updates hit the new URI.
                                 ok, current_ref = _rename_or_move(
                                     ont,
+                                    "property",
                                     ont.rename_property,
                                     prop["uri"],
                                     prop["name"],

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -22,6 +22,7 @@ from ..ui import (
     save_checkpoint,
     set_flash_message,
     show_message,
+    viz_note_rename,
 )
 
 
@@ -468,6 +469,15 @@ def render_skos_vocabulary():
                                         if renamed
                                         else concept["uri"]
                                     )
+                                    if renamed:
+                                        # Concept nodes are keyed by local name,
+                                        # which is what a custom-URI rename
+                                        # leaves behind too.
+                                        viz_note_rename(
+                                            "concept",
+                                            concept["name"],
+                                            ont._local_name(target),
+                                        )
                                     # Handle broader change (resolve by URI)
                                     broader_val = _broader_lookup.get(new_broader) or ""
                                     old_broader = _cur_broader_uri or ""

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -38,6 +38,7 @@ from ..ui import (
     build_filter_entries,
     filter_entry_token,
     focus_seeds_from_selection,
+    follow_focus_seed_renames,
     graph_node_cap,
     local_store,
     panel_subject_uri,
@@ -52,6 +53,7 @@ from ..ui import (
     viz_hidden_caption,
     viz_hidden_note_style,
     viz_mark_ontology_seen,
+    viz_node_id,
     viz_ontology_was_replaced,
     viz_sync,
 )
@@ -375,18 +377,38 @@ def render_visualization():
         focus_targets: dict[str, str] = {}
         if show_classes:
             for e in class_entries:
-                focus_targets[f"Class: {e['display']}"] = _uid(e["uri"])
+                focus_targets[f"Class: {e['display']}"] = viz_node_id("class", e["uri"])
         if show_individuals:
             for e in ind_entries:
-                focus_targets[f"Individual: {e['display']}"] = f"ind_{_uid(e['uri'])}"
+                focus_targets[f"Individual: {e['display']}"] = viz_node_id(
+                    "individual", e["uri"]
+                )
         if show_data_props:
             for prop in data_props:
-                focus_targets[f"Data Property: {prop['name']}"] = (
-                    f"dprop_{_uid(prop['uri'])}"
+                focus_targets[f"Data Property: {prop['name']}"] = viz_node_id(
+                    "property", prop["uri"]
                 )
         if show_skos and _has_skos:
             for concept in ont.get_concepts():
-                focus_targets[f"Concept: {concept['name']}"] = f"skos_{concept['name']}"
+                focus_targets[f"Concept: {concept['name']}"] = viz_node_id(
+                    "concept", concept["name"]
+                )
+
+        # A seed whose entity was renamed is held under a label that no longer
+        # exists; re-point it at the new one first, or the prune below reads the
+        # rename as "the class is gone" and focus mode falls back to an
+        # arbitrary node (issue #275).
+        _renames = st.session_state.pop("_viz_pending_renames", None)
+        if _renames and "_viz_cfg_focus_seeds" in st.session_state:
+            (
+                st.session_state["_viz_cfg_focus_seeds"],
+                st.session_state["_viz_cfg_focus_seed_ids_by_label"],
+            ) = follow_focus_seed_renames(
+                st.session_state["_viz_cfg_focus_seeds"],
+                st.session_state.get("_viz_cfg_focus_seed_ids_by_label"),
+                focus_targets,
+                _renames,
+            )
 
         # Seeds whose label now names a *different* entity than it did last
         # render belong to an ontology that has since been swapped out, so drop

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -39,6 +39,7 @@ from ..ui import (
     filter_entry_token,
     focus_seeds_from_selection,
     follow_focus_seed_renames,
+    follow_renamed_node_ids,
     graph_node_cap,
     local_store,
     panel_subject_uri,
@@ -397,8 +398,16 @@ def render_visualization():
         # A seed whose entity was renamed is held under a label that no longer
         # exists; re-point it at the new one first, or the prune below reads the
         # rename as "the class is gone" and focus mode falls back to an
-        # arbitrary node (issue #275).
+        # arbitrary node (issue #275). Both seed sources are re-pointed from this
+        # one pop: the labels already in session here, and the ids restored from
+        # the linked file further down.
         _renames = st.session_state.pop("_viz_pending_renames", None)
+        if replaced:
+            # The notes name entities of the ontology that has just been swapped
+            # out. Following them into the new one would re-point a seed at
+            # whatever happens to hold that URI now, which is the very thing the
+            # reuse prune below exists to stop (issue #180).
+            _renames = None
         if _renames and "_viz_cfg_focus_seeds" in st.session_state:
             (
                 st.session_state["_viz_cfg_focus_seeds"],
@@ -426,6 +435,10 @@ def render_visualization():
         # simply drops out, the same pruning the focus block does below.
         _pending_seed_ids = st.session_state.pop("_viz_pending_focus_seed_ids", None)
         if _pending_seed_ids and "_viz_cfg_focus_seeds" not in st.session_state:
+            # An id saved before a rename made earlier this session resolves to
+            # nothing, and there are no labels in session yet for the block above
+            # to have followed — this is the first look at the file's seeds.
+            _pending_seed_ids = follow_renamed_node_ids(_pending_seed_ids, _renames)
             _label_by_id = {node_id: label for label, node_id in focus_targets.items()}
             _restored_seeds = [
                 _label_by_id[i] for i in _pending_seed_ids if i in _label_by_id

--- a/tests/test_viz_focus_rename.py
+++ b/tests/test_viz_focus_rename.py
@@ -192,6 +192,44 @@ def test_no_renames_leaves_the_seeds_untouched(session):
     assert seen == {"Class: Person": targets["Class: Person"]}
 
 
+def test_saved_seed_ids_follow_a_rename_too(session):
+    """The seeds saved against a linked file are node ids (#164). Renaming the
+    entity before the first Visualization render of the session leaves the saved
+    id naming nothing, and there are no labels in session yet to follow."""
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+    saved = [app.viz_node_id("class", NS + "Person")]
+
+    followed = app.follow_renamed_node_ids(saved, session["_viz_pending_renames"])
+
+    assert followed == [app.viz_node_id("class", NS + "Human")]
+    # Which is what the restore turns back into a label.
+    after = _class_targets("Human", "Org")
+    label_by_id = {node_id: label for label, node_id in after.items()}
+    assert [label_by_id[i] for i in followed if i in label_by_id] == ["Class: Human"]
+
+
+def test_saved_seed_ids_follow_a_chain_of_renames(session):
+    """Same chain-following as the label path."""
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+    app.viz_note_rename("class", NS + "Human", NS + "Being")
+
+    followed = app.follow_renamed_node_ids(
+        [app.viz_node_id("class", NS + "Person")],
+        session["_viz_pending_renames"],
+    )
+
+    assert followed == [app.viz_node_id("class", NS + "Being")]
+
+
+def test_saved_seed_ids_are_untouched_without_notes(session):
+    """The common case: nothing was renamed, so the saved ids restore as they
+    always did, including ids that resolve to nothing."""
+    saved = [app.viz_node_id("class", NS + "Person"), "gone"]
+    assert app.follow_renamed_node_ids(saved, None) == saved
+    assert app.follow_renamed_node_ids(saved, {}) == saved
+    assert app.follow_renamed_node_ids(None, {}) == []
+
+
 def test_dropping_the_seeds_forgets_the_notes(session):
     """With no seeds left there is nothing for a note to re-point, and keeping
     them would apply a rename made against the file that was just closed."""

--- a/tests/test_viz_focus_rename.py
+++ b/tests/test_viz_focus_rename.py
@@ -1,0 +1,203 @@
+"""Focus seeds follow an entity that is renamed (issue #275).
+
+Seeds are held as the labels the "Focus node(s)" multiselect shows, so renaming
+the very class you were focused on left a seed naming nothing: it was pruned and
+focus mode fell back to an arbitrary first node, dropping the class you were
+looking at out of the graph. The rename leaves a note behind, and the next
+Visualization render turns it back into the new label.
+"""
+
+import pytest
+
+from orionbelt_ontology_builder import app
+
+NS = "http://test.org/ont#"
+
+
+def _class_targets(*names):
+    """The label -> node id map render_visualization builds for classes."""
+    return {f"Class: {n}": app.viz_node_id("class", NS + n) for n in names}
+
+
+def _seen(targets, *labels):
+    """What the previous render recorded for those seeds."""
+    return {label: targets[label] for label in labels}
+
+
+@pytest.fixture
+def session(monkeypatch):
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    return state
+
+
+def test_a_renamed_seed_moves_to_its_new_label(session):
+    """The point of the issue: the focus stays on the class you renamed."""
+    before = _class_targets("Person", "Org")
+    after = _class_targets("Human", "Org")
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+
+    seeds, seen = app.follow_focus_seed_renames(
+        ["Class: Person"],
+        _seen(before, "Class: Person"),
+        after,
+        session["_viz_pending_renames"],
+    )
+
+    assert seeds == ["Class: Human"]
+    # The recorded id has to move with it, or the reuse prune that runs next
+    # reads the seed as a label that has come to name something else.
+    assert seen == {"Class: Human": after["Class: Human"]}
+    assert app.prune_reused_focus_seeds(seeds, seen, after) == ["Class: Human"]
+
+
+def test_untouched_seeds_are_left_alone(session):
+    """Only the renamed entity moves; the rest of the selection is preserved."""
+    before = _class_targets("Person", "Org")
+    after = _class_targets("Human", "Org")
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+
+    seeds, seen = app.follow_focus_seed_renames(
+        ["Class: Org", "Class: Person"],
+        _seen(before, "Class: Org", "Class: Person"),
+        after,
+        session["_viz_pending_renames"],
+    )
+
+    assert seeds == ["Class: Org", "Class: Human"]
+    assert seen == {
+        "Class: Org": after["Class: Org"],
+        "Class: Human": after["Class: Human"],
+    }
+
+
+def test_a_chain_of_renames_lands_on_the_last_name(session):
+    """Seeds are only re-pointed on a Visualization render, so an entity can be
+    renamed more than once in between."""
+    before = _class_targets("Person")
+    after = _class_targets("Being")
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+    app.viz_note_rename("class", NS + "Human", NS + "Being")
+
+    seeds, _ = app.follow_focus_seed_renames(
+        ["Class: Person"],
+        _seen(before, "Class: Person"),
+        after,
+        session["_viz_pending_renames"],
+    )
+
+    assert seeds == ["Class: Being"]
+
+
+def test_a_rename_back_to_the_old_name_does_not_spin(session):
+    """A -> B -> A is a cycle in the notes; it resolves to the name in force."""
+    targets = _class_targets("Person")
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+    app.viz_note_rename("class", NS + "Human", NS + "Person")
+
+    seeds, _ = app.follow_focus_seed_renames(
+        ["Class: Person"],
+        _seen(targets, "Class: Person"),
+        targets,
+        session["_viz_pending_renames"],
+    )
+
+    assert seeds == ["Class: Person"]
+
+
+def test_a_no_op_rename_is_not_recorded(session):
+    """Saving the edit form without touching the name changes nothing."""
+    app.viz_note_rename("class", NS + "Person", NS + "Person")
+    assert "_viz_pending_renames" not in session
+
+
+def test_individuals_and_data_properties_follow_too(session):
+    """Every focusable kind is keyed by its own node id, and each is noted."""
+    before = {
+        "Individual: alice": app.viz_node_id("individual", NS + "alice"),
+        "Data Property: age": app.viz_node_id("property", NS + "age"),
+    }
+    after = {
+        "Individual: alicia": app.viz_node_id("individual", NS + "alicia"),
+        "Data Property: ageInYears": app.viz_node_id("property", NS + "ageInYears"),
+    }
+    app.viz_note_rename("individual", NS + "alice", NS + "alicia")
+    app.viz_note_rename("property", NS + "age", NS + "ageInYears")
+
+    seeds, _ = app.follow_focus_seed_renames(
+        list(before),
+        dict(before),
+        after,
+        session["_viz_pending_renames"],
+    )
+
+    assert seeds == ["Individual: alicia", "Data Property: ageInYears"]
+
+
+def test_a_renamed_concept_follows_by_name(session):
+    """SKOS concept nodes are keyed by local name rather than by URI."""
+    before = {"Concept: Widget": app.viz_node_id("concept", "Widget")}
+    after = {"Concept: Gadget": app.viz_node_id("concept", "Gadget")}
+    app.viz_note_rename("concept", "Widget", "Gadget")
+
+    seeds, _ = app.follow_focus_seed_renames(
+        ["Concept: Widget"],
+        dict(before),
+        after,
+        session["_viz_pending_renames"],
+    )
+
+    assert seeds == ["Concept: Gadget"]
+
+
+def test_a_seed_whose_type_is_switched_off_is_left_to_the_prune(session):
+    """The renamed class is not focusable with classes hidden, so the seed is
+    left exactly as it was and the existing prune deals with it."""
+    before = _class_targets("Person")
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+
+    seeds, seen = app.follow_focus_seed_renames(
+        ["Class: Person"],
+        _seen(before, "Class: Person"),
+        {},
+        session["_viz_pending_renames"],
+    )
+
+    assert seeds == ["Class: Person"]
+    assert app.prune_reused_focus_seeds(seeds, seen, {}) == []
+
+
+def test_a_freshly_picked_seed_has_no_recorded_id(session):
+    """Nothing to follow it by, and nothing that needs following."""
+    after = _class_targets("Person", "Org")
+    app.viz_note_rename("class", NS + "Widget", NS + "Gadget")
+
+    seeds, _ = app.follow_focus_seed_renames(
+        ["Class: Person", "Class: Org"],
+        {"Class: Person": after["Class: Person"]},
+        after,
+        session["_viz_pending_renames"],
+    )
+
+    assert seeds == ["Class: Person", "Class: Org"]
+
+
+def test_no_renames_leaves_the_seeds_untouched(session):
+    """The common case: nothing was renamed, so nothing is rewritten."""
+    targets = _class_targets("Person", "Org")
+    seeds, seen = app.follow_focus_seed_renames(
+        ["Class: Person"], _seen(targets, "Class: Person"), targets, {}
+    )
+    assert seeds == ["Class: Person"]
+    assert seen == {"Class: Person": targets["Class: Person"]}
+
+
+def test_dropping_the_seeds_forgets_the_notes(session):
+    """With no seeds left there is nothing for a note to re-point, and keeping
+    them would apply a rename made against the file that was just closed."""
+    session["_viz_cfg_focus_seeds"] = ["Class: Person"]
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+
+    app.viz_drop_focus_seeds()
+
+    assert "_viz_pending_renames" not in session


### PR DESCRIPTION
Closes #275.

## The bug

With "Focus on one node" switched on, renaming the class you are focused on
dropped it out of the graph and the view jumped to some unrelated class.

The focus seeds are held as the labels the "Focus node(s)" multiselect shows
(`"Class: Person"`), not as identities, and a rename mints a new URI. On the next
render the old label names nothing, so the seed was pruned twice over:

* `prune_reused_focus_seeds` sees a seed whose recorded node id no longer matches
  and drops it. That guard was written for ontology swaps (#180), but a rename
  trips it identically.
* the label membership filter drops it too, and the empty result falls back to
  `focus_labels[0]`, an arbitrary first class.

That fallback was then written back over the user's selection and persisted to
the linked file's saved state, so the loss survived a restart.

## The fix

Nothing in the rebuilt state ties the old and new names together (the label
changed, and the node id is a hash of the URI, which changed with it), so the
rename itself now leaves a note behind: `viz_note_rename` records old node id to
new node id. The next Visualization render consumes it via
`follow_focus_seed_renames`, swapping the seed for the label the entity now
answers to and bringing its recorded id along so the reuse prune still
recognises it.

A note is only followed when the renamed entity is still in `focus_targets`,
which keeps two edge cases honest: an entity whose type is toggled off is left
to the existing prune, and an undone rename re-points nothing. Rename chains
resolve to the last name, and a rename back to an earlier name terminates rather
than cycling.

Covers classes, individuals, data properties and SKOS concepts, from both the
page edit forms and the graph side panel. `focus_targets` and the rename notes
now build node ids through one shared `viz_node_id`, since the two have to agree
on the id or a rename would re-point nothing.

## Verification

11 new tests in `tests/test_viz_focus_rename.py`. Full suite: 1068 passed. ruff
format and check clean, mypy clean.

Also verified in the running app rather than only in tests, since the bug lives
in the session state flow across a rerun: loaded gist (181 classes), switched on
focus mode seeded to `Class: Account`, renamed it to `ZzzAccount` so that it
sorts last, and the seed followed to `Class: ZzzAccount`. Before this change it
fell back to `Class: Address`.

## Noticed but not touched

`viz_find_entity` (the "Find and centre" pick) and `_viz_last_selection` also
keep stale labels and ids after a rename. Out of scope for the reported bug,
happy to fold them in if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)