### PR TITLE
feat: Alt-click a node to focus on it alone (#276)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Imports on an empty ontology go straight through. Otherwise you get a review pan
 
 ### Visualization
 
-Interactive vis-network graph with class filtering, configurable node limits, click-to-navigate into the editor, Ctrl/Cmd-click a node to add it to the "Focus on one node" selection (narrowing the graph to its neighbourhood), hierarchy tree view, and statistics charts.
+Interactive vis-network graph with class filtering, configurable node limits, click-to-navigate into the editor, Ctrl/Cmd-click a node to add it to the "Focus on one node" selection (narrowing the graph to its neighbourhood) or Alt-click to focus on it alone, hierarchy tree view, and statistics charts.
 
 ### Safety
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -152,6 +152,7 @@ from .ui import (  # noqa: F401
     confirm_delete,
     display_flash_message,
     filter_entry_token,
+    focus_seeds_after_request,
     focus_seeds_from_selection,
     follow_focus_seed_renames,
     follow_renamed_node_ids,

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -1054,17 +1054,26 @@ function renderGraph(args) {
 
     // Ctrl/Cmd-click a node to add it to the "Focus on one node" selection, so
     // the graph narrows to that node's neighbourhood without typing its name
-    // into the focus picker (issue #56). reqId makes each request distinct so
-    // the Python side applies it once. Sent after the normal selectNode value,
-    // so this is the value Streamlit keeps for this interaction.
+    // into the focus picker (issue #56). Alt-click focuses on that node alone,
+    // replacing whatever was focused before: hopping from one node to the next
+    // otherwise means emptying the picker by hand between hops (issue #276).
+    // Alt is checked first so it still means "only this one" when a stray
+    // Ctrl or Cmd is held with it. reqId makes each request distinct so the
+    // Python side applies it once. Sent after the normal selectNode value, so
+    // this is the value Streamlit keeps for this interaction.
     network.on('click', function(params) {
         var wasFresh = hlJustSelected;
         hlJustSelected = false;
         if (!params.nodes.length) return;
         var ev = params.event && params.event.srcEvent;
-        if (ev && (ev.ctrlKey || ev.metaKey)) {
+        if (ev && (ev.altKey || ev.ctrlKey || ev.metaKey)) {
             sendToStreamlit("streamlit:setComponentValue", {
-                value: {focusRequest: true, reqId: Date.now(), nodeId: params.nodes[0]}
+                value: {
+                    focusRequest: true,
+                    reqId: Date.now(),
+                    nodeId: params.nodes[0],
+                    replace: !!ev.altKey
+                }
             });
             return;
         }

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -673,6 +673,26 @@ def focus_seeds_from_selection(selected_classes, class_count):
     return labels
 
 
+def focus_seeds_after_request(seeds, label, replace=False):
+    """The focus seeds a modifier-click in the graph leaves behind.
+
+    Ctrl/Cmd-click adds the node to whatever is focused already (issue #56),
+    which is what building a neighbourhood up out of several nodes needs.
+    Alt-click focuses on that node alone (issue #276): wanting one node at a
+    time is the common case, and it otherwise means emptying the picker by hand
+    between hops.
+
+    Clicking a node that is already a seed changes nothing either way, rather
+    than duplicating it in the multiselect.
+    """
+    if replace:
+        return [label]
+    seeds = list(seeds or [])
+    if label not in seeds:
+        seeds.append(label)
+    return seeds
+
+
 def viz_focus_toggle():
     """Persist the focus toggle, seeding the focus nodes on first use.
 

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -37,6 +37,7 @@ from ..ui import (
     build_class_options,
     build_filter_entries,
     filter_entry_token,
+    focus_seeds_after_request,
     focus_seeds_from_selection,
     follow_focus_seed_renames,
     follow_renamed_node_ids,
@@ -1836,8 +1837,9 @@ def render_visualization():
                     except (OSError, ValueError) as e:
                         st.toast(f"Could not save image: {e}", icon="⚠️")
 
-            # Ctrl/Cmd-click in the graph requests focusing on a node: add it to
-            # the "Focus on one node" seeds and enable focus mode (issue #56). The
+            # A modifier-click in the graph requests focusing on a node: add it
+            # to the "Focus on one node" seeds and enable focus mode (issue #56),
+            # or replace them with it when the click was an Alt-click (#276). The
             # reqId guard ensures each click is applied once (the component value
             # persists across reruns).
             if isinstance(selection, dict) and selection.get("focusRequest"):
@@ -1847,14 +1849,20 @@ def render_visualization():
                     _id_to_label = {v: k for k, v in focus_targets.items()}
                     _focus_label = _id_to_label.get(selection.get("nodeId"))
                     if _focus_label:
+                        _replace = bool(selection.get("replace"))
                         st.session_state["_viz_cfg_focus_mode"] = True
-                        _seeds = list(
-                            st.session_state.get("_viz_cfg_focus_seeds") or []
+                        st.session_state["_viz_cfg_focus_seeds"] = (
+                            focus_seeds_after_request(
+                                st.session_state.get("_viz_cfg_focus_seeds"),
+                                _focus_label,
+                                replace=_replace,
+                            )
                         )
-                        if _focus_label not in _seeds:
-                            _seeds.append(_focus_label)
-                        st.session_state["_viz_cfg_focus_seeds"] = _seeds
-                        st.toast(f"Focusing on {_focus_label}", icon="🎯")
+                        st.toast(
+                            f"Focusing on {_focus_label}"
+                            + (" only" if _replace else ""),
+                            icon="🎯",
+                        )
                         st.rerun()
                     else:
                         st.toast(
@@ -1961,7 +1969,8 @@ def render_visualization():
                         )
                     elif not has_selection:
                         st.caption(
-                            "Click a node to see details. Ctrl/Cmd-click focuses on it."
+                            "Click a node to see details. Ctrl/Cmd-click adds it to "
+                            "the focus, Alt-click focuses on it alone."
                         )
                         _render_panel_add_buttons(classes, None, None, None)
                     else:
@@ -2010,7 +2019,8 @@ def render_visualization():
                 else:
                     sel_html = (
                         "Click a node or edge to see details · "
-                        "Ctrl/Cmd-click a node to focus on it"
+                        "Ctrl/Cmd-click a node to add it to the focus · "
+                        "Alt-click to focus on it alone"
                     )
 
                 # Inject CSS to remove gap between status bar columns

--- a/tests/test_viz_focus_click.py
+++ b/tests/test_viz_focus_click.py
@@ -1,0 +1,53 @@
+"""What a modifier-click on a graph node does to the focus seeds.
+
+Ctrl/Cmd-click adds the node to the focus (issue #56); Alt-click focuses on it
+alone (issue #276), because wanting one node at a time is the common case and
+it otherwise means emptying the picker by hand between hops.
+"""
+
+from orionbelt_ontology_builder import app
+
+
+def test_ctrl_click_adds_to_what_is_already_focused():
+    """Building a neighbourhood up out of several nodes."""
+    assert app.focus_seeds_after_request(["Class: Person"], "Class: Org") == [
+        "Class: Person",
+        "Class: Org",
+    ]
+
+
+def test_alt_click_focuses_on_that_node_alone():
+    """The point of issue #276."""
+    assert app.focus_seeds_after_request(
+        ["Class: Person", "Class: Org"], "Class: Role", replace=True
+    ) == ["Class: Role"]
+
+
+def test_ctrl_clicking_a_node_that_is_already_focused_changes_nothing():
+    """Not a duplicate entry in the multiselect."""
+    seeds = ["Class: Person", "Class: Org"]
+    assert app.focus_seeds_after_request(seeds, "Class: Person") == seeds
+
+
+def test_alt_clicking_the_only_focused_node_changes_nothing():
+    """Idempotent, so hopping back onto the node you are on is not a special
+    case the caller has to think about."""
+    assert app.focus_seeds_after_request(["Class: Person"], "Class: Person", True) == [
+        "Class: Person"
+    ]
+
+
+def test_a_first_click_starts_the_focus_either_way():
+    """Nothing focused yet, whichever modifier switched the mode on."""
+    assert app.focus_seeds_after_request(None, "Class: Person") == ["Class: Person"]
+    assert app.focus_seeds_after_request([], "Class: Person", replace=True) == [
+        "Class: Person"
+    ]
+
+
+def test_the_caller_s_list_is_not_mutated():
+    """The seeds come out of session state; adding to that list in place would
+    edit the stored value before the assignment that is meant to."""
+    seeds = ["Class: Person"]
+    app.focus_seeds_after_request(seeds, "Class: Org")
+    assert seeds == ["Class: Person"]


### PR DESCRIPTION
Closes #276.

Ctrl/Cmd-click adds a node to the "Focus on one node" selection (#56), which is
what building a neighbourhood up out of several nodes needs. Wanting one node at
a time is the more common case, and it meant emptying the focus picker by hand
between hops.

Alt-click now replaces the focus seeds with the node clicked. The click handler
sends the modifier along as `replace`, and both paths go through one
`focus_seeds_after_request` helper: add on a Ctrl/Cmd-click, replace on an
Alt-click, and no change either way when the node is already the whole focus.
Alt is tested first so it still means "only this one" when a stray Ctrl or Cmd
is held with it.

The side panel caption, the status bar under the graph, and the README all say
what both modifiers do.

## Verification

6 new tests in `tests/test_viz_focus_click.py`. Full suite: 1077 passed. ruff
format and check clean, mypy clean.

Driven live with real modifier-clicks on canvas nodes, since a click on a
vis-network canvas is not something the unit tests reach. Each node was centred
first so the click landed on it:

| action | focus seeds after | graph |
| --- | --- | --- |
| Ctrl-click `Address` | `Class: Address` | 500 to 32 nodes |
| Ctrl-click `Content` | `Class: Address`, `Class: Content` | 99 nodes |
| Alt-click `Component` | `Class: Component` alone | 47 nodes |
| Alt-click `Component` again | unchanged | idempotent |

The toast wording ("Focusing on X only") faded before it could be read out of
the DOM, so that one string is verified by reading the code rather than live.

## Note on Alt

Alt is Option on macOS, and neither vis-network nor the surrounding page binds
it, so it is free to take. Alt-click inside a canvas is not intercepted by the
browsers this was checked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)