### PR TITLE
feat: rename a custom annotation type (#287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Every entity page has a Bulk Operations tab:
 - **Edit** - spreadsheet view of all entities with editable labels, comments, parents
 - **Delete** - multi-select and remove in one go
 
-Annotations have their own bulk editor with per-row add/delete actions.
+Annotations have their own bulk editor with per-row add/delete actions, and an
+Annotation Types tab that renames a type you invented — every annotation using
+it is rewritten, so no values are lost.
 
 ### SKOS vocabularies
 
@@ -354,7 +356,7 @@ the 200 MB default; raise the value only when self-hosting with enough memory.
 | **Relations**       | Class, property, and individual relations                      |
 | **Restrictions**    | OWL restrictions and cardinality constraints                   |
 | **Advanced**        | Advanced OWL features                                          |
-| **Annotations**     | RDFS, SKOS, Dublin Core annotations with bulk editing          |
+| **Annotations**     | RDFS, SKOS, DC and custom annotations, bulk edit, rename       |
 | **SKOS Vocabulary** | Concept schemes, concepts, hierarchy, SKOS validation          |
 | **Import / Export** | File import with merge review, export, new ontology, templates |
 | **Source**          | Live Turtle source view of the ontology                        |

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -208,7 +208,10 @@ from .ui import (  # noqa: F401
 # They live in ``views`` rather than ``pages`` because Streamlit reads a
 # ``pages`` directory next to an entry script as a legacy multipage app (#269).
 from .views.advanced import render_advanced
-from .views.annotations import render_annotations
+from .views.annotations import (  # noqa: F401 - render_annotation_types is a tab, re-exported like the ui block's
+    render_annotation_types,
+    render_annotations,
+)
 from .views.classes import render_classes
 from .views.dashboard import render_dashboard
 from .views.import_export import render_import_export

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2617,21 +2617,27 @@ class OntologyManager:
         if self._annotation_predicate_in_use(new_uri):
             return False
 
-        updates: _TripleUpdates = []
-        # Statements about the type itself (its owl:AnnotationProperty
-        # declaration, its label, ...).
-        for p, o in self.graph.predicate_objects(old_uri):
-            updates.append(((old_uri, p, o), (new_uri, p, o)))
-        # References to it as an object (rdfs:subPropertyOf, seeAlso, ...).
-        for s, p in self.graph.subject_predicates(old_uri):
-            updates.append(((s, p, old_uri), (s, p, new_uri)))
-        # The annotations themselves.
-        for s, o in self.graph.subject_objects(old_uri):
-            updates.append(((s, old_uri, o), (s, new_uri, o)))
-
-        for old_triple, new_triple in updates:
-            self.graph.remove(old_triple)
-            self.graph.add(new_triple)
+        # Every triple mentioning the type, whichever position it stands in:
+        # statements about it (its owl:AnnotationProperty declaration, its
+        # label), the annotations that use it as their predicate, and references
+        # to it as an object (rdfs:subPropertyOf, seeAlso). Collected as one set
+        # and rewritten in all three positions at once, because a triple can
+        # mention it more than once — ``ex:tag rdfs:seeAlso ex:tag`` — and moving
+        # one position at a time would leave the old URI standing in the other.
+        mentions: set[_Triple] = {
+            *self.graph.triples((old_uri, None, None)),
+            *self.graph.triples((None, old_uri, None)),
+            *self.graph.triples((None, None, old_uri)),
+        }
+        for s, p, o in mentions:
+            self.graph.remove((s, p, o))
+            self.graph.add(
+                (
+                    new_uri if s == old_uri else s,
+                    new_uri if p == old_uri else p,
+                    new_uri if o == old_uri else o,
+                )
+            )
 
         return True
 

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2475,6 +2475,166 @@ class OntologyManager:
         result = sorted(predicates.values(), key=lambda x: x["local_name"].lower())
         return result
 
+    # Vocabularies whose terms are defined elsewhere, as a rename *target*: a
+    # custom type can be moved to a URI of the user's own choosing, but not onto
+    # a standard vocabulary term, which would give a private meaning to a term
+    # every other tool already understands (issue #287).
+    _EXTERNAL_ANNOTATION_NAMESPACES: ClassVar[frozenset[str]] = frozenset(
+        {str(RDF), str(RDFS), str(OWL), str(XSD), str(SKOS), str(DC), str(DCTERMS)}
+    )
+
+    def annotation_property_rename_reason(self, predicate: str) -> str | None:
+        """Why the annotation type ``predicate`` cannot be renamed, or ``None``.
+
+        Only a type in this ontology's own namespace can be renamed — the same
+        test :meth:`add_annotation` uses to decide that a type is one the user
+        invented here. ``rdfs:label``, ``skos:definition`` and the terms of any
+        imported vocabulary are defined by that vocabulary, so renaming one here
+        would not rename anything: it would fork the vocabulary and leave every
+        annotation pointing at a term no other tool knows (issue #287).
+        """
+        uri = self._resolve_predicate_uri(predicate)
+        if not str(uri).startswith(str(self.namespace)):
+            return (
+                f"'{predicate}' is defined by another vocabulary, not by this "
+                "ontology, so renaming it here would fork that vocabulary. Only "
+                f"annotation types in this ontology's own namespace "
+                f"({self.base_uri}) can be renamed."
+            )
+        return None
+
+    def get_custom_annotation_properties(self) -> list[dict[str, Any]]:
+        """The annotation types this ontology defines itself.
+
+        Everything the Annotations page can show as an annotation type, minus
+        the ones belonging to another vocabulary (see
+        :meth:`annotation_property_rename_reason`) and minus the predicates that
+        are declared as some other kind of entity — an object or data property
+        assertion also reads as an annotation here, but it is renamed on the
+        Properties page, not this one.
+
+        A type is listed whether it is declared as an ``owl:AnnotationProperty``
+        or only used, so one that came in from a loaded file is renameable too.
+        Each entry carries ``uri``, ``local_name``, ``prefix``, ``display`` (the
+        prefixed form) and ``usage`` (how many annotations use it).
+        """
+        candidates: dict[str, dict[str, Any]] = {
+            p["uri"]: dict(p) for p in self.get_used_annotation_predicates()
+        }
+        # Declared but unused: the values were deleted and the declaration
+        # stayed, so the type is still part of the ontology.
+        for pred in self.graph.subjects(RDF.type, OWL.AnnotationProperty):
+            if isinstance(pred, URIRef) and str(pred) not in candidates:
+                candidates[str(pred)] = {
+                    "uri": str(pred),
+                    "local_name": self._local_name(pred),
+                    "prefix": self._get_prefix_for_uri(str(pred)),
+                }
+
+        result: list[dict[str, Any]] = []
+        for uri, info in candidates.items():
+            if self.annotation_property_rename_reason(uri):
+                continue
+            pred_uri = URIRef(uri)
+            if set(self.graph.objects(pred_uri, RDF.type)) - {OWL.AnnotationProperty}:
+                continue
+            entry = dict(info)
+            entry["display"] = (
+                f"{info['prefix']}:{info['local_name']}"
+                if info["prefix"]
+                else info["local_name"]
+            )
+            entry["usage"] = sum(1 for _ in self.graph.triples((None, pred_uri, None)))
+            result.append(entry)
+
+        result.sort(key=lambda e: e["local_name"].lower())
+        return result
+
+    def _resolve_renamed_annotation_uri(self, name: str, namespace: str) -> URIRef:
+        """Resolve the new name of an annotation type being renamed.
+
+        Takes the same forms as :meth:`_resolve_predicate_uri` except a bare
+        name, which stays in ``namespace`` — the namespace the type already
+        lives in, the way the entity renames keep theirs. Mapping it the usual
+        way would turn renaming a custom type to 'label' into a silent merge
+        into ``rdfs:label``, and minting it in the base namespace would move a
+        type out of its own namespace as a side effect of renaming it.
+        """
+        name = name.strip()
+        if name.startswith(("http://", "https://")):
+            return URIRef(name)
+        if ":" in name:
+            return self._resolve_predicate_uri(name)
+        return URIRef(namespace + name)
+
+    def _annotation_predicate_in_use(self, uri: URIRef) -> bool:
+        """True if ``uri`` already names something in this graph — an entity, an
+        annotation type, or any resource carrying triples of its own."""
+        return (
+            self._name_in_use(uri)
+            or (uri, None, None) in self.graph
+            or (None, uri, None) in self.graph
+        )
+
+    def rename_annotation_property(self, old_name: str, new_name: str) -> bool:
+        """Rename a custom annotation type, updating every use of it (#287).
+
+        ``old_name`` may be written any way :meth:`_resolve_predicate_uri`
+        accepts — a full URI, a ``prefix:local`` CURIE or a local name. A bare
+        ``new_name`` keeps the type in its current namespace (see
+        :meth:`_resolve_renamed_annotation_uri`); a CURIE or a full URI moves it
+        where it says.
+
+        Every triple that mentions the type moves with it: its declaration and
+        any other statement about it, the annotations that use it as their
+        predicate, and any reference to it as an object. That is the whole point
+        of doing this here rather than by hand — a search-and-replace over the
+        Turtle catches the same triples only as long as the file uses one prefix
+        for them.
+
+        Returns False when the new name is already taken, so nothing is merged
+        into an existing term by accident. Raises ``ValueError`` when the new
+        name is unusable, when the type belongs to another vocabulary (see
+        :meth:`annotation_property_rename_reason`), or when the new name would
+        land on a standard vocabulary term.
+        """
+        old_uri = self._resolve_predicate_uri(old_name)
+        if reason := self.annotation_property_rename_reason(str(old_uri)):
+            raise ValueError(reason)
+        self._require_valid_annotation_predicate(new_name)
+
+        new_uri = self._resolve_renamed_annotation_uri(
+            new_name, self._namespace_of(old_uri)
+        )
+        if new_uri == old_uri:
+            return True
+        if self._namespace_of(new_uri) in self._EXTERNAL_ANNOTATION_NAMESPACES:
+            raise ValueError(
+                f"'{new_name}' is a standard vocabulary term. Renaming a type "
+                "onto one would give a private meaning to a term every other "
+                "tool already understands."
+            )
+        if self._annotation_predicate_in_use(new_uri):
+            return False
+
+        updates: _TripleUpdates = []
+        # Statements about the type itself (its owl:AnnotationProperty
+        # declaration, its label, ...).
+        for p, o in self.graph.predicate_objects(old_uri):
+            updates.append(((old_uri, p, o), (new_uri, p, o)))
+        # References to it as an object (rdfs:subPropertyOf, seeAlso, ...).
+        for s, p in self.graph.subject_predicates(old_uri):
+            updates.append(((s, p, old_uri), (s, p, new_uri)))
+        # The annotations themselves.
+        for s, o in self.graph.subject_objects(old_uri):
+            updates.append(((s, old_uri, o), (s, new_uri, o)))
+
+        for old_triple, new_triple in updates:
+            self.graph.remove(old_triple)
+            self.graph.add(new_triple)
+
+        return True
+
     def _get_prefix_for_uri(self, uri: str) -> str:
         """Get the prefix for a URI if bound in the graph."""
         for prefix, namespace in self.graph.namespaces():

--- a/orionbelt_ontology_builder/views/annotations.py
+++ b/orionbelt_ontology_builder/views/annotations.py
@@ -17,6 +17,99 @@ from ..ui import (
 )
 
 
+def _rename_annotation_type(ont, ann_type, new_name):
+    """Apply one annotation-type rename, reporting why it was refused (#287).
+
+    Returns True when the graph changed; the caller reruns. The engine tells the
+    two refusals apart: a name it cannot use at all raises, a name already taken
+    comes back as False, and only the second is about this ontology's contents.
+    """
+    new_name = (new_name or "").strip()
+    if not new_name:
+        show_message("Annotation type name is required!", "error")
+        return False
+    try:
+        renamed = ont.rename_annotation_property(ann_type["uri"], new_name)
+    except ValueError as exc:
+        show_message(str(exc), "error")
+        return False
+    if not renamed:
+        show_message(f"Cannot rename: '{new_name}' is already in use!", "error")
+        return False
+    save_checkpoint("Rename annotation type")
+    return True
+
+
+def render_annotation_types(ont):
+    """Render the "Annotation Types" tab.
+
+    A separate function so it can be driven directly in tests, for the reason
+    given on :func:`render_add_annotation`: the page's tab picker is a
+    ``segmented_control``, which AppTest mis-serializes.
+    """
+    st.subheader("Annotation Types")
+    st.caption(
+        "The annotation types this ontology defines itself. Renaming one "
+        "rewrites every annotation that uses it, so no values are lost. Types "
+        "from another vocabulary (rdfs:label, skos:definition, an imported "
+        "ontology's) are defined there, not here, and are not listed."
+    )
+
+    ann_types = ont.get_custom_annotation_properties()
+    if not ann_types:
+        st.info(
+            "No custom annotation types yet. Add an annotation under "
+            "'Add Annotation' with a type of your own to create one."
+        )
+        return
+
+    for ann_type in ann_types:
+        row_key = _uid(ann_type["uri"])
+        col1, col2, col3 = st.columns([3, 3, 0.7])
+        with col1:
+            st.write(f"**{ann_type['display']}**")
+        with col2:
+            uses = ann_type["usage"]
+            st.write(f"{uses} annotation{'' if uses == 1 else 's'}")
+        with col3:
+            st.button(
+                "✏️",
+                key=f"edit_anntype_{row_key}",
+                help="Rename this annotation type",
+                on_click=_cb_toggle_edit,
+                args=("anntype", row_key),
+            )
+
+        if _is_open("anntype", row_key, "edit"):
+            with st.form(f"rename_anntype_form_{row_key}"):
+                new_name = st.text_input(
+                    "Name",
+                    value=ann_type["local_name"],
+                    key=f"anntype_name_{row_key}",
+                    help="A name keeps the type in its current namespace. A "
+                    "bound prefix ('ex:note') or a full URI moves it.",
+                )
+                fcol1, fcol2 = st.columns(2)
+                with fcol1:
+                    submitted = st.form_submit_button(
+                        "Rename", type="primary", use_container_width=True
+                    )
+                with fcol2:
+                    cancelled = st.form_submit_button(
+                        "Cancel", use_container_width=True
+                    )
+
+            if cancelled:
+                _close_entity("anntype")
+                st.rerun()
+            if submitted and _rename_annotation_type(ont, ann_type, new_name):
+                _close_entity("anntype")
+                set_flash_message(
+                    f"Annotation type renamed to '{new_name.strip()}'", "success"
+                )
+                st.rerun()
+
+
 def render_annotations():
     """Render the annotations management page."""
     st.header("Annotations")
@@ -79,7 +172,7 @@ def render_annotations():
 
     _ann_tab = st.segmented_control(
         "Section",
-        ["View Annotations", "Add Annotation", "Bulk Edit"],
+        ["View Annotations", "Add Annotation", "Annotation Types", "Bulk Edit"],
         default="View Annotations",
         key="ann_active_tab",
         label_visibility="collapsed",
@@ -208,6 +301,9 @@ def render_annotations():
 
     if _ann_tab == "Add Annotation":
         render_add_annotation(ont, all_resources)
+
+    if _ann_tab == "Annotation Types":
+        render_annotation_types(ont)
 
     if _ann_tab == "Bulk Edit":
         st.subheader("Bulk Edit Annotations")

--- a/tests/test_annotation_type_rename.py
+++ b/tests/test_annotation_type_rename.py
@@ -8,7 +8,7 @@ that is already taken.
 """
 
 import pytest
-from rdflib import OWL, RDF, RDFS, URIRef
+from rdflib import OWL, RDF, RDFS, Literal, URIRef
 
 from orionbelt_ontology_builder.ontology_manager import OntologyManager
 
@@ -59,6 +59,22 @@ def test_rename_moves_references_to_the_type(annotated_om):
         RDFS.subPropertyOf,
         URIRef(NS + "wikidataItem"),
     ) in annotated_om.graph
+
+
+def test_rename_moves_a_triple_that_mentions_the_type_twice(annotated_om):
+    """A triple can name the type in two positions at once. Rewriting one
+    position at a time left the old URI standing in the other."""
+    old, new = URIRef(NS + "wikidataId"), URIRef(NS + "wikidataItem")
+    annotated_om.graph.add((old, RDFS.seeAlso, old))  # subject and object
+    annotated_om.graph.add((old, old, Literal("self-annotated")))  # and predicate
+
+    annotated_om.rename_annotation_property("wikidataId", "wikidataItem")
+
+    assert (new, RDFS.seeAlso, new) in annotated_om.graph
+    assert (new, new, Literal("self-annotated")) in annotated_om.graph
+    assert (old, None, None) not in annotated_om.graph
+    assert (None, old, None) not in annotated_om.graph
+    assert (None, None, old) not in annotated_om.graph
 
 
 def test_rename_accepts_the_full_uri_as_the_old_name(annotated_om):

--- a/tests/test_annotation_type_rename.py
+++ b/tests/test_annotation_type_rename.py
@@ -1,0 +1,223 @@
+"""Renaming a custom annotation type (issue #287).
+
+Doing it by hand means replacing every ``ns1:<name>`` in the Turtle, which only
+works while the file uses a single prefix for the type. The engine moves every
+triple that mentions it instead, and refuses the two renames that would quietly
+destroy meaning: forking a standard vocabulary term, and merging into a name
+that is already taken.
+"""
+
+import pytest
+from rdflib import OWL, RDF, RDFS, URIRef
+
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+NS = "http://test.org/ont#"
+
+
+@pytest.fixture
+def annotated_om(populated_om):
+    """Two resources carrying the same custom annotation type."""
+    populated_om.add_annotation("Person", "wikidataId", "Q215627")
+    populated_om.add_annotation("Organization", "wikidataId", "Q43229")
+    return populated_om
+
+
+# --- the rename itself ------------------------------------------------------
+
+
+def test_rename_moves_every_annotation(annotated_om):
+    assert annotated_om.rename_annotation_property("wikidataId", "wikidataItem")
+
+    for resource, value in (("Person", "Q215627"), ("Organization", "Q43229")):
+        anns = annotated_om.get_annotations(resource)
+        assert any(
+            a["predicate"] == "wikidataItem" and a["value"] == value for a in anns
+        ), anns
+        assert not any(a["predicate"] == "wikidataId" for a in anns), anns
+
+
+def test_rename_moves_the_declaration(annotated_om):
+    annotated_om.rename_annotation_property("wikidataId", "wikidataItem")
+    assert (
+        URIRef(NS + "wikidataItem"),
+        RDF.type,
+        OWL.AnnotationProperty,
+    ) in annotated_om.graph
+    assert (URIRef(NS + "wikidataId"), None, None) not in annotated_om.graph
+    assert (None, URIRef(NS + "wikidataId"), None) not in annotated_om.graph
+
+
+def test_rename_moves_references_to_the_type(annotated_om):
+    """A statement pointing *at* the type follows it, not just its uses."""
+    annotated_om.graph.add(
+        (URIRef(NS + "otherId"), RDFS.subPropertyOf, URIRef(NS + "wikidataId"))
+    )
+    annotated_om.rename_annotation_property("wikidataId", "wikidataItem")
+    assert (
+        URIRef(NS + "otherId"),
+        RDFS.subPropertyOf,
+        URIRef(NS + "wikidataItem"),
+    ) in annotated_om.graph
+
+
+def test_rename_accepts_the_full_uri_as_the_old_name(annotated_om):
+    assert annotated_om.rename_annotation_property(NS + "wikidataId", "wikidataItem")
+    assert any(
+        a["predicate"] == "wikidataItem" for a in annotated_om.get_annotations("Person")
+    )
+
+
+def test_rename_to_the_same_name_is_a_no_op(annotated_om):
+    before = len(annotated_om.graph)
+    assert annotated_om.rename_annotation_property("wikidataId", "wikidataId")
+    assert len(annotated_om.graph) == before
+
+
+def test_a_type_from_another_vocabulary_cannot_be_renamed(populated_om):
+    """Only this ontology's own types. Renaming a term of an imported (or bound
+    external) vocabulary would fork that vocabulary, not rename anything."""
+    populated_om.add_prefix("ex", "http://example.org/vocab#")
+    populated_om.add_annotation("Person", "ex:ticket", "OB-1")
+
+    with pytest.raises(ValueError, match="another vocabulary"):
+        populated_om.rename_annotation_property("ex:ticket", "issueKey")
+    assert not any(
+        t["local_name"] == "ticket"
+        for t in populated_om.get_custom_annotation_properties()
+    )
+
+
+def test_rename_to_a_curie_moves_the_type(populated_om):
+    populated_om.add_prefix("ex", "http://example.org/vocab#")
+    populated_om.add_annotation("Person", "wikidataId", "Q5")
+
+    assert populated_om.rename_annotation_property("wikidataId", "ex:wikidataId")
+    anns = populated_om.get_annotations("Person")
+    assert any(
+        a["predicate_uri"] == "http://example.org/vocab#wikidataId" for a in anns
+    ), anns
+
+
+def test_a_standard_name_is_not_a_merge_into_that_vocabulary(annotated_om):
+    """'label' names a new type here — renaming must never fold a custom type
+    into rdfs:label, which would silently relabel every annotated resource."""
+    assert annotated_om.rename_annotation_property("wikidataId", "label")
+    anns = annotated_om.get_annotations("Person")
+    assert any(a["predicate_uri"] == NS + "label" for a in anns), anns
+    assert not any(
+        a["predicate_uri"] == str(RDFS.label) for a in anns if a["value"] == "Q215627"
+    )
+
+
+# --- what it refuses --------------------------------------------------------
+
+
+def test_a_standard_type_cannot_be_renamed(populated_om):
+    populated_om.add_annotation("Person", "comment", "A human being")
+    with pytest.raises(ValueError, match="another vocabulary"):
+        populated_om.rename_annotation_property("comment", "remark")
+    anns = populated_om.get_annotations("Person")
+    assert any(a["predicate"] == "comment" for a in anns), anns
+
+
+def test_renaming_onto_a_standard_term_is_refused(annotated_om):
+    with pytest.raises(ValueError, match="standard vocabulary"):
+        annotated_om.rename_annotation_property("wikidataId", "rdfs:label")
+    assert any(
+        a["predicate"] == "wikidataId" for a in annotated_om.get_annotations("Person")
+    )
+
+
+def test_an_invalid_name_is_refused(annotated_om):
+    with pytest.raises(ValueError, match="wikidata id"):
+        annotated_om.rename_annotation_property("wikidataId", "wikidata id")
+
+
+def test_an_unbound_prefix_is_refused(annotated_om):
+    with pytest.raises(ValueError, match="wdt"):
+        annotated_om.rename_annotation_property("wikidataId", "wdt:P31")
+
+
+def test_a_taken_name_is_refused(annotated_om):
+    """Renaming onto an existing annotation type would merge the two."""
+    annotated_om.add_annotation("Person", "ticketId", "OB-1")
+    assert annotated_om.rename_annotation_property("wikidataId", "ticketId") is False
+    anns = annotated_om.get_annotations("Person")
+    assert any(a["predicate"] == "wikidataId" for a in anns), anns
+    assert any(a["predicate"] == "ticketId" for a in anns), anns
+
+
+def test_a_name_used_by_an_entity_is_refused(annotated_om):
+    assert (
+        annotated_om.rename_annotation_property("wikidataId", "Organization") is False
+    )
+    assert (
+        URIRef(NS + "wikidataId"),
+        RDF.type,
+        OWL.AnnotationProperty,
+    ) in annotated_om.graph
+
+
+# --- the list the UI offers -------------------------------------------------
+
+
+def test_custom_types_are_listed_with_their_usage(annotated_om):
+    listed = annotated_om.get_custom_annotation_properties()
+    entry = next(t for t in listed if t["local_name"] == "wikidataId")
+    assert entry["uri"] == NS + "wikidataId"
+    assert entry["usage"] == 2
+    assert entry["display"].endswith("wikidataId")
+
+
+def test_standard_types_are_not_listed(annotated_om):
+    annotated_om.add_annotation("Person", "comment", "A human being")
+    annotated_om.add_annotation("Person", "skos:example", "an example")
+    listed = {t["local_name"] for t in annotated_om.get_custom_annotation_properties()}
+    assert "comment" not in listed
+    assert "example" not in listed
+
+
+def test_properties_are_not_listed_as_annotation_types(annotated_om):
+    """An object/data property assertion reads as an annotation here, but it is
+    renamed on the Properties page — listing it would offer two renames with
+    different rules for the same thing."""
+    annotated_om.add_individual_property("alice", "worksFor", "acme")
+    listed = {t["local_name"] for t in annotated_om.get_custom_annotation_properties()}
+    assert "worksFor" not in listed
+
+
+def test_a_declared_but_unused_type_is_still_listed(annotated_om):
+    annotated_om.delete_annotation("Person", "wikidataId", "Q215627")
+    annotated_om.delete_annotation("Organization", "wikidataId", "Q43229")
+    listed = annotated_om.get_custom_annotation_properties()
+    entry = next(t for t in listed if t["local_name"] == "wikidataId")
+    assert entry["usage"] == 0
+
+
+def test_an_undeclared_type_from_a_loaded_file_is_listed():
+    """A type that arrived without an owl:AnnotationProperty declaration is
+    still this ontology's own, and still renameable."""
+    ttl = """
+    @prefix ns1: <http://acme.example/ont#> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    <http://acme.example/ont> a owl:Ontology .
+    ns1:Widget a owl:Class ; ns1:partNumber "W-1" .
+    """
+    om = OntologyManager()
+    om.load_from_string(ttl, "turtle")
+    listed = {t["local_name"] for t in om.get_custom_annotation_properties()}
+    assert "partNumber" in listed
+    assert om.rename_annotation_property("http://acme.example/ont#partNumber", "sku")
+    anns = om.get_annotations("http://acme.example/ont#Widget")
+    assert any(a["predicate"] == "sku" and a["value"] == "W-1" for a in anns), anns
+
+
+def test_rename_survives_a_round_trip(annotated_om):
+    annotated_om.rename_annotation_property("wikidataId", "wikidataItem")
+    reloaded = OntologyManager(base_uri=NS)
+    reloaded.load_from_string(annotated_om.export_to_string("turtle"), "turtle")
+    anns = reloaded.get_annotations("Person")
+    assert any(
+        a["predicate"] == "wikidataItem" and a["value"] == "Q215627" for a in anns
+    ), anns

--- a/tests/test_annotation_types_ui.py
+++ b/tests/test_annotation_types_ui.py
@@ -1,0 +1,133 @@
+"""The "Annotation Types" tab renames a custom annotation type (issue #287).
+
+Driven through the tab's own render function rather than the page: the page's
+tab picker is a ``segmented_control``, which AppTest mis-serializes (see
+``test_annotations_add_ui``).
+"""
+
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder.ui import _uid
+
+NS = "http://test.org/ont#"
+ROW = _uid(NS + "wikidataId")
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Person")
+        om.add_annotation("Person", "wikidataId", "Q215627")
+        om.add_annotation("Person", "comment", "A human being")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    app.render_annotation_types(st.session_state.ontology)
+
+
+def _open_rename(at):
+    at.button(key=f"edit_anntype_{ROW}").click().run(timeout=120)
+    return at
+
+
+def _submit(at, label):
+    next(b for b in at.button if b.label == label).click().run(timeout=120)
+    return at
+
+
+def test_the_custom_type_is_listed_and_the_standard_one_is_not():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+
+    rendered = " ".join(m.value for m in at.markdown)
+    assert "wikidataId" in rendered
+    assert "comment" not in rendered
+    assert at.button(key=f"edit_anntype_{ROW}") is not None
+
+
+def test_rename_rewrites_the_annotations():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_rename(at)
+
+    at.text_input(key=f"anntype_name_{ROW}").set_value("wikidataItem")
+    _submit(at, "Rename")
+    assert not at.exception, at.exception
+
+    ont = at.session_state["ontology"]
+    anns = ont.get_annotations("Person")
+    assert any(
+        a["predicate"] == "wikidataItem" and a["value"] == "Q215627" for a in anns
+    ), anns
+    # The row's editor is closed again, and the rename is undoable.
+    assert "active_anntype" not in at.session_state
+    assert at.session_state["flash_message"]["type"] == "success"
+
+
+def test_a_refused_rename_reports_why_and_changes_nothing():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_rename(at)
+
+    at.text_input(key=f"anntype_name_{ROW}").set_value("rdfs:label")
+    _submit(at, "Rename")
+    assert not at.exception, at.exception
+
+    assert at.error, "no reason shown"
+    assert "standard vocabulary" in at.error[0].value
+    ont = at.session_state["ontology"]
+    assert any(a["predicate"] == "wikidataId" for a in ont.get_annotations("Person"))
+
+
+def test_an_empty_name_is_reported():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_rename(at)
+
+    at.text_input(key=f"anntype_name_{ROW}").set_value("   ")
+    _submit(at, "Rename")
+
+    assert at.error, "no reason shown"
+    ont = at.session_state["ontology"]
+    assert any(a["predicate"] == "wikidataId" for a in ont.get_annotations("Person"))
+
+
+def test_cancel_closes_the_editor():
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    _open_rename(at)
+    assert at.session_state["active_anntype"] == (ROW, "edit")
+
+    _submit(at, "Cancel")
+    assert "active_anntype" not in at.session_state
+
+
+def test_an_ontology_without_custom_types_says_so():
+    def _empty():
+        import streamlit as st
+
+        from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+        if "ontology" not in st.session_state:
+            om = OntologyManager()
+            om.add_class("Person")
+            om.add_annotation("Person", "comment", "A human being")
+            st.session_state.ontology = om
+            st.session_state["_autosave_restored"] = True
+
+        from orionbelt_ontology_builder import app
+
+        app.render_annotation_types(st.session_state.ontology)
+
+    at = AppTest.from_function(_empty)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    assert at.info, "no empty-state message"
+    assert not [b for b in at.button if b.key and b.key.startswith("edit_anntype_")]


### PR DESCRIPTION
Closes #287.

Renaming a custom annotation type by hand means replacing every `ns1:<name>` in the exported Turtle, which only works as long as the file writes that type under one prefix, and only after unlinking the working copy.

## What this adds

A third tab on the Annotations page, **Annotation Types**, listing the annotation types this ontology defines itself with how many annotations use each one, and a rename per row. The rename moves every triple that mentions the type:

- its `owl:AnnotationProperty` declaration and any other statement about it,
- the annotations that use it as their predicate,
- any reference to it as an object (`rdfs:subPropertyOf`, `rdfs:seeAlso`, ...).

It goes through the undo history like every other mutation.

## What it refuses, and why

- **A type from another vocabulary.** Only types in the ontology's own namespace are listed and renameable, the same test `add_annotation` already uses to decide a type was invented here. `rdfs:label`, `skos:definition` or a term of an imported ontology is defined there, not here, so renaming it would fork that vocabulary instead of renaming anything.
- **A name already taken** by an entity or another annotation type. Refused rather than merged, so two types never silently collapse into one.
- **A new name landing on a standard vocabulary term** (`rdfs:label`), which would give a private meaning to a term every other tool understands.

A bare new name keeps the type in its current namespace rather than being resolved the way a new annotation's type is: renaming a custom type to `label` mints a local `<base>#label`, it does not fold every value into `rdfs:label`. A bound prefix or a full URI moves the type where it says.

Predicates that are declared as an object or data property are left off the list. They read as annotations on this page, but they are renamed on the Properties page, and offering two renames with different rules for the same thing invites the wrong one.

## Verification

- `pytest` (1104 passed), `ruff check`, `ruff format --check`, `mypy` all clean.
- 26 new tests: engine behaviour, the refusals, the listing, a Turtle round-trip, and the tab driven through AppTest.
- Checked live in the running app: added a custom `wikidataId` annotation, renamed the type to `wikidataItem` from the new tab, and the value came back under the new type on View Annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
