### PR TITLE
fix: focus mode keeps the annotations of what it shows (#272)

### DIFF
--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -63,6 +63,58 @@ from ..ui import (
 logger = logging.getLogger(__name__)
 
 
+def _add_annotation_nodes(net, ont, subject_uri, subject_node_id, room):
+    """Hang ``subject_uri``'s annotations off its node, at most ``room`` of them.
+
+    Returns ``(added, left_out)`` — how many nodes were drawn, and how many were
+    left for want of room, so the caller can say so.
+
+    Shared by the plain build and the pass focus mode runs after its prune
+    (issue #272), so an annotation node looks the same however it got there.
+    ``label`` and ``comment`` are skipped: they are already in the node's
+    tooltip. Annotations are read by URI, not local name — two classes sharing a
+    name would otherwise each show the other's.
+    """
+    added = 0
+    left_out = 0
+    for ann in ont.get_annotations(subject_uri):
+        if ann["predicate"] in ("label", "comment"):
+            continue
+        if added >= room:
+            left_out += 1
+            continue
+        ann_ename = annotation_ename(subject_uri, ann)
+        ann_id = f"ann_{_uid(ann_ename)}"
+        pred_display = ann.get("predicate_prefixed", ann["predicate"])
+        value_display = (
+            ann["value"][:30] + "..." if len(ann["value"]) > 30 else ann["value"]
+        )
+        # Count what was actually drawn: an id already in the graph is dropped by
+        # the builder, and charging the budget for it would leave room unused.
+        before = len(net.nodes)
+        net.add_node(
+            ann_id,
+            label=value_display,
+            title=f"{pred_display}: {ann['value']}",
+            color={"background": "#795548", "border": "#5D4037"},
+            shape="box",
+            size=8,
+            font={"size": 10, "color": "#f0f0f0"},
+            ntype="Annotation",
+            ename=ann_ename,
+        )
+        net.add_edge(
+            subject_node_id,
+            ann_id,
+            title=f"Annotation: {pred_display}",
+            color="#A1887F",
+            arrows="to",
+            dashes=True,
+        )
+        added += len(net.nodes) - before
+    return added, left_out
+
+
 def render_visualization():
     """Render the visualization page."""
     st.header("Visualization")
@@ -928,6 +980,10 @@ def render_visualization():
             displayed_class_uris: set = set()
             displayed_ind_ids: set = set()
             skos_node_ids: set = set()
+            # Node id -> the resource it stands for, for everything annotations
+            # can hang off. Focus mode adds them after its prune, so it needs a
+            # way back from a node it kept to the resource to read (issue #272).
+            annotatable: dict = {}
 
             # Add classes as nodes (only selected classes)
             if show_classes and (selected_classes or _find_is_class):
@@ -986,6 +1042,7 @@ def render_visualization():
                         ename=cls_node_id,
                     )
                     displayed_class_uris.add(cls["uri"])
+                    annotatable[cls_node_id] = cls["uri"]
                     node_count += 1
 
                 # Add class hierarchy edges (URI-based so cross-namespace collisions don't merge)
@@ -1191,6 +1248,7 @@ def render_visualization():
                         ename=_uid(ind["uri"]),
                     )
                     displayed_ind_ids.add(ind_node_id)
+                    annotatable[ind_node_id] = ind["uri"]
                     node_count += 1
 
                     # Connect to classes via URI so the edge points to the
@@ -1274,8 +1332,15 @@ def render_visualization():
                                 ename=rel_ename,
                             )
 
-            # Add annotations for classes and individuals
-            if show_annotations and node_count < max_nodes:
+            # Add annotations for classes and individuals.
+            #
+            # Not under a focus: that build is allowed past the render cap
+            # because the prune brings it back down, so an annotation added here
+            # could be spent on an entity the focus then throws away — and the
+            # ones belonging to the entities it keeps would never be reached at
+            # all (issue #272 review). The focus pass below adds them once it
+            # knows what survived.
+            if show_annotations and not focus_pruning and node_count < max_nodes:
                 # Annotations for classes
                 if show_classes and classes:
                     for cls in classes:
@@ -1286,50 +1351,14 @@ def render_visualization():
                         if cls["uri"] not in displayed_class_uris:
                             continue
                         try:
-                            # By URI, not local name: two classes sharing a name
-                            # would otherwise each show the other's annotations.
-                            annotations = ont.get_annotations(cls["uri"])
-                            for ann in annotations:
-                                if node_count >= max_nodes:
-                                    break
-                                # Skip label and comment as they're already shown in tooltip
-                                if ann["predicate"] in ["label", "comment"]:
-                                    continue
-                                ann_ename = annotation_ename(cls["uri"], ann)
-                                ann_id = f"ann_{_uid(ann_ename)}"
-                                # Use prefixed predicate name
-                                pred_display = ann.get(
-                                    "predicate_prefixed", ann["predicate"]
-                                )
-                                # Truncate long values
-                                value_display = (
-                                    ann["value"][:30] + "..."
-                                    if len(ann["value"]) > 30
-                                    else ann["value"]
-                                )
-                                net.add_node(
-                                    ann_id,
-                                    label=value_display,
-                                    title=f"{pred_display}: {ann['value']}",
-                                    color={
-                                        "background": "#795548",
-                                        "border": "#5D4037",
-                                    },
-                                    shape="box",
-                                    size=8,
-                                    font={"size": 10, "color": "#f0f0f0"},
-                                    ntype="Annotation",
-                                    ename=ann_ename,
-                                )
-                                node_count += 1
-                                net.add_edge(
-                                    _uid(cls["uri"]),
-                                    ann_id,
-                                    title=f"Annotation: {pred_display}",
-                                    color="#A1887F",
-                                    arrows="to",
-                                    dashes=True,
-                                )
+                            added, _left = _add_annotation_nodes(
+                                net,
+                                ont,
+                                cls["uri"],
+                                _uid(cls["uri"]),
+                                max_nodes - node_count,
+                            )
+                            node_count += added
                         except Exception:
                             logger.debug(
                                 "Skipping a class annotation node", exc_info=True
@@ -1344,45 +1373,14 @@ def render_visualization():
                         if ind_node_id not in displayed_ind_ids:
                             continue
                         try:
-                            annotations = ont.get_annotations(ind["uri"])
-                            for ann in annotations:
-                                if node_count >= max_nodes:
-                                    break
-                                if ann["predicate"] in ["label", "comment"]:
-                                    continue
-                                ann_ename = annotation_ename(ind["uri"], ann)
-                                ann_id = f"ann_{_uid(ann_ename)}"
-                                pred_display = ann.get(
-                                    "predicate_prefixed", ann["predicate"]
-                                )
-                                value_display = (
-                                    ann["value"][:30] + "..."
-                                    if len(ann["value"]) > 30
-                                    else ann["value"]
-                                )
-                                net.add_node(
-                                    ann_id,
-                                    label=value_display,
-                                    title=f"{pred_display}: {ann['value']}",
-                                    color={
-                                        "background": "#795548",
-                                        "border": "#5D4037",
-                                    },
-                                    shape="box",
-                                    size=8,
-                                    font={"size": 10, "color": "#f0f0f0"},
-                                    ntype="Annotation",
-                                    ename=ann_ename,
-                                )
-                                node_count += 1
-                                net.add_edge(
-                                    ind_node_id,
-                                    ann_id,
-                                    title=f"Annotation: {pred_display}",
-                                    color="#A1887F",
-                                    arrows="to",
-                                    dashes=True,
-                                )
+                            added, _left = _add_annotation_nodes(
+                                net,
+                                ont,
+                                ind["uri"],
+                                ind_node_id,
+                                max_nodes - node_count,
+                            )
+                            node_count += added
                         except Exception:
                             logger.debug(
                                 "Skipping an individual annotation node", exc_info=True
@@ -1573,20 +1571,8 @@ def render_visualization():
                 present_ids = {n["id"] for n in net.nodes}
                 seeds = {sid for sid in focus_seed_ids if sid in present_ids}
                 if seeds:
-                    # An annotation node hangs off the one entity it annotates
-                    # and leads nowhere else, so it rides along with whatever
-                    # survives instead of costing a hop (issue #272). Charging it
-                    # one meant a depth-1 focus drew its neighbours stripped of
-                    # their annotations while the Annotations toggle was on, and
-                    # the only way to bring them back — a deeper focus — pulled in
-                    # a whole ring of unrelated entities with them.
-                    ann_ids = {
-                        n["id"] for n in net.nodes if n.get("ntype") == "Annotation"
-                    }
                     adj: dict = {}
                     for edge in net.edges:
-                        if edge["from"] in ann_ids or edge["to"] in ann_ids:
-                            continue
                         adj.setdefault(edge["from"], set()).add(edge["to"])
                         adj.setdefault(edge["to"], set()).add(edge["from"])
                     # Ring by ring, starting with the seeds themselves, and never
@@ -1615,31 +1601,52 @@ def render_visualization():
                         for nid in ring:
                             nxt |= adj.get(nid, set())
                         ring = nxt - keep
-                    # The annotations of everything kept, hung back on now that
-                    # the hops are counted, and still inside what can be drawn.
-                    if ann_ids:
-                        riders = {
-                            e["to"]
-                            for e in net.edges
-                            if e["to"] in ann_ids and e["from"] in keep
-                        } - keep
-                        room = GRAPH_MAX_NODES - len(keep)
-                        if len(riders) > room:
-                            riders = set(sorted(riders)[:room])
-                            if not graph_notice:
-                                graph_notice = (
-                                    f"This focus and its annotations cover more "
-                                    f"than the {GRAPH_MAX_NODES} nodes the graph "
-                                    f"can draw, so only part of them is shown. "
-                                    f"Turn Annotations off, or pick fewer focus "
-                                    f"nodes, to see the rest."
-                                )
-                        keep |= riders
                     net.nodes = [n for n in net.nodes if n["id"] in keep]
                     net.edges = [
                         e for e in net.edges if e["from"] in keep and e["to"] in keep
                     ]
                     focus_hidden = _before_prune - len(net.nodes)
+
+                    # Now that the hops are counted, hang the annotations off
+                    # what survived (issue #272). An annotation node belongs to
+                    # the one entity it annotates and leads nowhere else, so it
+                    # is no part of the neighbourhood walk — it used to cost a
+                    # hop, which drew the seed's neighbours stripped of their
+                    # annotations. Built here rather than with the rest of the
+                    # graph so the ones that end up drawn are the ones the focus
+                    # kept, whatever the assembly ran out of before it
+                    # (issue #272 review). Counted after focus_hidden, which is
+                    # about the entities the focus hid.
+                    if show_annotations:
+                        room = GRAPH_MAX_NODES - len(net.nodes)
+                        ann_left_out = 0
+                        # Sorted, so which annotations a tight budget reaches is
+                        # the same on every render of the same graph.
+                        for node_id in sorted(keep & set(annotatable)):
+                            try:
+                                added, left_out = _add_annotation_nodes(
+                                    net,
+                                    ont,
+                                    annotatable[node_id],
+                                    node_id,
+                                    max(room, 0),
+                                )
+                            except Exception:
+                                logger.debug(
+                                    "Skipping a focused annotation node",
+                                    exc_info=True,
+                                )
+                                continue
+                            room -= added
+                            ann_left_out += left_out
+                        if ann_left_out and not graph_notice:
+                            graph_notice = (
+                                f"This focus and its annotations cover more than "
+                                f"the {GRAPH_MAX_NODES} nodes the graph can draw, "
+                                f"so {ann_left_out} annotation(s) are not shown. "
+                                f"Pick fewer focus nodes, a lower depth, or turn "
+                                f"Annotations off."
+                            )
                 else:
                     # No seed was built (past the assembly cap, or its type
                     # toggled off) — show nothing rather than the whole graph,

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -535,7 +535,9 @@ def render_visualization():
                 help=(
                     "Show only a chosen node plus everything linked to it within "
                     "N hops, across all node types — handy for large ontologies "
-                    "where showing everything at once is overwhelming."
+                    "where showing everything at once is overwhelming. "
+                    "Annotations come along with whatever is shown; the "
+                    "Annotations checkbox above still turns them off."
                 ),
             )
             if focus_mode and focus_targets:
@@ -767,8 +769,10 @@ def render_visualization():
         # Bump to invalidate cached graph data after code changes. 19: annotation
         # nodes gained a stable id, ntype and ename (issue #223), and a session
         # holding a pre-#223 payload would otherwise keep serving nodes a click
-        # cannot resolve until some unrelated change happened to evict it.
-        _graph_ver = 19
+        # cannot resolve until some unrelated change happened to evict it. 20:
+        # focus mode stopped charging an annotation a hop (issue #272), so a
+        # cached focus payload is one built under the old pruning.
+        _graph_ver = 20
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.
@@ -1569,8 +1573,20 @@ def render_visualization():
                 present_ids = {n["id"] for n in net.nodes}
                 seeds = {sid for sid in focus_seed_ids if sid in present_ids}
                 if seeds:
+                    # An annotation node hangs off the one entity it annotates
+                    # and leads nowhere else, so it rides along with whatever
+                    # survives instead of costing a hop (issue #272). Charging it
+                    # one meant a depth-1 focus drew its neighbours stripped of
+                    # their annotations while the Annotations toggle was on, and
+                    # the only way to bring them back — a deeper focus — pulled in
+                    # a whole ring of unrelated entities with them.
+                    ann_ids = {
+                        n["id"] for n in net.nodes if n.get("ntype") == "Annotation"
+                    }
                     adj: dict = {}
                     for edge in net.edges:
+                        if edge["from"] in ann_ids or edge["to"] in ann_ids:
+                            continue
                         adj.setdefault(edge["from"], set()).add(edge["to"])
                         adj.setdefault(edge["to"], set()).add(edge["from"])
                     # Ring by ring, starting with the seeds themselves, and never
@@ -1599,6 +1615,26 @@ def render_visualization():
                         for nid in ring:
                             nxt |= adj.get(nid, set())
                         ring = nxt - keep
+                    # The annotations of everything kept, hung back on now that
+                    # the hops are counted, and still inside what can be drawn.
+                    if ann_ids:
+                        riders = {
+                            e["to"]
+                            for e in net.edges
+                            if e["to"] in ann_ids and e["from"] in keep
+                        } - keep
+                        room = GRAPH_MAX_NODES - len(keep)
+                        if len(riders) > room:
+                            riders = set(sorted(riders)[:room])
+                            if not graph_notice:
+                                graph_notice = (
+                                    f"This focus and its annotations cover more "
+                                    f"than the {GRAPH_MAX_NODES} nodes the graph "
+                                    f"can draw, so only part of them is shown. "
+                                    f"Turn Annotations off, or pick fewer focus "
+                                    f"nodes, to see the rest."
+                                )
+                        keep |= riders
                     net.nodes = [n for n in net.nodes if n["id"] in keep]
                     net.edges = [
                         e for e in net.edges if e["from"] in keep and e["to"] in keep

--- a/tests/test_viz_focus_annotations.py
+++ b/tests/test_viz_focus_annotations.py
@@ -153,6 +153,33 @@ def test_the_app_says_when_annotations_were_cut(patch_ui):
     assert "annotations" in notice.lower(), notice
 
 
+def test_annotations_survive_an_assembly_that_ran_out_of_room(patch_ui):
+    """The focus build is allowed past the render cap because the prune brings it
+    back down, so the annotations cannot be built with the rest of the graph: the
+    budget is spent on entities the focus then throws away, and the ones the
+    focus keeps are never reached. They are built after the prune instead, from
+    what it kept (issue #272 review)."""
+    patch_ui("FOCUS_BUILD_MAX_NODES", 4)
+    nodes, edges = _graph(seed="Class: C", depth=1)
+
+    # The assembly stops at 4 entity nodes, well before any annotation would
+    # have been added under the old order.
+    assert "C" in _class_labels(nodes)
+    assert "Q-C" in _annotation_labels(nodes)
+    kept = {n["id"] for n in nodes}
+    assert all(e["from"] in kept and e["to"] in kept for e in edges)
+
+
+def test_annotations_do_not_eat_the_focus_assembly_budget(patch_ui):
+    """The entity the assembly cap can just reach is still reachable with
+    Annotations on: they are no longer competing for that budget."""
+    patch_ui("FOCUS_BUILD_MAX_NODES", 3)
+    with_anns, _ = _graph(seed="Class: C", depth=1, annotations=True)
+    without, _ = _graph(seed="Class: C", depth=1, annotations=False)
+
+    assert _class_labels(with_anns) == _class_labels(without)
+
+
 def test_the_graph_cache_version_moved_with_the_pruning():
     """A session holding a payload built under the old prune would keep serving
     a focus without its annotations until something unrelated evicted it."""

--- a/tests/test_viz_focus_annotations.py
+++ b/tests/test_viz_focus_annotations.py
@@ -1,0 +1,160 @@
+"""Annotations in focus mode (issue #272).
+
+An annotation node hangs off the one entity it annotates and leads nowhere else,
+but the focus prune counted it as a hop like any other node: a depth-1 focus drew
+its neighbours stripped of their annotations while the Annotations toggle was on,
+and the only way to bring them back — a deeper focus — pulled in a ring of
+unrelated entities as well.
+
+Same harness as ``test_viz_node_cap``: the real ``render_visualization`` through
+AppTest, inspecting the graph payload it caches, seeded through the environment
+because ``AppTest.from_function`` runs the script source in a fresh namespace.
+"""
+
+import json
+import os
+
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import app
+
+
+def _script():
+    import os
+
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        # A subclass chain A -> B -> C, one custom annotation each, so a depth-1
+        # focus on A covers A and B (and their annotations) but not C.
+        om = OntologyManager()
+        om.add_class("A")
+        om.add_class("B", parent="A")
+        om.add_class("C", parent="B")
+        for name in ("A", "B", "C"):
+            om.add_annotation(name, "wikidataId", f"Q-{name}")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        # The cross-session settings restore mounts the localStorage component,
+        # which blocks forever without a browser to answer it. Mark it done.
+        st.session_state["_viz_settings_restored"] = True
+        st.session_state["_viz_cfg_show_annotations"] = os.environ["ANNOTATIONS"] == "1"
+        st.session_state["_viz_cfg_focus_mode"] = os.environ["SEED"] != ""
+        if os.environ["SEED"]:
+            st.session_state["_viz_cfg_focus_seeds"] = [os.environ["SEED"]]
+        st.session_state["_viz_cfg_focus_depth"] = int(os.environ["DEPTH"])
+
+    app.render_visualization()
+
+
+def _graph(seed="Class: A", depth=1, annotations=True):
+    """Render once and return ``(nodes, edges)``. An empty seed means focus off."""
+    os.environ["SEED"] = seed
+    os.environ["DEPTH"] = str(depth)
+    os.environ["ANNOTATIONS"] = "1" if annotations else "0"
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    data = at.session_state["last_graph_data"]
+    assert data, "the visualization built no graph"
+    return json.loads(data["nodes"]), json.loads(data["edges"])
+
+
+def _annotation_labels(nodes):
+    return {n.get("label") for n in nodes if n.get("ntype") == "Annotation"}
+
+
+def _class_labels(nodes):
+    return {n.get("label") for n in nodes if n.get("ntype") != "Annotation"}
+
+
+# --- the bug ----------------------------------------------------------------
+
+
+def test_a_neighbour_keeps_its_annotations():
+    """The regression: at depth 1 only the seed's own annotation survived, since
+    a neighbour's annotation sits one hop further out."""
+    nodes, _ = _graph(seed="Class: A", depth=1)
+    assert _class_labels(nodes) == {"A", "B"}
+    assert _annotation_labels(nodes) == {"Q-A", "Q-B"}
+
+
+def test_a_riding_annotation_keeps_its_edge():
+    """A node whose edge was dropped is an orphan box floating in the graph."""
+    nodes, edges = _graph(seed="Class: A", depth=1)
+    ann_ids = {n["id"] for n in nodes if n.get("ntype") == "Annotation"}
+    assert ann_ids
+    linked = {e["to"] for e in edges if e["to"] in ann_ids}
+    assert linked == ann_ids
+
+
+def test_annotations_do_not_widen_the_neighbourhood():
+    """They ride along; they do not buy a hop for the entity they hang off."""
+    nodes, _ = _graph(seed="Class: A", depth=1)
+    assert "C" not in _class_labels(nodes)
+
+
+def test_a_deeper_focus_still_reaches_further_classes():
+    nodes, _ = _graph(seed="Class: A", depth=2)
+    assert _class_labels(nodes) == {"A", "B", "C"}
+    assert _annotation_labels(nodes) == {"Q-A", "Q-B", "Q-C"}
+
+
+# --- the toggle still decides ----------------------------------------------
+
+
+def test_the_annotations_toggle_still_turns_them_off_under_focus():
+    nodes, _ = _graph(seed="Class: A", depth=1, annotations=False)
+    assert _annotation_labels(nodes) == set()
+    assert _class_labels(nodes) == {"A", "B"}
+
+
+def test_without_focus_annotations_are_unchanged():
+    nodes, _ = _graph(seed="", annotations=True)
+    assert _class_labels(nodes) == {"A", "B", "C"}
+    assert _annotation_labels(nodes) == {"Q-A", "Q-B", "Q-C"}
+
+
+# --- the render cap still binds ---------------------------------------------
+
+
+def test_riding_annotations_stay_inside_the_render_cap(patch_ui):
+    """They are hung back on after the hops are counted, so they have to respect
+    the cap the prune exists to hold."""
+    patch_ui("GRAPH_MAX_NODES", 3)
+    nodes, edges = _graph(seed="Class: A", depth=2)
+
+    assert len(nodes) <= 3
+    kept = {n["id"] for n in nodes}
+    assert all(e["from"] in kept and e["to"] in kept for e in edges)
+
+
+def test_annotations_are_dropped_before_the_focus_itself(patch_ui):
+    """The classes asked for come first; the annotations fill what is left."""
+    patch_ui("GRAPH_MAX_NODES", 4)
+    nodes, _ = _graph(seed="Class: A", depth=2)
+
+    assert _class_labels(nodes) == {"A", "B", "C"}
+    assert len(_annotation_labels(nodes)) == 1
+
+
+def test_the_app_says_when_annotations_were_cut(patch_ui):
+    patch_ui("GRAPH_MAX_NODES", 3)
+    os.environ["SEED"] = "Class: A"
+    os.environ["DEPTH"] = "2"
+    os.environ["ANNOTATIONS"] = "1"
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    notice = at.session_state["last_graph_data"].get("notice") or ""
+    assert "annotations" in notice.lower(), notice
+
+
+def test_the_graph_cache_version_moved_with_the_pruning():
+    """A session holding a payload built under the old prune would keep serving
+    a focus without its annotations until something unrelated evicted it."""
+    source = (app.PKG_DIR / "views" / "visualization.py").read_text("utf-8")
+    assert "_graph_ver = 20" in source


### PR DESCRIPTION
Closes #272.

The issue is right that the rest of the functionality is already there: all that was needed was to stop the focus prune from cutting annotations.

## What was wrong

The prune is a BFS over the assembled graph, and it walked every node type alike, so an annotation node cost a hop exactly like a class does. Focusing on a node at depth 1 therefore drew its neighbours stripped of their annotations while the Annotations checkbox was on, with nothing said about why. Raising the depth brought them back only by pulling in a ring of unrelated entities as well.

## What changed

An annotation node hangs off the one entity it annotates and leads nowhere else, so it no longer takes part in the ring walk:

- annotation edges are left out of the BFS adjacency, so the depth counts entity hops,
- after the hops are counted, the annotations of every node that survived are hung back on,
- that still respects the render cap the prune exists to hold, with its own notice when they do not all fit,
- the Annotations checkbox still decides whether any are drawn at all.

The graph cache version moved to 20, so a session holding a payload built under the old pruning does not keep serving a focus without its annotations.

## Verification

- `pytest` (1115 passed), `ruff check`, `ruff format --check`, `mypy` all clean.
- 10 new tests in `tests/test_viz_focus_annotations.py`, running the real `render_visualization` through AppTest and inspecting the graph payload (same harness as `test_viz_node_cap`). Confirmed the key ones fail on `main` before the fix.
- Checked live in the running app on a small hierarchy (Agent, its two subclasses, one custom annotation each): focusing on Agent at depth 1 now shows Agent, Person and Organization each with its annotation, and Employee two hops out stays absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
