### PR TITLE
feat: selectable language codes for annotations (#252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ Annotations have their own bulk editor with per-row add/delete actions, and an
 Annotation Types tab that renames a type you invented — every annotation using
 it is rewritten, so no values are lost.
 
+### Language codes
+
+Every Language field is a searchable list of codes with the language they name
+(`eng · English`), so a tag can be found by either half. Two packs ship with the
+app — ISO 639-3 (alpha-3, including the historical languages ISO 639-1 has no
+code for) and ISO 639-1 (alpha-2) — and the sidebar switches between them. A
+Language Packs tab under Annotations builds packs of your own: the short list of
+languages one ontology actually uses, or private codes for a language no
+standard names, importable and exportable as JSON. Any BCP 47 tag can still be
+typed straight into the field, pack or no pack.
+
 ### SKOS vocabularies
 
 A dedicated page for building controlled vocabularies:
@@ -356,7 +367,7 @@ the 200 MB default; raise the value only when self-hosting with enough memory.
 | **Relations**       | Class, property, and individual relations                      |
 | **Restrictions**    | OWL restrictions and cardinality constraints                   |
 | **Advanced**        | Advanced OWL features                                          |
-| **Annotations**     | RDFS, SKOS, DC and custom annotations, bulk edit, rename       |
+| **Annotations**     | RDFS, SKOS, DC and custom annotations, language packs, bulk edit, rename |
 | **SKOS Vocabulary** | Concept schemes, concepts, hierarchy, SKOS validation          |
 | **Import / Export** | File import with merge review, export, new ontology, templates |
 | **Source**          | Live Turtle source view of the ontology                        |

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -35,15 +35,18 @@ from .ui import (  # noqa: F401
     _SEARCH_ANY,
     _VIZ_INT_RANGES,
     _VIZ_PERSIST_KEYS,
+    ACTIVE_LANG_PACK_KEY,
     APP_NAME,
     APP_VERSION,
     AUTOSAVE_DEBOUNCE_SECONDS,
     AUTOSAVE_KEY,
     AUTOSAVE_MAX_BYTES,
+    CUSTOM_LANG_PACKS_KEY,
     FOCUS_BUILD_MAX_NODES,
     GITHUB_ISSUES_URL,
     GRAPH_MAX_NODES,
     LABEL_NAME_SEPARATOR,
+    LANG_PACKS_KEY,
     LIST_PAGE_SIZE,
     PKG_DIR,
     SEARCH_PAD_WIDTH,
@@ -54,6 +57,7 @@ from .ui import (  # noqa: F401
     _apply_class_edit,
     _apply_class_relation_add,
     _apply_individual_edit,
+    _apply_language_packs,
     _apply_property_edit,
     _apply_restriction_add,
     _apply_viz_settings,
@@ -85,6 +89,7 @@ from .ui import (  # noqa: F401
     _is_open,
     _load_linked_file,
     _mark_disk_source_saved,
+    _mark_language_packs_dirty,
     _matches_slots,
     _namespace_option_index,
     _nav_open_entity,
@@ -138,6 +143,7 @@ from .ui import (  # noqa: F401
     _viz_selection_key,
     _viz_settings_payload,
     _viz_widget_missing,
+    active_language_pack,
     annotation_ename,
     annotation_matches_ename,
     annotation_option_for_predicate,
@@ -150,6 +156,8 @@ from .ui import (  # noqa: F401
     build_uri_options,
     clearable_selectbox,
     confirm_delete,
+    custom_language_packs,
+    delete_custom_language_pack,
     display_flash_message,
     filter_entry_token,
     focus_seeds_after_request,
@@ -160,6 +168,10 @@ from .ui import (  # noqa: F401
     get_ontology_manager_class,
     graph_node_cap,
     init_session_state,
+    language_pack_entries,
+    language_pack_names,
+    language_selectbox,
+    language_tag_error,
     log_error,
     maybe_restore_autosave,
     missing_required,
@@ -168,6 +180,7 @@ from .ui import (  # noqa: F401
     parse_filter_text,
     parse_search_query,
     persist_autosave,
+    persist_language_packs,
     prioritise_find_target,
     prune_reused_focus_seeds,
     reconcile_filter_selection,
@@ -175,6 +188,7 @@ from .ui import (  # noqa: F401
     render_add_class_form,
     render_add_restriction,
     render_annotation_form,
+    render_language_pack_sidebar,
     render_relation_form,
     render_relation_rows,
     render_restriction_editor,
@@ -184,10 +198,12 @@ from .ui import (  # noqa: F401
     required_selectbox,
     resolve_annotation_predicate_choice,
     resolve_picked_object,
+    restore_language_packs,
     restriction_references_class,
     restriction_takes_on_class,
     restriction_value_is_class,
     save_checkpoint,
+    save_custom_language_pack,
     seed_filter_from_saved,
     set_flash_message,
     show_message,
@@ -208,9 +224,10 @@ from .ui import (  # noqa: F401
 # They live in ``views`` rather than ``pages`` because Streamlit reads a
 # ``pages`` directory next to an entry script as a legacy multipage app (#269).
 from .views.advanced import render_advanced
-from .views.annotations import (  # noqa: F401 - render_annotation_types is a tab, re-exported like the ui block's
+from .views.annotations import (  # noqa: F401 - the tabs are re-exported like the ui block's
     render_annotation_types,
     render_annotations,
+    render_language_packs,
 )
 from .views.classes import render_classes
 from .views.dashboard import render_dashboard
@@ -554,6 +571,13 @@ def main():
                         st.rerun()
         else:
             st.sidebar.caption("No results found.")
+
+    st.sidebar.divider()
+
+    # Which language codes every Language field offers (issue #252). It sits in
+    # the sidebar because those fields are on three pages and in the graph
+    # panel, and one pack is meant to hold for all of them.
+    render_language_pack_sidebar()
 
     st.sidebar.divider()
 

--- a/orionbelt_ontology_builder/languages.py
+++ b/orionbelt_ontology_builder/languages.py
@@ -1,0 +1,399 @@
+"""Language codes offered in the annotation Language fields (issue #252).
+
+The language tag is the one part of an annotation that cannot be looked up in
+the ontology itself: ``eng`` and ``enm`` are one letter apart and six hundred
+years apart, so a field that takes one offers a searchable list of codes with
+the language they name instead of an empty text box.
+
+Two packs ship with the app. Both are projected from the single
+:data:`_LANGUAGES` table below, so a language's alpha-2 and alpha-3 codes can
+never drift apart, and a name is written once. On top of those the user can
+define **custom packs** — own codes, own labels — which live in the UI layer
+(``ui.custom_language_packs``); this module only knows their shape and how to
+validate, read and write one.
+
+Everything here is plain data plus string helpers: no Streamlit, so the packs
+can be tested without an app run.
+"""
+
+import json
+import re
+
+#: ``(alpha-3, alpha-2, English name)``, alpha-2 empty where ISO 639-1 has no
+#: code for the language. The list covers every ISO 639-1 language, plus the
+#: historical languages an ontology is most likely to need a tag for (which is
+#: the whole reason to reach for alpha-3), plus ISO 639-2/3's special-purpose
+#: codes for "undetermined" and friends.
+_LANGUAGES: tuple[tuple[str, str, str], ...] = (
+    # -- ISO 639-1 languages, alpha-3 (T) code first --------------------------
+    ("aar", "aa", "Afar"),
+    ("abk", "ab", "Abkhazian"),
+    ("afr", "af", "Afrikaans"),
+    ("aka", "ak", "Akan"),
+    ("amh", "am", "Amharic"),
+    ("ara", "ar", "Arabic"),
+    ("arg", "an", "Aragonese"),
+    ("asm", "as", "Assamese"),
+    ("ava", "av", "Avaric"),
+    ("ave", "ae", "Avestan"),
+    ("aym", "ay", "Aymara"),
+    ("aze", "az", "Azerbaijani"),
+    ("bak", "ba", "Bashkir"),
+    ("bam", "bm", "Bambara"),
+    ("bel", "be", "Belarusian"),
+    ("ben", "bn", "Bengali"),
+    ("bih", "bh", "Bihari languages"),
+    ("bis", "bi", "Bislama"),
+    ("bod", "bo", "Tibetan"),
+    ("bos", "bs", "Bosnian"),
+    ("bre", "br", "Breton"),
+    ("bul", "bg", "Bulgarian"),
+    ("cat", "ca", "Catalan"),
+    ("ces", "cs", "Czech"),
+    ("cha", "ch", "Chamorro"),
+    ("che", "ce", "Chechen"),
+    ("chu", "cu", "Church Slavonic"),
+    ("chv", "cv", "Chuvash"),
+    ("cor", "kw", "Cornish"),
+    ("cos", "co", "Corsican"),
+    ("cre", "cr", "Cree"),
+    ("cym", "cy", "Welsh"),
+    ("dan", "da", "Danish"),
+    ("deu", "de", "German"),
+    ("div", "dv", "Divehi"),
+    ("dzo", "dz", "Dzongkha"),
+    ("ell", "el", "Greek, Modern"),
+    ("eng", "en", "English"),
+    ("epo", "eo", "Esperanto"),
+    ("est", "et", "Estonian"),
+    ("eus", "eu", "Basque"),
+    ("ewe", "ee", "Ewe"),
+    ("fao", "fo", "Faroese"),
+    ("fas", "fa", "Persian"),
+    ("fij", "fj", "Fijian"),
+    ("fin", "fi", "Finnish"),
+    ("fra", "fr", "French"),
+    ("fry", "fy", "Western Frisian"),
+    ("ful", "ff", "Fulah"),
+    ("gla", "gd", "Gaelic, Scottish"),
+    ("gle", "ga", "Irish"),
+    ("glg", "gl", "Galician"),
+    ("glv", "gv", "Manx"),
+    ("grn", "gn", "Guarani"),
+    ("guj", "gu", "Gujarati"),
+    ("hat", "ht", "Haitian Creole"),
+    ("hau", "ha", "Hausa"),
+    ("heb", "he", "Hebrew"),
+    ("her", "hz", "Herero"),
+    ("hin", "hi", "Hindi"),
+    ("hmo", "ho", "Hiri Motu"),
+    ("hrv", "hr", "Croatian"),
+    ("hun", "hu", "Hungarian"),
+    ("hye", "hy", "Armenian"),
+    ("ibo", "ig", "Igbo"),
+    ("ido", "io", "Ido"),
+    ("iii", "ii", "Sichuan Yi"),
+    ("iku", "iu", "Inuktitut"),
+    ("ile", "ie", "Interlingue"),
+    ("ina", "ia", "Interlingua"),
+    ("ind", "id", "Indonesian"),
+    ("ipk", "ik", "Inupiaq"),
+    ("isl", "is", "Icelandic"),
+    ("ita", "it", "Italian"),
+    ("jav", "jv", "Javanese"),
+    ("jpn", "ja", "Japanese"),
+    ("kal", "kl", "Kalaallisut"),
+    ("kan", "kn", "Kannada"),
+    ("kas", "ks", "Kashmiri"),
+    ("kat", "ka", "Georgian"),
+    ("kau", "kr", "Kanuri"),
+    ("kaz", "kk", "Kazakh"),
+    ("khm", "km", "Khmer"),
+    ("kik", "ki", "Kikuyu"),
+    ("kin", "rw", "Kinyarwanda"),
+    ("kir", "ky", "Kyrgyz"),
+    ("kom", "kv", "Komi"),
+    ("kon", "kg", "Kongo"),
+    ("kor", "ko", "Korean"),
+    ("kua", "kj", "Kuanyama"),
+    ("kur", "ku", "Kurdish"),
+    ("lao", "lo", "Lao"),
+    ("lat", "la", "Latin"),
+    ("lav", "lv", "Latvian"),
+    ("lim", "li", "Limburgish"),
+    ("lin", "ln", "Lingala"),
+    ("lit", "lt", "Lithuanian"),
+    ("ltz", "lb", "Luxembourgish"),
+    ("lub", "lu", "Luba-Katanga"),
+    ("lug", "lg", "Ganda"),
+    ("mah", "mh", "Marshallese"),
+    ("mal", "ml", "Malayalam"),
+    ("mar", "mr", "Marathi"),
+    ("mkd", "mk", "Macedonian"),
+    ("mlg", "mg", "Malagasy"),
+    ("mlt", "mt", "Maltese"),
+    ("mon", "mn", "Mongolian"),
+    ("mri", "mi", "Maori"),
+    ("msa", "ms", "Malay"),
+    ("mya", "my", "Burmese"),
+    ("nau", "na", "Nauru"),
+    ("nav", "nv", "Navajo"),
+    ("nbl", "nr", "Ndebele, South"),
+    ("nde", "nd", "Ndebele, North"),
+    ("ndo", "ng", "Ndonga"),
+    ("nep", "ne", "Nepali"),
+    ("nld", "nl", "Dutch"),
+    ("nno", "nn", "Norwegian Nynorsk"),
+    ("nob", "nb", "Norwegian Bokmål"),
+    ("nor", "no", "Norwegian"),
+    ("nya", "ny", "Nyanja"),
+    ("oci", "oc", "Occitan"),
+    ("oji", "oj", "Ojibwa"),
+    ("ori", "or", "Oriya"),
+    ("orm", "om", "Oromo"),
+    ("oss", "os", "Ossetian"),
+    ("pan", "pa", "Punjabi"),
+    ("pli", "pi", "Pali"),
+    ("pol", "pl", "Polish"),
+    ("por", "pt", "Portuguese"),
+    ("pus", "ps", "Pashto"),
+    ("que", "qu", "Quechua"),
+    ("roh", "rm", "Romansh"),
+    ("ron", "ro", "Romanian"),
+    ("run", "rn", "Rundi"),
+    ("rus", "ru", "Russian"),
+    ("sag", "sg", "Sango"),
+    ("san", "sa", "Sanskrit"),
+    ("sin", "si", "Sinhala"),
+    ("slk", "sk", "Slovak"),
+    ("slv", "sl", "Slovenian"),
+    ("sme", "se", "Northern Sami"),
+    ("smo", "sm", "Samoan"),
+    ("sna", "sn", "Shona"),
+    ("snd", "sd", "Sindhi"),
+    ("som", "so", "Somali"),
+    ("sot", "st", "Sotho, Southern"),
+    ("spa", "es", "Spanish"),
+    ("sqi", "sq", "Albanian"),
+    ("srd", "sc", "Sardinian"),
+    ("srp", "sr", "Serbian"),
+    ("ssw", "ss", "Swati"),
+    ("sun", "su", "Sundanese"),
+    ("swa", "sw", "Swahili"),
+    ("swe", "sv", "Swedish"),
+    ("tah", "ty", "Tahitian"),
+    ("tam", "ta", "Tamil"),
+    ("tat", "tt", "Tatar"),
+    ("tel", "te", "Telugu"),
+    ("tgk", "tg", "Tajik"),
+    ("tgl", "tl", "Tagalog"),
+    ("tha", "th", "Thai"),
+    ("tir", "ti", "Tigrinya"),
+    ("ton", "to", "Tongan"),
+    ("tsn", "tn", "Tswana"),
+    ("tso", "ts", "Tsonga"),
+    ("tuk", "tk", "Turkmen"),
+    ("tur", "tr", "Turkish"),
+    ("twi", "tw", "Twi"),
+    ("uig", "ug", "Uighur"),
+    ("ukr", "uk", "Ukrainian"),
+    ("urd", "ur", "Urdu"),
+    ("uzb", "uz", "Uzbek"),
+    ("ven", "ve", "Venda"),
+    ("vie", "vi", "Vietnamese"),
+    ("vol", "vo", "Volapük"),
+    ("wln", "wa", "Walloon"),
+    ("wol", "wo", "Wolof"),
+    ("xho", "xh", "Xhosa"),
+    ("yid", "yi", "Yiddish"),
+    ("yor", "yo", "Yoruba"),
+    ("zha", "za", "Zhuang"),
+    ("zho", "zh", "Chinese"),
+    ("zul", "zu", "Zulu"),
+    # -- Historical languages, which ISO 639-1 has no code for ----------------
+    ("akk", "", "Akkadian"),
+    ("ang", "", "English, Old"),
+    ("arc", "", "Aramaic, Imperial"),
+    ("chb", "", "Chibcha"),
+    ("cop", "", "Coptic"),
+    ("dum", "", "Dutch, Middle"),
+    ("egy", "", "Egyptian, Ancient"),
+    ("elx", "", "Elamite"),
+    ("enm", "", "English, Middle"),
+    ("frm", "", "French, Middle"),
+    ("fro", "", "French, Old"),
+    ("gez", "", "Geez"),
+    ("gmh", "", "German, Middle High"),
+    ("goh", "", "German, Old High"),
+    ("got", "", "Gothic"),
+    ("grc", "", "Greek, Ancient"),
+    ("hit", "", "Hittite"),
+    ("lzh", "", "Chinese, Literary"),
+    ("mga", "", "Irish, Middle"),
+    ("non", "", "Norse, Old"),
+    ("osc", "", "Oscan"),
+    ("ota", "", "Turkish, Ottoman"),
+    ("pal", "", "Pahlavi"),
+    ("peo", "", "Persian, Old"),
+    ("phn", "", "Phoenician"),
+    ("pro", "", "Provençal, Old"),
+    ("sga", "", "Irish, Old"),
+    ("sux", "", "Sumerian"),
+    ("syc", "", "Syriac, Classical"),
+    ("uga", "", "Ugaritic"),
+    ("xno", "", "Anglo-Norman"),
+    # -- Living languages an alpha-3 user is likely to reach for ---------------
+    ("arb", "", "Arabic, Standard"),
+    ("ceb", "", "Cebuano"),
+    ("cmn", "", "Chinese, Mandarin"),
+    ("fil", "", "Filipino"),
+    ("nds", "", "German, Low"),
+    ("pes", "", "Persian, Iranian"),
+    ("tpi", "", "Tok Pisin"),
+    ("yue", "", "Chinese, Cantonese"),
+    # -- Special-purpose codes, for when the language is not one language ------
+    ("mis", "", "Uncoded languages"),
+    ("mul", "", "Multiple languages"),
+    ("qaa", "", "Reserved for local use (qaa–qtz)"),
+    ("und", "", "Undetermined"),
+    ("zxx", "", "No linguistic content"),
+)
+
+#: Display name of the alpha-3 pack — the default, since alpha-3 is the reason
+#: this exists: it can name a language ISO 639-1 has no code for.
+ALPHA3_PACK = "ISO 639-3 (alpha-3)"
+#: Display name of the alpha-2 pack, for an ontology in modern languages only.
+ALPHA2_PACK = "ISO 639-1 (alpha-2)"
+#: The packs that ship with the app, in the order the picker offers them.
+BUILTIN_PACKS: tuple[str, ...] = (ALPHA3_PACK, ALPHA2_PACK)
+DEFAULT_PACK = ALPHA3_PACK
+
+#: Between the code and the language name in a dropdown option. The same
+#: separator the rest of the UI puts between a name and its label.
+OPTION_SEPARATOR = " · "
+
+#: What rdflib accepts as a language tag (``rdflib.term._lang_tag_regex``).
+#: Mirrored rather than imported: it is private, and a tag it rejects raises out
+#: of ``add_annotation`` — a custom pack has to be refused where it is written,
+#: not where it is used.
+_TAG_RE = re.compile(r"^[a-zA-Z]+(?:-[a-zA-Z0-9]+)*$")
+
+
+def builtin_pack(name: str) -> list[dict]:
+    """The ``[{"code", "label"}, ...]`` entries of a built-in pack.
+
+    Unknown names give the default pack rather than raising: the active pack is
+    persisted, and a saved custom pack that has since been deleted must not take
+    every Language field down with it.
+    """
+    if name == ALPHA2_PACK:
+        rows = [(a2, name_) for _a3, a2, name_ in _LANGUAGES if a2]
+    else:
+        rows = [(a3, name_) for a3, _a2, name_ in _LANGUAGES]
+    return [{"code": code, "label": label} for code, label in sorted(rows)]
+
+
+def format_option(code: str, label: str) -> str:
+    """``"eng · English"`` — what a language dropdown shows for one entry."""
+    label = (label or "").strip()
+    return f"{code}{OPTION_SEPARATOR}{label}" if label else code
+
+
+def code_from_option(option: str | None) -> str:
+    """The bare tag behind a dropdown option, or a typed one unchanged.
+
+    Every language field accepts a code that is in no pack, so this has to cope
+    with both ``"eng · English"`` and a plain ``"pt-BR"``.
+    """
+    if not option:
+        return ""
+    return option.split(OPTION_SEPARATOR, 1)[0].strip()
+
+
+def is_valid_tag(tag: str) -> bool:
+    """True when rdflib will accept ``tag`` as a literal's language."""
+    return bool(_TAG_RE.match(tag or ""))
+
+
+def invalid_tag_reason(tag: str) -> str | None:
+    """Why ``tag`` cannot be a language tag, or ``None`` when it can.
+
+    Written for the pack editor and the add forms, so the two refusals a user
+    actually hits — a digit in the primary subtag (``xx1``), an underscore
+    (``en_GB``) — come back as advice rather than as a traceback.
+    """
+    tag = (tag or "").strip()
+    if not tag:
+        return "A language code is required."
+    if is_valid_tag(tag):
+        return None
+    return (
+        f"'{tag}' is not a valid language tag. A tag is letters, optionally "
+        "followed by '-' and more letters or digits — 'de', 'grc', 'pt-BR'. "
+        "For a language of your own, use a private-use tag such as 'x-mycode' "
+        "or a code from the 'qaa'–'qtz' range."
+    )
+
+
+def normalize_pack(entries) -> tuple[list[dict], list[str]]:
+    """Clean a pack's rows, returning ``(entries, errors)``.
+
+    Rows come from a spreadsheet editor or an imported file, so anything can be
+    in them: blank rows (dropped), a code twice (first kept), a code rdflib
+    would reject (refused, with a reason). A pack is saved only when ``errors``
+    is empty, so a bad row is never quietly discarded.
+    """
+    cleaned: list[dict] = []
+    errors: list[str] = []
+    seen: set[str] = set()
+    for entry in entries or []:
+        if isinstance(entry, dict):
+            code = str(entry.get("code") or "").strip()
+            label = str(entry.get("label") or "").strip()
+        else:
+            code, label = str(entry or "").strip(), ""
+        if not code and not label:
+            continue  # an empty row is the editor's, not the user's
+        if reason := invalid_tag_reason(code):
+            errors.append(reason)
+            continue
+        if code in seen:
+            errors.append(f"'{code}' is listed more than once.")
+            continue
+        seen.add(code)
+        cleaned.append({"code": code, "label": label})
+    return cleaned, errors
+
+
+def pack_to_json(name: str, entries) -> str:
+    """Serialize one custom pack for download."""
+    return json.dumps(
+        {"name": name, "entries": [dict(e) for e in entries]},
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+def pack_from_json(text: str) -> tuple[str, list[dict]]:
+    """Read a downloaded pack back, raising ``ValueError`` on anything else.
+
+    Accepts the shape :func:`pack_to_json` writes and, for a hand-written file,
+    a bare list of entries (which carries no name — the caller names it).
+    """
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Not a readable JSON file: {exc}") from exc
+    name = str(data.get("name") or "") if isinstance(data, dict) else ""
+    raw = data if isinstance(data, list) else None
+    if isinstance(data, dict) and isinstance(data.get("entries"), list):
+        raw = data["entries"]
+    # Anything else — a number, a string, an object with no entries — falls
+    # through as nothing found, which is the one message worth giving: a file
+    # that is not a pack and a pack with no codes are the same mistake here.
+    entries, errors = normalize_pack(raw or [])
+    if errors:
+        raise ValueError(errors[0])
+    if not entries:
+        raise ValueError("No language codes in that file.")
+    return name, entries

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -15,6 +15,8 @@ from rdflib.collection import Collection
 from rdflib.namespace import DC, DCTERMS, OWL, RDF, RDFS, SKOS, XSD
 from rdflib.term import Node
 
+from .languages import invalid_tag_reason
+
 logger = logging.getLogger(__name__)
 
 #: RDF serialization format for a file, keyed by lower-case extension. Used so a
@@ -2319,6 +2321,14 @@ class OntologyManager:
         subj_uri = self._uri(subject)
         pred_uri = self._resolve_predicate_uri(predicate)
 
+        # The object is built before anything is written, because building it is
+        # what refuses a bad IRI or a language tag rdflib will not take. Declared
+        # first, the annotation property below outlived the write it was for: the
+        # caller was told the annotation had failed and was left with a new,
+        # zero-use annotation type in the ontology — reachable from Bulk Edit,
+        # which reports the row and carries on (review of PR #291).
+        obj = self._annotation_object(value, lang, datatype, value_is_uri)
+
         if (
             str(pred_uri).startswith(str(self.namespace))
             and (
@@ -2330,6 +2340,20 @@ class OntologyManager:
         ):
             self.graph.add((pred_uri, RDF.type, OWL.AnnotationProperty))
 
+        self.graph.add((subj_uri, pred_uri, obj))
+
+    def _annotation_object(
+        self,
+        value: str,
+        lang: str | None,
+        datatype: str | None,
+        value_is_uri: bool,
+    ) -> Node:
+        """The object an annotation writes, or ``ValueError`` saying why not.
+
+        Split out of :meth:`add_annotation` so every refusal happens before the
+        graph is touched. See that method for what each argument means.
+        """
         if value_is_uri:
             # Keep a resource-valued annotation a resource. Writing it back as a
             # literal would leave the original triple in place beside a string
@@ -2341,17 +2365,19 @@ class OntologyManager:
             # Raising instead lets the caller's rollback put the original back.
             if reason := self.invalid_uri_reason(value):
                 raise ValueError(reason)
-            obj: Node = URIRef(value)
-        elif lang:
-            obj = Literal(value, lang=lang)
-        elif datatype:
-            obj = Literal(
+            return URIRef(value)
+        if lang:
+            # Asked before rdflib is handed the tag, so the refusal names what a
+            # language tag may look like and what to use for a language no
+            # standard names, rather than only that this one is not one.
+            if reason := invalid_tag_reason(lang):
+                raise ValueError(reason)
+            return Literal(value, lang=lang)
+        if datatype:
+            return Literal(
                 value, datatype=self.XSD_DATATYPES.get(datatype, URIRef(datatype))
             )
-        else:
-            obj = Literal(value)
-
-        self.graph.add((subj_uri, pred_uri, obj))
+        return Literal(value)
 
     def get_annotations(self, subject: str) -> list[dict[str, Any]]:
         """Get all annotations/predicates for a resource (like Protege shows)."""

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -24,7 +24,7 @@ from pathlib import Path as _Path
 
 import streamlit as st
 
-from . import local_store
+from . import languages, local_store
 
 """
 OrionBelt Ontology Builder - A Streamlit application for building, editing,
@@ -63,6 +63,16 @@ _VIZ_INT_RANGES = {
 }
 VIZ_FILE_STATE_KEY = "viz_file_state"
 VIZ_FILE_STATE_MAX_FILES = 20
+#: Where the chosen language pack and any custom ones are stored (issue #252) —
+#: the local config file when the launcher allows disk, browser localStorage on
+#: the cloud, the same two places the viz settings use.
+LANG_PACKS_KEY = "orionbelt_language_packs"
+#: Session key holding the active pack's name; also the sidebar picker's widget
+#: key, so the widget and what is persisted are one value, never two.
+ACTIVE_LANG_PACK_KEY = "lang_pack_active"
+#: Session key holding ``{pack name: [{"code", "label"}, ...]}`` of the user's
+#: own packs.
+CUSTOM_LANG_PACKS_KEY = "lang_packs_custom"
 AUTOSAVE_DEBOUNCE_SECONDS = 2.0
 # The package directory, not this module's: assets are the package's, and a
 # module that moves into a subpackage must not take their paths with it — the
@@ -588,6 +598,263 @@ def _persist_viz_settings() -> None:
             VIZ_SETTINGS_KEY, payload, key=f"orionbelt_viz_settings_set_{h[:12]}"
         )
     st.session_state["_viz_settings_saved_json"] = payload
+
+
+def custom_language_packs() -> dict[str, list[dict]]:
+    """The user's own language packs, ``{name: [{"code", "label"}, ...]}``."""
+    packs = st.session_state.get(CUSTOM_LANG_PACKS_KEY)
+    return packs if isinstance(packs, dict) else {}
+
+
+def language_pack_names() -> list[str]:
+    """Every pack the picker offers: the built-in ones, then the user's."""
+    return [*languages.BUILTIN_PACKS, *sorted(custom_language_packs())]
+
+
+def active_language_pack() -> str:
+    """The pack the Language fields are currently drawing their codes from.
+
+    Falls back to the default when the saved name names nothing — the choice
+    outlives the session that made it, and a custom pack deleted since must not
+    empty every Language dropdown in the app.
+    """
+    name = st.session_state.get(ACTIVE_LANG_PACK_KEY)
+    if isinstance(name, str) and name in language_pack_names():
+        return name
+    return languages.DEFAULT_PACK
+
+
+def language_pack_entries(pack: str | None = None) -> list[dict]:
+    """``[{"code", "label"}, ...]`` for a pack, the active one by default."""
+    name = pack or active_language_pack()
+    custom = custom_language_packs()
+    if name in custom:
+        return [dict(e) for e in custom[name]]
+    return languages.builtin_pack(name)
+
+
+def _mark_language_packs_dirty() -> None:
+    """Note that the packs or the choice of one changed, so it is worth saving.
+
+    Same gate as the viz settings: writing on every run would let a cloud reload
+    put the starting defaults back over the saved set before localStorage had
+    answered.
+    """
+    st.session_state["_lang_packs_dirty"] = True
+
+
+def save_custom_language_pack(name: str, entries) -> str | None:
+    """Store one custom pack, returning the reason it was refused, or ``None``.
+
+    Refuses a built-in's name rather than shadowing it: the built-ins are how
+    you get back to a known list, and a pack that quietly replaced one would
+    leave no way back.
+    """
+    name = (name or "").strip()
+    if not name:
+        return "A pack name is required."
+    if name in languages.BUILTIN_PACKS:
+        return f"'{name}' is a built-in pack. Choose another name."
+    cleaned, errors = languages.normalize_pack(entries)
+    if errors:
+        return errors[0]
+    # An empty pack is allowed: it is what starting one from scratch looks like
+    # before the first row is typed, and a Language field with no options still
+    # takes a typed tag.
+    st.session_state[CUSTOM_LANG_PACKS_KEY] = {**custom_language_packs(), name: cleaned}
+    _mark_language_packs_dirty()
+    return None
+
+
+def delete_custom_language_pack(name: str) -> None:
+    """Drop one custom pack.
+
+    Deleting the pack that is in use deliberately leaves its name in
+    :data:`ACTIVE_LANG_PACK_KEY`: that key belongs to the sidebar picker, which
+    is drawn before the page that deletes from, and assigning a widget's value
+    after the widget exists raises rather than falling back — which took the
+    page down with it. :func:`active_language_pack` resolves the dangling name
+    for every reader in the meantime, and the sidebar re-seeds itself on the
+    next run.
+    """
+    packs = {k: v for k, v in custom_language_packs().items() if k != name}
+    st.session_state[CUSTOM_LANG_PACKS_KEY] = packs
+    _mark_language_packs_dirty()
+
+
+def _language_packs_payload() -> str:
+    """Serialize the packs and the active choice for change detection/storage."""
+    return json.dumps(
+        {"active": active_language_pack(), "packs": custom_language_packs()},
+        sort_keys=True,
+    )
+
+
+def _apply_language_packs(data) -> None:
+    """Seed the session from a stored payload, dropping anything malformed.
+
+    Storage is a file or a browser the user can edit, so every pack is put back
+    through the same validation an edited one goes through.
+    """
+    if not isinstance(data, dict):
+        return
+    raw = data.get("packs")
+    packs: dict[str, list[dict]] = {}
+    if isinstance(raw, dict):
+        for name, entries in raw.items():
+            if not isinstance(name, str) or not name.strip():
+                continue
+            if not isinstance(entries, list):
+                continue
+            cleaned, errors = languages.normalize_pack(entries)
+            # An empty list is a pack that has been started and not filled in,
+            # which is savable — dropping it here would also drop the choice of
+            # it as the active pack on the next launch.
+            if not errors:
+                packs[name] = cleaned
+    st.session_state[CUSTOM_LANG_PACKS_KEY] = packs
+    active = data.get("active")
+    if isinstance(active, str) and (
+        active in languages.BUILTIN_PACKS or active in packs
+    ):
+        st.session_state[ACTIVE_LANG_PACK_KEY] = active
+
+
+def restore_language_packs() -> None:
+    """Restore the saved packs and pack choice once per session (issue #252).
+
+    Mirrors :func:`_restore_viz_settings`, including its retry: on the cloud the
+    localStorage value only arrives on a later rerun, so this is not finished
+    until a real value is read. It must run before the sidebar picker is drawn —
+    seeding a widget's key after the widget exists is an error, and the picker's
+    key *is* the stored value.
+    """
+    if st.session_state.get("_lang_packs_restored"):
+        return
+    if st.session_state.get("_lang_packs_dirty"):
+        st.session_state["_lang_packs_restored"] = True
+        return
+    if local_store.local_persist_enabled():
+        _apply_language_packs(local_store.load_config().get(LANG_PACKS_KEY))
+        st.session_state["_lang_packs_restored"] = True
+        return
+    ls = _get_local_storage()
+    if ls is None:
+        st.session_state["_lang_packs_restored"] = True
+        return
+    saved = ls.getItem(LANG_PACKS_KEY)
+    if isinstance(saved, dict):
+        saved = saved.get(LANG_PACKS_KEY) or next(
+            (v for v in saved.values() if isinstance(v, str)), None
+        )
+    if isinstance(saved, str) and saved.strip():
+        try:
+            _apply_language_packs(json.loads(saved))
+        except (ValueError, TypeError):
+            pass
+        st.session_state["_lang_packs_restored"] = True
+
+
+def persist_language_packs() -> None:
+    """Save the packs and the active choice after a change. No-op otherwise."""
+    if not st.session_state.get("_lang_packs_dirty"):
+        return
+    payload = _language_packs_payload()
+    if payload == st.session_state.get("_lang_packs_saved_json"):
+        return
+    if local_store.local_persist_enabled():
+        try:
+            cfg = local_store.load_config()
+            cfg[LANG_PACKS_KEY] = json.loads(payload)
+            local_store.save_config(cfg)
+        except OSError as e:
+            log_error(e, context="Language packs save")
+            return
+    else:
+        ls = _get_local_storage()
+        if ls is None:
+            return
+        h = _content_hash(payload)
+        ls.setItem(LANG_PACKS_KEY, payload, key=f"orionbelt_lang_packs_set_{h[:12]}")
+    st.session_state["_lang_packs_saved_json"] = payload
+
+
+def render_language_pack_sidebar() -> None:
+    """The app-wide language-pack picker (issue #252).
+
+    One control in the sidebar rather than one beside each Language field: the
+    fields sit on three pages and in the graph panel, and a per-field switch
+    would have to be set four times over to mean one thing.
+    """
+    restore_language_packs()
+    names = language_pack_names()
+    # Put the resolved name back before the widget reads it: a saved pack that
+    # has since been deleted is a value the selectbox has no option for, which
+    # is an exception rather than a fallback. The selection is carried by
+    # session state alone, with no ``index`` — passing both is what Streamlit
+    # warns about as "created with a default value but also had its value set
+    # via the Session State API".
+    active = active_language_pack()
+    if st.session_state.get(ACTIVE_LANG_PACK_KEY) != active:
+        st.session_state[ACTIVE_LANG_PACK_KEY] = active
+    st.sidebar.selectbox(
+        "Language pack",
+        names,
+        key=ACTIVE_LANG_PACK_KEY,
+        on_change=_mark_language_packs_dirty,
+        help="Which codes the Language fields offer. Build your own under "
+        "Annotations → Language Packs.",
+    )
+    persist_language_packs()
+
+
+def language_selectbox(label, key, value="", help=None):
+    """A searchable code picker for a Language field, returning the bare tag.
+
+    Options come from the active pack and read ``eng · English``, so a code can
+    be found by either half. Typing is still accepted, so a tag no pack lists
+    (``pt-BR``, ``x-inhouse``) can be entered as before — the picker adds codes,
+    it does not fence them off. A value already on the annotation is offered
+    even when the active pack has no entry for it, so switching packs cannot
+    silently rewrite the tag of an annotation you open to edit.
+    """
+    options = [
+        languages.format_option(e["code"], e["label"]) for e in language_pack_entries()
+    ]
+    current = (value or "").strip()
+    display = None
+    if current:
+        display = next(
+            (o for o in options if languages.code_from_option(o) == current), None
+        )
+        if display is None:
+            display = current
+            options = [display, *options]
+    choice = clearable_selectbox(
+        label,
+        options,
+        key=key,
+        current_display=display,
+        accept_new_options=True,
+        format_func=_pad_option,
+        help=help
+        or (
+            "Optional. Pick a code from the active language pack, or type any "
+            "BCP 47 tag (`de`, `grc`, `pt-BR`) to use it as it stands."
+        ),
+    )
+    return languages.code_from_option(choice)
+
+
+def language_tag_error(tag: str) -> str | None:
+    """The message for a language tag the graph would reject, or ``None``.
+
+    Empty is not an error: the tag is optional everywhere it is asked for. A
+    tag rdflib refuses raises out of the write, which without this surfaces as
+    a page-level crash rather than as something to fix in the field.
+    """
+    tag = (tag or "").strip()
+    return languages.invalid_tag_reason(tag) if tag else None
 
 
 def _viz_file_state_id() -> str | None:
@@ -2174,10 +2441,10 @@ def render_annotation_form(
             # it stays a resource through the rewrite.
             st.caption("Points at a resource, not a literal.")
         else:
-            new_lang = st.text_input(
+            new_lang = language_selectbox(
                 "Language",
+                key=f"ann_lang_{form_key}",
                 value=ann.get("language") or "",
-                help="Optional BCP 47 tag such as en or de. Leave empty for none.",
             )
         if ann.get("datatype") and not ann.get("is_uri"):
             # Not editable here, but say it is there: it is carried through the
@@ -2224,6 +2491,8 @@ def render_annotation_form(
             show_message(_missing, "error")
         elif not new_value.strip():
             show_message("Annotation value is required!", "error")
+        elif lang_error := language_tag_error(new_lang):
+            show_message(lang_error, "error")
         elif _apply_annotation_edit(
             ont,
             subject_uri,
@@ -2475,11 +2744,7 @@ def _render_panel_add_annotation_form(ont, subject_uri, subject_label):
             ),
         )
         value = st.text_area("Value *", key="panel_ann_value")
-        lang = st.text_input(
-            "Language",
-            key="panel_ann_lang",
-            help="Optional BCP 47 tag such as en or de. Leave empty for none.",
-        )
+        lang = language_selectbox("Language", key="panel_ann_lang")
         add_col, cancel_col = st.columns(2)
         with add_col:
             submitted = st.form_submit_button(
@@ -2497,6 +2762,9 @@ def _render_panel_add_annotation_form(ont, subject_uri, subject_label):
             return
         if not value.strip():
             show_message("Annotation value is required!", "error")
+            return
+        if lang_error := language_tag_error(lang):
+            show_message(lang_error, "error")
             return
         predicate = lookup.get(predicate_display, predicate_display)
         try:
@@ -4232,14 +4500,14 @@ def render_add_annotation(ont, all_resources):
     else:
         predicate_options, predicate_lookup = annotation_predicate_options(ont)
 
-        # Clear the value/language of the annotation just saved, on the run
-        # after it was added: a widget's state can't be changed once it has
-        # been instantiated, so the add flags it here instead. The type and
-        # the resource are left alone, so the same type can be applied to one
-        # resource after another without re-picking it.
+        # Clear the value of the annotation just saved, on the run after it was
+        # added: a widget's state can't be changed once it has been
+        # instantiated, so the add flags it here instead. The type, the
+        # resource and the language are left alone, so the same type can be
+        # applied to one resource after another without re-picking it, and a
+        # run of labels in one language is entered without re-picking that.
         if st.session_state.pop("_ann_clear_value", False):
             st.session_state["ann_value"] = ""
-            st.session_state["ann_lang"] = ""
 
         # Re-select the type just used. The picker holds whatever was typed
         # ("wikidataId"), but once the annotation exists the options carry that
@@ -4291,11 +4559,7 @@ def render_add_annotation(ont, all_resources):
 
             value = st.text_area("Value", key="ann_value")
 
-            language = st.text_input(
-                "Language Tag (optional)",
-                placeholder="en, de, fr...",
-                key="ann_lang",
-            )
+            language = language_selectbox("Language Tag (optional)", key="ann_lang")
 
             submitted = st.form_submit_button("Add Annotation")
             if submitted:
@@ -4316,6 +4580,8 @@ def render_add_annotation(ont, all_resources):
                     show_message("Value is required!", "error")
                 elif predicate_reason:
                     show_message(predicate_reason, "error")
+                elif lang_error := language_tag_error(language):
+                    show_message(lang_error, "error")
                 else:
                     # Find the resource by matching the option string
                     idx = resource_options.index(selected)

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -706,6 +706,13 @@ def _apply_language_packs(data) -> None:
                 continue
             if not isinstance(entries, list):
                 continue
+            # The same refusal :func:`save_custom_language_pack` makes, applied
+            # again on the way in: storage is a file the user can edit, and a
+            # custom pack under a built-in's name would take that name's place
+            # (entries are looked up in the custom packs first) while the tab
+            # still showed it as a read-only built-in with no way back.
+            if name in languages.BUILTIN_PACKS:
+                continue
             cleaned, errors = languages.normalize_pack(entries)
             # An empty list is a pack that has been started and not filled in,
             # which is savable — dropping it here would also drop the choice of

--- a/orionbelt_ontology_builder/views/annotations.py
+++ b/orionbelt_ontology_builder/views/annotations.py
@@ -2,16 +2,23 @@
 
 import streamlit as st
 
+from .. import languages
 from ..ui import (
     _cb_toggle_edit,
     _close_entity,
+    _download_or_save,
     _is_open,
     _uid,
+    active_language_pack,
     clearable_selectbox,
+    delete_custom_language_pack,
     format_label_name,
+    language_pack_entries,
+    language_pack_names,
     render_add_annotation,
     render_annotation_form,
     save_checkpoint,
+    save_custom_language_pack,
     set_flash_message,
     show_message,
 )
@@ -110,6 +117,218 @@ def render_annotation_types(ont):
                 st.rerun()
 
 
+def custom_pack_names() -> list[str]:
+    """Names already taken by a custom pack, for the two create paths."""
+    return [n for n in language_pack_names() if n not in languages.BUILTIN_PACKS]
+
+
+def _pack_rows_to_entries(frame) -> list[dict]:
+    """The editor's rows as pack entries.
+
+    ``fillna`` before anything else: a cell the user left alone comes back as
+    NaN, and a NaN read as a string is the code ``nan`` — a valid language tag,
+    which is exactly how it would have reached the graph unnoticed.
+    """
+    rows = frame.fillna("").astype(str).to_dict("records")
+    return [
+        {"code": r.get("Code", "").strip(), "label": r.get("Language", "").strip()}
+        for r in rows
+    ]
+
+
+def render_language_packs():
+    """Render the "Language Packs" tab (issue #252).
+
+    Where packs are made; *which* pack is in use is the sidebar's picker, since
+    it applies to the Language fields on three pages and in the graph panel.
+    The built-in packs are read-only lists to copy from — they are the way back
+    to a known set of codes, so nothing here can overwrite one.
+    """
+    import pandas as pd
+
+    st.subheader("Language Packs")
+    st.caption(
+        "Which codes the Language fields offer. Two packs ship with the app; "
+        "a pack of your own can be the short list of languages this ontology "
+        "actually uses, or codes for a language no standard names. Pick the "
+        "pack in use in the sidebar."
+    )
+
+    # A widget's value can't be assigned once it has been instantiated, so the
+    # create / import / delete paths flag which pack to show next and it is
+    # applied here, before the picker is drawn — the same deferral the
+    # annotation type picker uses.
+    if _next := st.session_state.pop("_lang_pack_select_next", None):
+        st.session_state["lang_pack_edit_select"] = _next
+    if st.session_state.pop("_lang_pack_clear_new_name", False):
+        st.session_state["lang_pack_new_name"] = ""
+
+    names = language_pack_names()
+    # Opens on the pack in use, then follows this picker. Seeded into session
+    # state rather than passed as ``index``: a widget given both a default and
+    # a session-state value draws a warning above the page.
+    if "lang_pack_edit_select" not in st.session_state:
+        _active = active_language_pack()
+        st.session_state["lang_pack_edit_select"] = (
+            _active if _active in names else names[0]
+        )
+    viewing = st.selectbox("Pack", names, key="lang_pack_edit_select")
+    entries = language_pack_entries(viewing)
+    frame = pd.DataFrame(
+        [{"Code": e["code"], "Language": e["label"]} for e in entries],
+        columns=["Code", "Language"],
+    )
+    is_builtin = viewing in languages.BUILTIN_PACKS
+    # Keyed by pack: one editor key across packs would carry the rows you typed
+    # into one pack over into the next one you looked at.
+    pack_key = _uid(viewing)
+
+    if is_builtin:
+        st.caption(
+            f"{len(entries)} codes. Built-in packs can't be edited — copy one "
+            "below to make a version of your own."
+        )
+        st.dataframe(frame, hide_index=True, width="stretch")
+    else:
+        edited = st.data_editor(
+            frame,
+            num_rows="dynamic",
+            hide_index=True,
+            column_config={
+                "Code": st.column_config.TextColumn(
+                    "Code",
+                    help="The tag written into the ontology: letters, "
+                    "optionally '-' and more letters or digits. For a language "
+                    "no standard names, use 'x-yourcode' or one of "
+                    "'qaa'–'qtz'.",
+                    required=True,
+                ),
+                "Language": st.column_config.TextColumn(
+                    "Language", help="Shown beside the code, e.g. 'Old Norse'."
+                ),
+            },
+            key=f"lang_pack_rows_{pack_key}",
+            width="stretch",
+        )
+        save_col, del_col = st.columns(2)
+        with save_col:
+            if st.button(
+                "Save pack",
+                type="primary",
+                use_container_width=True,
+                key=f"lang_pack_save_{pack_key}",
+            ):
+                reason = save_custom_language_pack(
+                    viewing, _pack_rows_to_entries(edited)
+                )
+                if reason:
+                    show_message(reason, "error")
+                else:
+                    set_flash_message(f"Pack '{viewing}' saved!", "success")
+                    st.rerun()
+        with del_col:
+            if st.button(
+                "Delete pack",
+                use_container_width=True,
+                key=f"lang_pack_del_{pack_key}",
+            ):
+                st.session_state["_lang_pack_confirm_delete"] = viewing
+        if st.session_state.get("_lang_pack_confirm_delete") == viewing:
+            st.warning(
+                f"Delete '{viewing}'? Annotations already tagged with its codes "
+                "keep them; only the list goes."
+            )
+            yes_col, no_col = st.columns(2)
+            with yes_col:
+                if st.button(
+                    "Confirm delete",
+                    type="primary",
+                    use_container_width=True,
+                    key=f"lang_pack_del_yes_{pack_key}",
+                ):
+                    delete_custom_language_pack(viewing)
+                    st.session_state.pop("_lang_pack_confirm_delete", None)
+                    st.session_state["_lang_pack_select_next"] = languages.DEFAULT_PACK
+                    set_flash_message(f"Pack '{viewing}' deleted.", "success")
+                    st.rerun()
+            with no_col:
+                if st.button(
+                    "Cancel",
+                    use_container_width=True,
+                    key=f"lang_pack_del_no_{pack_key}",
+                ):
+                    st.session_state.pop("_lang_pack_confirm_delete", None)
+                    st.rerun()
+
+    _download_or_save(
+        "Download pack",
+        languages.pack_to_json(viewing, entries),
+        f"{viewing.replace(' ', '_')}.json",
+        mime="application/json",
+        key=f"lang_pack_{pack_key}",
+    )
+
+    st.divider()
+    st.markdown("**New pack**")
+    new_col, from_col = st.columns([2, 2])
+    with new_col:
+        new_name = st.text_input(
+            "Name", key="lang_pack_new_name", placeholder="Project codes"
+        )
+    with from_col:
+        start_from = st.selectbox(
+            "Start from",
+            ["Empty", *names],
+            key="lang_pack_new_from",
+            help="Copy an existing pack's codes into the new one, then trim it.",
+        )
+    if st.button("Create pack", key="lang_pack_create"):
+        seed = [] if start_from == "Empty" else language_pack_entries(start_from)
+        if new_name.strip() in custom_pack_names():
+            show_message(f"'{new_name.strip()}' already exists.", "error")
+        elif reason := save_custom_language_pack(new_name, seed):
+            show_message(reason, "error")
+        else:
+            # Point the pack picker at what was just created, so the editor
+            # below it is the new pack's rather than the one copied from.
+            st.session_state["_lang_pack_select_next"] = new_name.strip()
+            st.session_state["_lang_pack_clear_new_name"] = True
+            set_flash_message(f"Pack '{new_name.strip()}' created!", "success")
+            st.rerun()
+
+    st.divider()
+    st.markdown("**Import a pack**")
+    uploaded = st.file_uploader(
+        "Pack file (.json)", type=["json"], key="lang_pack_upload"
+    )
+    import_name = st.text_input(
+        "Name it",
+        key="lang_pack_import_name",
+        help="Leave empty to use the name inside the file.",
+    )
+    if uploaded is not None and st.button("Import pack", key="lang_pack_import"):
+        try:
+            file_name, file_entries = languages.pack_from_json(
+                uploaded.getvalue().decode("utf-8")
+            )
+        except (ValueError, UnicodeDecodeError) as exc:
+            show_message(str(exc), "error")
+            return
+        target = import_name.strip() or file_name
+        if not target:
+            show_message("The file has no name in it — name it above.", "error")
+        elif target in custom_pack_names():
+            show_message(f"'{target}' already exists. Name it something else.", "error")
+        elif reason := save_custom_language_pack(target, file_entries):
+            show_message(reason, "error")
+        else:
+            st.session_state["_lang_pack_select_next"] = target
+            set_flash_message(
+                f"Pack '{target}' imported ({len(file_entries)} codes).", "success"
+            )
+            st.rerun()
+
+
 def render_annotations():
     """Render the annotations management page."""
     st.header("Annotations")
@@ -172,7 +391,13 @@ def render_annotations():
 
     _ann_tab = st.segmented_control(
         "Section",
-        ["View Annotations", "Add Annotation", "Annotation Types", "Bulk Edit"],
+        [
+            "View Annotations",
+            "Add Annotation",
+            "Annotation Types",
+            "Language Packs",
+            "Bulk Edit",
+        ],
         default="View Annotations",
         key="ann_active_tab",
         label_visibility="collapsed",
@@ -304,6 +529,9 @@ def render_annotations():
 
     if _ann_tab == "Annotation Types":
         render_annotation_types(ont)
+
+    if _ann_tab == "Language Packs":
+        render_language_packs()
 
     if _ann_tab == "Bulk Edit":
         st.subheader("Bulk Edit Annotations")

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -17,6 +17,8 @@ from ..ui import (
     clearable_selectbox,
     confirm_delete,
     format_label_name,
+    language_selectbox,
+    language_tag_error,
     missing_required,
     required_selectbox,
     save_checkpoint,
@@ -538,7 +540,7 @@ def render_skos_vocabulary():
                 current_display="None",
                 format_func=_pad_option,
             )
-            c_lang = st.text_input("Language Tag (e.g., en, de)", key="concept_lang")
+            c_lang = language_selectbox("Language Tag", key="concept_lang")
             if st.form_submit_button("Add Concept"):
                 if not c_name:
                     show_message("Concept name is required!", "error")
@@ -548,6 +550,8 @@ def render_skos_vocabulary():
                 # across every entity kind (issue #279), as for schemes above.
                 elif taken := ont.name_conflict_reason(c_name, "concept"):
                     show_message(taken, "error")
+                elif lang_error := language_tag_error(c_lang):
+                    show_message(lang_error, "error")
                 else:
                     ont.add_concept(
                         c_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,29 @@
+import os
+
 import pytest
 
 from ontology_manager import OntologyManager
+from orionbelt_ontology_builder.local_store import ENV_FLAG
+
+
+@pytest.fixture(autouse=True)
+def no_leaked_local_persist():
+    """Keep ``ORIONBELT_LOCAL_PERSIST`` from leaking out of one test into the rest.
+
+    The launcher tests call ``cli``/``desktop`` ``main()``, which sets that env
+    var to opt the *process* into filesystem persistence, and nothing unset it
+    again — so every test that ran later (they sort after ``test_c...``)
+    believed it was the desktop app. Anything that then saved a setting saved it
+    into the developer's real ``~/.orionbelt_ontology_builder/config.json``,
+    which is also where it read from on the next run, so tests polluted each
+    other through the home directory.
+    """
+    before = os.environ.get(ENV_FLAG)
+    yield
+    if before is None:
+        os.environ.pop(ENV_FLAG, None)
+    else:
+        os.environ[ENV_FLAG] = before
 
 
 @pytest.fixture

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,5 +1,7 @@
 """Tests for annotation operations, including language-tagged and typed literals."""
 
+import pytest
+
 
 def test_add_annotation(populated_om):
     populated_om.add_annotation("Person", "label", "Persona", lang="es")
@@ -96,3 +98,50 @@ def test_add_delete_roundtrip_all_common_predicates(populated_om):
         populated_om.delete_annotation("Person", local, f"v-{local}")
     anns = populated_om.get_annotations("Person")
     assert not any(a["value"].startswith("v-") for a in anns)
+
+
+def test_a_refused_annotation_leaves_nothing_behind(populated_om):
+    """A rejected write must not declare the annotation type it was for.
+
+    The type was declared before the object was built, so a language tag rdflib
+    refuses left a new, zero-use annotation property in the ontology while the
+    caller was told the annotation had failed. Bulk Edit reaches this and
+    carries on to the next row, so nothing undid it (review of PR #291).
+    """
+    before = populated_om.get_custom_annotation_properties()
+    with pytest.raises(ValueError, match="not a valid language tag"):
+        populated_om.add_annotation("Person", "badLangNote", "value", lang="xx1")
+
+    assert populated_om.get_custom_annotation_properties() == before
+    assert not any(
+        a["value"] == "value" for a in populated_om.get_annotations("Person")
+    )
+
+
+def test_a_refused_iri_annotation_leaves_nothing_behind(populated_om):
+    """The same, for the other refusal on that path: a value that is no IRI."""
+    before = populated_om.get_custom_annotation_properties()
+    with pytest.raises(ValueError):
+        populated_om.add_annotation(
+            "Person", "badIriNote", "not an iri", value_is_uri=True
+        )
+
+    assert populated_om.get_custom_annotation_properties() == before
+
+
+def test_a_bad_language_tag_is_reported_per_row_in_a_bulk_edit(populated_om):
+    """One bad row is refused with advice and changes nothing."""
+    result = populated_om.bulk_update_annotations(
+        [
+            {
+                "resource": "Person",
+                "predicate": "badLangNote",
+                "value": "value",
+                "lang": "xx1",
+                "action": "add",
+            }
+        ]
+    )
+    assert result["applied"] == 0
+    assert "x-mycode" in result["errors"][0]["error"]
+    assert populated_om.get_custom_annotation_properties() == []

--- a/tests/test_clearable_required_dropdowns.py
+++ b/tests/test_clearable_required_dropdowns.py
@@ -106,12 +106,16 @@ def test_no_form_checks_without_offering_one():
 
 # The dropdowns the rule below cannot read off the call itself, because their
 # options were built a line earlier and passed by name: three fixed sets from
-# the engine (the restriction types, the relation types) and one "All" filter.
+# the engine (the restriction types, the relation types), one "All" filter, and
+# the two language-pack pickers, whose options are the packs that exist and
+# where "no pack" is not a state the Language fields can be in (issue #252).
 ALLOWED_BY_NAME = {
     ("render_restriction_form", "Restriction Type"),
     ("_render_panel_add_restriction_form", "Restriction Type"),
     ("render_relation_form", "Relation"),
     ("render_annotations", "Filter by Type"),
+    ("render_language_pack_sidebar", "Language pack"),
+    ("render_language_packs", "Pack"),
 }
 
 

--- a/tests/test_language_packs.py
+++ b/tests/test_language_packs.py
@@ -1,0 +1,320 @@
+"""Selectable language codes for annotations (issue #252).
+
+Two halves: the shipped code tables and the pack helpers, which are plain data
+and need no app run; and the session/persistence layer in ``ui``, which is
+driven the way ``test_viz_settings.py`` drives the viz settings.
+"""
+
+import json
+
+import pytest
+from rdflib import Literal
+
+from orionbelt_ontology_builder import app, languages
+from orionbelt_ontology_builder.views.annotations import _pack_rows_to_entries
+
+
+class _FakeLS:
+    """Minimal stand-in for the streamlit_local_storage handle."""
+
+    def __init__(self, value=None):
+        self._value = value
+        self.saved = None
+
+    def getItem(self, _key):
+        return self._value
+
+    def setItem(self, _key, value, key=None):
+        self.saved = value
+
+
+# --- the shipped packs ------------------------------------------------------
+
+
+def test_every_shipped_code_is_a_tag_the_graph_accepts():
+    """A code no ontology can carry is worse than no code at all: it is offered
+    in a dropdown and then raises out of the write."""
+    for pack in languages.BUILTIN_PACKS:
+        for entry in languages.builtin_pack(pack):
+            assert languages.is_valid_tag(entry["code"]), entry
+            Literal("v", lang=entry["code"])  # raises if rdflib disagrees
+
+
+def test_alpha2_pack_is_the_alpha3_pack_minus_what_iso_639_1_cannot_name():
+    a3 = {e["code"]: e["label"] for e in languages.builtin_pack(languages.ALPHA3_PACK)}
+    a2 = {e["code"]: e["label"] for e in languages.builtin_pack(languages.ALPHA2_PACK)}
+    assert all(len(code) == 2 for code in a2)
+    assert len(a3) > len(a2)
+    # Same language, same name in both packs — they are projections of one table.
+    assert a2["de"] == a3["deu"] == "German"
+    # The historical languages are the point of alpha-3, and have no alpha-2.
+    assert "grc" in a3 and "ang" in a3
+
+
+def test_no_pack_lists_a_code_twice():
+    for pack in languages.BUILTIN_PACKS:
+        codes = [e["code"] for e in languages.builtin_pack(pack)]
+        assert len(codes) == len(set(codes))
+
+
+def test_an_unknown_pack_name_falls_back_rather_than_raising():
+    # The active pack is persisted; one deleted since must not take every
+    # Language field down with it.
+    assert languages.builtin_pack("no such pack") == languages.builtin_pack(
+        languages.DEFAULT_PACK
+    )
+
+
+# --- options and codes ------------------------------------------------------
+
+
+def test_an_option_reads_as_code_and_language_and_resolves_back():
+    option = languages.format_option("eng", "English")
+    assert option == "eng · English"
+    assert languages.code_from_option(option) == "eng"
+
+
+def test_a_typed_tag_survives_the_round_trip_unchanged():
+    # Every Language field still takes a tag no pack lists.
+    assert languages.code_from_option("pt-BR") == "pt-BR"
+    assert languages.code_from_option("") == ""
+    assert languages.code_from_option(None) == ""
+
+
+@pytest.mark.parametrize("tag", ["de", "grc", "pt-BR", "x-inhouse", "qaa"])
+def test_tags_the_graph_takes_are_accepted(tag):
+    assert languages.invalid_tag_reason(tag) is None
+    Literal("v", lang=tag)
+
+
+@pytest.mark.parametrize("tag", ["xx1", "en_GB", "1de", "de/at"])
+def test_tags_the_graph_refuses_come_back_as_advice(tag):
+    reason = languages.invalid_tag_reason(tag)
+    assert reason and tag in reason
+    with pytest.raises(ValueError):
+        Literal("v", lang=tag)
+
+
+def test_an_empty_tag_is_only_an_error_where_one_is_required():
+    # The pack editor needs a code in every row; the annotation forms do not.
+    assert languages.invalid_tag_reason("") == "A language code is required."
+    assert app.language_tag_error("") is None
+    assert app.language_tag_error("  ") is None
+    assert app.language_tag_error("xx1")
+
+
+# --- custom packs -----------------------------------------------------------
+
+
+def test_normalize_drops_empty_rows_and_refuses_the_rest():
+    entries, errors = languages.normalize_pack(
+        [
+            {"code": "x-old", "label": "House Old Norse"},
+            {"code": "", "label": ""},  # the editor's spare row
+            {"code": " nor ", "label": " Norwegian "},
+        ]
+    )
+    assert errors == []
+    assert entries == [
+        {"code": "x-old", "label": "House Old Norse"},
+        {"code": "nor", "label": "Norwegian"},
+    ]
+
+    _, bad = languages.normalize_pack([{"code": "xx1", "label": "Mine"}])
+    assert len(bad) == 1
+    _, dupe = languages.normalize_pack(
+        [{"code": "nor", "label": "A"}, {"code": "nor", "label": "B"}]
+    )
+    assert dupe == ["'nor' is listed more than once."]
+
+
+def test_a_pack_file_round_trips():
+    entries = [{"code": "x-a", "label": "A"}, {"code": "x-b", "label": "B"}]
+    name, read_back = languages.pack_from_json(languages.pack_to_json("Mine", entries))
+    assert (name, read_back) == ("Mine", entries)
+
+
+def test_a_bare_list_of_entries_is_read_as_a_nameless_pack():
+    name, entries = languages.pack_from_json('[{"code": "x-a", "label": "A"}]')
+    assert name == ""
+    assert entries == [{"code": "x-a", "label": "A"}]
+
+
+@pytest.mark.parametrize(
+    "text", ["not json", "42", '{"name": "Mine"}', "[]", '[{"code": "xx1"}]']
+)
+def test_a_file_that_is_not_a_pack_is_refused_with_a_reason(text):
+    with pytest.raises(ValueError):
+        languages.pack_from_json(text)
+
+
+def test_an_untouched_editor_cell_does_not_become_the_code_nan():
+    pd = pytest.importorskip("pandas")
+    frame = pd.DataFrame(
+        [{"Code": "x-a", "Language": None}, {"Code": "x-b", "Language": "B"}]
+    )
+    assert _pack_rows_to_entries(frame) == [
+        {"code": "x-a", "label": ""},
+        {"code": "x-b", "label": "B"},
+    ]
+
+
+# --- the session layer ------------------------------------------------------
+
+
+def test_a_custom_pack_is_offered_after_the_built_in_ones(monkeypatch, patch_ui):
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    assert (
+        app.save_custom_language_pack("Mine", [{"code": "x-a", "label": "A"}]) is None
+    )
+    assert app.language_pack_names() == [*languages.BUILTIN_PACKS, "Mine"]
+    assert app.language_pack_entries("Mine") == [{"code": "x-a", "label": "A"}]
+
+
+def test_a_built_in_pack_cannot_be_shadowed(monkeypatch, patch_ui):
+    # The built-ins are the way back to a known list of codes.
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    reason = app.save_custom_language_pack(
+        languages.ALPHA2_PACK, [{"code": "x-a", "label": "A"}]
+    )
+    assert reason and languages.ALPHA2_PACK in reason
+    assert app.custom_language_packs() == {}
+
+
+def test_a_pack_is_refused_whole_when_one_row_is_bad(monkeypatch, patch_ui):
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    reason = app.save_custom_language_pack(
+        "Mine", [{"code": "x-a", "label": "A"}, {"code": "xx1", "label": "B"}]
+    )
+    assert reason and "xx1" in reason
+    assert app.custom_language_packs() == {}
+
+
+def test_an_empty_pack_is_allowed(monkeypatch, patch_ui):
+    # What starting a pack from scratch looks like before the first row.
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    assert app.save_custom_language_pack("Mine", []) is None
+    assert app.language_pack_entries("Mine") == []
+
+
+def test_the_active_pack_survives_the_pack_it_names_being_deleted(
+    monkeypatch, patch_ui
+):
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app.save_custom_language_pack("Mine", [{"code": "x-a", "label": "A"}])
+    state[app.ACTIVE_LANG_PACK_KEY] = "Mine"
+    assert app.active_language_pack() == "Mine"
+
+    app.delete_custom_language_pack("Mine")
+    assert app.active_language_pack() == languages.DEFAULT_PACK
+    assert app.language_pack_entries()[0]["code"] != "x-a"
+
+
+def test_a_stale_saved_pack_name_falls_back(monkeypatch, patch_ui):
+    state: dict = {app.ACTIVE_LANG_PACK_KEY: "Deleted last week"}
+    monkeypatch.setattr(app.st, "session_state", state)
+    assert app.active_language_pack() == languages.DEFAULT_PACK
+
+
+# --- persistence ------------------------------------------------------------
+
+
+def test_disk_persist_and_restore_roundtrip(monkeypatch, patch_ui, tmp_path):
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
+    monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
+
+    save_state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", save_state)
+    app.save_custom_language_pack("Mine", [{"code": "x-a", "label": "A"}])
+    save_state[app.ACTIVE_LANG_PACK_KEY] = "Mine"
+    app.persist_language_packs()
+    stored = json.loads(cfg_file.read_text())[app.LANG_PACKS_KEY]
+    assert stored == {
+        "active": "Mine",
+        "packs": {"Mine": [{"code": "x-a", "label": "A"}]},
+    }
+
+    restore_state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", restore_state)
+    app.restore_language_packs()
+    assert restore_state["_lang_packs_restored"] is True
+    assert restore_state[app.ACTIVE_LANG_PACK_KEY] == "Mine"
+    assert app.language_pack_entries("Mine") == [{"code": "x-a", "label": "A"}]
+
+
+def test_persist_requires_a_change(monkeypatch, patch_ui, tmp_path):
+    # Rendering the sidebar is not a change: on the cloud a reload could
+    # otherwise write the defaults over the saved packs before localStorage
+    # had answered.
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
+    monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
+    monkeypatch.setattr(
+        app.st, "session_state", {app.ACTIVE_LANG_PACK_KEY: languages.ALPHA2_PACK}
+    )
+    app.persist_language_packs()
+    assert not cfg_file.exists()
+
+
+def test_browser_restore_retries_until_a_real_value_arrives(monkeypatch, patch_ui):
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
+    patch_ui("_get_local_storage", lambda: _FakeLS(None))
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app.restore_language_packs()
+    assert "_lang_packs_restored" not in state
+
+
+def test_browser_restore_applies_a_real_value(monkeypatch, patch_ui):
+    saved = json.dumps(
+        {"active": "Mine", "packs": {"Mine": [{"code": "x-a", "label": "A"}]}}
+    )
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
+    patch_ui("_get_local_storage", lambda: _FakeLS(saved))
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app.restore_language_packs()
+    assert state[app.ACTIVE_LANG_PACK_KEY] == "Mine"
+    assert state[app.CUSTOM_LANG_PACKS_KEY] == {"Mine": [{"code": "x-a", "label": "A"}]}
+
+
+def test_a_stored_pack_that_no_longer_validates_is_dropped(monkeypatch, patch_ui):
+    # Storage is a file (or a browser) the user can edit.
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app._apply_language_packs(
+        {
+            "active": "Broken",
+            "packs": {
+                "Broken": [{"code": "xx1", "label": "no"}],
+                "Fine": [{"code": "x-a", "label": "A"}],
+                "": [{"code": "x-b", "label": "B"}],
+                "Junk": "not a list",
+                # Started and not filled in yet — savable, so it comes back.
+                "Started": [],
+            },
+        }
+    )
+    assert set(state[app.CUSTOM_LANG_PACKS_KEY]) == {"Fine", "Started"}
+    assert app.active_language_pack() == languages.DEFAULT_PACK
+
+
+def test_an_empty_pack_is_still_the_active_one_after_a_restart(monkeypatch, patch_ui):
+    # It was dropped on restore, which silently reset the pack in use too.
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app._apply_language_packs({"active": "Started", "packs": {"Started": []}})
+    assert app.active_language_pack() == "Started"
+
+
+def test_apply_ignores_anything_that_is_not_a_payload(monkeypatch, patch_ui):
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app._apply_language_packs(None)
+    assert state == {}

--- a/tests/test_language_packs.py
+++ b/tests/test_language_packs.py
@@ -305,6 +305,23 @@ def test_a_stored_pack_that_no_longer_validates_is_dropped(monkeypatch, patch_ui
     assert app.active_language_pack() == languages.DEFAULT_PACK
 
 
+def test_a_stored_pack_cannot_take_a_built_in_pack_s_name(monkeypatch, patch_ui):
+    """Saving one is refused, so only an edited config can get one in — and a
+    pack under a built-in's name would be used in its place (custom packs are
+    looked up first) while the tab still showed it as read-only."""
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    app._apply_language_packs(
+        {
+            "active": languages.ALPHA3_PACK,
+            "packs": {languages.ALPHA3_PACK: [{"code": "x-a", "label": "A"}]},
+        }
+    )
+    assert app.custom_language_packs() == {}
+    assert app.language_pack_entries() == languages.builtin_pack(languages.ALPHA3_PACK)
+    assert app.language_pack_names() == list(languages.BUILTIN_PACKS)
+
+
 def test_an_empty_pack_is_still_the_active_one_after_a_restart(monkeypatch, patch_ui):
     # It was dropped on restore, which silently reset the pack in use too.
     state: dict = {}

--- a/tests/test_language_packs_ui.py
+++ b/tests/test_language_packs_ui.py
@@ -1,0 +1,133 @@
+"""The Language Packs tab: making, switching and deleting a pack (issue #252).
+
+The pack's rows are a ``data_editor``, which AppTest cannot type into, so what
+is driven here is everything around it — create, delete, and the deferred
+re-selection each of those does, since assigning a widget's value after the
+widget has been drawn is an exception rather than a no-op.
+
+The script draws the sidebar picker *before* the page, as the app does. That
+ordering is the point rather than scenery: deleting the pack in use used to
+write the picker's own key from the page body, which is exactly the assignment
+Streamlit refuses, and with the page rendered on its own nothing noticed.
+"""
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import app, languages
+
+
+@pytest.fixture(autouse=True)
+def no_disk_persist(monkeypatch):
+    """Nothing here may reach the filesystem.
+
+    The sidebar picker saves the packs after a change, and on a local/desktop
+    run that save goes to ``~/.orionbelt_ontology_builder/config.json`` — the
+    developer's own. Belt and braces with the env-var guard in ``conftest``.
+    """
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        st.session_state.ontology = OntologyManager()
+        st.session_state["_autosave_restored"] = True
+        # No browser storage: mounting that component under AppTest hangs, and
+        # what is driven here is the picker, not the persistence (which
+        # test_language_packs.py covers). ``None`` is the cached handle
+        # _get_local_storage() hands back when the component is unavailable.
+        st.session_state["_local_storage"] = None
+
+    from orionbelt_ontology_builder import app
+
+    app.render_language_pack_sidebar()
+    app.render_language_packs()
+
+
+def _run(**session):
+    at = AppTest.from_function(_script)
+    for key, value in session.items():
+        at.session_state[key] = value
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    return at
+
+
+def _packs(at):
+    """The custom packs in the app-test's session, not this process's."""
+    if app.CUSTOM_LANG_PACKS_KEY not in at.session_state:
+        return {}
+    return at.session_state[app.CUSTOM_LANG_PACKS_KEY]
+
+
+def _create(at, name, start_from="Empty"):
+    at.text_input(key="lang_pack_new_name").set_value(name)
+    at.selectbox(key="lang_pack_new_from").set_value(start_from)
+    at.button(key="lang_pack_create").click().run(timeout=120)
+    assert not at.exception, at.exception
+    return at
+
+
+def test_the_tab_opens_on_the_pack_that_is_in_use():
+    at = _run(**{app.ACTIVE_LANG_PACK_KEY: languages.ALPHA2_PACK})
+    assert at.selectbox(key="lang_pack_edit_select").value == languages.ALPHA2_PACK
+
+
+def test_a_new_pack_is_created_and_becomes_the_one_being_edited():
+    at = _run()
+    _create(at, "Project codes")
+
+    assert _packs(at) == {"Project codes": []}
+    assert at.selectbox(key="lang_pack_edit_select").value == "Project codes"
+    # The name box is cleared, so the next create doesn't reuse it by accident.
+    assert at.text_input(key="lang_pack_new_name").value == ""
+
+
+def test_a_pack_can_start_from_a_built_in_one():
+    at = _run()
+    _create(at, "Trimmed", start_from=languages.ALPHA2_PACK)
+
+    entries = _packs(at)["Trimmed"]
+    assert entries == languages.builtin_pack(languages.ALPHA2_PACK)
+
+
+def test_a_name_already_taken_is_refused():
+    at = _run()
+    _create(at, "Mine")
+    _create(at, "Mine")
+    assert "already exists" in at.error[0].value
+    assert list(_packs(at)) == ["Mine"]
+
+
+def test_a_built_in_pack_is_shown_but_not_editable():
+    at = _run(**{app.ACTIVE_LANG_PACK_KEY: languages.ALPHA3_PACK})
+    assert at.dataframe  # a read-only listing, with no Save beside it
+    assert not [b for b in at.button if b.key.startswith("lang_pack_save_")]
+    assert "can't be edited" in at.caption[1].value
+
+
+def test_deleting_the_pack_in_use_asks_first_and_then_falls_back():
+    at = _run()
+    _create(at, "Mine")
+    pack_key = app._uid("Mine")
+    # Put it in use first: deleting the *active* pack is the case that took the
+    # page down, because the fallback was written to the sidebar picker's own
+    # key from the page body, after the picker had been drawn.
+    at.selectbox(key=app.ACTIVE_LANG_PACK_KEY).set_value("Mine").run(timeout=120)
+    assert not at.exception, at.exception
+
+    at.button(key=f"lang_pack_del_{pack_key}").click().run(timeout=120)
+    assert not at.exception, at.exception
+    assert _packs(at)  # still there: it only armed the confirm
+    assert at.warning
+
+    at.button(key=f"lang_pack_del_yes_{pack_key}").click().run(timeout=120)
+    assert not at.exception, at.exception
+    assert _packs(at) == {}
+    assert at.selectbox(key="lang_pack_edit_select").value == languages.DEFAULT_PACK
+    # And the sidebar, whose pack has gone out from under it.
+    assert at.selectbox(key=app.ACTIVE_LANG_PACK_KEY).value == languages.DEFAULT_PACK

--- a/tests/test_language_picker_ui.py
+++ b/tests/test_language_picker_ui.py
@@ -1,0 +1,149 @@
+"""The Language fields pick from a pack instead of being typed (issue #252).
+
+Driven through ``render_add_annotation`` and ``render_annotation_form`` rather
+than the page, for the reason the other annotation UI tests give: the page's tab
+picker is a ``segmented_control``, which AppTest mis-serializes.
+
+Note when extending these: AppTest can only select an option that is already in
+the list, so what a user *types* into an ``accept_new_options`` dropdown cannot
+be simulated here. Assertions about a typed tag therefore belong on
+``languages.code_from_option`` and ``ui.language_tag_error`` (see
+``test_language_packs.py``).
+"""
+
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import languages
+
+
+def _add_script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Animal")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    resources = [
+        {
+            "name": c["name"],
+            "label": c.get("label"),
+            "type": "Class",
+            "display": c["name"],
+        }
+        for c in ont.get_classes()
+    ]
+    app.render_add_annotation(ont, resources)
+
+
+def _edit_script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Animal")
+        # A tag no built-in pack lists: a regional subtag.
+        om.add_annotation("Animal", "rdfs:comment", "a beast", lang="pt-BR")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    classes = ont.get_classes()
+    ann = ont.get_annotations("Animal")[0]
+    app.render_annotation_form(
+        ont,
+        next(c for c in classes if c["name"] == "Animal")["uri"],
+        ann,
+        "row0",
+        classes,
+        ont.get_object_properties(),
+        ont.get_data_properties(),
+        ont.get_individuals(),
+    )
+
+
+def _run(script, **session):
+    at = AppTest.from_function(script)
+    for key, value in session.items():
+        at.session_state[key] = value
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    return at
+
+
+def _options(at, key):
+    """The dropdown's options, unpadded.
+
+    Every entity dropdown is padded to a fixed width for search ranking
+    (``_pad_option``), and AppTest reports options as the widget formats them.
+    """
+    return [o.strip() for o in at.selectbox(key=key).options]
+
+
+def test_the_language_field_offers_the_active_packs_codes_with_their_names():
+    at = _run(_add_script)
+    options = _options(at, "ann_lang")
+    assert "eng · English" in options
+    # The alpha-3 pack is the default, and its point is a language ISO 639-1
+    # cannot name.
+    assert "grc · Greek, Ancient" in options
+    assert "en · English" not in options
+
+
+def test_switching_the_pack_switches_the_codes_on_offer():
+    from orionbelt_ontology_builder import app
+
+    at = _run(_add_script, **{app.ACTIVE_LANG_PACK_KEY: languages.ALPHA2_PACK})
+    options = _options(at, "ann_lang")
+    assert "en · English" in options
+    assert "eng · English" not in options
+
+
+def test_adding_writes_the_bare_code_not_the_option_text():
+    at = _run(_add_script)
+    at.selectbox(key="ann_predicate").set_value("rdfs:label")
+    at.text_area(key="ann_value").set_value("Tier")
+    at.selectbox(key="ann_lang").set_value("deu · German")
+    at.button[0].click().run(timeout=120)
+    assert not at.exception, at.exception
+
+    anns = at.session_state["ontology"].get_annotations("Animal")
+    assert [(a["value"], a["language"]) for a in anns] == [("Tier", "deu")]
+
+
+def test_the_language_stays_put_for_the_next_annotation():
+    """The value is what changes from one annotation to the next; a run of
+    labels in one language should not mean picking it again each time."""
+    at = _run(_add_script)
+    at.selectbox(key="ann_predicate").set_value("rdfs:label")
+    at.text_area(key="ann_value").set_value("Tier")
+    at.selectbox(key="ann_lang").set_value("deu · German")
+    at.button[0].click().run(timeout=120)
+    assert not at.exception, at.exception
+
+    assert at.text_area(key="ann_value").value == ""
+    assert at.selectbox(key="ann_lang").value == "deu · German"
+
+
+def test_a_tag_outside_the_pack_is_offered_and_survives_a_save():
+    """Switching packs must not quietly rewrite the tag of an annotation you
+    open to edit for another reason."""
+    at = _run(_edit_script)
+    assert at.selectbox(key="ann_lang_row0").value == "pt-BR"
+
+    at.text_input[1].set_value("a large beast")
+    at.button(key="FormSubmitter:edit_ann_row0-Save").click().run(timeout=120)
+    assert not at.exception, at.exception
+
+    anns = at.session_state["ontology"].get_annotations("Animal")
+    assert [(a["value"], a["language"]) for a in anns] == [("a large beast", "pt-BR")]


### PR DESCRIPTION
Closes #252.

## What changed

Every Language field (Add Annotation, the annotation editor, the graph panel's annotate form, Add Concept on the SKOS page) was an empty text box: you had to recall the tag and type it exactly. They are now searchable pickers over a **language pack**. Options read `eng · English`, so a code can be found by either half, and any BCP 47 tag can still be typed to be used as it stands, pack or no pack.

**Two built-in packs**, projected from one table in the new `languages.py` so a language's alpha-2 and alpha-3 codes cannot drift apart:

* **ISO 639-3 (alpha-3)**, the default, 228 codes: every ISO 639-1 language plus the historical ones alpha-2 has no code for (`grc`, `ang`, `non`, `sux`, `syc`, ...), a few living languages an alpha-3 user reaches for (`yue`, `fil`, `nds`), and the special-purpose codes (`und`, `mul`, `zxx`, `qaa`).
* **ISO 639-1 (alpha-2)**, 184 codes, for an ontology in modern languages only.

**Custom packs**: a Language Packs tab under Annotations. Pick a pack to view, start a new one empty or copied from an existing one, edit its code/label rows in a spreadsheet, and import or export it as JSON. Built-in packs are read-only, so there is always a way back to a known list of codes. A pack of your own can be the short list of languages one ontology actually uses, or private codes for a language no standard names.

**One switch, in the sidebar**: the fields sit on three pages and in the graph panel, so a per-field switch would have to be set four times over to mean one thing. The choice and the packs persist the way the Visualization settings do: the local config file on a desktop run, browser localStorage on the cloud.

Two smaller things that came with it:

* A tag rdflib would refuse (`xx1`, `en_GB`) now comes back as advice naming the private-use alternatives (`x-mycode`, the `qaa`-`qtz` range) instead of raising out of the write and taking the page down.
* The language now stays put after adding an annotation, the way the type and the resource already did, so a run of labels in one language needs one pick rather than one per row. The value still clears.

## Test-suite fix included

Verifying this in the running app surfaced a leak worth fixing at the source: the launcher tests call `cli`/`desktop` `main()`, which sets `ORIONBELT_LOCAL_PERSIST` for the whole process, and nothing unset it. Every test sorting after `test_c...` therefore believed it was the desktop app, and the first one to save a setting saved it into the developer's real `~/.orionbelt_ontology_builder/config.json`, which it also read back on the next run. An autouse fixture in `conftest.py` now restores the variable after each test.

## Verified

`pytest` (1167 passing, 55 new), `ruff format`/`check` at the pinned 0.16.2, and `mypy` all clean. Driven live in the app as well, which is where three real bugs turned up and were fixed:

* deleting the pack in use crashed the page (the fallback was written to the sidebar picker's own widget key from the page body, which Streamlit refuses). The delete test now renders the sidebar before the page, as the app does, and reproduces the crash without the fix.
* an empty pack was dropped when restored from storage, silently resetting the pack in use with it.
* the pack picker drew Streamlit's "created with a default value but also had its value set via the Session State API" warning above the page.

## Not in this PR

The Bulk Edit tab's Language column stays a free-text spreadsheet column: a `SelectboxColumn` cannot accept a value outside its options, and pasting arbitrary tags is the point of that view. Bad tags there are already reported per row rather than raising.

Separately, while testing I hit a pre-existing bug that has nothing to do with this change and deserves its own issue: on the Annotations page, Add Annotation resolves the chosen resource by local name, so an annotation added to an imported class (gist, FOAF) lands on the base namespace instead of that class's own URI. The row still lists it, but the editor's Save and Delete target the real URI and quietly do nothing. Reproduced in isolation against `OntologyManager`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
