### PR TITLE
fix: annotate the resource, not its local name

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -148,6 +148,7 @@ from .ui import (  # noqa: F401
     annotation_matches_ename,
     annotation_option_for_predicate,
     annotation_predicate_options,
+    annotation_resource_options,
     annotation_subject_options,
     build_class_hierarchy_text,
     build_class_options,

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -225,9 +225,11 @@ from .ui import (  # noqa: F401
 # ``pages`` directory next to an entry script as a legacy multipage app (#269).
 from .views.advanced import render_advanced
 from .views.annotations import (  # noqa: F401 - the tabs are re-exported like the ui block's
+    bulk_annotation_updates,
     render_annotation_types,
     render_annotations,
     render_language_packs,
+    render_view_annotations,
 )
 from .views.classes import render_classes
 from .views.dashboard import render_dashboard

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -370,15 +370,27 @@ class OntologyManager:
         # Re-bind the default namespace
         self.graph.bind("", self.namespace)
 
+    #: The ``scheme:`` an absolute IRI opens with (RFC 3986). A local name can
+    #: never match it: :attr:`_LOCAL_NAME_RE` allows no colon, so "already a
+    #: URI" and "a name to place in a namespace" cannot be the same string.
+    _IRI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*:")
+
     def _uri(self, local_name: str, namespace: str | None = None) -> URIRef:
         """Create a URI from a local name.
 
-        A value that is already a full ``http(s)`` URI is returned unchanged.
+        A value that is already an absolute URI is returned unchanged.
         Otherwise the local name is placed in ``namespace`` when one is given
         (any bound namespace, e.g. a custom prefix), or in the base namespace
         by default.
+
+        Any scheme counts, not only ``http(s)``: an imported ontology can name
+        its resources ``urn:``, ``did:``, ``file:`` or anything else, and
+        passing one of those through here used to mint
+        ``http://base#urn:example:Account`` instead. The UI hid it, because
+        reading the annotations back minted the same wrong subject, but an
+        export carried them on a resource nothing declares (review of PR #292).
         """
-        if local_name.startswith(("http://", "https://")):
+        if self._IRI_SCHEME_RE.match(local_name):
             return URIRef(local_name)
         if namespace:
             return URIRef(namespace + local_name)

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2379,41 +2379,42 @@ class OntologyManager:
             )
         return Literal(value)
 
+    #: What a resource says about its place in the ontology rather than about
+    #: itself, and so is not an annotation. A class constant because the repair
+    #: below has to move exactly what :meth:`get_annotations` reports.
+    _STRUCTURAL_PREDICATES: ClassVar[set] = {
+        RDF.type,
+        RDFS.subClassOf,
+        RDFS.subPropertyOf,
+        RDFS.domain,
+        RDFS.range,
+        OWL.equivalentClass,
+        OWL.equivalentProperty,
+        OWL.disjointWith,
+        OWL.inverseOf,
+        OWL.propertyChainAxiom,
+        OWL.onProperty,
+        OWL.someValuesFrom,
+        OWL.allValuesFrom,
+        OWL.hasValue,
+        OWL.minCardinality,
+        OWL.maxCardinality,
+        OWL.cardinality,
+        OWL.unionOf,
+        OWL.intersectionOf,
+        OWL.complementOf,
+        OWL.oneOf,
+        OWL.imports,
+    }
+
     def get_annotations(self, subject: str) -> list[dict[str, Any]]:
         """Get all annotations/predicates for a resource (like Protege shows)."""
         subj_uri = self._uri(subject)
         annotations: list[dict[str, Any]] = []
 
-        # Get all predicates for this subject, excluding rdf:type, rdfs:subClassOf,
-        # rdfs:domain, rdfs:range, and other structural predicates
-        structural_predicates = {
-            RDF.type,
-            RDFS.subClassOf,
-            RDFS.subPropertyOf,
-            RDFS.domain,
-            RDFS.range,
-            OWL.equivalentClass,
-            OWL.equivalentProperty,
-            OWL.disjointWith,
-            OWL.inverseOf,
-            OWL.propertyChainAxiom,
-            OWL.onProperty,
-            OWL.someValuesFrom,
-            OWL.allValuesFrom,
-            OWL.hasValue,
-            OWL.minCardinality,
-            OWL.maxCardinality,
-            OWL.cardinality,
-            OWL.unionOf,
-            OWL.intersectionOf,
-            OWL.complementOf,
-            OWL.oneOf,
-            OWL.imports,
-        }
-
         for pred, obj in self.graph.predicate_objects(subj_uri):
             # Skip structural predicates
-            if pred in structural_predicates:
+            if pred in self._STRUCTURAL_PREDICATES:
                 continue
             # Skip blank nodes (restrictions, etc.)
             if isinstance(obj, BNode):
@@ -2452,37 +2453,56 @@ class OntologyManager:
         annotations.sort(key=lambda x: x["predicate"])
         return annotations
 
+    def stray_annotation_subject(self, subject: str) -> str | None:
+        """The base-namespace namesake holding annotations meant for ``subject``.
+
+        Until this was fixed, the Annotations page addressed the resource it was
+        annotating by local name, and a local name resolves into *this*
+        ontology's namespace — so annotating an imported class (``gist:Account``)
+        wrote to ``:Account``, a subject nothing declares. The page listed those
+        annotations, because it read them back the same way, but the editor and
+        the row delete aimed at the real URI and quietly did nothing.
+
+        Returns the namesake's URI when it holds something to adopt, else
+        ``None``. Only an *undeclared* subject qualifies: a base-namespace
+        resource of the same local name that this ontology actually defines is a
+        resource in its own right, and its annotations are its own.
+        """
+        subj_uri = self._uri(subject)
+        stray = self.namespace[self._local_name(subj_uri)]
+        if stray == subj_uri or (stray, RDF.type, None) in self.graph:
+            return None
+        return str(stray) if self.get_annotations(str(stray)) else None
+
+    def adopt_stray_annotations(self, subject: str) -> int:
+        """Move a namesake's annotations onto ``subject``, returning how many.
+
+        The repair for what :meth:`stray_annotation_subject` finds. The triples
+        are moved rather than copied, so the namesake is left with nothing and
+        running this again finds nothing to do.
+        """
+        stray = self.stray_annotation_subject(subject)
+        if stray is None:
+            return 0
+        subj_uri = self._uri(subject)
+        stray_uri = URIRef(stray)
+        moved = 0
+        for pred, obj in list(self.graph.predicate_objects(stray_uri)):
+            # Exactly what get_annotations reports, so nothing structural and no
+            # blank node (a restriction) is dragged along with it.
+            if pred in self._STRUCTURAL_PREDICATES or isinstance(obj, BNode):
+                continue
+            self.graph.remove((stray_uri, pred, obj))
+            self.graph.add((subj_uri, pred, obj))
+            moved += 1
+        return moved
+
     def get_used_annotation_predicates(self) -> list[dict[str, str]]:
         """Get all unique annotation predicates used in the ontology."""
-        structural_predicates = {
-            RDF.type,
-            RDFS.subClassOf,
-            RDFS.subPropertyOf,
-            RDFS.domain,
-            RDFS.range,
-            OWL.equivalentClass,
-            OWL.equivalentProperty,
-            OWL.disjointWith,
-            OWL.inverseOf,
-            OWL.propertyChainAxiom,
-            OWL.onProperty,
-            OWL.someValuesFrom,
-            OWL.allValuesFrom,
-            OWL.hasValue,
-            OWL.minCardinality,
-            OWL.maxCardinality,
-            OWL.cardinality,
-            OWL.unionOf,
-            OWL.intersectionOf,
-            OWL.complementOf,
-            OWL.oneOf,
-            OWL.imports,
-        }
-
         predicates = {}
         for subj, pred, obj in self.graph:
             # Skip structural predicates
-            if pred in structural_predicates:
+            if pred in self._STRUCTURAL_PREDICATES:
                 continue
             # Skip blank node objects
             if isinstance(obj, BNode):

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -4592,9 +4592,18 @@ def render_add_annotation(ont, all_resources):
                 else:
                     # Find the resource by matching the option string
                     idx = resource_options.index(selected)
-                    resource_name = all_resources[idx]["name"]
+                    # By URI, not by local name: a local name resolves into this
+                    # ontology's own namespace, so annotating an imported class
+                    # wrote to a namesake nothing declares. It looked right —
+                    # the page read the annotations back the same way — but the
+                    # editor and the row delete aimed at the real URI and
+                    # quietly did nothing (the same reason every other form here
+                    # picks by URI).
+                    resource_ref = (
+                        all_resources[idx].get("uri") or (all_resources[idx]["name"])
+                    )
                     ont.add_annotation(
-                        resource_name,
+                        resource_ref,
                         predicate_uri,
                         value,
                         lang=language if language else None,

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -4492,6 +4492,35 @@ def annotation_predicate_options(ont):
     return predicate_options, predicate_lookup
 
 
+def annotation_resource_options(resources) -> tuple:
+    """``(options, lookup)`` for the pickers that choose what to annotate.
+
+    Two resources can share a local name across namespaces (issue #119), and
+    both annotation pickers identified the chosen one by its display string —
+    positionally in the Add form, by first match in the View list. Either way
+    the namesake was unreachable: choosing it annotated the first one instead,
+    which is the same class of bug as writing by local name, one step earlier.
+
+    Options carry the namespace tag the rest of the app already uses for this
+    (``Organization (foaf)``) and the resource kind, and the lookup returns the
+    resource itself, so nothing has to be matched back by string.
+    """
+    collisions = _build_name_collision_set(resources)
+    options: list[str] = []
+    lookup: dict[str, dict] = {}
+    for r in resources:
+        display = format_label_name(_disambiguated_name(r, collisions), r.get("label"))
+        option = f"{display} [{r['type']}]"
+        if option in lookup:
+            # Nothing else tells them apart (the same name, kind and namespace
+            # under two URIs, or an entry listed twice): name the URI rather
+            # than let one option stand for both resources.
+            option = f"{option} <{r.get('uri') or r['name']}>"
+        options.append(option)
+        lookup[option] = r
+    return options, lookup
+
+
 def render_add_annotation(ont, all_resources):
     """Render the "Add Annotation" tab.
 
@@ -4531,8 +4560,10 @@ def render_add_annotation(ont, all_resources):
                 st.session_state["ann_predicate"] = _ann_option
 
         with st.form("add_annotation_form"):
-            # Use display format with label
-            resource_options = [f"{r['display']} [{r['type']}]" for r in all_resources]
+            # Display, kind, and a namespace tag where two share a local name.
+            resource_options, resource_lookup = annotation_resource_options(
+                all_resources
+            )
             selected = required_selectbox(
                 "Select Resource",
                 resource_options,
@@ -4590,8 +4621,10 @@ def render_add_annotation(ont, all_resources):
                 elif lang_error := language_tag_error(language):
                     show_message(lang_error, "error")
                 else:
-                    # Find the resource by matching the option string
-                    idx = resource_options.index(selected)
+                    # The option the picker holds, not its position: two
+                    # resources of the same local name used to produce the same
+                    # option, and the second one resolved to the first.
+                    picked = resource_lookup[selected]
                     # By URI, not by local name: a local name resolves into this
                     # ontology's own namespace, so annotating an imported class
                     # wrote to a namesake nothing declares. It looked right —
@@ -4599,9 +4632,7 @@ def render_add_annotation(ont, all_resources):
                     # editor and the row delete aimed at the real URI and
                     # quietly did nothing (the same reason every other form here
                     # picks by URI).
-                    resource_ref = (
-                        all_resources[idx].get("uri") or (all_resources[idx]["name"])
-                    )
+                    resource_ref = picked.get("uri") or picked["name"]
                     ont.add_annotation(
                         resource_ref,
                         predicate_uri,

--- a/orionbelt_ontology_builder/views/annotations.py
+++ b/orionbelt_ontology_builder/views/annotations.py
@@ -10,6 +10,7 @@ from ..ui import (
     _is_open,
     _uid,
     active_language_pack,
+    annotation_resource_options,
     clearable_selectbox,
     delete_custom_language_pack,
     format_label_name,
@@ -441,9 +442,9 @@ def render_view_annotations(
                 r for r in all_resources if r["type"] == selected_type
             ]
 
+        _view_opts, _view_lookup = annotation_resource_options(filtered_resources)
         with col2:
             if filtered_resources:
-                _view_opts = [r["display"] for r in filtered_resources]
                 selected = clearable_selectbox(
                     "Select Resource",
                     _view_opts,
@@ -455,10 +456,10 @@ def render_view_annotations(
                 st.info(f"No {selected_type} resources found.")
 
         if selected:
-            # Find the actual resource name from display string
-            resource = next(
-                (r for r in filtered_resources if r["display"] == selected), None
-            )
+            # The option the picker holds, not the first resource that renders
+            # the same way: two of the same local name used to share an option,
+            # so the namesake's annotations could not be reached from here.
+            resource = _view_lookup.get(selected)
             if resource:
                 resource_name = resource["name"]
                 # By URI, as the editor below already addresses it: read by

--- a/orionbelt_ontology_builder/views/annotations.py
+++ b/orionbelt_ontology_builder/views/annotations.py
@@ -329,6 +329,216 @@ def render_language_packs():
             st.rerun()
 
 
+def bulk_annotation_updates(frame, uris_by_name):
+    """The Bulk Edit rows as engine updates, plus the names it could not resolve.
+
+    Rows are labelled with the resource's local name, which is what a
+    spreadsheet can be read and typed in, but they are applied by URI: a local
+    name resolves into this ontology's namespace, so a row about an imported
+    resource used to annotate a namesake that does not exist. A name that more
+    than one resource answers to is returned as ambiguous rather than guessed
+    at, and a name nothing answers to is passed through as typed, so a row
+    written by hand still behaves as it did.
+
+    ``fillna`` first, for the reason :func:`_pack_rows_to_entries` gives: a cell
+    the user never touched arrives as NaN, and the engine strips the language
+    tag before its per-row guard, so one such cell used to abort the whole batch
+    with an AttributeError.
+
+    Split out of the page so it can be tested directly: the tab picker is a
+    ``segmented_control``, which AppTest mis-serializes.
+    """
+    updates: list[dict] = []
+    ambiguous: list[str] = []
+    for row in frame.fillna("").astype(str).to_dict("records"):
+        action = row.get("Action", "keep")
+        if action not in ("add", "delete"):
+            continue
+        named = row.get("Resource", "").strip()
+        known = uris_by_name.get(named, set())
+        if len(known) > 1:
+            # Two namespaces, one local name: which one the row means cannot be
+            # read off it, and either guess writes to the wrong resource.
+            ambiguous.append(named)
+            continue
+        updates.append(
+            {
+                "resource": next(iter(known), named),
+                "predicate": row.get("Predicate", ""),
+                "value": row.get("Value", ""),
+                "lang": row.get("Language", ""),
+                "action": action,
+            }
+        )
+    return updates, ambiguous
+
+
+def _render_stray_annotation_repair(ont, resource_uri, resource_name):
+    """Offer to move annotations an older version put on the wrong subject.
+
+    Adding an annotation used to address the resource by local name, which
+    resolves into this ontology's namespace — so anything annotated on an
+    imported class landed on a namesake nothing declares. Reading by URI now
+    means those annotations are no longer listed here, which would leave them
+    invisible as well as unreachable, so where one exists it is named and can be
+    moved onto the resource it was meant for.
+    """
+    stray = ont.stray_annotation_subject(resource_uri)
+    if not stray:
+        return
+    count = len(ont.get_annotations(stray))
+    one = count == 1
+    st.warning(
+        f"{count} annotation{'' if one else 's'} for '{resource_name}' "
+        f"{'sits' if one else 'sit'} on `{stray}`, where an earlier version of "
+        f"this app wrote {'it' if one else 'them'}. Nothing here can edit or "
+        f"delete {'it' if one else 'them'} while "
+        f"{'it is' if one else 'they are'} there."
+    )
+    if st.button(
+        f"Move {'it' if one else 'them'} onto {resource_name}",
+        key=f"adopt_ann_{_uid(resource_uri)}",
+        type="primary",
+    ):
+        moved = ont.adopt_stray_annotations(resource_uri)
+        save_checkpoint("Move misplaced annotations")
+        set_flash_message(
+            f"Moved {moved} annotation{'' if moved == 1 else 's'} "
+            f"onto '{resource_name}'.",
+            "success",
+        )
+        st.rerun()
+
+
+def render_view_annotations(
+    ont, all_resources, classes, object_props, data_props, individuals
+):
+    """Render the "View Annotations" tab.
+
+    A separate function so it can be driven directly in tests, for the reason
+    given on :func:`render_add_annotation`: the page's tab picker is a
+    ``segmented_control``, which AppTest mis-serializes, so a row's buttons
+    cannot be clicked from a page run.
+    """
+    if not all_resources:
+        st.info(
+            "No resources to annotate. Create classes, properties, or individuals first."
+        )
+    else:
+        # Filter by resource type
+        col1, col2 = st.columns([1, 3])
+        with col1:
+            filter_types = ["All"] + list({r["type"] for r in all_resources})
+            selected_type = st.selectbox(
+                "Filter by Type", options=filter_types, key="filter_type"
+            )
+
+        # Filter resources based on selection
+        if selected_type == "All":
+            filtered_resources = all_resources
+        else:
+            filtered_resources = [
+                r for r in all_resources if r["type"] == selected_type
+            ]
+
+        with col2:
+            if filtered_resources:
+                _view_opts = [r["display"] for r in filtered_resources]
+                selected = clearable_selectbox(
+                    "Select Resource",
+                    _view_opts,
+                    key="view_annotations_select",
+                    current_display=_view_opts[0] if _view_opts else None,
+                )
+            else:
+                selected = None
+                st.info(f"No {selected_type} resources found.")
+
+        if selected:
+            # Find the actual resource name from display string
+            resource = next(
+                (r for r in filtered_resources if r["display"] == selected), None
+            )
+            if resource:
+                resource_name = resource["name"]
+                # By URI, as the editor below already addresses it: read by
+                # local name, an imported resource's annotations were looked
+                # for in this ontology's namespace instead of its own.
+                resource_uri = resource.get("uri") or resource_name
+                annotations = ont.get_annotations(resource_uri)
+                _render_stray_annotation_repair(ont, resource_uri, resource_name)
+
+                if not annotations:
+                    st.info(f"No annotations found for '{resource_name}'")
+                else:
+                    st.subheader(f"Annotations for {selected}")
+                    for _ai, ann in enumerate(annotations):
+                        # By position, the way the restriction rows are
+                        # keyed: a resource can carry two annotations that
+                        # differ only in language, and they would otherwise
+                        # share a key and open each other's editor.
+                        row_key = f"{_uid(resource_uri)}_{_ai}"
+                        col1, col2, col3, col4 = st.columns([2, 4, 0.7, 0.7])
+                        with col1:
+                            # Show prefixed predicate (e.g., rdfs:label, skos:prefLabel)
+                            predicate_display = ann.get(
+                                "predicate_prefixed", ann["predicate"]
+                            )
+                            st.write(f"**{predicate_display}**")
+                        with col2:
+                            lang_str = (
+                                f" @{ann['language']}" if ann.get("language") else ""
+                            )
+                            dtype_str = (
+                                f" ({ann['datatype']})" if ann.get("datatype") else ""
+                            )
+                            st.write(f"{ann['value']}{lang_str}{dtype_str}")
+                        with col3:
+                            st.button(
+                                "✏️",
+                                key=f"edit_ann_{row_key}",
+                                help="Edit this annotation",
+                                on_click=_cb_toggle_edit,
+                                args=("ann", row_key),
+                            )
+                        with col4:
+                            if st.button(
+                                "🗑️",
+                                key=f"del_ann_{row_key}",
+                                help="Delete this annotation",
+                            ):
+                                ont.delete_annotation(
+                                    resource_uri,
+                                    ann.get("predicate_uri", ann["predicate"]),
+                                    ann["value"],
+                                    lang=ann.get("language"),
+                                    # Full URI, and the resource/literal
+                                    # distinction: passing the display local
+                                    # name or treating an IRI object as a
+                                    # literal deletes nothing while
+                                    # reporting success (issue #223 review).
+                                    datatype=ann.get("datatype_uri")
+                                    or ann.get("datatype"),
+                                    value_is_uri=bool(ann.get("is_uri")),
+                                )
+                                save_checkpoint("Delete annotation")
+                                set_flash_message("Annotation deleted!", "success")
+                                st.rerun()
+
+                        if _is_open("ann", row_key, "edit"):
+                            render_annotation_form(
+                                ont,
+                                resource_uri,
+                                ann,
+                                row_key,
+                                classes,
+                                object_props,
+                                data_props,
+                                individuals,
+                                on_close=lambda: _close_entity("ann"),
+                            )
+
+
 def render_annotations():
     """Render the annotations management page."""
     st.header("Annotations")
@@ -406,123 +616,9 @@ def render_annotations():
         _ann_tab = "View Annotations"
 
     if _ann_tab == "View Annotations":
-        if not all_resources:
-            st.info(
-                "No resources to annotate. Create classes, properties, or individuals first."
-            )
-        else:
-            # Filter by resource type
-            col1, col2 = st.columns([1, 3])
-            with col1:
-                filter_types = ["All"] + list({r["type"] for r in all_resources})
-                selected_type = st.selectbox(
-                    "Filter by Type", options=filter_types, key="filter_type"
-                )
-
-            # Filter resources based on selection
-            if selected_type == "All":
-                filtered_resources = all_resources
-            else:
-                filtered_resources = [
-                    r for r in all_resources if r["type"] == selected_type
-                ]
-
-            with col2:
-                if filtered_resources:
-                    _view_opts = [r["display"] for r in filtered_resources]
-                    selected = clearable_selectbox(
-                        "Select Resource",
-                        _view_opts,
-                        key="view_annotations_select",
-                        current_display=_view_opts[0] if _view_opts else None,
-                    )
-                else:
-                    selected = None
-                    st.info(f"No {selected_type} resources found.")
-
-            if selected:
-                # Find the actual resource name from display string
-                resource = next(
-                    (r for r in filtered_resources if r["display"] == selected), None
-                )
-                if resource:
-                    resource_name = resource["name"]
-                    annotations = ont.get_annotations(resource_name)
-
-                    if not annotations:
-                        st.info(f"No annotations found for '{resource_name}'")
-                    else:
-                        st.subheader(f"Annotations for {selected}")
-                        resource_uri = resource.get("uri") or resource_name
-                        for _ai, ann in enumerate(annotations):
-                            # By position, the way the restriction rows are
-                            # keyed: a resource can carry two annotations that
-                            # differ only in language, and they would otherwise
-                            # share a key and open each other's editor.
-                            row_key = f"{_uid(resource_uri)}_{_ai}"
-                            col1, col2, col3, col4 = st.columns([2, 4, 0.7, 0.7])
-                            with col1:
-                                # Show prefixed predicate (e.g., rdfs:label, skos:prefLabel)
-                                predicate_display = ann.get(
-                                    "predicate_prefixed", ann["predicate"]
-                                )
-                                st.write(f"**{predicate_display}**")
-                            with col2:
-                                lang_str = (
-                                    f" @{ann['language']}"
-                                    if ann.get("language")
-                                    else ""
-                                )
-                                dtype_str = (
-                                    f" ({ann['datatype']})"
-                                    if ann.get("datatype")
-                                    else ""
-                                )
-                                st.write(f"{ann['value']}{lang_str}{dtype_str}")
-                            with col3:
-                                st.button(
-                                    "✏️",
-                                    key=f"edit_ann_{row_key}",
-                                    help="Edit this annotation",
-                                    on_click=_cb_toggle_edit,
-                                    args=("ann", row_key),
-                                )
-                            with col4:
-                                if st.button(
-                                    "🗑️",
-                                    key=f"del_ann_{row_key}",
-                                    help="Delete this annotation",
-                                ):
-                                    ont.delete_annotation(
-                                        resource_name,
-                                        ann.get("predicate_uri", ann["predicate"]),
-                                        ann["value"],
-                                        lang=ann.get("language"),
-                                        # Full URI, and the resource/literal
-                                        # distinction: passing the display local
-                                        # name or treating an IRI object as a
-                                        # literal deletes nothing while
-                                        # reporting success (issue #223 review).
-                                        datatype=ann.get("datatype_uri")
-                                        or ann.get("datatype"),
-                                        value_is_uri=bool(ann.get("is_uri")),
-                                    )
-                                    save_checkpoint("Delete annotation")
-                                    set_flash_message("Annotation deleted!", "success")
-                                    st.rerun()
-
-                            if _is_open("ann", row_key, "edit"):
-                                render_annotation_form(
-                                    ont,
-                                    resource_uri,
-                                    ann,
-                                    row_key,
-                                    classes,
-                                    object_props,
-                                    data_props,
-                                    individuals,
-                                    on_close=lambda: _close_entity("ann"),
-                                )
+        render_view_annotations(
+            ont, all_resources, classes, object_props, data_props, individuals
+        )
 
     if _ann_tab == "Add Annotation":
         render_add_annotation(ont, all_resources)
@@ -539,10 +635,17 @@ def render_annotations():
             "Edit annotations in a spreadsheet. Add rows to create, mark action as 'delete' to remove."
         )
 
+        # Which URIs each local name answers to, for bulk_annotation_updates.
+        uris_by_name: dict[str, set[str]] = {}
+        for res in all_resources:
+            uris_by_name.setdefault(res["name"], set()).add(
+                res.get("uri") or res["name"]
+            )
+
         # Build initial data from existing annotations
         annotation_data = []
         for res in all_resources:
-            annots = ont.get_annotations(res["name"])
+            annots = ont.get_annotations(res.get("uri") or res["name"])
             for a in annots:
                 annotation_data.append(
                     {
@@ -580,27 +683,26 @@ def render_annotations():
         )
 
         if st.button("Apply Changes", type="primary", key="bulk_apply_annotations"):
-            updates = []
-            for _, row in edited_df.iterrows():
-                action = row.get("Action", "keep")
-                if action in ("add", "delete"):
-                    updates.append(
-                        {
-                            "resource": row["Resource"],
-                            "predicate": row["Predicate"],
-                            "value": row["Value"],
-                            "lang": row.get("Language", ""),
-                            "action": action,
-                        }
-                    )
-            if updates:
-                result = ont.bulk_update_annotations(updates)
-                save_checkpoint("Bulk edit annotations")
-                msg = f"Applied {result['applied']} change(s)"
-                if result["errors"]:
-                    msg += f", {len(result['errors'])} error(s)"
+            updates, ambiguous = bulk_annotation_updates(edited_df, uris_by_name)
+            if updates or ambiguous:
+                result = ont.bulk_update_annotations(updates) if updates else None
+                applied = result["applied"] if result else 0
+                errors = list(result["errors"]) if result else []
+                errors += [
+                    {
+                        "resource": name,
+                        "error": f"'{name}' names more than one resource. "
+                        "Use its full URI in this column.",
+                    }
+                    for name in ambiguous
+                ]
+                if applied:
+                    save_checkpoint("Bulk edit annotations")
+                msg = f"Applied {applied} change(s)"
+                if errors:
+                    msg += f", {len(errors)} error(s): {errors[0]['error']}"
                 # Flash (not show_message) so the summary survives the rerun below.
-                set_flash_message(msg, "success" if not result["errors"] else "warning")
+                set_flash_message(msg, "success" if not errors else "warning")
                 st.rerun()
             else:
                 show_message(

--- a/tests/test_annotation_subject_uris.py
+++ b/tests/test_annotation_subject_uris.py
@@ -27,9 +27,14 @@ COMMENT = "http://www.w3.org/2000/01/rdf-schema#comment"
 
 
 def _om():
-    """An ontology with one class of its own and one from another namespace."""
+    """An ontology with one class of its own and one from another namespace.
+
+    The prefix is bound as an import would bind it, so a namesake reads
+    ``Account (gist)`` rather than falling back to the whole namespace.
+    """
     m = OntologyManager(base_uri=BASE)
     m.add_class("Invoice")
+    m.graph.bind("gist", GIST)
     m.graph.add((URIRef(ACCOUNT), RDF.type, OWL.Class))
     return m
 
@@ -220,7 +225,7 @@ def test_the_view_tab_offers_to_move_a_stray_onto_the_resource():
     """Reading by URI means those annotations are no longer listed, so the tab
     has to say where they went or they are invisible as well as unreachable."""
     at = _run(_view_script, _om_with_stray())
-    assert at.selectbox(key="view_annotations_select").value == "Account"
+    assert at.selectbox(key="view_annotations_select").value == "Account [Class]"
     assert BASE + "Account" in at.warning[0].value
 
     at.button(key=f"adopt_ann_{app._uid(ACCOUNT)}").click().run(timeout=120)
@@ -369,3 +374,65 @@ def test_a_bulk_round_trip_reaches_an_imported_resource(action, value, expected)
     assert result["applied"] == 1
     assert not result["errors"]
     assert sorted(a["value"] for a in m.get_annotations(ACCOUNT)) == expected
+
+
+# --- picking between two resources of the same local name -------------------
+
+
+def _om_with_namesakes():
+    """Two classes called Account: one imported, one this ontology's own."""
+    m = _om()
+    m.add_class("Account")
+    return m
+
+
+def test_two_resources_of_one_local_name_get_an_option_each():
+    """They rendered identically, so the second could not be picked at all: the
+    Add form resolved by position and the View list by first match, and both
+    landed on the first of the two."""
+    options, lookup = app.annotation_resource_options(_resources(_om_with_namesakes()))
+    assert len(set(options)) == len(options)
+
+    picked = {lookup[o]["uri"] for o in options if o.startswith("Account")}
+    assert picked == {ACCOUNT, BASE + "Account"}
+    # Tagged with what tells them apart, as the sidebar search already does.
+    # The bound prefix ("Account (gist)") needs the session's ontology to
+    # resolve it, so outside an app run this is the namespace it falls back to.
+    assert any(GIST in o for o in options)
+
+
+def test_a_local_name_only_one_resource_answers_to_is_left_plain():
+    options, _ = app.annotation_resource_options(_resources(_om()))
+    assert "Invoice [Class]" in options
+
+
+def test_the_add_form_annotates_the_namesake_that_was_chosen():
+    at = _run(_add_script, _om_with_namesakes())
+    option = next(
+        o
+        for o in at.selectbox(key="ann_resource").options
+        if o.strip().startswith("Account (gist)")
+    )
+    _add(at, option.strip(), "the imported one")
+
+    ont = at.session_state["ontology"]
+    assert [a["value"] for a in ont.get_annotations(ACCOUNT)] == ["the imported one"]
+    assert ont.get_annotations(BASE + "Account") == []
+
+
+def test_the_view_tab_lists_the_namesake_that_was_chosen():
+    om = _om_with_namesakes()
+    om.add_annotation(ACCOUNT, "comment", "the imported one")
+    om.add_annotation(BASE + "Account", "comment", "the local one")
+    at = _run(_view_script, om)
+
+    picker = at.selectbox(key="view_annotations_select")
+    option = next(
+        o for o in picker.options if o.strip().startswith("Account (gist)")
+    ).strip()
+    picker.set_value(option).run(timeout=120)
+    assert not at.exception, at.exception
+
+    shown = " ".join(m.value for m in at.markdown)
+    assert "the imported one" in shown
+    assert "the local one" not in shown

--- a/tests/test_annotation_subject_uris.py
+++ b/tests/test_annotation_subject_uris.py
@@ -14,7 +14,7 @@ which AppTest mis-serializes.
 
 import pandas as pd
 import pytest
-from rdflib import OWL, RDF, BNode, Literal, URIRef
+from rdflib import OWL, RDF, BNode, Graph, Literal, URIRef
 from streamlit.testing.v1 import AppTest
 
 from orionbelt_ontology_builder import app
@@ -436,3 +436,91 @@ def test_the_view_tab_lists_the_namesake_that_was_chosen():
     shown = " ".join(m.value for m in at.markdown)
     assert "the imported one" in shown
     assert "the local one" not in shown
+
+
+# --- resources whose URI is not http ----------------------------------------
+
+URN_ACCOUNT = "urn:example:Account"
+
+
+def test_a_uri_of_any_scheme_is_left_as_it_is():
+    """``_uri`` only passed ``http(s)`` through, so every other scheme was read
+    as a local name and placed in the base namespace."""
+    m = _om()
+    assert str(m._uri(URN_ACCOUNT)) == URN_ACCOUNT
+    assert str(m._uri("did:example:123")) == "did:example:123"
+    assert str(m._uri("file:///tmp/o.ttl")) == "file:///tmp/o.ttl"
+    # A name is still a name: no colon can appear in one, so the two never meet.
+    assert str(m._uri("Account")) == BASE + "Account"
+    assert str(m._uri("Account", namespace=GIST)) == ACCOUNT
+
+
+def _om_with_urn_class():
+    m = _om()
+    m.graph.add((URIRef(URN_ACCOUNT), RDF.type, OWL.Class))
+    return m
+
+
+def test_a_urn_resource_is_annotated_read_and_deleted_as_itself():
+    m = _om_with_urn_class()
+    m.add_annotation(URN_ACCOUNT, "comment", "an account")
+
+    assert [str(s) for s, _p, o in m.graph if str(o) == "an account"] == [URN_ACCOUNT]
+    assert [a["value"] for a in m.get_annotations(URN_ACCOUNT)] == ["an account"]
+    m.delete_annotation(URN_ACCOUNT, "comment", "an account")
+    assert m.get_annotations(URN_ACCOUNT) == []
+
+
+def test_a_urn_resources_annotation_survives_a_round_trip_through_turtle():
+    """Read back through a plain graph, not through the manager: asking the
+    manager was what hid this, since reading minted the same wrong subject as
+    writing. Only the exported triples say where the annotation really went."""
+    m = _om_with_urn_class()
+    m.add_annotation(URN_ACCOUNT, "comment", "an account")
+
+    exported = Graph().parse(data=m.graph.serialize(format="turtle"), format="turtle")
+    assert (URIRef(URN_ACCOUNT), URIRef(COMMENT), Literal("an account")) in exported
+
+
+def test_the_add_form_annotates_a_urn_resource_as_itself():
+    at = _run(_add_script, _om_with_urn_class())
+    option = next(
+        o for o in at.selectbox(key="ann_resource").options if URN_ACCOUNT in o
+    ).strip()
+    _add(at, option, "an account")
+
+    # Against the graph, for the reason the turtle test gives.
+    ont = at.session_state["ontology"]
+    assert (URIRef(URN_ACCOUNT), URIRef(COMMENT), Literal("an account")) in ont.graph
+
+
+def test_a_bulk_row_reaches_a_urn_resource():
+    m = _om_with_urn_class()
+    updates, ambiguous = app.bulk_annotation_updates(
+        _frame(
+            [
+                {
+                    "Resource": URN_ACCOUNT,
+                    "Predicate": "rdfs:comment",
+                    "Value": "an account",
+                    "Action": "add",
+                }
+            ]
+        ),
+        {URN_ACCOUNT: {URN_ACCOUNT}},
+    )
+    assert ambiguous == []
+    assert m.bulk_update_annotations(updates)["applied"] == 1
+    assert (URIRef(URN_ACCOUNT), URIRef(COMMENT), Literal("an account")) in m.graph
+
+
+def test_what_the_old_behaviour_wrote_for_a_urn_resource_can_be_adopted():
+    """The wrong subject was the base namespace plus the whole URN, which is
+    exactly where the repair looks."""
+    m = _om_with_urn_class()
+    m.graph.add(
+        (URIRef(BASE + URN_ACCOUNT), URIRef(COMMENT), Literal("an account")),
+    )
+    assert m.stray_annotation_subject(URN_ACCOUNT) == BASE + URN_ACCOUNT
+    assert m.adopt_stray_annotations(URN_ACCOUNT) == 1
+    assert [a["value"] for a in m.get_annotations(URN_ACCOUNT)] == ["an account"]

--- a/tests/test_annotation_subject_uris.py
+++ b/tests/test_annotation_subject_uris.py
@@ -1,0 +1,371 @@
+"""An annotation belongs to the resource's own URI, not to its local name.
+
+The Annotations page addressed the resource it was annotating by local name,
+and a local name resolves into *this* ontology's namespace — so annotating an
+imported class (``gist:Account``) wrote to ``:Account``, a subject nothing
+declares. It looked right, because the page read the annotations back the same
+way, but the row editor's Save and Delete aimed at the real URI and quietly did
+nothing.
+
+The Add form is driven directly rather than through the page, for the reason the
+other annotation UI tests give: the page's tab picker is a ``segmented_control``,
+which AppTest mis-serializes.
+"""
+
+import pandas as pd
+import pytest
+from rdflib import OWL, RDF, BNode, Literal, URIRef
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import app
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+GIST = "https://w3id.org/semanticarts/ns/ontology/gist/"
+ACCOUNT = GIST + "Account"
+BASE = "http://test.org/ont#"
+COMMENT = "http://www.w3.org/2000/01/rdf-schema#comment"
+
+
+def _om():
+    """An ontology with one class of its own and one from another namespace."""
+    m = OntologyManager(base_uri=BASE)
+    m.add_class("Invoice")
+    m.graph.add((URIRef(ACCOUNT), RDF.type, OWL.Class))
+    return m
+
+
+def _resources(om):
+    """``all_resources`` as the page builds it, which carries each URI."""
+    return [
+        {
+            "name": c["name"],
+            "uri": c["uri"],
+            "label": c.get("label"),
+            "type": "Class",
+            "display": c["name"],
+        }
+        for c in om.get_classes()
+    ]
+
+
+# --- the write path ---------------------------------------------------------
+
+
+def _add_script():
+    # AppTest runs this function's own source as the script, so it takes the
+    # ontology from session state rather than from anything at module level
+    # here, which is not in scope inside it.
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    app.render_add_annotation(
+        ont,
+        [
+            {
+                "name": c["name"],
+                "uri": c["uri"],
+                "label": c.get("label"),
+                "type": "Class",
+                "display": c["name"],
+            }
+            for c in ont.get_classes()
+        ],
+    )
+
+
+def _run(script, om):
+    at = AppTest.from_function(script)
+    at.session_state["ontology"] = om
+    at.session_state["_autosave_restored"] = True
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    return at
+
+
+def _add(at, resource, value):
+    at.selectbox(key="ann_resource").set_value(resource)
+    at.selectbox(key="ann_predicate").set_value("rdfs:comment")
+    at.text_area(key="ann_value").set_value(value)
+    at.button[0].click().run(timeout=120)
+    assert not at.exception, at.exception
+
+
+def test_the_add_form_annotates_the_resource_it_was_shown():
+    at = _run(_add_script, _om())
+    _add(at, "Account [Class]", "an account")
+
+    ont = at.session_state["ontology"]
+    assert (URIRef(ACCOUNT), URIRef(COMMENT), Literal("an account")) in ont.graph
+    # And nothing on the namesake in this ontology's own namespace.
+    assert ont.get_annotations(BASE + "Account") == []
+
+
+def test_what_the_add_form_writes_can_be_deleted_again():
+    """The round trip the bug broke: the editor and the row delete address the
+    resource by URI, so they must find what the form wrote."""
+    at = _run(_add_script, _om())
+    _add(at, "Account [Class]", "an account")
+
+    ont = at.session_state["ontology"]
+    # Listed under the resource itself, so what the editor reads is what the
+    # form wrote — the delete below would otherwise pass by removing nothing.
+    assert [a["value"] for a in ont.get_annotations(ACCOUNT)] == ["an account"]
+    ont.delete_annotation(ACCOUNT, COMMENT, "an account")
+    assert ont.get_annotations(ACCOUNT) == []
+
+
+def test_a_resource_of_this_ontologys_own_is_unaffected():
+    at = _run(_add_script, _om())
+    _add(at, "Invoice [Class]", "a bill")
+
+    ont = at.session_state["ontology"]
+    assert [a["value"] for a in ont.get_annotations(BASE + "Invoice")] == ["a bill"]
+
+
+# --- what the old behaviour left behind -------------------------------------
+
+
+def _om_with_stray():
+    """What an older version produced: the annotation on the local-name URI."""
+    m = _om()
+    m.graph.add((URIRef(BASE + "Account"), URIRef(COMMENT), Literal("an account")))
+    return m
+
+
+def test_a_stray_annotation_is_found_under_the_resource_it_was_meant_for():
+    m = _om_with_stray()
+    assert m.stray_annotation_subject(ACCOUNT) == BASE + "Account"
+    # Nothing to adopt for a resource that has no misplaced namesake.
+    assert m.stray_annotation_subject(BASE + "Invoice") is None
+
+
+def test_a_resource_of_this_ontologys_own_never_looks_stray():
+    m = _om_with_stray()
+    m.add_annotation(BASE + "Invoice", "comment", "a bill")
+    assert m.stray_annotation_subject(BASE + "Invoice") is None
+
+
+def test_a_declared_namesake_is_left_alone():
+    """A base-namespace class of the same name is a resource in its own right,
+    and its annotations are its own."""
+    m = _om_with_stray()
+    m.add_class("Account")
+    assert m.stray_annotation_subject(ACCOUNT) is None
+    assert m.adopt_stray_annotations(ACCOUNT) == 0
+    assert [a["value"] for a in m.get_annotations(BASE + "Account")] == ["an account"]
+
+
+def test_adopting_moves_the_annotations_and_leaves_nothing_behind():
+    m = _om_with_stray()
+    assert m.adopt_stray_annotations(ACCOUNT) == 1
+    assert [a["value"] for a in m.get_annotations(ACCOUNT)] == ["an account"]
+    assert m.get_annotations(BASE + "Account") == []
+    # Moved, not copied, so a second run finds nothing to do.
+    assert m.adopt_stray_annotations(ACCOUNT) == 0
+
+
+def test_adopting_carries_the_language_tag_and_the_datatype():
+    m = _om()
+    m.add_annotation(BASE + "Account", "label", "Konto", lang="deu")
+    m.add_annotation(BASE + "Account", "date", "2026-01-01", datatype="date")
+    assert m.adopt_stray_annotations(ACCOUNT) == 2
+
+    moved = {a["value"]: a for a in m.get_annotations(ACCOUNT)}
+    assert moved["Konto"]["language"] == "deu"
+    assert moved["2026-01-01"]["datatype"] == "date"
+
+
+def test_adopting_leaves_structure_and_blank_nodes_where_they_are():
+    m = _om_with_stray()
+    stray = URIRef(BASE + "Account")
+    m.graph.add((stray, RDF.type, OWL.Class))  # now declared: not stray at all
+    assert m.adopt_stray_annotations(ACCOUNT) == 0
+
+    m.graph.remove((stray, RDF.type, OWL.Class))
+    node = BNode()
+    m.graph.add((stray, URIRef(BASE + "sub"), node))
+    assert m.adopt_stray_annotations(ACCOUNT) == 1
+    assert (stray, URIRef(BASE + "sub"), node) in m.graph
+
+
+def _view_script():
+    # Self-contained, for the reason given on _add_script.
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+
+    ont = st.session_state.ontology
+    app.render_view_annotations(
+        ont,
+        [
+            {
+                "name": c["name"],
+                "uri": c["uri"],
+                "label": c.get("label"),
+                "type": "Class",
+                "display": c["name"],
+            }
+            for c in ont.get_classes()
+        ],
+        ont.get_classes(),
+        ont.get_object_properties(),
+        ont.get_data_properties(),
+        ont.get_individuals(),
+    )
+
+
+def test_the_view_tab_offers_to_move_a_stray_onto_the_resource():
+    """Reading by URI means those annotations are no longer listed, so the tab
+    has to say where they went or they are invisible as well as unreachable."""
+    at = _run(_view_script, _om_with_stray())
+    assert at.selectbox(key="view_annotations_select").value == "Account"
+    assert BASE + "Account" in at.warning[0].value
+
+    at.button(key=f"adopt_ann_{app._uid(ACCOUNT)}").click().run(timeout=120)
+    assert not at.exception, at.exception
+
+    ont = at.session_state["ontology"]
+    assert [a["value"] for a in ont.get_annotations(ACCOUNT)] == ["an account"]
+    assert not at.warning
+
+
+def test_the_row_delete_reaches_an_annotation_on_an_imported_resource():
+    """The other half of the bug: the row deleted by local name, so a listed
+    annotation on an imported resource could not be removed from here."""
+    om = _om()
+    om.add_annotation(ACCOUNT, "comment", "an account")
+    at = _run(_view_script, om)
+    assert not at.warning  # nothing misplaced to report
+
+    at.button(key=f"del_ann_{app._uid(ACCOUNT)}_0").click().run(timeout=120)
+    assert not at.exception, at.exception
+    assert at.session_state["ontology"].get_annotations(ACCOUNT) == []
+
+
+# --- the bulk editor --------------------------------------------------------
+
+
+def _frame(rows):
+    return pd.DataFrame(rows, columns=["Resource", "Predicate", "Value", "Action"])
+
+
+def test_a_bulk_row_is_applied_to_the_uri_it_was_listed_from():
+    updates, ambiguous = app.bulk_annotation_updates(
+        _frame(
+            [
+                {
+                    "Resource": "Account",
+                    "Predicate": "comment",
+                    "Value": "v",
+                    "Action": "add",
+                }
+            ]
+        ),
+        {"Account": {ACCOUNT}},
+    )
+    assert ambiguous == []
+    assert updates[0]["resource"] == ACCOUNT
+
+
+def test_a_bulk_row_for_a_name_two_resources_answer_to_is_refused():
+    updates, ambiguous = app.bulk_annotation_updates(
+        _frame(
+            [
+                {
+                    "Resource": "Account",
+                    "Predicate": "comment",
+                    "Value": "v",
+                    "Action": "add",
+                }
+            ]
+        ),
+        {"Account": {ACCOUNT, BASE + "Account"}},
+    )
+    assert updates == []
+    assert ambiguous == ["Account"]
+
+
+def test_a_hand_written_bulk_row_is_passed_through_as_typed():
+    updates, _ = app.bulk_annotation_updates(
+        _frame(
+            [
+                {
+                    "Resource": "Newcomer",
+                    "Predicate": "comment",
+                    "Value": "v",
+                    "Action": "add",
+                }
+            ]
+        ),
+        {"Account": {ACCOUNT}},
+    )
+    assert updates[0]["resource"] == "Newcomer"
+
+
+def test_rows_left_on_keep_are_not_applied():
+    updates, ambiguous = app.bulk_annotation_updates(
+        _frame(
+            [
+                {
+                    "Resource": "Account",
+                    "Predicate": "comment",
+                    "Value": "v",
+                    "Action": "keep",
+                }
+            ]
+        ),
+        {"Account": {ACCOUNT}},
+    )
+    assert (updates, ambiguous) == ([], [])
+
+
+def test_a_cell_the_user_never_touched_does_not_abort_the_batch():
+    """The engine strips the language tag before its per-row guard, so a NaN
+    from an untouched cell used to take the whole batch down with it."""
+    frame = pd.DataFrame(
+        [
+            {
+                "Resource": "Account",
+                "Predicate": "comment",
+                "Value": "v",
+                "Language": None,
+                "Action": "add",
+            }
+        ]
+    )
+    updates, _ = app.bulk_annotation_updates(frame, {"Account": {ACCOUNT}})
+    assert updates[0]["lang"] == ""
+
+    result = _om().bulk_update_annotations(updates)
+    assert result["applied"] == 1
+
+
+@pytest.mark.parametrize(
+    ("action", "value", "expected"),
+    [
+        ("delete", "an account", []),
+        ("add", "and another", ["an account", "and another"]),
+    ],
+)
+def test_a_bulk_round_trip_reaches_an_imported_resource(action, value, expected):
+    m = _om()
+    m.add_annotation(ACCOUNT, "comment", "an account")
+    updates, _ = app.bulk_annotation_updates(
+        _frame(
+            [
+                {
+                    "Resource": "Account",
+                    "Predicate": "rdfs:comment",
+                    "Value": value,
+                    "Action": action,
+                }
+            ]
+        ),
+        {"Account": {ACCOUNT}},
+    )
+    result = m.bulk_update_annotations(updates)
+    assert result["applied"] == 1
+    assert not result["errors"]
+    assert sorted(a["value"] for a in m.get_annotations(ACCOUNT)) == expected

--- a/tests/test_clearable_required_dropdowns.py
+++ b/tests/test_clearable_required_dropdowns.py
@@ -113,7 +113,7 @@ ALLOWED_BY_NAME = {
     ("render_restriction_form", "Restriction Type"),
     ("_render_panel_add_restriction_form", "Restriction Type"),
     ("render_relation_form", "Relation"),
-    ("render_annotations", "Filter by Type"),
+    ("render_view_annotations", "Filter by Type"),
     ("render_language_pack_sidebar", "Language pack"),
     ("render_language_packs", "Pack"),
 }


### PR DESCRIPTION
Fixes the bug found while testing #291: adding an annotation addressed the resource by **local name**, and a local name resolves into this ontology's own namespace. Annotating an imported class (`gist:Account`) therefore wrote to `:Account`, a subject nothing declares. It looked right, because the page read the annotations back the same way, but the row editor's Save and Delete address the resource by URI and quietly did nothing to what was listed in front of them.

Reproduced against `OntologyManager` alone:

```python
m.add_annotation("Account", "http://purl.org/dc/terms/contributor", "Konto", lang="deu")
# landed on http://example.org/ontology#Account, not on gist:Account
m.delete_annotation(class_uri, "http://purl.org/dc/terms/contributor", "Konto", lang="deu")
# removes nothing, reports nothing
```

## What changed

The Add form, the View list, its row delete and the Bulk Edit rows now address the resource by URI, as the graph panel's annotate form and the row editor already did. This is the same rule the entity pickers were given in #87: selecting by local name resolves into the base namespace and rewrites an imported entity.

Bulk rows stay labelled with the local name, which is what a spreadsheet can be read and typed in, and are mapped back to the URI they were listed from. A name that more than one resource answers to is refused with a reason rather than guessed at, and a name nothing answers to is passed through as typed, so a hand-written row behaves as it did.

## What the old behaviour left behind

Reading by URI would leave annotations the old code wrote invisible as well as unreachable: they sit on a subject the page does not list. So where a resource has an undeclared namesake holding annotations, the View tab names it and offers to move them across, under an undo checkpoint.

Only an undeclared namesake counts. A base-namespace resource of the same local name that this ontology actually defines is a resource in its own right and its annotations are its own, so it is left alone. Nothing structural and no blank node moves with them.

## Two things that came along

* The View tab is now its own function, as the other three tabs already are, so its rows can be driven in tests. The page's tab picker is a `segmented_control`, which AppTest mis-serializes, so a row's buttons cannot be clicked from a page run.
* Bulk Edit rows are read through the same `fillna` the pack editor uses. A cell the user never touched arrives as NaN, and the engine strips the language tag before its per-row guard, so one such cell used to abort the whole batch with an AttributeError.

## Verified

`pytest` (1189 passing, 18 new), `ruff format`/`check` at the pinned 0.16.2 and `mypy` all clean. I checked each new test against the unfixed code: the add-form, row-delete and bulk tests fail there and pass here.

Driven live against the bundled gist ontology as well: an annotation added to `gist:Account` now lands on the gist URI, the stray one an earlier session had left on `http://example.org/ontology#Account` was reported and moved across, and the row editor's Delete then removed it, which is exactly what did nothing before.

## Noticed, not changed

Deleting a row whose literal has no language tag also removes same-valued literals that do have one, because `delete_annotation` treats "no tag given" as "any tag". That is deliberate engine behaviour with a test pinning it (`test_delete_annotation_without_lang_removes_all_matching_values`), but from a row editor it reads as deleting more than the row you clicked. Worth its own decision rather than a drive-by change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
