### PR TITLE
chore: bump to v1.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.21.2` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.22.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -31,7 +31,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.21.2"
+APP_VERSION = "1.22.0"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.21.2"
+version = "1.22.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -1114,7 +1114,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.21.2"
+version = "1.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Minor release. Four features landed since v1.21.2, so the middle number moves rather than the patch one.

## Features
- Alt-click a node to focus on it alone (#276, PR #285)
- Rename a custom annotation type (#287, PR #289)
- Selectable language codes for annotations (#252, PR #291)
- The pack picked in Language Packs is the pack in use (#293, PR #294)

## Fixes
- Keep the focus on an entity you rename (#275, PR #284)
- Focus mode keeps the annotations of what it shows (#272, PR #290)
- Annotate the resource, not its local name (PR #292)

Plus two Dependabot bumps (ruff, astral-sh/uv) and a docs note on the Streamlit rebuild webhook.

## Version strings
Bumped in `pyproject.toml`, `uv.lock`, `README.md` (Docker pin example) and `APP_VERSION` in `orionbelt_ontology_builder/ui.py`. The remaining `1.21.2` in `AGENTS.md` is prose about that past release and stays as is.

## Checks
- `pytest`: 1205 passed
- `ruff==0.16.3` format and check: clean
- `mypy`: no issues in 118 source files

After merge, remember the hosted app needs a manual Manage app -> Reboot at share.streamlit.io, and the sidebar version should read 1.22.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)