### PR TITLE
feat(skos): language-aware, multi-valued concept editing (WS-3)

### DIFF
--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2788,6 +2788,63 @@ class OntologyManager:
         SKOS.relatedMatch,
     }
 
+    #: The three SKOS lexical labels. A concept may carry many of each, and at
+    #: most one ``prefLabel`` per language tag (SKOS Reference S14).
+    SKOS_LABEL_KINDS: ClassVar[dict[str, URIRef]] = {
+        "prefLabel": SKOS.prefLabel,
+        "altLabel": SKOS.altLabel,
+        "hiddenLabel": SKOS.hiddenLabel,
+    }
+
+    #: SKOS documentation properties. All are repeatable and language-tagged.
+    SKOS_NOTE_KINDS: ClassVar[dict[str, URIRef]] = {
+        "definition": SKOS.definition,
+        "scopeNote": SKOS.scopeNote,
+        "example": SKOS.example,
+        "note": SKOS.note,
+        "editorialNote": SKOS.editorialNote,
+        "historyNote": SKOS.historyNote,
+        "changeNote": SKOS.changeNote,
+    }
+
+    #: The subset of :attr:`SKOS_RELATIONS` that links across vocabularies, and
+    #: so may point at a URI this graph does not otherwise know about.
+    SKOS_MAPPING_RELATIONS: ClassVar[tuple[str, ...]] = (
+        "broadMatch",
+        "narrowMatch",
+        "exactMatch",
+        "closeMatch",
+        "relatedMatch",
+    )
+
+    def _tagged_literals(self, uri: Node, prop: URIRef) -> list[dict[str, str]]:
+        """Return ``prop``'s literal objects as ``{"value", "lang"}`` records.
+
+        Sorted untagged-first, then by language tag, so the order a caller sees
+        does not depend on the store's iteration order. ``lang`` is ``""`` for
+        an untagged literal, never ``None``, so the UI can render it without a
+        null check.
+        """
+        values = [
+            {"value": str(o), "lang": o.language or ""}
+            for o in self.graph.objects(uri, prop)
+            if isinstance(o, Literal)
+        ]
+        return sorted(values, key=lambda v: (v["lang"] != "", v["lang"], v["value"]))
+
+    @staticmethod
+    def _flatten_literal(values: list[dict[str, str]]) -> str:
+        """Pick one value out of :meth:`_tagged_literals` output.
+
+        The flat ``prefLabel`` / ``definition`` keys predate language-aware
+        editing and are still read by the visualization, the dashboard and the
+        hierarchy tree. They stay, as a computed view over the structured list,
+        so those callers keep working. Untagged wins, then the first tag
+        alphabetically; both are deterministic, which is what those callers
+        actually need.
+        """
+        return values[0]["value"] if values else ""
+
     def add_concept_scheme(
         self, name: str, label: str | None = None, comment: str | None = None
     ) -> URIRef:
@@ -2963,10 +3020,32 @@ class OntologyManager:
 
             name = self._local_name(uri)
 
-            pref_label = str(self.graph.value(uri, SKOS.prefLabel) or "")
-            definition = str(self.graph.value(uri, SKOS.definition) or "")
+            labels = {
+                kind: self._tagged_literals(uri, prop)
+                for kind, prop in self.SKOS_LABEL_KINDS.items()
+            }
+            notes = {
+                kind: self._tagged_literals(uri, prop)
+                for kind, prop in self.SKOS_NOTE_KINDS.items()
+            }
+            pref_label = self._flatten_literal(labels["prefLabel"])
+            definition = self._flatten_literal(notes["definition"])
+            alt_labels = [v["value"] for v in labels["altLabel"]]
 
-            alt_labels = [str(o) for o in self.graph.objects(uri, SKOS.altLabel)]
+            notation = str(self.graph.value(uri, SKOS.notation) or "")
+            top_of_uris = [
+                str(o)
+                for o in self.graph.objects(uri, SKOS.topConceptOf)
+                if isinstance(o, URIRef)
+            ]
+            mappings = {
+                rel: sorted(
+                    str(o)
+                    for o in self.graph.objects(uri, self.SKOS_RELATIONS[rel])
+                    if isinstance(o, URIRef)
+                )
+                for rel in self.SKOS_MAPPING_RELATIONS
+            }
 
             broader_uris = [
                 str(o)
@@ -3007,6 +3086,14 @@ class OntologyManager:
                     "narrower_uris": narrower_uris,
                     "related_uris": related_uris,
                     "scheme_uris": scheme_uris,
+                    # Structured, language-aware views. The flat keys above are
+                    # computed from these and kept for existing readers.
+                    "labels": labels,
+                    "notes": notes,
+                    "notation": notation,
+                    "top_of_uris": top_of_uris,
+                    "top_of": [self._local_name(URIRef(u)) for u in top_of_uris],
+                    "mappings": mappings,
                 }
             )
 
@@ -3039,6 +3126,10 @@ class OntologyManager:
                 self.graph.add((uri, SKOS.definition, Literal(new_definition)))
 
         if new_broader is not _UNSET:
+            # Check before removing the old parent: a refusal must leave the
+            # concept's hierarchy exactly as it was, not orphaned.
+            if new_broader:
+                self._refuse_broader_cycle(uri, self._uri(new_broader))
             # Remove old broader/narrower links
             for old_broader in list(self.graph.objects(uri, SKOS.broader)):
                 self.graph.remove((uri, SKOS.broader, old_broader))
@@ -3054,6 +3145,235 @@ class OntologyManager:
 
         if remove_scheme:
             self.graph.remove((uri, SKOS.inScheme, self._uri(remove_scheme)))
+
+    def _label_property(self, kind: str) -> URIRef:
+        """Resolve a label kind, or say which kinds exist."""
+        prop = self.SKOS_LABEL_KINDS.get(kind)
+        if prop is None:
+            known = ", ".join(self.SKOS_LABEL_KINDS)
+            raise ValueError(
+                f"Unknown SKOS label kind: {kind} (expected one of {known})"
+            )
+        return prop
+
+    def _note_property(self, kind: str) -> URIRef:
+        """Resolve a documentation-property kind, or say which kinds exist."""
+        prop = self.SKOS_NOTE_KINDS.get(kind)
+        if prop is None:
+            known = ", ".join(self.SKOS_NOTE_KINDS)
+            raise ValueError(
+                f"Unknown SKOS note kind: {kind} (expected one of {known})"
+            )
+        return prop
+
+    @staticmethod
+    def _literal_text(value: str, what: str) -> str:
+        """Reject a blank literal before it reaches the graph."""
+        text = (value or "").strip()
+        if not text:
+            raise ValueError(f"A {what} cannot be empty.")
+        return text
+
+    def _checked_lang(self, lang: str | None) -> str | None:
+        """Return a usable language tag, or ``None``; raise on a malformed one."""
+        tag = (lang or "").strip()
+        if not tag:
+            return None
+        if reason := invalid_tag_reason(tag):
+            raise ValueError(reason)
+        return tag
+
+    def _broader_ancestors(self, uri: Node) -> set[Node]:
+        """Every concept reachable from ``uri`` by following ``skos:broader``.
+
+        Carries a visited set rather than recursing, because an imported
+        vocabulary can already contain a cycle and this must terminate on one
+        rather than be the thing that discovers it.
+        """
+        seen: set[Node] = set()
+        stack = [uri]
+        while stack:
+            for parent in self.graph.objects(stack.pop(), SKOS.broader):
+                if isinstance(parent, URIRef) and parent not in seen:
+                    seen.add(parent)
+                    stack.append(parent)
+        return seen
+
+    def _refuse_broader_cycle(self, child: Node, parent: Node) -> None:
+        """Reject a ``child skos:broader parent`` edge that would close a cycle.
+
+        Refusing at write time is worth more than reporting later: the user is
+        looking at the form and can pick a different parent. The validation-side
+        detector still earns its place, for cycles that arrive through import.
+        """
+        if child == parent:
+            raise ValueError(
+                f"'{self._local_name(child)}' cannot be its own broader concept."
+            )
+        if child in self._broader_ancestors(parent):
+            raise ValueError(
+                f"'{self._local_name(parent)}' is already a narrower concept of "
+                f"'{self._local_name(child)}'; this would create a hierarchy cycle."
+            )
+
+    def set_concept_label(
+        self, concept: str, kind: str, value: str, lang: str | None = None
+    ) -> None:
+        """Add a ``prefLabel``/``altLabel``/``hiddenLabel`` to a concept.
+
+        A ``prefLabel`` **replaces** any existing prefLabel carrying the same
+        language tag, because SKOS allows at most one per tag (SKOS Reference
+        S14). ``altLabel`` and ``hiddenLabel`` are repeatable and are appended.
+        Adding the same value and tag twice is a no-op either way, since the
+        graph is a set.
+        """
+        prop = self._label_property(kind)
+        text = self._literal_text(value, kind)
+        tag = self._checked_lang(lang)
+        uri = self._uri(concept)
+
+        if kind == "prefLabel":
+            for existing in list(self.graph.objects(uri, prop)):
+                if isinstance(existing, Literal) and (existing.language or "") == (
+                    tag or ""
+                ):
+                    self.graph.remove((uri, prop, existing))
+
+        self.graph.add((uri, prop, Literal(text, lang=tag) if tag else Literal(text)))
+
+    def remove_concept_label(
+        self, concept: str, kind: str, value: str, lang: str | None = None
+    ) -> bool:
+        """Remove one label literal. Returns whether anything was removed."""
+        prop = self._label_property(kind)
+        uri = self._uri(concept)
+        target_lang = (lang or "").strip()
+        removed = False
+        for existing in list(self.graph.objects(uri, prop)):
+            if (
+                isinstance(existing, Literal)
+                and str(existing) == value
+                and (existing.language or "") == target_lang
+            ):
+                self.graph.remove((uri, prop, existing))
+                removed = True
+        return removed
+
+    def set_concept_note(
+        self, concept: str, kind: str, value: str, lang: str | None = None
+    ) -> None:
+        """Add a documentation property (definition, scopeNote, example, …).
+
+        All SKOS documentation properties are repeatable, so this appends. Use
+        :meth:`remove_concept_note` to drop one.
+        """
+        prop = self._note_property(kind)
+        text = self._literal_text(value, kind)
+        tag = self._checked_lang(lang)
+        uri = self._uri(concept)
+        self.graph.add((uri, prop, Literal(text, lang=tag) if tag else Literal(text)))
+
+    def remove_concept_note(
+        self, concept: str, kind: str, value: str, lang: str | None = None
+    ) -> bool:
+        """Remove one documentation literal. Returns whether anything was removed."""
+        prop = self._note_property(kind)
+        uri = self._uri(concept)
+        target_lang = (lang or "").strip()
+        removed = False
+        for existing in list(self.graph.objects(uri, prop)):
+            if (
+                isinstance(existing, Literal)
+                and str(existing) == value
+                and (existing.language or "") == target_lang
+            ):
+                self.graph.remove((uri, prop, existing))
+                removed = True
+        return removed
+
+    def set_concept_notation(
+        self, concept: str, value: str, datatype: str | None = None
+    ) -> None:
+        """Set (or clear, with an empty value) a concept's ``skos:notation``.
+
+        A notation carries a datatype, never a language tag: it is a code in a
+        symbol scheme, not text in a language (SKOS Reference 6.5.1). Passing a
+        language tag here is not possible by construction, which is the point.
+        """
+        uri = self._uri(concept)
+        self.graph.remove((uri, SKOS.notation, None))
+        text = (value or "").strip()
+        if not text:
+            return
+        if datatype:
+            self.graph.add(
+                (uri, SKOS.notation, Literal(text, datatype=URIRef(datatype)))
+            )
+        else:
+            self.graph.add((uri, SKOS.notation, Literal(text)))
+
+    def set_top_concept(self, concept: str, scheme: str, is_top: bool = True) -> None:
+        """Assert or retract that a concept is a top concept of a scheme.
+
+        Writes both directions: ``skos:topConceptOf`` on the concept and
+        ``skos:hasTopConcept`` on the scheme. They are declared inverses, and
+        leaving one behind is the half-edge problem the relation helpers exist
+        to avoid.
+        """
+        concept_uri = self._uri(concept)
+        scheme_uri = self._uri(scheme)
+        if is_top:
+            self.graph.add((concept_uri, SKOS.topConceptOf, scheme_uri))
+            self.graph.add((scheme_uri, SKOS.hasTopConcept, concept_uri))
+            # A top concept is in its scheme by definition (SKOS Reference S6).
+            self.graph.add((concept_uri, SKOS.inScheme, scheme_uri))
+        else:
+            self.graph.remove((concept_uri, SKOS.topConceptOf, scheme_uri))
+            self.graph.remove((scheme_uri, SKOS.hasTopConcept, concept_uri))
+
+    def add_concept_mapping(self, concept: str, relation: str, target: str) -> None:
+        """Link a concept to a resource in another vocabulary.
+
+        Unlike :meth:`add_concept_relation`, ``target`` is an absolute IRI that
+        need not exist in this graph — the whole point of a mapping property is
+        to reach Wikidata, EuroVoc, AGROVOC or anything else. Only the five
+        mapping properties are accepted; the semantic relations stay internal.
+        """
+        if relation not in self.SKOS_MAPPING_RELATIONS:
+            known = ", ".join(self.SKOS_MAPPING_RELATIONS)
+            raise ValueError(
+                f"Not a SKOS mapping property: {relation} (expected one of {known})"
+            )
+        target = (target or "").strip()
+        if not self._IRI_SCHEME_RE.match(target):
+            shown = target or "(empty)"
+            raise ValueError(f"A mapping target must be an absolute IRI, got: {shown}")
+        self.add_concept_relation(concept, relation, target)
+
+    def remove_concept_relation(
+        self, concept1: str, relation: str, concept2: str
+    ) -> bool:
+        """Remove a SKOS relation, and the inverse or symmetric triple with it.
+
+        The mirror of :meth:`add_concept_relation`. Removing only the asserted
+        direction would leave the auto-added inverse behind as a half-edge,
+        which reads as a relation the UI cannot see or delete.
+        """
+        rel_uri = self.SKOS_RELATIONS.get(relation)
+        if not rel_uri:
+            raise ValueError(f"Unknown SKOS relation: {relation}")
+
+        c1_uri = self._uri(concept1)
+        c2_uri = self._uri(concept2)
+        removed = (c1_uri, rel_uri, c2_uri) in self.graph
+        self.graph.remove((c1_uri, rel_uri, c2_uri))
+
+        inverse = self.SKOS_INVERSES.get(rel_uri)
+        if inverse:
+            self.graph.remove((c2_uri, inverse, c1_uri))
+        if rel_uri in self.SKOS_SYMMETRIC:
+            self.graph.remove((c2_uri, rel_uri, c1_uri))
+        return removed
 
     def rename_concept(self, old_name: str, new_name: str) -> bool:
         """Rename a SKOS concept, updating all references.
@@ -3096,6 +3416,13 @@ class OntologyManager:
         rel_uri = self.SKOS_RELATIONS.get(relation)
         if not rel_uri:
             raise ValueError(f"Unknown SKOS relation: {relation}")
+
+        if relation == "broader":
+            self._refuse_broader_cycle(c1_uri, c2_uri)
+        elif relation == "narrower":
+            self._refuse_broader_cycle(c2_uri, c1_uri)
+        elif c1_uri == c2_uri:
+            raise ValueError(f"A concept cannot be its own '{relation}'.")
 
         self.graph.add((c1_uri, rel_uri, c2_uri))
 

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -3570,7 +3570,11 @@ class OntologyManager:
         # prefLabel in several languages, and flattening picks one, so a clash
         # in any other language went unreported.
         for scheme in schemes:
-            scheme_concepts = self.get_concepts(scheme=scheme["name"])
+            # By URI, not by local name: two schemes can share a local name
+            # across namespaces (issue #87 part B), and resolving by name picks
+            # whichever the store yields first, so one scheme's concepts get
+            # checked twice and the other's not at all.
+            scheme_concepts = self.get_concepts(scheme=scheme["uri"])
             labels_seen: dict[tuple[str, str], str] = {}
             for concept in scheme_concepts:
                 for item in concept["labels"]["prefLabel"]:
@@ -3601,9 +3605,24 @@ class OntologyManager:
         # vocabulary would otherwise blow the recursion limit, and each cycle is
         # canonicalised by its member set so it is reported once rather than
         # once per member.
-        concept_names = {c["name"] for c in concepts}
+        # Keyed by URI, for the same reason as the scheme lookup above: two
+        # concepts can share a local name across namespaces, and a name-keyed
+        # map silently collapses them into one node. That both hides real
+        # cycles and invents false ones, depending on which of the two the
+        # store happens to yield last.
+        known = {c["uri"] for c in concepts}
         parents = {
-            c["name"]: [p for p in c["broader"] if p in concept_names] for c in concepts
+            c["uri"]: [u for u in c["broader_uris"] if u in known] for c in concepts
+        }
+        # Local name where it identifies the concept, full URI where it does
+        # not: a cycle between two concepts that share a name renders as
+        # "A -> A -> A", which says nothing about which A.
+        name_counts: dict[str, int] = {}
+        for c in concepts:
+            name_counts[c["name"]] = name_counts.get(c["name"], 0) + 1
+        shown = {
+            c["uri"]: (c["name"] if name_counts[c["name"]] == 1 else c["uri"])
+            for c in concepts
         }
         WHITE, GREY, BLACK = 0, 1, 2
         colour = dict.fromkeys(parents, WHITE)
@@ -3629,10 +3648,10 @@ class OntologyManager:
                                 {
                                     "severity": "error",
                                     "type": "broader_cycle",
-                                    "subject": cycle[0],
+                                    "subject": shown[cycle[0]],
                                     "message": (
                                         "Broader/narrower cycle detected: "
-                                        + " -> ".join([*cycle, nxt])
+                                        + " -> ".join(shown[u] for u in [*cycle, nxt])
                                     ),
                                 }
                             )

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -3331,6 +3331,42 @@ class OntologyManager:
             self.graph.remove((concept_uri, SKOS.topConceptOf, scheme_uri))
             self.graph.remove((scheme_uri, SKOS.hasTopConcept, concept_uri))
 
+    def set_concept_broader(self, concept: str, targets: list[str]) -> None:
+        """Replace a concept's ``skos:broader`` edges with ``targets``.
+
+        All or nothing. Removing the old parents first is what lets a concept
+        be re-parented under one of its own former descendants, but it means a
+        refusal partway through would otherwise leave the concept with no
+        parent at all: the edit is rejected *and* the user loses the hierarchy
+        they had. On any refusal this restores the exact prior state and
+        re-raises.
+
+        Restoring cannot itself be refused: the rollback removes what this call
+        added before putting the original edges back, so the graph it writes
+        into is a subset of the one those edges were already valid in.
+        """
+        uri = self._uri(concept)
+        want = [self._uri(t) for t in targets]
+        have = [
+            o for o in self.graph.objects(uri, SKOS.broader) if isinstance(o, URIRef)
+        ]
+        dropped = [o for o in have if o not in want]
+        for gone in dropped:
+            self.remove_concept_relation(uri, "broader", gone)
+
+        added: list[URIRef] = []
+        try:
+            for target in want:
+                if target not in have:
+                    self.add_concept_relation(uri, "broader", target)
+                    added.append(target)
+        except ValueError:
+            for target in added:
+                self.remove_concept_relation(uri, "broader", target)
+            for gone in dropped:
+                self.add_concept_relation(uri, "broader", gone)
+            raise
+
     def add_concept_mapping(self, concept: str, relation: str, target: str) -> None:
         """Link a concept to a resource in another vocabulary.
 
@@ -3348,6 +3384,12 @@ class OntologyManager:
         if not self._IRI_SCHEME_RE.match(target):
             shown = target or "(empty)"
             raise ValueError(f"A mapping target must be an absolute IRI, got: {shown}")
+        # Having a scheme is not enough. rdflib accepts any string as a URIRef
+        # and only objects when asked to serialize, so a target with a space in
+        # it would be stored happily and then break every export of the whole
+        # ontology.
+        if reason := self.invalid_uri_reason(target):
+            raise ValueError(reason)
         self.add_concept_relation(concept, relation, target)
 
     def remove_concept_relation(
@@ -3509,23 +3551,32 @@ class OntologyManager:
                     }
                 )
 
-        # Duplicate prefLabels within schemes
+        # Duplicate prefLabels within schemes. Compared per language tag, not
+        # through the flattened compatibility value: a concept may carry a
+        # prefLabel in several languages, and flattening picks one, so a clash
+        # in any other language went unreported.
         for scheme in schemes:
             scheme_concepts = self.get_concepts(scheme=scheme["name"])
-            labels_seen: dict[str, str] = {}
+            labels_seen: dict[tuple[str, str], str] = {}
             for concept in scheme_concepts:
-                lbl = concept["prefLabel"]
-                if lbl and lbl in labels_seen:
-                    issues.append(
-                        {
-                            "severity": "warning",
-                            "type": "duplicate_prefLabel",
-                            "subject": concept["name"],
-                            "message": f"Duplicate prefLabel '{lbl}' in scheme '{scheme['name']}' (also on '{labels_seen[lbl]}')",
-                        }
+                for item in concept["labels"]["prefLabel"]:
+                    key = (item["lang"], item["value"])
+                    tagged = (
+                        f"'{item['value']}'@{item['lang']}"
+                        if item["lang"]
+                        else f"'{item['value']}'"
                     )
-                elif lbl:
-                    labels_seen[lbl] = concept["name"]
+                    if key in labels_seen:
+                        issues.append(
+                            {
+                                "severity": "warning",
+                                "type": "duplicate_prefLabel",
+                                "subject": concept["name"],
+                                "message": f"Duplicate prefLabel {tagged} in scheme '{scheme['name']}' (also on '{labels_seen[key]}')",
+                            }
+                        )
+                    else:
+                        labels_seen[key] = concept["name"]
 
         # Broader/narrower cycle detection
         concept_names = {c["name"] for c in concepts}

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2964,6 +2964,11 @@ class OntologyManager:
             if ref:
                 self._require_valid_name(ref)
         concept_uri = self._uri(name)
+        # Before anything is written: a broader given at creation time went
+        # straight into the graph, so ``add_concept("A", broader="A")`` minted a
+        # self-cycle the editing paths refuse.
+        if broader:
+            self._refuse_broader_cycle(concept_uri, self._uri(broader))
         self.graph.add((concept_uri, RDF.type, SKOS.Concept))
 
         if scheme:
@@ -3341,30 +3346,39 @@ class OntologyManager:
         they had. On any refusal this restores the exact prior state and
         re-raises.
 
-        Restoring cannot itself be refused: the rollback removes what this call
-        added before putting the original edges back, so the graph it writes
-        into is a subset of the one those edges were already valid in.
+        The rollback puts the original triples back verbatim rather than
+        re-asserting them through :meth:`add_concept_relation`. Those edges
+        were never checked by the guard in the first place when they arrived by
+        import, so an already-cyclic vocabulary would have its restore refused
+        too, losing the edge and reporting the rollback's error instead of the
+        real one.
         """
         uri = self._uri(concept)
         want = [self._uri(t) for t in targets]
+
+        def _edges() -> set:
+            """This concept's broader triples, with their narrower inverses."""
+            return set(self.graph.triples((uri, SKOS.broader, None))) | set(
+                self.graph.triples((None, SKOS.narrower, uri))
+            )
+
+        before = _edges()
         have = [
             o for o in self.graph.objects(uri, SKOS.broader) if isinstance(o, URIRef)
         ]
-        dropped = [o for o in have if o not in want]
-        for gone in dropped:
-            self.remove_concept_relation(uri, "broader", gone)
+        for gone in have:
+            if gone not in want:
+                self.remove_concept_relation(uri, "broader", gone)
 
-        added: list[URIRef] = []
         try:
             for target in want:
                 if target not in have:
                     self.add_concept_relation(uri, "broader", target)
-                    added.append(target)
         except ValueError:
-            for target in added:
-                self.remove_concept_relation(uri, "broader", target)
-            for gone in dropped:
-                self.add_concept_relation(uri, "broader", gone)
+            for triple in _edges():
+                self.graph.remove(triple)
+            for triple in before:
+                self.graph.add(triple)
             raise
 
     def add_concept_mapping(self, concept: str, relation: str, target: str) -> None:
@@ -3578,40 +3592,60 @@ class OntologyManager:
                     else:
                         labels_seen[key] = concept["name"]
 
-        # Broader/narrower cycle detection
+        # Broader/narrower cycle detection, over *every* parent.
+        #
+        # This used to follow ``broader[0]`` only, so a cycle reachable through
+        # a second parent was invisible. That was survivable while the UI could
+        # only set one broader; poly-hierarchy makes it reachable, so this is an
+        # iterative three-colour DFS instead. Iterative because a deep imported
+        # vocabulary would otherwise blow the recursion limit, and each cycle is
+        # canonicalised by its member set so it is reported once rather than
+        # once per member.
         concept_names = {c["name"] for c in concepts}
-        for concept in concepts:
-            visited: set[str] = set()
-            current = concept["name"]
-            chain = [current]
-            has_cycle = False
-            while True:
-                broader_list = []
-                for c in concepts:
-                    if c["name"] == current:
-                        broader_list = c["broader"]
-                        break
-                if not broader_list:
-                    break
-                next_name = broader_list[0]
-                if next_name in visited:
-                    has_cycle = True
-                    break
-                if next_name not in concept_names:
-                    break
-                visited.add(current)
-                current = next_name
-                chain.append(current)
+        parents = {
+            c["name"]: [p for p in c["broader"] if p in concept_names] for c in concepts
+        }
+        WHITE, GREY, BLACK = 0, 1, 2
+        colour = dict.fromkeys(parents, WHITE)
+        seen_cycles: set[frozenset] = set()
 
-            if has_cycle:
-                issues.append(
-                    {
-                        "severity": "error",
-                        "type": "broader_cycle",
-                        "subject": concept["name"],
-                        "message": f"Broader/narrower cycle detected: {' -> '.join(chain)}",
-                    }
-                )
+        for root in sorted(parents):
+            if colour[root] != WHITE:
+                continue
+            colour[root] = GREY
+            path = [root]
+            stack = [(root, iter(parents[root]))]
+            while stack:
+                node, remaining = stack[-1]
+                descended = False
+                for nxt in remaining:
+                    if colour.get(nxt) == GREY:
+                        # A grey node is on the current path, so we just closed
+                        # a loop. Slice the path from it to name the real cycle.
+                        cycle = path[path.index(nxt) :]
+                        if frozenset(cycle) not in seen_cycles:
+                            seen_cycles.add(frozenset(cycle))
+                            issues.append(
+                                {
+                                    "severity": "error",
+                                    "type": "broader_cycle",
+                                    "subject": cycle[0],
+                                    "message": (
+                                        "Broader/narrower cycle detected: "
+                                        + " -> ".join([*cycle, nxt])
+                                    ),
+                                }
+                            )
+                    elif colour.get(nxt, BLACK) == WHITE:
+                        colour[nxt] = GREY
+                        path.append(nxt)
+                        stack.append((nxt, iter(parents[nxt])))
+                        descended = True
+                        break
+                if not descended:
+                    colour[node] = BLACK
+                    stack.pop()
+                    path.pop()
 
         return issues
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -910,8 +910,12 @@ def render_skos_literal_editor(ont, concept, ck):
             "Kind", list(kinds), key=f"add_lit_kind_{ck}", label_visibility="collapsed"
         )
     with col_lang:
+        # Collapsed like the other two: a visible label here pushes the picker
+        # onto its own line and the add row stops reading as a row.
         new_lang = language_selectbox(
-            "Language", key=f"add_lit_lang_{ck}", help="Optional."
+            "Language",
+            key=f"add_lit_lang_{ck}",
+            label_visibility="collapsed",
         )
     with col_text:
         new_text = st.text_input(
@@ -935,7 +939,7 @@ def render_skos_literal_editor(ont, concept, ck):
                 st.rerun()
 
 
-def language_selectbox(label, key, value="", help=None):
+def language_selectbox(label, key, value="", help=None, label_visibility="visible"):
     """A searchable code picker for a Language field, returning the bare tag.
 
     Options come from the active pack and read ``eng · English``, so a code can
@@ -964,6 +968,7 @@ def language_selectbox(label, key, value="", help=None):
         current_display=display,
         accept_new_options=True,
         format_func=_pad_option,
+        label_visibility=label_visibility,
         help=help
         or (
             "Optional. Pick a code from the active language pack, or type any "

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -859,6 +859,82 @@ def render_language_pack_sidebar() -> None:
     persist_language_packs()
 
 
+def render_skos_literal_editor(ont, concept, ck):
+    """One table of a concept's labels and notes, with add and delete.
+
+    Labels and notes are separate halves of the engine API but the same thing
+    to edit: a kind, a language and some text. Rendering them as one table with
+    one add row rather than two stacked sections halves the height of the
+    editor, which is what makes the panel usable without scrolling.
+
+    This renders *outside* the concept form on purpose. A form submits as a
+    unit, so per-row add and delete buttons inside one cannot take effect until
+    the whole form is saved, which reads as a dead button. It also renders for
+    the single open concept only, per the active-entity state model, so the
+    cost does not scale with the size of the vocabulary.
+    """
+    kinds = [*ont.SKOS_LABEL_KINDS, *ont.SKOS_NOTE_KINDS]
+
+    def _api(kind):
+        """(add, remove) for a kind, whichever half of the API owns it."""
+        if kind in ont.SKOS_LABEL_KINDS:
+            return ont.set_concept_label, ont.remove_concept_label
+        return ont.set_concept_note, ont.remove_concept_note
+
+    rows = [
+        (kind, item)
+        for kind in kinds
+        for item in (
+            concept["labels"] if kind in ont.SKOS_LABEL_KINDS else concept["notes"]
+        )[kind]
+    ]
+    for i, (kind, item) in enumerate(rows):
+        col_kind, col_lang, col_text, col_del = st.columns([2, 1, 5, 0.7])
+        with col_kind:
+            st.write(f"`{kind}`")
+        with col_lang:
+            st.write(item["lang"] or "—")
+        with col_text:
+            st.write(item["value"])
+        with col_del:
+            if st.button("🗑️", key=f"del_lit_{ck}_{i}", help=f"Delete this {kind}"):
+                _api(kind)[1](concept["uri"], kind, item["value"], item["lang"])
+                save_checkpoint(f"Delete {kind}")
+                st.rerun()
+    if not rows:
+        st.caption("No labels or notes yet.")
+
+    col_kind, col_lang, col_text, col_add = st.columns([2, 1, 5, 0.7])
+    with col_kind:
+        new_kind = st.selectbox(
+            "Kind", list(kinds), key=f"add_lit_kind_{ck}", label_visibility="collapsed"
+        )
+    with col_lang:
+        new_lang = language_selectbox(
+            "Language", key=f"add_lit_lang_{ck}", help="Optional."
+        )
+    with col_text:
+        new_text = st.text_input(
+            "Text",
+            key=f"add_lit_text_{ck}",
+            placeholder="New label or note…",
+            label_visibility="collapsed",
+        )
+    with col_add:
+        if st.button("➕", key=f"add_lit_btn_{ck}", help="Add this label or note"):
+            try:
+                _api(new_kind)[0](concept["uri"], new_kind, new_text, new_lang or None)
+            except ValueError as exc:
+                show_message(str(exc), "error")
+            else:
+                save_checkpoint(f"Add {new_kind}")
+                # Clear the text but keep the kind and the language: adding
+                # several values in one language is the common case, and a
+                # value left in the box invites adding it twice.
+                st.session_state.pop(f"add_lit_text_{ck}", None)
+                st.rerun()
+
+
 def language_selectbox(label, key, value="", help=None):
     """A searchable code picker for a Language field, returning the bare tag.
 

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -520,11 +520,10 @@ def render_skos_vocabulary():
                             _broader_opts, _broader_lookup = build_uri_options(
                                 [c for c in concepts if c["uri"] != concept["uri"]]
                             )
-                            _have_broader = set(concept["broader_uris"])
                             _cur_broader_disp = [
                                 d
                                 for d, u in _broader_lookup.items()
-                                if u in _have_broader
+                                if u in set(concept["broader_uris"])
                             ]
                             new_broader = st.multiselect(
                                 "Broader Concepts",
@@ -640,27 +639,23 @@ def render_skos_vocabulary():
                                         remove_scheme=remove_s,
                                     )
 
-                                    # Broader diff. Remove before adding, so
-                                    # re-parenting under a former descendant is
-                                    # not refused by the cycle guard for an edge
-                                    # this very save is removing.
-                                    _want = {
-                                        _broader_lookup[d]
-                                        for d in new_broader
-                                        if d in _broader_lookup
-                                    }
-                                    for _gone in _have_broader - _want:
-                                        ont.remove_concept_relation(
-                                            target, "broader", _gone
-                                        )
+                                    # One atomic call, not a remove-then-add
+                                    # loop here: the engine restores the prior
+                                    # parents if any new edge is refused, so a
+                                    # rejected re-parent cannot also cost the
+                                    # user the hierarchy they already had.
                                     _refused = []
-                                    for _added in sorted(_want - _have_broader):
-                                        try:
-                                            ont.add_concept_relation(
-                                                target, "broader", _added
-                                            )
-                                        except ValueError as exc:
-                                            _refused.append(str(exc))
+                                    try:
+                                        ont.set_concept_broader(
+                                            target,
+                                            [
+                                                _broader_lookup[d]
+                                                for d in new_broader
+                                                if d in _broader_lookup
+                                            ],
+                                        )
+                                    except ValueError as exc:
+                                        _refused.append(str(exc))
 
                                     ont.set_concept_notation(target, new_notation)
 

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -20,12 +20,21 @@ from ..ui import (
     language_selectbox,
     language_tag_error,
     missing_required,
+    render_skos_literal_editor,
     required_selectbox,
     save_checkpoint,
     set_flash_message,
     show_message,
     viz_note_rename,
 )
+
+
+def _fmt_tagged(items):
+    """Render ``[{"value","lang"}]`` as ``value (lang), value (lang)``."""
+    return ", ".join(
+        f"{item['value']} ({item['lang']})" if item["lang"] else item["value"]
+        for item in items
+    )
 
 
 def render_skos_vocabulary():
@@ -211,6 +220,56 @@ def render_skos_vocabulary():
 
     if _skos_tab == "Concepts":
         st.subheader("Concepts")
+        # Above the list, not below it: adding a concept meant scrolling
+        # past every concept already there. Collapsed by default, and the
+        # label never changes — a changed expander label force-closes it.
+        with (
+            st.expander("➕ Add Concept", expanded=False),
+            st.form("add_concept_form"),
+        ):
+            c_name = st.text_input("Concept Name *")
+            c_pref = st.text_input("Preferred Label")
+            c_def = st.text_area("Definition")
+            c_scheme = clearable_selectbox(
+                "Scheme",
+                ["None"] + scheme_opts,
+                key="concept_scheme_select",
+                current_display="None",
+                format_func=_pad_option,
+            )
+            _add_broader_opts, _add_broader_lookup = build_uri_options(concepts)
+            c_broader = clearable_selectbox(
+                "Broader Concept",
+                ["None"] + _add_broader_opts,
+                key="concept_broader_select",
+                current_display="None",
+                format_func=_pad_option,
+            )
+            c_lang = language_selectbox("Language Tag", key="concept_lang")
+            if st.form_submit_button("Add Concept"):
+                if not c_name:
+                    show_message("Concept name is required!", "error")
+                elif reason := ont.invalid_name_reason(c_name):
+                    show_message(reason, "error")
+                # Rejected by target URI, not local name (issue #87 part B), and
+                # across every entity kind (issue #279), as for schemes above.
+                elif taken := ont.name_conflict_reason(c_name, "concept"):
+                    show_message(taken, "error")
+                elif lang_error := language_tag_error(c_lang):
+                    show_message(lang_error, "error")
+                else:
+                    ont.add_concept(
+                        c_name,
+                        scheme=scheme_lookup.get(c_scheme),
+                        pref_label=c_pref or None,
+                        definition=c_def or None,
+                        broader=_add_broader_lookup.get(c_broader),
+                        lang=c_lang or None,
+                    )
+                    save_checkpoint("Add concept")
+                    show_message(f"Concept '{c_name}' added!", "success")
+                    st.rerun()
+
         if not concepts:
             st.info("No concepts defined yet.")
         else:
@@ -291,12 +350,40 @@ def render_skos_vocabulary():
                     if _is_open("skos", _ck, "view"):
                         st.divider()
                         st.write(f"**Name:** {concept['name']}")
-                        st.write(f"**prefLabel:** {concept['prefLabel'] or '—'}")
-                        st.write(f"**definition:** {concept['definition'] or '—'}")
-                        if concept["altLabels"]:
+                        for _kind in ont.SKOS_LABEL_KINDS:
+                            if concept["labels"][_kind]:
+                                st.write(
+                                    f"**{_kind}:** "
+                                    f"{_fmt_tagged(concept['labels'][_kind])}"
+                                )
+                        if concept["notation"]:
+                            st.write(f"**notation:** {concept['notation']}")
+                        for _kind in ont.SKOS_NOTE_KINDS:
+                            if concept["notes"][_kind]:
+                                st.write(
+                                    f"**{_kind}:** "
+                                    f"{_fmt_tagged(concept['notes'][_kind])}"
+                                )
+                        if concept["top_of"]:
                             st.write(
-                                f"**altLabels:** {', '.join(concept['altLabels'])}"
+                                f"**topConceptOf:** {', '.join(concept['top_of'])}"
                             )
+                        for _rel in ont.SKOS_MAPPING_RELATIONS:
+                            for _i, _target in enumerate(concept["mappings"][_rel]):
+                                _mc1, _mc2 = st.columns([8, 0.7])
+                                with _mc1:
+                                    st.write(f"**{_rel}:** {_target}")
+                                with _mc2:
+                                    if st.button(
+                                        "🗑️",
+                                        key=f"del_map_{_ck}_{_rel}_{_i}",
+                                        help="Remove this mapping",
+                                    ):
+                                        ont.remove_concept_relation(
+                                            concept["uri"], _rel, _target
+                                        )
+                                        save_checkpoint("Remove concept mapping")
+                                        st.rerun()
                         if concept["broader"]:
                             st.write(f"**broader:** {', '.join(concept['broader'])}")
                         if concept["narrower"]:
@@ -308,25 +395,53 @@ def render_skos_vocabulary():
 
                         # Add relation inline
                         with st.popover("Add Relation"):
+                            # A mapping property is the one kind of SKOS link
+                            # meant to leave the vocabulary, so an external
+                            # target offers only those. Before this, the engine
+                            # accepted an exactMatch to Wikidata but the UI had
+                            # no way to express one.
+                            _target_mode = st.radio(
+                                "Target",
+                                ["Concept in this vocabulary", "External URI"],
+                                key=f"rel_mode_{_ck}",
+                                horizontal=True,
+                            )
+                            _external = _target_mode == "External URI"
                             rel_type = st.selectbox(
                                 "Relation",
-                                list(ont.SKOS_RELATIONS.keys()),
-                                key=f"rel_type_{_ck}",
+                                list(ont.SKOS_MAPPING_RELATIONS)
+                                if _external
+                                else list(ont.SKOS_RELATIONS.keys()),
+                                key=f"rel_type_{_ck}_{'ext' if _external else 'int'}",
                             )
-                            _rel_opts, _rel_lookup = build_uri_options(
-                                [c for c in concepts if c["uri"] != concept["uri"]]
-                            )
-                            rel_target = required_selectbox(
-                                "Target Concept",
-                                _rel_opts,
-                                key=f"rel_target_{_ck}",
-                                current_display=_rel_opts[0] if _rel_opts else None,
-                                format_func=_pad_option,
-                            )
+                            if _external:
+                                rel_target = st.text_input(
+                                    "Target URI",
+                                    key=f"rel_uri_{_ck}",
+                                    placeholder=("http://www.wikidata.org/entity/Q144"),
+                                    help="An absolute IRI in another "
+                                    "vocabulary — Wikidata, EuroVoc, AGROVOC, "
+                                    "anything addressable.",
+                                )
+                                _resolved = rel_target
+                                _required_label = "Target URI"
+                            else:
+                                _rel_opts, _rel_lookup = build_uri_options(
+                                    [c for c in concepts if c["uri"] != concept["uri"]]
+                                )
+                                rel_target = required_selectbox(
+                                    "Target Concept",
+                                    _rel_opts,
+                                    key=f"rel_target_{_ck}",
+                                    current_display=_rel_opts[0] if _rel_opts else None,
+                                    format_func=_pad_option,
+                                )
+                                _resolved = _rel_lookup.get(rel_target)
+                                _required_label = "Target Concept"
                             _add_rel = st.button("Add", key=f"add_rel_{_ck}")
                             if _add_rel and (
                                 _missing := missing_required(
-                                    **{"Target Concept": rel_target}
+                                    **{_required_label: rel_target}
                                 )
                             ):
                                 show_message(_missing, "error")
@@ -336,14 +451,23 @@ def render_skos_vocabulary():
                                 # custom URI) would not resolve through the base
                                 # namespace, and two concepts can share a local
                                 # name across namespaces (issue #87 part B).
-                                ont.add_concept_relation(
-                                    concept["uri"],
-                                    rel_type,
-                                    _rel_lookup.get(rel_target),
-                                )
-                                save_checkpoint("Add concept relation")
-                                show_message(f"Added {rel_type} relation!", "success")
-                                st.rerun()
+                                try:
+                                    if _external:
+                                        ont.add_concept_mapping(
+                                            concept["uri"], rel_type, _resolved
+                                        )
+                                    else:
+                                        ont.add_concept_relation(
+                                            concept["uri"], rel_type, _resolved
+                                        )
+                                except ValueError as exc:
+                                    show_message(str(exc), "error")
+                                else:
+                                    save_checkpoint("Add concept relation")
+                                    show_message(
+                                        f"Added {rel_type} relation!", "success"
+                                    )
+                                    st.rerun()
 
                         st.button(
                             "✏️ Edit",
@@ -363,6 +487,14 @@ def render_skos_vocabulary():
                     # Inline edit form
                     if _is_open("skos", _ck, "edit"):
                         st.divider()
+                        # Labels and notes are repeatable and language-tagged,
+                        # so they are edited as rows with their own add/delete
+                        # rather than as fields in the form below: a button
+                        # inside a form cannot act until the form is submitted.
+                        st.markdown("**Labels and notes**")
+                        render_skos_literal_editor(ont, concept, _ck)
+
+                        st.divider()
                         with st.form(f"edit_concept_form_{_ck}"):
                             new_name = st.text_input(
                                 "Name (URI local part)",
@@ -372,44 +504,37 @@ def render_skos_vocabulary():
                                 "concept (broader/narrower, inScheme, etc.) — "
                                 "nothing is lost, unlike delete-and-recreate.",
                             )
-                            new_pref = st.text_input(
-                                "Preferred Label",
-                                value=concept["prefLabel"] or "",
-                                key=f"pref_{_ck}",
-                            )
-                            new_def = st.text_area(
-                                "Definition",
-                                value=concept["definition"] or "",
-                                key=f"def_{_ck}",
+                            new_notation = st.text_input(
+                                "Notation",
+                                value=concept["notation"],
+                                key=f"notation_{_ck}",
+                                help="A code in a classification scheme "
+                                "(e.g. `636.7`). Carries a datatype, never a "
+                                "language tag.",
                             )
 
-                            # Broader concept — URI-keyed so a broader concept in
-                            # a non-base namespace resolves unambiguously (#87).
+                            # Broader concepts — multi-valued: SKOS allows a
+                            # concept more than one parent (poly-hierarchy), and
+                            # URI-keyed so a parent in a non-base namespace
+                            # resolves unambiguously (#87).
                             _broader_opts, _broader_lookup = build_uri_options(
                                 [c for c in concepts if c["uri"] != concept["uri"]]
                             )
-                            _cur_broader_uri = (
-                                concept["broader_uris"][0]
-                                if concept["broader_uris"]
-                                else None
-                            )
-                            _cur_broader_disp = next(
-                                (
-                                    d
-                                    for d, u in _broader_lookup.items()
-                                    if u == _cur_broader_uri
-                                ),
-                                "None",
-                            )
-                            broader_options = ["None"] + _broader_opts
-                            new_broader = clearable_selectbox(
-                                "Broader Concept",
-                                broader_options,
+                            _have_broader = set(concept["broader_uris"])
+                            _cur_broader_disp = [
+                                d
+                                for d, u in _broader_lookup.items()
+                                if u in _have_broader
+                            ]
+                            new_broader = st.multiselect(
+                                "Broader Concepts",
+                                _broader_opts,
+                                default=_cur_broader_disp,
                                 key=f"broader_{_ck}",
-                                current_display=_cur_broader_disp
-                                if _cur_broader_disp in broader_options
-                                else "None",
                                 format_func=_pad_option,
+                                help="A concept may have several parents. An "
+                                "edge that would make this concept its own "
+                                "ancestor is refused.",
                             )
 
                             # Scheme — URI-keyed for the same reason.
@@ -436,6 +561,20 @@ def render_skos_vocabulary():
                                 else "None",
                                 format_func=_pad_option,
                             )
+
+                            # Top concepts: checked writes skos:topConceptOf and
+                            # the scheme's skos:hasTopConcept together, and puts
+                            # the concept in that scheme if it was not already.
+                            _top_now = set(concept["top_of_uris"])
+                            _top_choices = {}
+                            for _scheme in schemes:
+                                _su = _scheme["uri"]
+                                _top_choices[_su] = st.checkbox(
+                                    f"Top concept of {_scheme['name']}",
+                                    value=_su in _top_now,
+                                    key=f"top_{_ck}_{str(abs(hash(_su)))[:8]}",
+                                )
+
                             new_name = _custom_uri_field(
                                 concept["uri"],
                                 new_name,
@@ -480,10 +619,6 @@ def render_skos_vocabulary():
                                             concept["name"],
                                             ont._local_name(target),
                                         )
-                                    # Handle broader change (resolve by URI)
-                                    broader_val = _broader_lookup.get(new_broader) or ""
-                                    old_broader = _cur_broader_uri or ""
-                                    broader_changed = broader_val != old_broader
 
                                     # Handle scheme change (resolve by URI)
                                     old_scheme = _cur_scheme_uri or ""
@@ -499,71 +634,55 @@ def render_skos_vocabulary():
                                         if old_scheme and old_scheme != new_scheme_val
                                         else None
                                     )
+                                    ont.update_concept(
+                                        target,
+                                        add_scheme=add_s,
+                                        remove_scheme=remove_s,
+                                    )
 
-                                    _update_kwargs = {
-                                        "new_pref_label": new_pref,
-                                        "new_definition": new_def,
-                                        "add_scheme": add_s,
-                                        "remove_scheme": remove_s,
+                                    # Broader diff. Remove before adding, so
+                                    # re-parenting under a former descendant is
+                                    # not refused by the cycle guard for an edge
+                                    # this very save is removing.
+                                    _want = {
+                                        _broader_lookup[d]
+                                        for d in new_broader
+                                        if d in _broader_lookup
                                     }
-                                    if broader_changed:
-                                        _update_kwargs["new_broader"] = broader_val
-                                    ont.update_concept(target, **_update_kwargs)
+                                    for _gone in _have_broader - _want:
+                                        ont.remove_concept_relation(
+                                            target, "broader", _gone
+                                        )
+                                    _refused = []
+                                    for _added in sorted(_want - _have_broader):
+                                        try:
+                                            ont.add_concept_relation(
+                                                target, "broader", _added
+                                            )
+                                        except ValueError as exc:
+                                            _refused.append(str(exc))
+
+                                    ont.set_concept_notation(target, new_notation)
+
+                                    for _su, _checked in _top_choices.items():
+                                        if _checked != (_su in _top_now):
+                                            ont.set_top_concept(target, _su, _checked)
+
                                     save_checkpoint("Update concept")
                                     _new_ck = (
                                         str(abs(hash(target)))[:8] if renamed else _ck
                                     )
                                     _open_entity("skos", _new_ck)
-                                    show_message(
-                                        f"Concept '{target}' updated!", "success"
-                                    )
+                                    # A flash, not show_message: the rerun below
+                                    # throws away anything rendered in this run,
+                                    # so a refusal reported that way is silent.
+                                    if _refused:
+                                        set_flash_message(" ".join(_refused), "error")
+                                    else:
+                                        set_flash_message(
+                                            f"Concept '{target}' updated!", "success"
+                                        )
                                     st.rerun()
-
-        st.divider()
-        st.subheader("Add Concept")
-        with st.form("add_concept_form"):
-            c_name = st.text_input("Concept Name *")
-            c_pref = st.text_input("Preferred Label")
-            c_def = st.text_area("Definition")
-            c_scheme = clearable_selectbox(
-                "Scheme",
-                ["None"] + scheme_opts,
-                key="concept_scheme_select",
-                current_display="None",
-                format_func=_pad_option,
-            )
-            _add_broader_opts, _add_broader_lookup = build_uri_options(concepts)
-            c_broader = clearable_selectbox(
-                "Broader Concept",
-                ["None"] + _add_broader_opts,
-                key="concept_broader_select",
-                current_display="None",
-                format_func=_pad_option,
-            )
-            c_lang = language_selectbox("Language Tag", key="concept_lang")
-            if st.form_submit_button("Add Concept"):
-                if not c_name:
-                    show_message("Concept name is required!", "error")
-                elif reason := ont.invalid_name_reason(c_name):
-                    show_message(reason, "error")
-                # Rejected by target URI, not local name (issue #87 part B), and
-                # across every entity kind (issue #279), as for schemes above.
-                elif taken := ont.name_conflict_reason(c_name, "concept"):
-                    show_message(taken, "error")
-                elif lang_error := language_tag_error(c_lang):
-                    show_message(lang_error, "error")
-                else:
-                    ont.add_concept(
-                        c_name,
-                        scheme=scheme_lookup.get(c_scheme),
-                        pref_label=c_pref or None,
-                        definition=c_def or None,
-                        broader=_add_broader_lookup.get(c_broader),
-                        lang=c_lang or None,
-                    )
-                    save_checkpoint("Add concept")
-                    show_message(f"Concept '{c_name}' added!", "success")
-                    st.rerun()
 
     if _skos_tab == "Concept Hierarchy":
         st.subheader("Concept Hierarchy")
@@ -586,18 +705,27 @@ def render_skos_vocabulary():
                 all_children.update(children)
             roots = [name for name in hierarchy if name not in all_children]
 
-            def render_tree(name, indent=0):
+            def render_tree(name, indent=0, trail=()):
+                pad = "&nbsp;&nbsp;&nbsp;&nbsp;" * indent
+                arm = "└─ " if indent > 0 else ""
+                # The trail is the current path, not a global visited set: under
+                # poly-hierarchy a concept legitimately appears beneath several
+                # parents, and de-duplicating that would hide real structure.
+                # Only a repeat *on the same path* is a cycle, and without this
+                # guard an imported cyclic vocabulary recurses until the app
+                # dies, before the warning below ever renders.
+                if name in trail:
+                    st.markdown(f"{pad}{arm}↻ **{name}** — cycle, not expanded")
+                    return
                 concept_data = next((c for c in concepts if c["name"] == name), None)
                 pref = (
                     concept_data["prefLabel"]
                     if concept_data and concept_data["prefLabel"]
                     else name
                 )
-                st.markdown(
-                    f"{'&nbsp;&nbsp;&nbsp;&nbsp;' * indent}{'└─ ' if indent > 0 else ''}**{pref}** ({name})"
-                )
+                st.markdown(f"{pad}{arm}**{pref}** ({name})")
                 for child in sorted(hierarchy.get(name, [])):
-                    render_tree(child, indent + 1)
+                    render_tree(child, indent + 1, (*trail, name))
 
             for root in sorted(roots):
                 render_tree(root)

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -1398,14 +1398,18 @@ def render_visualization():
                     ):
                         break
                     c_id = f"skos_{concept['name']}"
-                    label = concept.get("pref_label") or concept["name"]
+                    # ``get_concepts()`` returns ``prefLabel`` and ``schemes``.
+                    # This read ``pref_label`` and ``scheme``, which it has never
+                    # returned, so every SKOS node fell back to its local name
+                    # and the tooltip never showed a label or a scheme.
+                    label = concept.get("prefLabel") or concept["name"]
                     title = f"SKOS Concept: {concept['name']}"
-                    if concept.get("pref_label"):
-                        title += f"\nprefLabel: {concept['pref_label']}"
+                    if concept.get("prefLabel"):
+                        title += f"\nprefLabel: {concept['prefLabel']}"
                     if concept.get("definition"):
                         title += f"\nDefinition: {concept['definition'][:100]}"
-                    if concept.get("scheme"):
-                        title += f"\nScheme: {concept['scheme']}"
+                    if concept.get("schemes"):
+                        title += f"\nScheme: {', '.join(concept['schemes'])}"
                     net.add_node(
                         c_id,
                         label=label,

--- a/tests/test_clearable_required_dropdowns.py
+++ b/tests/test_clearable_required_dropdowns.py
@@ -150,13 +150,29 @@ def _options_of(node):
     return next((k.value for k in node.keywords if k.arg == "options"), None)
 
 
+def _is_a_fixed_enum(options):
+    """Whether an options expression is a closed set the user picks from.
+
+    A list or tuple literal, or one built straight from an engine constant with
+    ``list()``/``sorted()``. A conditional between two such expressions still
+    is one: offering mapping properties for an external target and all relations
+    for an internal one narrows the enum, it does not make the value clearable.
+    """
+    if isinstance(options, (ast.List, ast.Tuple)):
+        return True
+    if isinstance(options, ast.Call) and isinstance(options.func, ast.Name):
+        return options.func.id in ("list", "sorted")
+    if isinstance(options, ast.IfExp):
+        return _is_a_fixed_enum(options.body) and _is_a_fixed_enum(options.orelse)
+    return False
+
+
 def _is_exempt(func, label, node):
     """A plain dropdown is fine when clearing it would mean nothing.
 
     Three shapes qualify: it already passes ``index=None`` (so it draws the
     cross itself), its options carry an explicit "All" (empty already has a
-    name), or its options are a fixed enum — a list literal, or one built
-    straight from an engine constant.
+    name), or its options are a fixed enum — see :func:`_is_a_fixed_enum`.
     """
     if func == "clearable_selectbox":
         return True
@@ -167,10 +183,8 @@ def _is_exempt(func, label, node):
         return True
     if any(isinstance(c, ast.Constant) and c.value == "All" for c in ast.walk(options)):
         return True
-    if isinstance(options, (ast.List, ast.Tuple)):
+    if _is_a_fixed_enum(options):
         return True
-    if isinstance(options, ast.Call) and isinstance(options.func, ast.Name):
-        return options.func.id in ("list", "sorted")
     return (func, label) in ALLOWED_BY_NAME
 
 

--- a/tests/test_custom_uri.py
+++ b/tests/test_custom_uri.py
@@ -319,6 +319,53 @@ def test_get_concepts_exposes_uris():
     assert narrow["broader_uris"] == [BASE + "Broad"]
 
 
+def test_skos_validation_keys_cycles_by_uri_not_local_name():
+    """Two concepts sharing a local name are two nodes, not one.
+
+    ``validate_skos`` built its hierarchy from local names, so both collapsed
+    into a single node. Depending on which the store yielded last, that either
+    hid the edge entirely or turned an acyclic ``base#A broader ext#A`` into a
+    self-cycle on "A".
+    """
+    om = _om()
+    om.add_concept("A")
+    om.add_concept("Tmp")
+    om.rename_concept("Tmp", EXT + "A")  # same local name, other namespace
+    om.graph.add((URIRef(BASE + "A"), SKOS.broader, URIRef(EXT + "A")))
+
+    assert not [i for i in om.validate_skos() if i["type"] == "broader_cycle"]
+
+
+def test_skos_validation_still_finds_a_real_cycle_across_namespaces():
+    om = _om()
+    om.add_concept("A")
+    om.add_concept("Tmp")
+    om.rename_concept("Tmp", EXT + "A")
+    om.graph.add((URIRef(BASE + "A"), SKOS.broader, URIRef(EXT + "A")))
+    om.graph.add((URIRef(EXT + "A"), SKOS.broader, URIRef(BASE + "A")))
+
+    cycles = [i for i in om.validate_skos() if i["type"] == "broader_cycle"]
+    assert len(cycles) == 1
+    # Named by URI, since "A -> A -> A" would not say which A.
+    assert BASE + "A" in cycles[0]["message"]
+    assert EXT + "A" in cycles[0]["message"]
+
+
+def test_duplicate_pref_label_resolves_the_scheme_by_uri():
+    """Resolving the scheme by local name checked one twice and the other not
+    at all, so a duplicate in the second scheme went unreported."""
+    om = _om()
+    om.add_concept_scheme("Scheme")  # base#Scheme, left empty
+    om.add_concept_scheme("Tmp")
+    om.rename_concept_scheme("Tmp", EXT + "Scheme")
+    for name in ("X", "Y"):
+        om.add_concept(name, scheme=EXT + "Scheme")
+        om.set_concept_label(name, "prefLabel", "Same", lang="en")
+
+    dupes = [i for i in om.validate_skos() if i["type"] == "duplicate_prefLabel"]
+    assert len(dupes) == 1
+
+
 def test_get_concepts_filter_by_scheme_uri_disambiguates():
     om = _om()
     om.add_concept_scheme("Scheme")  # base#Scheme

--- a/tests/test_skos.py
+++ b/tests/test_skos.py
@@ -1,6 +1,7 @@
 """Tests for SKOS vocabulary operations."""
 
 import pytest
+from rdflib.namespace import SKOS
 
 from ontology_manager import OntologyManager
 
@@ -134,10 +135,18 @@ class TestValidateSKOS:
     def test_broader_cycle(self, om):
         om.add_concept("X", pref_label="X")
         om.add_concept("Y", pref_label="Y", broader="X")
-        # Create cycle: X broader Y (but Y is already broader X)
-        om.add_concept_relation("X", "broader", "Y")
+        # Write the closing edge straight into the graph rather than through
+        # ``add_concept_relation``, which now refuses it. A cycle can still
+        # reach the validator by import, which is what this covers.
+        om.graph.add((om._uri("X"), SKOS.broader, om._uri("Y")))
         issues = om.validate_skos()
         assert any(i["type"] == "broader_cycle" for i in issues)
+
+    def test_broader_cycle_refused_at_write_time(self, om):
+        om.add_concept("X", pref_label="X")
+        om.add_concept("Y", pref_label="Y", broader="X")
+        with pytest.raises(ValueError, match="cycle"):
+            om.add_concept_relation("X", "broader", "Y")
 
     def test_valid_skos_no_issues(self, skos_om):
         issues = skos_om.validate_skos()

--- a/tests/test_skos.py
+++ b/tests/test_skos.py
@@ -148,6 +148,30 @@ class TestValidateSKOS:
         with pytest.raises(ValueError, match="cycle"):
             om.add_concept_relation("X", "broader", "Y")
 
+    def test_duplicate_pref_label_found_in_any_language(self, om):
+        """Duplicates are compared per language tag.
+
+        Flattening a multi-language concept to one value picks one language, so
+        a clash in any other language went unreported.
+        """
+        om.add_concept_scheme("S")
+        om.add_concept("A", scheme="S")
+        om.add_concept("B", scheme="S")
+        om.set_concept_label("A", "prefLabel", "Hund", lang="de")
+        om.set_concept_label("A", "prefLabel", "Dog", lang="en")
+        om.set_concept_label("B", "prefLabel", "Dog", lang="en")
+        dupes = [i for i in om.validate_skos() if i["type"] == "duplicate_prefLabel"]
+        assert len(dupes) == 1
+        assert "@en" in dupes[0]["message"]
+
+    def test_same_label_in_different_languages_is_not_a_duplicate(self, om):
+        om.add_concept_scheme("S")
+        om.add_concept("A", scheme="S")
+        om.add_concept("B", scheme="S")
+        om.set_concept_label("A", "prefLabel", "Dog", lang="en")
+        om.set_concept_label("B", "prefLabel", "Dog", lang="de")
+        assert not [i for i in om.validate_skos() if i["type"] == "duplicate_prefLabel"]
+
     def test_valid_skos_no_issues(self, skos_om):
         issues = skos_om.validate_skos()
         assert len(issues) == 0

--- a/tests/test_skos.py
+++ b/tests/test_skos.py
@@ -1,7 +1,7 @@
 """Tests for SKOS vocabulary operations."""
 
 import pytest
-from rdflib.namespace import SKOS
+from rdflib.namespace import RDF, SKOS
 
 from ontology_manager import OntologyManager
 
@@ -171,6 +171,51 @@ class TestValidateSKOS:
         om.set_concept_label("A", "prefLabel", "Dog", lang="en")
         om.set_concept_label("B", "prefLabel", "Dog", lang="de")
         assert not [i for i in om.validate_skos() if i["type"] == "duplicate_prefLabel"]
+
+    def test_cycle_through_a_second_parent_is_found(self, om):
+        """The detector used to follow ``broader[0]`` only.
+
+        Survivable while a concept could have one parent; poly-hierarchy makes
+        it reachable, and B being listed first hid the A -> C -> A loop.
+        """
+        for name in ("A", "B", "C"):
+            om.add_concept(name)
+        om.add_concept_relation("A", "broader", "B")
+        om.add_concept_relation("A", "broader", "C")
+        om.graph.add((om._uri("C"), SKOS.broader, om._uri("A")))
+        cycles = [i for i in om.validate_skos() if i["type"] == "broader_cycle"]
+        assert len(cycles) == 1
+        assert "A -> C -> A" in cycles[0]["message"]
+
+    def test_a_cycle_is_reported_once_not_once_per_member(self, om):
+        for name in ("A", "B", "C"):
+            om.add_concept(name)
+        om.add_concept_relation("A", "broader", "B")
+        om.add_concept_relation("B", "broader", "C")
+        om.graph.add((om._uri("C"), SKOS.broader, om._uri("A")))
+        assert len([i for i in om.validate_skos() if i["type"] == "broader_cycle"]) == 1
+
+    def test_poly_hierarchy_without_a_cycle_is_clean(self, om):
+        for name in ("Animal", "Pet", "Dog"):
+            om.add_concept(name)
+        om.add_concept_relation("Dog", "broader", "Animal")
+        om.add_concept_relation("Dog", "broader", "Pet")
+        assert not [i for i in om.validate_skos() if i["type"] == "broader_cycle"]
+
+    def test_a_deep_chain_does_not_exhaust_the_stack(self, om):
+        """Iterative, not recursive: an imported vocabulary can be deep.
+
+        Written straight into the graph rather than through ``add_concept``,
+        which checks the name against every existing entity and would make
+        seeding this quadratic. Depth is past the default recursion limit,
+        which is the whole point of the test.
+        """
+        depth = 1500
+        for i in range(depth):
+            om.graph.add((om._uri(f"c{i}"), RDF.type, SKOS.Concept))
+            if i:
+                om.graph.add((om._uri(f"c{i}"), SKOS.broader, om._uri(f"c{i - 1}")))
+        assert not [i for i in om.validate_skos() if i["type"] == "broader_cycle"]
 
     def test_valid_skos_no_issues(self, skos_om):
         issues = skos_om.validate_skos()

--- a/tests/test_skos_data_model.py
+++ b/tests/test_skos_data_model.py
@@ -271,6 +271,37 @@ class TestCycleGuard:
         assert _concept(chain, "Dog")["broader"] == []
         assert _concept(chain, "Mammal")["narrower"] == []
 
+    def test_add_concept_cannot_bypass_the_guard(self, om):
+        """``broader`` at creation time went straight into the graph."""
+        with pytest.raises(ValueError, match="its own broader"):
+            om.add_concept("A", broader="A")
+        assert om.get_concepts() == []
+
+    def test_rollback_survives_an_already_cyclic_graph(self, om):
+        """Restoring must put the original triples back, not re-assert them.
+
+        An imported cycle was never checked by the guard, so re-asserting one of
+        its edges during rollback is itself refused: the concept loses the
+        parent anyway and the caller sees the rollback's error rather than the
+        real one.
+        """
+        for name in ("X", "Y", "Z"):
+            om.add_concept(name)
+        # An imported X <-> Y cycle, with Z beneath X.
+        for subject, prop, obj in (
+            ("X", SKOS.broader, "Y"),
+            ("Y", SKOS.narrower, "X"),
+            ("Y", SKOS.broader, "X"),
+            ("X", SKOS.narrower, "Y"),
+            ("Z", SKOS.broader, "X"),
+        ):
+            om.graph.add((om._uri(subject), prop, om._uri(obj)))
+
+        with pytest.raises(ValueError, match="'Z' is already a narrower concept"):
+            om.set_concept_broader("X", ["Z"])
+        assert _concept(om, "X")["broader"] == ["Y"]
+        assert _concept(om, "Y")["narrower"] == ["X"]
+
     def test_poly_hierarchy_is_allowed(self, om):
         for name in ("Animal", "Pet", "Dog"):
             om.add_concept(name)

--- a/tests/test_skos_data_model.py
+++ b/tests/test_skos_data_model.py
@@ -165,6 +165,18 @@ class TestMappings:
         with pytest.raises(ValueError, match="mapping property"):
             dogs.add_concept_mapping("Dogs", "broader", WIKIDATA_DOG)
 
+    def test_target_that_cannot_be_serialised_is_refused(self, dogs):
+        """A scheme is not enough: rdflib stores any string and only objects
+        when asked to serialize, so this would break every later export."""
+        with pytest.raises(ValueError, match="no spaces"):
+            dogs.add_concept_mapping(
+                "Dogs", "exactMatch", "http://example.org/bad path"
+            )
+
+    def test_an_accepted_target_still_serialises(self, dogs):
+        dogs.add_concept_mapping("Dogs", "exactMatch", WIKIDATA_DOG)
+        assert "Q144" in dogs.graph.serialize(format="turtle")
+
 
 class TestRemoveRelation:
     def test_removes_the_auto_added_inverse(self, om):
@@ -228,6 +240,36 @@ class TestCycleGuard:
             chain.update_concept("Mammal", new_broader="Dog")
         assert _concept(chain, "Mammal")["broader"] == ["Animal"]
         assert _concept(chain, "Animal")["narrower"] == ["Mammal"]
+
+    def test_replacing_broader_is_all_or_nothing(self, chain):
+        """A refused re-parent must not also drop the parent that was there.
+
+        ``set_concept_broader`` removes the old parents before adding the new
+        ones, which is what lets a concept move under a former descendant. A
+        refusal partway through would otherwise reject the edit *and* leave the
+        concept with no parent at all.
+        """
+        with pytest.raises(ValueError, match="cycle"):
+            chain.set_concept_broader("Mammal", ["Dog"])
+        assert _concept(chain, "Mammal")["broader"] == ["Animal"]
+        assert _concept(chain, "Animal")["narrower"] == ["Mammal"]
+        assert _concept(chain, "Dog")["broader"] == ["Mammal"]
+
+    def test_replacing_broader_allows_a_legal_swap(self, chain):
+        chain.add_concept("Pet")
+        chain.set_concept_broader("Dog", ["Pet"])
+        assert _concept(chain, "Dog")["broader"] == ["Pet"]
+        assert _concept(chain, "Mammal")["narrower"] == []
+
+    def test_replacing_broader_sets_several(self, chain):
+        chain.add_concept("Pet")
+        chain.set_concept_broader("Dog", ["Mammal", "Pet"])
+        assert sorted(_concept(chain, "Dog")["broader"]) == ["Mammal", "Pet"]
+
+    def test_replacing_broader_with_nothing_clears_it(self, chain):
+        chain.set_concept_broader("Dog", [])
+        assert _concept(chain, "Dog")["broader"] == []
+        assert _concept(chain, "Mammal")["narrower"] == []
 
     def test_poly_hierarchy_is_allowed(self, om):
         for name in ("Animal", "Pet", "Dog"):

--- a/tests/test_skos_data_model.py
+++ b/tests/test_skos_data_model.py
@@ -1,0 +1,274 @@
+"""Tests for the language-aware, multi-valued SKOS data model (WS-3).
+
+The engine used to expose one untagged ``prefLabel``, one ``definition`` and
+one ``broader`` per concept. These cover what it exposes now: labels and notes
+per language, notation, top concepts, mappings to external vocabularies, and
+the write-time refusals that keep the hierarchy acyclic.
+"""
+
+import pytest
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import SKOS
+
+from ontology_manager import OntologyManager
+
+WIKIDATA_DOG = "http://www.wikidata.org/entity/Q144"
+
+
+@pytest.fixture
+def om():
+    return OntologyManager(base_uri="http://test.org/ont#")
+
+
+@pytest.fixture
+def dogs(om):
+    """One concept in one scheme, to hang label/note tests off."""
+    om.add_concept_scheme("Animals")
+    om.add_concept("Dogs", scheme="Animals")
+    return om
+
+
+def _concept(om, name):
+    return next(c for c in om.get_concepts() if c["name"] == name)
+
+
+class TestLabels:
+    def test_pref_labels_per_language(self, dogs):
+        dogs.set_concept_label("Dogs", "prefLabel", "Dogs", lang="en")
+        dogs.set_concept_label("Dogs", "prefLabel", "Hunde", lang="de")
+        assert _concept(dogs, "Dogs")["labels"]["prefLabel"] == [
+            {"value": "Hunde", "lang": "de"},
+            {"value": "Dogs", "lang": "en"},
+        ]
+
+    def test_pref_label_replaces_same_language(self, dogs):
+        """SKOS Reference S14: at most one prefLabel per language tag."""
+        dogs.set_concept_label("Dogs", "prefLabel", "Dogs", lang="en")
+        dogs.set_concept_label("Dogs", "prefLabel", "Doggos", lang="en")
+        dogs.set_concept_label("Dogs", "prefLabel", "Hunde", lang="de")
+        pref = _concept(dogs, "Dogs")["labels"]["prefLabel"]
+        assert [v["value"] for v in pref] == ["Hunde", "Doggos"]
+
+    def test_untagged_pref_label_is_its_own_slot(self, dogs):
+        """An untagged label does not collide with a tagged one."""
+        dogs.set_concept_label("Dogs", "prefLabel", "Dogs")
+        dogs.set_concept_label("Dogs", "prefLabel", "Hunde", lang="de")
+        assert len(_concept(dogs, "Dogs")["labels"]["prefLabel"]) == 2
+
+    @pytest.mark.parametrize("kind", ["altLabel", "hiddenLabel"])
+    def test_alt_and_hidden_are_repeatable(self, dogs, kind):
+        dogs.set_concept_label("Dogs", kind, "Canines", lang="en")
+        dogs.set_concept_label("Dogs", kind, "Doggies", lang="en")
+        assert len(_concept(dogs, "Dogs")["labels"][kind]) == 2
+
+    def test_remove_label(self, dogs):
+        dogs.set_concept_label("Dogs", "altLabel", "Canines", lang="en")
+        assert dogs.remove_concept_label("Dogs", "altLabel", "Canines", lang="en")
+        assert _concept(dogs, "Dogs")["labels"]["altLabel"] == []
+
+    def test_remove_label_matches_language_too(self, dogs):
+        """Same text, different tag, is a different literal."""
+        dogs.set_concept_label("Dogs", "altLabel", "Hunde", lang="de")
+        assert not dogs.remove_concept_label("Dogs", "altLabel", "Hunde", lang="en")
+        assert len(_concept(dogs, "Dogs")["labels"]["altLabel"]) == 1
+
+    def test_blank_label_refused(self, dogs):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            dogs.set_concept_label("Dogs", "prefLabel", "   ", lang="en")
+
+    def test_malformed_language_tag_refused(self, dogs):
+        with pytest.raises(ValueError):
+            dogs.set_concept_label("Dogs", "prefLabel", "Dogs", lang="en_GB")
+
+    def test_unknown_kind_names_the_alternatives(self, dogs):
+        with pytest.raises(ValueError, match="prefLabel"):
+            dogs.set_concept_label("Dogs", "notALabel", "x")
+
+
+class TestNotes:
+    def test_notes_are_repeatable_and_tagged(self, dogs):
+        dogs.set_concept_note("Dogs", "scopeNote", "Domestic only", lang="en")
+        dogs.set_concept_note("Dogs", "scopeNote", "Nur Haushunde", lang="de")
+        assert len(_concept(dogs, "Dogs")["notes"]["scopeNote"]) == 2
+
+    def test_all_documentation_kinds_available(self, dogs):
+        for kind in OntologyManager.SKOS_NOTE_KINDS:
+            dogs.set_concept_note("Dogs", kind, f"a {kind}", lang="en")
+        notes = _concept(dogs, "Dogs")["notes"]
+        assert all(notes[kind] for kind in OntologyManager.SKOS_NOTE_KINDS)
+
+    def test_remove_note(self, dogs):
+        dogs.set_concept_note("Dogs", "definition", "A dog", lang="en")
+        assert dogs.remove_concept_note("Dogs", "definition", "A dog", lang="en")
+        assert _concept(dogs, "Dogs")["notes"]["definition"] == []
+
+
+class TestNotation:
+    def test_set_and_replace(self, dogs):
+        dogs.set_concept_notation("Dogs", "636.7")
+        assert _concept(dogs, "Dogs")["notation"] == "636.7"
+        dogs.set_concept_notation("Dogs", "636.8")
+        assert _concept(dogs, "Dogs")["notation"] == "636.8"
+
+    def test_empty_value_clears(self, dogs):
+        dogs.set_concept_notation("Dogs", "636.7")
+        dogs.set_concept_notation("Dogs", "")
+        assert _concept(dogs, "Dogs")["notation"] == ""
+
+    def test_notation_carries_a_datatype_never_a_language(self, dogs):
+        """A notation is a code in a symbol scheme, not text in a language."""
+        dogs.set_concept_notation("Dogs", "636.7", datatype="http://example.org/ddc")
+        value = dogs.graph.value(URIRef("http://test.org/ont#Dogs"), SKOS.notation)
+        assert isinstance(value, Literal)
+        assert value.language is None
+        assert str(value.datatype) == "http://example.org/ddc"
+
+
+class TestTopConcepts:
+    def test_writes_both_directions(self, dogs):
+        dogs.set_top_concept("Dogs", "Animals")
+        concept = URIRef("http://test.org/ont#Dogs")
+        scheme = URIRef("http://test.org/ont#Animals")
+        assert (concept, SKOS.topConceptOf, scheme) in dogs.graph
+        assert (scheme, SKOS.hasTopConcept, concept) in dogs.graph
+        assert _concept(dogs, "Dogs")["top_of"] == ["Animals"]
+
+    def test_top_concept_is_in_its_scheme(self, om):
+        om.add_concept_scheme("Animals")
+        om.add_concept("Dogs")
+        om.set_top_concept("Dogs", "Animals")
+        assert "Animals" in _concept(om, "Dogs")["schemes"]
+
+    def test_retract_removes_both_directions(self, dogs):
+        dogs.set_top_concept("Dogs", "Animals")
+        dogs.set_top_concept("Dogs", "Animals", is_top=False)
+        concept = URIRef("http://test.org/ont#Dogs")
+        scheme = URIRef("http://test.org/ont#Animals")
+        assert (concept, SKOS.topConceptOf, scheme) not in dogs.graph
+        assert (scheme, SKOS.hasTopConcept, concept) not in dogs.graph
+
+
+class TestMappings:
+    def test_map_to_an_external_uri(self, dogs):
+        dogs.add_concept_mapping("Dogs", "exactMatch", WIKIDATA_DOG)
+        assert _concept(dogs, "Dogs")["mappings"]["exactMatch"] == [WIKIDATA_DOG]
+
+    def test_target_must_be_absolute(self, dogs):
+        with pytest.raises(ValueError, match="absolute IRI"):
+            dogs.add_concept_mapping("Dogs", "exactMatch", "Cats")
+
+    def test_non_http_schemes_accepted(self, dogs):
+        dogs.add_concept_mapping("Dogs", "closeMatch", "urn:example:dog")
+        assert _concept(dogs, "Dogs")["mappings"]["closeMatch"] == ["urn:example:dog"]
+
+    def test_semantic_relations_refused_here(self, dogs):
+        with pytest.raises(ValueError, match="mapping property"):
+            dogs.add_concept_mapping("Dogs", "broader", WIKIDATA_DOG)
+
+
+class TestRemoveRelation:
+    def test_removes_the_auto_added_inverse(self, om):
+        om.add_concept("Animal")
+        om.add_concept("Dog")
+        om.add_concept_relation("Dog", "broader", "Animal")
+        assert om.remove_concept_relation("Dog", "broader", "Animal")
+        assert _concept(om, "Dog")["broader"] == []
+        assert _concept(om, "Animal")["narrower"] == []
+
+    def test_removes_the_symmetric_triple(self, om):
+        om.add_concept("Cat")
+        om.add_concept("Dog")
+        om.add_concept_relation("Dog", "related", "Cat")
+        om.remove_concept_relation("Dog", "related", "Cat")
+        assert _concept(om, "Cat")["related"] == []
+
+    def test_reports_when_nothing_was_there(self, om):
+        om.add_concept("Dog")
+        om.add_concept("Cat")
+        assert not om.remove_concept_relation("Dog", "related", "Cat")
+
+
+class TestCycleGuard:
+    @pytest.fixture
+    def chain(self, om):
+        for name in ("Animal", "Mammal", "Dog"):
+            om.add_concept(name)
+        om.add_concept_relation("Mammal", "broader", "Animal")
+        om.add_concept_relation("Dog", "broader", "Mammal")
+        return om
+
+    def test_transitive_cycle_refused(self, chain):
+        with pytest.raises(ValueError, match="cycle"):
+            chain.add_concept_relation("Animal", "broader", "Dog")
+
+    def test_narrower_direction_refused_too(self, chain):
+        with pytest.raises(ValueError, match="cycle"):
+            chain.add_concept_relation("Dog", "narrower", "Animal")
+
+    def test_self_relation_refused(self, chain):
+        with pytest.raises(ValueError, match="its own broader"):
+            chain.add_concept_relation("Dog", "broader", "Dog")
+
+    def test_self_related_refused(self, chain):
+        with pytest.raises(ValueError, match="its own"):
+            chain.add_concept_relation("Dog", "related", "Dog")
+
+    def test_update_concept_refuses_too(self, chain):
+        with pytest.raises(ValueError, match="cycle"):
+            chain.update_concept("Animal", new_broader="Dog")
+
+    def test_refusal_leaves_the_hierarchy_untouched(self, chain):
+        """A rejected re-parent must not orphan the concept it refused.
+
+        ``update_concept`` drops the old broader before adding the new one, so
+        the guard has to run first or a refused edit costs the user the parent
+        they already had.
+        """
+        with pytest.raises(ValueError):
+            chain.update_concept("Mammal", new_broader="Dog")
+        assert _concept(chain, "Mammal")["broader"] == ["Animal"]
+        assert _concept(chain, "Animal")["narrower"] == ["Mammal"]
+
+    def test_poly_hierarchy_is_allowed(self, om):
+        for name in ("Animal", "Pet", "Dog"):
+            om.add_concept(name)
+        om.add_concept_relation("Dog", "broader", "Animal")
+        om.add_concept_relation("Dog", "broader", "Pet")
+        assert sorted(_concept(om, "Dog")["broader"]) == ["Animal", "Pet"]
+
+
+class TestBackwardCompatibility:
+    def test_flat_keys_are_computed_from_the_structured_ones(self, dogs):
+        dogs.set_concept_label("Dogs", "prefLabel", "Dogs", lang="en")
+        dogs.set_concept_label("Dogs", "altLabel", "Canines", lang="en")
+        dogs.set_concept_note("Dogs", "definition", "A dog", lang="en")
+        concept = _concept(dogs, "Dogs")
+        assert concept["prefLabel"] == "Dogs"
+        assert concept["definition"] == "A dog"
+        assert concept["altLabels"] == ["Canines"]
+
+    def test_flat_pref_label_is_deterministic(self, dogs):
+        """Untagged wins; otherwise the first tag alphabetically."""
+        dogs.set_concept_label("Dogs", "prefLabel", "Hunde", lang="de")
+        dogs.set_concept_label("Dogs", "prefLabel", "Dogs", lang="en")
+        assert _concept(dogs, "Dogs")["prefLabel"] == "Hunde"
+        dogs.set_concept_label("Dogs", "prefLabel", "Untagged")
+        assert _concept(dogs, "Dogs")["prefLabel"] == "Untagged"
+
+
+class TestRoundTrip:
+    def test_serialises_and_reparses_identically(self, dogs):
+        """Correctness here is defined by an external parser, not by us."""
+        dogs.set_concept_label("Dogs", "prefLabel", "Dogs", lang="en")
+        dogs.set_concept_label("Dogs", "prefLabel", "Hunde", lang="de")
+        dogs.set_concept_label("Dogs", "altLabel", "Canines", lang="en")
+        dogs.set_concept_label("Dogs", "hiddenLabel", "dogz", lang="en")
+        dogs.set_concept_note("Dogs", "scopeNote", "Domestic only", lang="en")
+        dogs.set_concept_notation("Dogs", "636.7")
+        dogs.set_top_concept("Dogs", "Animals")
+        dogs.add_concept_mapping("Dogs", "exactMatch", WIKIDATA_DOG)
+
+        reparsed = Graph().parse(
+            data=dogs.graph.serialize(format="turtle"), format="turtle"
+        )
+        assert set(reparsed) == set(dogs.graph)


### PR DESCRIPTION
Implements WS-3 (SKOS data model completeness) from the SKOS improvement plan. First step toward a SPARQL query sheet: a SKOS graph holding one untagged `prefLabel` and one `broader` per concept is not worth querying.

## Engine

- `get_concepts()` gains structured, language-aware `labels` and `notes`, plus `notation`, `top_of` and `mappings`. The flat `prefLabel` / `definition` / `altLabels` keys stay, as computed views over the structured ones, so the visualization and dashboard readers keep working.
- `set_concept_label` / `remove_concept_label` and `set_concept_note` / `remove_concept_note` cover the three label kinds and the seven documentation properties. A `prefLabel` replaces any existing one carrying the same language tag, per SKOS Reference S14, so the UI cannot create that violation.
- `set_concept_notation` (carries a datatype, never a language tag), `set_top_concept` (writes `topConceptOf` and the scheme's `hasTopConcept` together), `add_concept_mapping` (an absolute IRI in another vocabulary rather than a local name).
- `remove_concept_relation`, which did not exist. Relations could be added but never removed, and removing only the asserted direction would leave the auto-added inverse behind as a half-edge.
- A `broader` / `narrower` edge that would close a hierarchy cycle is refused at write time, in both `add_concept_relation` and `update_concept`. A refused edit leaves the hierarchy exactly as it was, which is why the check runs before the old parent is dropped.

## UI

- Labels and notes are one table of (kind, language, text) rows with their own add and delete, rendered outside the form: a button inside a form cannot take effect until the form is submitted.
- `Broader` becomes a multiselect, so poly-hierarchy is expressible.
- Notation field, and a top-concept checkbox per scheme.
- `Add Relation` gains an External URI target mode offering the five mapping properties, so an `exactMatch` to Wikidata is finally reachable. The engine already supported it; the UI had no way to express it.
- `Add Concept` moved above the concept list, collapsed by default, instead of below every concept already there.

## Two bugs found along the way

- The visualization read `pref_label` and `scheme` from `get_concepts()`, which has never returned either key. It used `.get()`, so nothing crashed: every SKOS node silently fell back to its local name and the tooltip never showed a label or a scheme.
- `render_tree` recursed with no visited set, so an imported cyclic vocabulary hung the app before the "possible cycle" warning could render. The guard is path-local rather than a global visited set, because under poly-hierarchy a concept legitimately appears beneath several parents and de-duplicating that would hide real structure.

## Testing

- New `tests/test_skos_data_model.py`: 36 tests over labels, notes, notation, top concepts, mappings, relation removal, the cycle guard, backward compatibility of the flat keys, and a Turtle round-trip asserting triple-level equality against a fresh `rdflib.Graph`.
- `test_broader_cycle` now builds its cycle by writing the triple directly, since the API refuses it, and a companion test asserts the refusal. A cycle can still reach the validator by import, which is what that test covers.
- The dropdown rule test learned that a conditional between two fixed enums is still a fixed enum.
- Full suite, ruff, and mypy pass. Verified live in the running app: label rows, the multiselect, the refusal message, and the new layout.

Part of the SKOS workstream; does not close the plan on its own.