### PR TITLE
feat(skos): validation depth (WS-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ each issue carrying a stable `type`, a `severity`, the `subject` concept and its
 | Check | What it means | Source |
 |---|---|---|
 | `missing_lang` | A label carries no language tag. | Practice |
-| `label_overlap` | The same text is used as a prefLabel and as an altLabel or hiddenLabel on one concept. | SKOS Reference S13 |
+| `label_overlap` | One concept uses the same text in the same language as two of prefLabel, altLabel and hiddenLabel. | SKOS Reference S13 |
 | `duplicate_prefLabel` | Two concepts in one scheme share a prefLabel in the same language. | qSKOS |
 | `ambiguous_prefLabel` | Two concepts anywhere in the vocabulary share a prefLabel in the same language, without sharing a scheme. | qSKOS |
 | `orphan` | The concept has no broader, narrower or related concept and is not a top concept, so nothing reaches it. | qSKOS |

--- a/README.md
+++ b/README.md
@@ -96,11 +96,61 @@ into the field, pack or no pack.
 A dedicated page for building controlled vocabularies:
 
 - Concept schemes with concept counts
-- Concepts with prefLabel, definition, broader/narrower (inverses auto-managed)
+- Concepts with labels and notes in any number of languages: `prefLabel`,
+  `altLabel`, `hiddenLabel`, `definition`, `scopeNote` and the rest
+- `notation`, top concepts, and poly-hierarchy (a concept may have several parents)
+- Full SKOS relation support (broader, narrower, related, all match types),
+  with mapping properties able to point at an external IRI such as Wikidata
+- An edge that would make a concept its own ancestor is refused as you save it
 - Hierarchy tree view, filterable by scheme
-- Full SKOS relation support (broader, narrower, related, all match types)
-- SKOS validation: missing prefLabels, orphans, duplicate labels, cycles
 
+#### What SKOS validation checks
+
+Twenty checks in three tiers. The page groups results by check and lets you
+switch either advisory tier off, which is what makes it usable on a large
+imported vocabulary. `validate_skos()` returns the same list to Python callers,
+each issue carrying a stable `type`, a `severity`, the `subject` concept and its
+`subject_uri`.
+
+**Errors.** Broken data, or a condition the SKOS Reference states outright. Always checked.
+
+| Check | What it means | Source |
+|---|---|---|
+| `missing_prefLabel` | The concept has no skos:prefLabel in any language. | Practice |
+| `multi_prefLabel_per_lang` | More than one skos:prefLabel shares a language tag. | SKOS Reference S14 |
+| `empty_label` | A label literal is empty or only whitespace. | Practice |
+| `self_relation` | The concept is its own broader, narrower or related. | Practice |
+| `dangling_relation` | A broader, narrower or related link points at something that is not a Concept here. Mapping properties are exempt: reaching outside the vocabulary is what they are for. | Practice |
+| `relation_clash` | Two concepts are skos:related and also connected up or down the hierarchy. | SKOS Reference S27 |
+| `broader_cycle` | A chain of skos:broader links returns to its start. | qSKOS |
+
+**Conventions.** Thesaurus practice rather than broken data. Switch off with `check_conventions=False`.
+
+| Check | What it means | Source |
+|---|---|---|
+| `missing_lang` | A label carries no language tag. | Practice |
+| `label_overlap` | The same text is used as a prefLabel and as an altLabel or hiddenLabel on one concept. | SKOS Reference S13 |
+| `duplicate_prefLabel` | Two concepts in one scheme share a prefLabel in the same language. | qSKOS |
+| `ambiguous_prefLabel` | Two concepts anywhere in the vocabulary share a prefLabel in the same language, without sharing a scheme. | qSKOS |
+| `orphan` | The concept has no broader, narrower or related concept and is not a top concept, so nothing reaches it. | qSKOS |
+| `top_with_broader` | A top concept of a scheme also has a broader concept in that same scheme. Having one in another scheme is fine. | Practice |
+| `hierarchy_redundancy` | A direct broader concept is already reachable through another parent, so the edge says nothing new. | qSKOS |
+| `mapping_within_scheme` | A mapping property links two concepts of the same scheme; it is meant for links between vocabularies. | Practice |
+| `notation_lang_tagged` | A skos:notation carries a language tag. A notation is a code in a symbol scheme and takes a datatype instead. | SKOS Reference 6.5 |
+
+**Editorial.** Completeness and vocabulary shape. Switch off with `check_editorial=False`.
+
+| Check | What it means | Source |
+|---|---|---|
+| `no_scheme` | The concept belongs to no ConceptScheme. | Practice |
+| `undocumented` | The concept has neither a definition nor a scopeNote. | Practice |
+| `valueless_association` | Two concepts are skos:related and already share a parent, which relates them anyway. | qSKOS |
+| `disconnected_components` | A cluster of concepts has no link to the main body of the vocabulary. | qSKOS |
+
+Sources cite the SKOS Reference integrity condition where the condition is
+stated there, [qSKOS](https://github.com/cmader/qSKOS) where the check comes
+from that tool's published quality criteria, and say "practice" where it is
+thesaurus convention rather than anything normative.
 ### Templates
 
 Five starter templates you can merge into or replace your current ontology: Organization, Product Catalog, Event, Person/Contact, and SKOS Thesaurus. Each is a valid Turtle snippet with a preview before you apply it.

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -3001,6 +3001,20 @@ class OntologyManager:
         """
         return values[0]["value"] if values else ""
 
+    def _concept_in_scheme(self, concept: Node, scheme: Node) -> bool:
+        """Whether a concept belongs to a scheme, however that was asserted.
+
+        ``skos:topConceptOf`` is a sub-property of ``skos:inScheme``, and it has
+        ``skos:hasTopConcept`` as its inverse, so any of the three says the
+        concept is in the scheme. An import that carries only the scheme side
+        would otherwise have its top concepts counted in no scheme at all.
+        """
+        return (
+            (concept, SKOS.inScheme, scheme) in self.graph
+            or (concept, SKOS.topConceptOf, scheme) in self.graph
+            or (scheme, SKOS.hasTopConcept, concept) in self.graph
+        )
+
     def add_concept_scheme(
         self, name: str, label: str | None = None, comment: str | None = None
     ) -> URIRef:
@@ -3025,7 +3039,12 @@ class OntologyManager:
             label = str(self.graph.value(uri, RDFS.label) or "")
             comment = str(self.graph.value(uri, RDFS.comment) or "")
             # Count concepts in this scheme
-            concept_count = sum(1 for _ in self.graph.subjects(SKOS.inScheme, uri))
+            members = (
+                set(self.graph.subjects(SKOS.inScheme, uri))
+                | set(self.graph.subjects(SKOS.topConceptOf, uri))
+                | set(self.graph.objects(uri, SKOS.hasTopConcept))
+            )
+            concept_count = len({m for m in members if isinstance(m, URIRef)})
             schemes.append(
                 {
                     "name": name,
@@ -3175,7 +3194,7 @@ class OntologyManager:
             if (
                 scheme
                 and scheme_uri
-                and (uri, SKOS.inScheme, scheme_uri) not in self.graph
+                and not self._concept_in_scheme(uri, scheme_uri)
             ):
                 continue
 
@@ -3194,11 +3213,22 @@ class OntologyManager:
             alt_labels = [v["value"] for v in labels["altLabel"]]
 
             notation = str(self.graph.value(uri, SKOS.notation) or "")
-            top_of_uris = [
-                str(o)
-                for o in self.graph.objects(uri, SKOS.topConceptOf)
-                if isinstance(o, URIRef)
-            ]
+            # Both directions of the pair. ``set_top_concept`` writes both, but
+            # a published vocabulary often asserts only the scheme side,
+            # ``scheme skos:hasTopConcept concept``, and reading one direction
+            # made such a concept look like an orphan belonging to no scheme.
+            top_of_uris = sorted(
+                {
+                    str(o)
+                    for o in self.graph.objects(uri, SKOS.topConceptOf)
+                    if isinstance(o, URIRef)
+                }
+                | {
+                    str(s)
+                    for s in self.graph.subjects(SKOS.hasTopConcept, uri)
+                    if isinstance(s, URIRef)
+                }
+            )
             mappings = {
                 rel: sorted(
                     str(o)
@@ -3223,11 +3253,16 @@ class OntologyManager:
                 for o in self.graph.objects(uri, SKOS.related)
                 if isinstance(o, URIRef)
             ]
-            scheme_uris = [
-                str(o)
-                for o in self.graph.objects(uri, SKOS.inScheme)
-                if isinstance(o, URIRef)
-            ]
+            # skos:topConceptOf is a sub-property of skos:inScheme, so heading a
+            # scheme is membership of it whether or not inScheme was asserted.
+            scheme_uris = sorted(
+                {
+                    str(o)
+                    for o in self.graph.objects(uri, SKOS.inScheme)
+                    if isinstance(o, URIRef)
+                }
+                | set(top_of_uris)
+            )
 
             # Full URIs (``*_uris``) accompany the local-name lists so callers can
             # address a broader/related concept or scheme unambiguously even when

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2875,8 +2875,8 @@ class OntologyManager:
         "label_overlap": {
             "severity": "warning",
             "summary": (
-                "The same text is used as a prefLabel and as an altLabel or "
-                "hiddenLabel on one concept."
+                "The same text in the same language is used as a prefLabel "
+                "and as an altLabel or hiddenLabel on one concept."
             ),
             "source": "SKOS Reference S13",
         },
@@ -3725,12 +3725,48 @@ class OntologyManager:
         }
 
     @staticmethod
-    def _skos_parent_map(concepts: list[dict[str, Any]]) -> dict[str, list[str]]:
-        """URI -> its broader URIs, restricted to concepts this graph knows."""
+    def _skos_link_maps(
+        concepts: list[dict[str, Any]],
+    ) -> tuple[dict[str, list[str]], dict[str, list[str]], dict[str, list[str]]]:
+        """``(parents, children, related)``, each read from both directions.
+
+        SKOS declares broader and narrower inverses of each other, and related
+        symmetric, but a published vocabulary usually asserts only one side:
+        ``B skos:broader A`` with no matching ``A skos:narrower B``. Our own
+        writes materialise both, so reading one direction works on a graph this
+        app built and quietly fails on an imported one, which is exactly the
+        graph validation exists for. A broader-only import made every parent
+        look like an orphan; a narrower-only import hid the hierarchy from the
+        checks that walk it.
+        """
         known = {c["uri"] for c in concepts}
-        return {
-            c["uri"]: [u for u in c["broader_uris"] if u in known] for c in concepts
-        }
+        parents: dict[str, set[str]] = {uri: set() for uri in known}
+        children: dict[str, set[str]] = {uri: set() for uri in known}
+        related: dict[str, set[str]] = {uri: set() for uri in known}
+        for concept in concepts:
+            uri = concept["uri"]
+            for target in concept["broader_uris"]:
+                if target in known:
+                    parents[uri].add(target)
+                    children[target].add(uri)
+            for target in concept["narrower_uris"]:
+                if target in known:
+                    children[uri].add(target)
+                    parents[target].add(uri)
+            for target in concept["related_uris"]:
+                if target in known:
+                    related[uri].add(target)
+                    related[target].add(uri)
+        return (
+            {uri: sorted(v) for uri, v in parents.items()},
+            {uri: sorted(v) for uri, v in children.items()},
+            {uri: sorted(v) for uri, v in related.items()},
+        )
+
+    @classmethod
+    def _skos_parent_map(cls, concepts: list[dict[str, Any]]) -> dict[str, list[str]]:
+        """URI -> its broader URIs, from both asserted directions."""
+        return cls._skos_link_maps(concepts)[0]
 
     @staticmethod
     def _skos_ancestors(parents: dict[str, list[str]], start: str) -> set[str]:
@@ -3785,7 +3821,12 @@ class OntologyManager:
                         )
                     )
 
-            pref_values = {item["value"] for item in labels["prefLabel"]}
+            # (value, language), not value alone: an RDF literal's language is
+            # part of its identity, so a prefLabel "Bank"@en and an altLabel
+            # "Bank"@de are different objects and S13 is not violated.
+            pref_values = {
+                (item["value"], item["lang"]) for item in labels["prefLabel"]
+            }
             for kind in self.SKOS_LABEL_KINDS:
                 for item in labels[kind]:
                     if not item["value"].strip():
@@ -3811,7 +3852,10 @@ class OntologyManager:
                     # the Literal is constructed, by the API and by the parser
                     # alike, and it refuses exactly what languages.py refuses,
                     # so such a literal cannot reach this graph to be found.
-                    if kind != "prefLabel" and item["value"] in pref_values:
+                    if (
+                        kind != "prefLabel"
+                        and (item["value"], item["lang"]) in pref_values
+                    ):
                         issues.append(
                             self._skos_issue(
                                 "warning",
@@ -3823,18 +3867,22 @@ class OntologyManager:
                             )
                         )
 
-            notation = self.graph.value(URIRef(concept["uri"]), SKOS.notation)
-            if isinstance(notation, Literal) and notation.language:
-                issues.append(
-                    self._skos_issue(
-                        "warning",
-                        "notation_lang_tagged",
-                        concept,
-                        f"notation '{notation}' on '{name}' carries a language "
-                        "tag; a notation is a code in a symbol scheme and takes "
-                        "a datatype instead (SKOS Reference 6.5)",
+            # Every notation, not ``graph.value``'s arbitrary one: a concept
+            # carrying a correct typed notation alongside a language-tagged one
+            # would otherwise be reported or not depending on iteration order.
+            for notation in self.graph.objects(URIRef(concept["uri"]), SKOS.notation):
+                if isinstance(notation, Literal) and notation.language:
+                    issues.append(
+                        self._skos_issue(
+                            "warning",
+                            "notation_lang_tagged",
+                            concept,
+                            f"notation '{notation}' on '{name}' carries a "
+                            "language tag; a notation is a code in a symbol "
+                            "scheme and takes a datatype instead "
+                            "(SKOS Reference 6.5)",
+                        )
                     )
-                )
         return issues
 
     def _skos_relation_issues(
@@ -3843,7 +3891,7 @@ class OntologyManager:
         """Semantic relations: self-links, dangling targets, and S27 clashes."""
         issues: list[dict[str, str]] = []
         shown = self._skos_display_names(concepts)
-        parents = self._skos_parent_map(concepts)
+        parents, _children, related_map = self._skos_link_maps(concepts)
         known = set(shown)
 
         for concept in concepts:
@@ -3875,7 +3923,7 @@ class OntologyManager:
                         )
 
             ancestry = self._skos_ancestors(parents, uri)
-            for target in concept["related_uris"]:
+            for target in related_map[uri]:
                 if target not in known or target == uri:
                     continue
                 if target in ancestry or uri in self._skos_ancestors(parents, target):
@@ -3898,7 +3946,7 @@ class OntologyManager:
         """Shape of the hierarchy: redundant edges and stranded concepts."""
         issues: list[dict[str, str]] = []
         shown = self._skos_display_names(concepts)
-        parents = self._skos_parent_map(concepts)
+        parents, children, related_map = self._skos_link_maps(concepts)
 
         for concept in concepts:
             uri, name = concept["uri"], concept["name"]
@@ -3924,9 +3972,9 @@ class OntologyManager:
                     )
 
             if (
-                not concept["broader_uris"]
-                and not concept["narrower_uris"]
-                and not concept["related_uris"]
+                not parents[uri]
+                and not children[uri]
+                and not related_map[uri]
                 and not concept["top_of_uris"]
             ):
                 issues.append(
@@ -3940,7 +3988,7 @@ class OntologyManager:
                 )
 
             for scheme_uri in concept["top_of_uris"]:
-                if set(concept["broader_uris"]) & set(
+                if set(parents[uri]) & set(
                     self._skos_concepts_in_scheme(concepts, scheme_uri)
                 ):
                     issues.append(
@@ -4070,7 +4118,7 @@ class OntologyManager:
         """Completeness and shape, all advisory: nothing here is a SKOS error."""
         issues: list[dict[str, str]] = []
         shown = self._skos_display_names(concepts)
-        parents = self._skos_parent_map(concepts)
+        parents, _children, related_map = self._skos_link_maps(concepts)
 
         for concept in concepts:
             if not concept["notes"]["definition"] and not concept["notes"]["scopeNote"]:
@@ -4087,7 +4135,7 @@ class OntologyManager:
             # Two concepts under the same parent are related by that parent
             # already; saying so again with skos:related adds nothing.
             direct = set(parents.get(concept["uri"], ()))
-            for target in concept["related_uris"]:
+            for target in related_map[concept["uri"]]:
                 if target in shown and direct & set(parents.get(target, ())):
                     issues.append(
                         self._skos_issue(

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -3191,11 +3191,7 @@ class OntologyManager:
                 continue
 
             # Filter by scheme if specified
-            if (
-                scheme
-                and scheme_uri
-                and not self._concept_in_scheme(uri, scheme_uri)
-            ):
+            if scheme and scheme_uri and not self._concept_in_scheme(uri, scheme_uri):
                 continue
 
             name = self._local_name(uri)

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2807,6 +2807,162 @@ class OntologyManager:
         "changeNote": SKOS.changeNote,
     }
 
+    #: What :meth:`validate_skos` checks, keyed by the ``type`` on each issue.
+    #:
+    #: The single source of truth for the check list: the page renders its
+    #: reference from this, the README documents it from this, and
+    #: ``tests/test_skos_validation.py`` fails if the validator emits a check
+    #: this does not describe, or describes one it cannot emit.
+    #:
+    #: ``source`` cites the SKOS Reference by its integrity-condition number
+    #: where the condition is stated there, qSKOS where the check comes from
+    #: that tool's published quality criteria, and says "practice" where it is
+    #: thesaurus convention rather than anything normative. It does not invent
+    #: a citation for a check that has none.
+    SKOS_CHECKS: ClassVar[dict[str, dict[str, str]]] = {
+        # Errors: broken or contradicted by the standard. Always checked.
+        "missing_prefLabel": {
+            "severity": "error",
+            "summary": "The concept has no skos:prefLabel in any language.",
+            "source": "Practice",
+        },
+        "multi_prefLabel_per_lang": {
+            "severity": "error",
+            "summary": "More than one skos:prefLabel shares a language tag.",
+            "source": "SKOS Reference S14",
+        },
+        "empty_label": {
+            "severity": "error",
+            "summary": "A label literal is empty or only whitespace.",
+            "source": "Practice",
+        },
+        "self_relation": {
+            "severity": "error",
+            "summary": "The concept is its own broader, narrower or related.",
+            "source": "Practice",
+        },
+        "dangling_relation": {
+            "severity": "error",
+            "summary": (
+                "A broader, narrower or related link points at something that "
+                "is not a Concept here. Mapping properties are exempt: reaching "
+                "outside the vocabulary is what they are for."
+            ),
+            "source": "Practice",
+        },
+        "relation_clash": {
+            "severity": "error",
+            "summary": (
+                "Two concepts are skos:related and also connected up or down "
+                "the hierarchy."
+            ),
+            "source": "SKOS Reference S27",
+        },
+        "broader_cycle": {
+            "severity": "error",
+            "summary": "A chain of skos:broader links returns to its start.",
+            # Not a SKOS Reference integrity condition: the standard does not
+            # forbid a cycle. It is an error here because a cyclic hierarchy
+            # breaks tree rendering and every ancestor query built on it.
+            "source": "qSKOS",
+        },
+        # Conventions: stated practice rather than broken data.
+        "missing_lang": {
+            "severity": "warning",
+            "summary": "A label carries no language tag.",
+            "source": "Practice",
+        },
+        "label_overlap": {
+            "severity": "warning",
+            "summary": (
+                "The same text is used as a prefLabel and as an altLabel or "
+                "hiddenLabel on one concept."
+            ),
+            "source": "SKOS Reference S13",
+        },
+        "duplicate_prefLabel": {
+            "severity": "warning",
+            "summary": (
+                "Two concepts in one scheme share a prefLabel in the same language."
+            ),
+            "source": "qSKOS",
+        },
+        "ambiguous_prefLabel": {
+            "severity": "warning",
+            "summary": (
+                "Two concepts anywhere in the vocabulary share a prefLabel in "
+                "the same language, without sharing a scheme."
+            ),
+            "source": "qSKOS",
+        },
+        "orphan": {
+            "severity": "warning",
+            "summary": (
+                "The concept has no broader, narrower or related concept and is "
+                "not a top concept, so nothing reaches it."
+            ),
+            "source": "qSKOS",
+        },
+        "top_with_broader": {
+            "severity": "warning",
+            "summary": (
+                "A top concept of a scheme also has a broader concept in that "
+                "same scheme. Having one in another scheme is fine."
+            ),
+            "source": "Practice",
+        },
+        "hierarchy_redundancy": {
+            "severity": "warning",
+            "summary": (
+                "A direct broader concept is already reachable through another "
+                "parent, so the edge says nothing new."
+            ),
+            "source": "qSKOS",
+        },
+        "mapping_within_scheme": {
+            "severity": "warning",
+            "summary": (
+                "A mapping property links two concepts of the same scheme; it "
+                "is meant for links between vocabularies."
+            ),
+            "source": "Practice",
+        },
+        "notation_lang_tagged": {
+            "severity": "warning",
+            "summary": (
+                "A skos:notation carries a language tag. A notation is a code "
+                "in a symbol scheme and takes a datatype instead."
+            ),
+            "source": "SKOS Reference 6.5",
+        },
+        # Editorial: completeness and shape. Nothing here is wrong as such.
+        "no_scheme": {
+            "severity": "info",
+            "summary": "The concept belongs to no ConceptScheme.",
+            "source": "Practice",
+        },
+        "undocumented": {
+            "severity": "info",
+            "summary": "The concept has neither a definition nor a scopeNote.",
+            "source": "Practice",
+        },
+        "valueless_association": {
+            "severity": "info",
+            "summary": (
+                "Two concepts are skos:related and already share a parent, "
+                "which relates them anyway."
+            ),
+            "source": "qSKOS",
+        },
+        "disconnected_components": {
+            "severity": "info",
+            "summary": (
+                "A cluster of concepts has no link to the main body of the vocabulary."
+            ),
+            "source": "qSKOS",
+        },
+    }
+
     #: The subset of :attr:`SKOS_RELATIONS` that links across vocabularies, and
     #: so may point at a URI this graph does not otherwise know about.
     SKOS_MAPPING_RELATIONS: ClassVar[tuple[str, ...]] = (
@@ -3527,56 +3683,334 @@ class OntologyManager:
 
         return hierarchy
 
-    def validate_skos(self) -> list[dict[str, str]]:
-        """Validate SKOS concepts and schemes.
+    # SKOS validation is split into one method per family of checks. Each takes
+    # the already-fetched concept list so ``get_concepts()`` is walked once, and
+    # each returns issue dicts rather than appending to shared state, so a check
+    # can be read, tested and switched off on its own.
+    #
+    # Every index here is keyed by URI, never by local name: two concepts can
+    # share a local name across namespaces (issue #87 part B), and a name-keyed
+    # map silently merges them.
 
-        Checks:
-        - Missing prefLabel
-        - Concept not in any scheme
-        - Orphan concepts (no broader and not top concept)
-        - Duplicate prefLabels within a scheme
-        - Broader/narrower cycles
+    @staticmethod
+    def _skos_issue(
+        severity: str, kind: str, concept: dict[str, Any], message: str
+    ) -> dict[str, str]:
+        """One issue, carrying the subject's URI as well as its display name.
+
+        ``subject_uri`` is what the UI navigates by; resolving ``subject``
+        through the base namespace would land on the wrong concept whenever two
+        share a local name.
         """
-        issues = []
+        return {
+            "severity": severity,
+            "type": kind,
+            "subject": concept["name"],
+            "subject_uri": concept["uri"],
+            "message": message,
+        }
 
-        concepts = self.get_concepts()
-        schemes = self.get_concept_schemes()
+    def _skos_display_names(self, concepts: list[dict[str, Any]]) -> dict[str, str]:
+        """URI -> the shortest label that still identifies the concept.
+
+        The local name where it is unique, the full URI where it is not, so a
+        message about two concepts sharing a name does not read as one concept.
+        """
+        counts: dict[str, int] = {}
+        for concept in concepts:
+            counts[concept["name"]] = counts.get(concept["name"], 0) + 1
+        return {
+            c["uri"]: (c["name"] if counts[c["name"]] == 1 else c["uri"])
+            for c in concepts
+        }
+
+    @staticmethod
+    def _skos_parent_map(concepts: list[dict[str, Any]]) -> dict[str, list[str]]:
+        """URI -> its broader URIs, restricted to concepts this graph knows."""
+        known = {c["uri"] for c in concepts}
+        return {
+            c["uri"]: [u for u in c["broader_uris"] if u in known] for c in concepts
+        }
+
+    @staticmethod
+    def _skos_ancestors(parents: dict[str, list[str]], start: str) -> set[str]:
+        """Every concept above ``start``, cycle-safe.
+
+        A vocabulary that arrived by import may already contain a cycle, so this
+        carries a visited set rather than trusting the hierarchy to be acyclic.
+        """
+        seen: set[str] = set()
+        stack = list(parents.get(start, ()))
+        while stack:
+            node = stack.pop()
+            if node in seen:
+                continue
+            seen.add(node)
+            stack.extend(parents.get(node, ()))
+        return seen
+
+    def _skos_label_issues(
+        self, concepts: list[dict[str, Any]]
+    ) -> list[dict[str, str]]:
+        """Labels: presence, language tagging, and the SKOS disjointness rules."""
+        issues: list[dict[str, str]] = []
+        for concept in concepts:
+            labels = concept["labels"]
+            name = concept["name"]
+
+            if not labels["prefLabel"]:
+                issues.append(
+                    self._skos_issue(
+                        "error",
+                        "missing_prefLabel",
+                        concept,
+                        f"Concept '{name}' has no prefLabel",
+                    )
+                )
+
+            by_lang: dict[str, int] = {}
+            for item in labels["prefLabel"]:
+                by_lang[item["lang"]] = by_lang.get(item["lang"], 0) + 1
+            for lang, count in sorted(by_lang.items()):
+                if count > 1:
+                    tag = f"@{lang}" if lang else " (untagged)"
+                    issues.append(
+                        self._skos_issue(
+                            "error",
+                            "multi_prefLabel_per_lang",
+                            concept,
+                            f"Concept '{name}' has {count} prefLabels{tag}; SKOS "
+                            "allows at most one per language tag "
+                            "(SKOS Reference S14)",
+                        )
+                    )
+
+            pref_values = {item["value"] for item in labels["prefLabel"]}
+            for kind in self.SKOS_LABEL_KINDS:
+                for item in labels[kind]:
+                    if not item["value"].strip():
+                        issues.append(
+                            self._skos_issue(
+                                "error",
+                                "empty_label",
+                                concept,
+                                f"Concept '{name}' has an empty {kind}",
+                            )
+                        )
+                    elif not item["lang"]:
+                        issues.append(
+                            self._skos_issue(
+                                "warning",
+                                "missing_lang",
+                                concept,
+                                f"{kind} '{item['value']}' on '{name}' has no "
+                                "language tag",
+                            )
+                        )
+                    # No malformed-tag check here. rdflib refuses a bad tag when
+                    # the Literal is constructed, by the API and by the parser
+                    # alike, and it refuses exactly what languages.py refuses,
+                    # so such a literal cannot reach this graph to be found.
+                    if kind != "prefLabel" and item["value"] in pref_values:
+                        issues.append(
+                            self._skos_issue(
+                                "warning",
+                                "label_overlap",
+                                concept,
+                                f"'{item['value']}' is both a prefLabel and a "
+                                f"{kind} on '{name}'; the three label properties "
+                                "are pairwise disjoint (SKOS Reference S13)",
+                            )
+                        )
+
+            notation = self.graph.value(URIRef(concept["uri"]), SKOS.notation)
+            if isinstance(notation, Literal) and notation.language:
+                issues.append(
+                    self._skos_issue(
+                        "warning",
+                        "notation_lang_tagged",
+                        concept,
+                        f"notation '{notation}' on '{name}' carries a language "
+                        "tag; a notation is a code in a symbol scheme and takes "
+                        "a datatype instead (SKOS Reference 6.5)",
+                    )
+                )
+        return issues
+
+    def _skos_relation_issues(
+        self, concepts: list[dict[str, Any]]
+    ) -> list[dict[str, str]]:
+        """Semantic relations: self-links, dangling targets, and S27 clashes."""
+        issues: list[dict[str, str]] = []
+        shown = self._skos_display_names(concepts)
+        parents = self._skos_parent_map(concepts)
+        known = set(shown)
 
         for concept in concepts:
-            # Missing prefLabel
-            if not concept["prefLabel"]:
+            uri, name = concept["uri"], concept["name"]
+
+            for kind in ("broader", "narrower", "related"):
+                targets = concept[f"{kind}_uris"]
+                if uri in targets:
+                    issues.append(
+                        self._skos_issue(
+                            "error",
+                            "self_relation",
+                            concept,
+                            f"Concept '{name}' is its own {kind}",
+                        )
+                    )
+                # Mapping properties are excluded on purpose: pointing outside
+                # this graph is the whole point of exactMatch and friends.
+                for target in targets:
+                    if target not in known:
+                        issues.append(
+                            self._skos_issue(
+                                "error",
+                                "dangling_relation",
+                                concept,
+                                f"{kind} on '{name}' points at {target}, which "
+                                "is not a Concept in this vocabulary",
+                            )
+                        )
+
+            ancestry = self._skos_ancestors(parents, uri)
+            for target in concept["related_uris"]:
+                if target not in known or target == uri:
+                    continue
+                if target in ancestry or uri in self._skos_ancestors(parents, target):
+                    issues.append(
+                        self._skos_issue(
+                            "error",
+                            "relation_clash",
+                            concept,
+                            f"'{name}' is related to '{shown[target]}' and also "
+                            "hierarchically connected to it; skos:related is "
+                            "disjoint with skos:broaderTransitive "
+                            "(SKOS Reference S27)",
+                        )
+                    )
+        return issues
+
+    def _skos_hierarchy_issues(
+        self, concepts: list[dict[str, Any]]
+    ) -> list[dict[str, str]]:
+        """Shape of the hierarchy: redundant edges and stranded concepts."""
+        issues: list[dict[str, str]] = []
+        shown = self._skos_display_names(concepts)
+        parents = self._skos_parent_map(concepts)
+
+        for concept in concepts:
+            uri, name = concept["uri"], concept["name"]
+
+            # A direct parent that is also an ancestor through another parent
+            # says nothing the hierarchy does not already say.
+            direct = parents.get(uri, [])
+            for parent in direct:
+                via_others = set()
+                for other in direct:
+                    if other != parent:
+                        via_others |= self._skos_ancestors(parents, other)
+                if parent in via_others:
+                    issues.append(
+                        self._skos_issue(
+                            "warning",
+                            "hierarchy_redundancy",
+                            concept,
+                            f"broader '{shown[parent]}' on '{name}' is already "
+                            "reachable through another parent (qSKOS: "
+                            "hierarchical redundancy)",
+                        )
+                    )
+
+            if (
+                not concept["broader_uris"]
+                and not concept["narrower_uris"]
+                and not concept["related_uris"]
+                and not concept["top_of_uris"]
+            ):
                 issues.append(
-                    {
-                        "severity": "warning",
-                        "type": "missing_prefLabel",
-                        "subject": concept["name"],
-                        "message": f"Concept '{concept['name']}' has no prefLabel",
-                    }
+                    self._skos_issue(
+                        "warning",
+                        "orphan",
+                        concept,
+                        f"Concept '{name}' has no broader, narrower or related "
+                        "concept and is not a top concept (qSKOS: orphan concept)",
+                    )
                 )
 
-            # Not in any scheme
-            if not concept["schemes"] and schemes:
+            for scheme_uri in concept["top_of_uris"]:
+                if set(concept["broader_uris"]) & set(
+                    self._skos_concepts_in_scheme(concepts, scheme_uri)
+                ):
+                    issues.append(
+                        self._skos_issue(
+                            "warning",
+                            "top_with_broader",
+                            concept,
+                            f"'{name}' is a top concept of "
+                            f"'{self._local_name(URIRef(scheme_uri))}' but also "
+                            "has a broader concept in that same scheme",
+                        )
+                    )
+        return issues
+
+    @staticmethod
+    def _skos_concepts_in_scheme(
+        concepts: list[dict[str, Any]], scheme_uri: str
+    ) -> set[str]:
+        """URIs of the concepts in one scheme, addressed by the scheme's URI."""
+        return {c["uri"] for c in concepts if scheme_uri in c["scheme_uris"]}
+
+    def _skos_scheme_issues(
+        self, concepts: list[dict[str, Any]], schemes: list[dict[str, Any]]
+    ) -> list[dict[str, str]]:
+        """Scheme membership, label clashes, and cross-scheme mapping misuse."""
+        issues: list[dict[str, str]] = []
+        shown = self._skos_display_names(concepts)
+
+        for concept in concepts:
+            if not concept["scheme_uris"] and schemes:
                 issues.append(
-                    {
-                        "severity": "info",
-                        "type": "no_scheme",
-                        "subject": concept["name"],
-                        "message": f"Concept '{concept['name']}' is not in any ConceptScheme",
-                    }
+                    self._skos_issue(
+                        "info",
+                        "no_scheme",
+                        concept,
+                        f"Concept '{concept['name']}' is not in any ConceptScheme",
+                    )
                 )
 
-        # Duplicate prefLabels within schemes. Compared per language tag, not
-        # through the flattened compatibility value: a concept may carry a
-        # prefLabel in several languages, and flattening picks one, so a clash
-        # in any other language went unreported.
+            # A mapping property is for reaching another vocabulary. Between two
+            # concepts of the same scheme, a semantic relation is meant instead.
+            for relation in self.SKOS_MAPPING_RELATIONS:
+                for target in concept["mappings"][relation]:
+                    shared = set(concept["scheme_uris"]) & {
+                        s
+                        for c in concepts
+                        if c["uri"] == target
+                        for s in c["scheme_uris"]
+                    }
+                    if shared:
+                        issues.append(
+                            self._skos_issue(
+                                "warning",
+                                "mapping_within_scheme",
+                                concept,
+                                f"{relation} links '{concept['name']}' to "
+                                f"'{shown.get(target, target)}' in the same "
+                                "scheme; mapping properties are for links "
+                                "between vocabularies",
+                            )
+                        )
+
+        # Duplicate prefLabels within a scheme. Compared per language tag rather
+        # than through the flattened compatibility value, and the scheme is
+        # addressed by URI: two schemes can share a local name, and resolving by
+        # name checks one twice and the other not at all.
+        same_scheme_pairs: set[tuple[str, str, str, str]] = set()
         for scheme in schemes:
-            # By URI, not by local name: two schemes can share a local name
-            # across namespaces (issue #87 part B), and resolving by name picks
-            # whichever the store yields first, so one scheme's concepts get
-            # checked twice and the other's not at all.
-            scheme_concepts = self.get_concepts(scheme=scheme["uri"])
-            labels_seen: dict[tuple[str, str], str] = {}
-            for concept in scheme_concepts:
+            seen: dict[tuple[str, str], dict[str, Any]] = {}
+            for concept in self.get_concepts(scheme=scheme["uri"]):
                 for item in concept["labels"]["prefLabel"]:
                     key = (item["lang"], item["value"])
                     tagged = (
@@ -3584,46 +4018,157 @@ class OntologyManager:
                         if item["lang"]
                         else f"'{item['value']}'"
                     )
-                    if key in labels_seen:
+                    if key in seen:
+                        first = seen[key]
+                        same_scheme_pairs.add((*key, first["uri"], concept["uri"]))
                         issues.append(
-                            {
-                                "severity": "warning",
-                                "type": "duplicate_prefLabel",
-                                "subject": concept["name"],
-                                "message": f"Duplicate prefLabel {tagged} in scheme '{scheme['name']}' (also on '{labels_seen[key]}')",
-                            }
+                            self._skos_issue(
+                                "warning",
+                                "duplicate_prefLabel",
+                                concept,
+                                f"Duplicate prefLabel {tagged} in scheme "
+                                f"'{scheme['name']}' (also on "
+                                f"'{shown[first['uri']]}')",
+                            )
                         )
                     else:
-                        labels_seen[key] = concept["name"]
+                        seen[key] = concept
 
-        # Broader/narrower cycle detection, over *every* parent.
-        #
-        # This used to follow ``broader[0]`` only, so a cycle reachable through
-        # a second parent was invisible. That was survivable while the UI could
-        # only set one broader; poly-hierarchy makes it reachable, so this is an
-        # iterative three-colour DFS instead. Iterative because a deep imported
-        # vocabulary would otherwise blow the recursion limit, and each cycle is
-        # canonicalised by its member set so it is reported once rather than
-        # once per member.
-        # Keyed by URI, for the same reason as the scheme lookup above: two
-        # concepts can share a local name across namespaces, and a name-keyed
-        # map silently collapses them into one node. That both hides real
-        # cycles and invents false ones, depending on which of the two the
-        # store happens to yield last.
-        known = {c["uri"] for c in concepts}
-        parents = {
-            c["uri"]: [u for u in c["broader_uris"] if u in known] for c in concepts
-        }
-        # Local name where it identifies the concept, full URI where it does
-        # not: a cycle between two concepts that share a name renders as
-        # "A -> A -> A", which says nothing about which A.
-        name_counts: dict[str, int] = {}
-        for c in concepts:
-            name_counts[c["name"]] = name_counts.get(c["name"], 0) + 1
-        shown = {
-            c["uri"]: (c["name"] if name_counts[c["name"]] == 1 else c["uri"])
-            for c in concepts
-        }
+        # The same clash across the whole vocabulary. Pairs already reported
+        # above are skipped rather than reported twice: within-scheme and
+        # vocabulary-wide duplication are different problems, and a reader who
+        # has seen the first does not need the second for the same two concepts.
+        vocabulary: dict[tuple[str, str], dict[str, Any]] = {}
+        for concept in concepts:
+            for item in concept["labels"]["prefLabel"]:
+                key = (item["lang"], item["value"])
+                tagged = (
+                    f"'{item['value']}'@{item['lang']}"
+                    if item["lang"]
+                    else f"'{item['value']}'"
+                )
+                earlier = vocabulary.get(key)
+                if earlier is None:
+                    vocabulary[key] = concept
+                    continue
+                if (*key, earlier["uri"], concept["uri"]) in same_scheme_pairs:
+                    continue
+                issues.append(
+                    self._skos_issue(
+                        "warning",
+                        "ambiguous_prefLabel",
+                        concept,
+                        f"prefLabel {tagged} is also on '{shown[earlier['uri']]}' "
+                        "elsewhere in this vocabulary (qSKOS: ambiguous label)",
+                    )
+                )
+        return issues
+
+    def _skos_editorial_issues(
+        self, concepts: list[dict[str, Any]]
+    ) -> list[dict[str, str]]:
+        """Completeness and shape, all advisory: nothing here is a SKOS error."""
+        issues: list[dict[str, str]] = []
+        shown = self._skos_display_names(concepts)
+        parents = self._skos_parent_map(concepts)
+
+        for concept in concepts:
+            if not concept["notes"]["definition"] and not concept["notes"]["scopeNote"]:
+                issues.append(
+                    self._skos_issue(
+                        "info",
+                        "undocumented",
+                        concept,
+                        f"Concept '{concept['name']}' has neither a definition "
+                        "nor a scopeNote",
+                    )
+                )
+
+            # Two concepts under the same parent are related by that parent
+            # already; saying so again with skos:related adds nothing.
+            direct = set(parents.get(concept["uri"], ()))
+            for target in concept["related_uris"]:
+                if target in shown and direct & set(parents.get(target, ())):
+                    issues.append(
+                        self._skos_issue(
+                            "info",
+                            "valueless_association",
+                            concept,
+                            f"'{concept['name']}' is related to "
+                            f"'{shown[target]}' and both share a parent "
+                            "(qSKOS: valueless associative relation)",
+                        )
+                    )
+
+        issues.extend(self._skos_component_issues(concepts))
+        return issues
+
+    def _skos_component_issues(
+        self, concepts: list[dict[str, Any]]
+    ) -> list[dict[str, str]]:
+        """Clusters with no connection to the bulk of the vocabulary.
+
+        Reported per stranded cluster rather than once for the vocabulary, so
+        each issue names a concept the user can open. The largest cluster is
+        taken as the vocabulary proper and is not reported.
+        """
+        known = {c["uri"]: c for c in concepts}
+        adjacency: dict[str, set[str]] = {uri: set() for uri in known}
+        for concept in concepts:
+            for key in ("broader_uris", "narrower_uris", "related_uris"):
+                for target in concept[key]:
+                    if target in known:
+                        adjacency[concept["uri"]].add(target)
+                        adjacency[target].add(concept["uri"])
+
+        seen: set[str] = set()
+        components: list[list[str]] = []
+        for uri in sorted(known):
+            if uri in seen:
+                continue
+            stack, cluster = [uri], []
+            seen.add(uri)
+            while stack:
+                node = stack.pop()
+                cluster.append(node)
+                for neighbour in sorted(adjacency[node]):
+                    if neighbour not in seen:
+                        seen.add(neighbour)
+                        stack.append(neighbour)
+            components.append(sorted(cluster))
+
+        if len(components) < 2:
+            return []
+        components.sort(key=lambda c: (-len(c), c[0]))
+        biggest = len(components[0])
+        return [
+            self._skos_issue(
+                "info",
+                "disconnected_components",
+                known[cluster[0]],
+                f"'{known[cluster[0]]['name']}' is in a cluster of "
+                f"{len(cluster)} concept{'s' if len(cluster) != 1 else ''} with "
+                f"no link to the main body of {biggest} "
+                "(qSKOS: disconnected concept cluster)",
+            )
+            for cluster in components[1:]
+        ]
+
+    def _skos_cycle_issues(
+        self, concepts: list[dict[str, Any]]
+    ) -> list[dict[str, str]]:
+        """Every distinct ``skos:broader`` cycle, reported once.
+
+        An iterative three-colour DFS over *all* parents. Iterative because an
+        imported vocabulary can be deeper than the recursion limit, over all
+        parents because following only the first missed any cycle reachable
+        through a second, and canonicalised by member set so a cycle is not
+        reported once per member.
+        """
+        issues: list[dict[str, str]] = []
+        parents = self._skos_parent_map(concepts)
+        shown = self._skos_display_names(concepts)
+        by_uri = {c["uri"]: c for c in concepts}
         WHITE, GREY, BLACK = 0, 1, 2
         colour = dict.fromkeys(parents, WHITE)
         seen_cycles: set[frozenset] = set()
@@ -3645,15 +4190,13 @@ class OntologyManager:
                         if frozenset(cycle) not in seen_cycles:
                             seen_cycles.add(frozenset(cycle))
                             issues.append(
-                                {
-                                    "severity": "error",
-                                    "type": "broader_cycle",
-                                    "subject": shown[cycle[0]],
-                                    "message": (
-                                        "Broader/narrower cycle detected: "
-                                        + " -> ".join(shown[u] for u in [*cycle, nxt])
-                                    ),
-                                }
+                                self._skos_issue(
+                                    "error",
+                                    "broader_cycle",
+                                    by_uri[cycle[0]],
+                                    "Broader/narrower cycle detected: "
+                                    + " -> ".join(shown[u] for u in [*cycle, nxt]),
+                                )
                             )
                     elif colour.get(nxt, BLACK) == WHITE:
                         colour[nxt] = GREY
@@ -3665,8 +4208,55 @@ class OntologyManager:
                     colour[node] = BLACK
                     stack.pop()
                     path.pop()
-
         return issues
+
+    def validate_skos(
+        self,
+        *,
+        check_editorial: bool = True,
+        check_conventions: bool = True,
+    ) -> list[dict[str, str]]:
+        """Validate a SKOS vocabulary against the Reference and common practice.
+
+        Three tiers, so a large imported vocabulary can be checked for real
+        errors without drowning in advice:
+
+        - **error** — conditions the SKOS Reference states outright, plus
+          structural breakage (a cycle, a relation to something that is not a
+          concept). Always checked.
+        - **warning** — stated conventions and thesaurus practice. Gated by
+          ``check_conventions``.
+        - **info** — editorial completeness and vocabulary shape. Gated by
+          ``check_editorial``.
+
+        Each issue carries ``severity``, ``type``, ``subject``, ``subject_uri``
+        and ``message``. ``type`` is stable, so the UI can group by it and the
+        autofixers can target it; ``subject_uri`` is what to navigate by, since
+        two concepts may share a local name.
+        """
+        concepts = self.get_concepts()
+        schemes = self.get_concept_schemes()
+
+        issues = self._skos_label_issues(concepts)
+        issues += self._skos_relation_issues(concepts)
+        issues += self._skos_cycle_issues(concepts)
+        issues += self._skos_scheme_issues(concepts, schemes)
+        if check_editorial:
+            issues += self._skos_editorial_issues(concepts)
+        # Hierarchy shape is the most expensive family (an ancestor walk per
+        # parent per concept) and every issue in it is advisory, so it is
+        # skipped wholesale rather than computed and filtered away.
+        if check_conventions:
+            issues += self._skos_hierarchy_issues(concepts)
+        else:
+            issues = [i for i in issues if i["severity"] != "warning"]
+        if not check_editorial:
+            issues = [i for i in issues if i["severity"] != "info"]
+
+        order = {"error": 0, "warning": 1, "info": 2}
+        return sorted(
+            issues, key=lambda i: (order[i["severity"]], i["type"], i["subject"])
+        )
 
     # ==================== RELATIONS OPERATIONS ====================
 

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2875,8 +2875,8 @@ class OntologyManager:
         "label_overlap": {
             "severity": "warning",
             "summary": (
-                "The same text in the same language is used as a prefLabel "
-                "and as an altLabel or hiddenLabel on one concept."
+                "One concept uses the same text in the same language as two "
+                "of prefLabel, altLabel and hiddenLabel."
             ),
             "source": "SKOS Reference S13",
         },
@@ -3852,12 +3852,6 @@ class OntologyManager:
                         )
                     )
 
-            # (value, language), not value alone: an RDF literal's language is
-            # part of its identity, so a prefLabel "Bank"@en and an altLabel
-            # "Bank"@de are different objects and S13 is not violated.
-            pref_values = {
-                (item["value"], item["lang"]) for item in labels["prefLabel"]
-            }
             for kind in self.SKOS_LABEL_KINDS:
                 for item in labels[kind]:
                     if not item["value"].strip():
@@ -3883,20 +3877,37 @@ class OntologyManager:
                     # the Literal is constructed, by the API and by the parser
                     # alike, and it refuses exactly what languages.py refuses,
                     # so such a literal cannot reach this graph to be found.
-                    if (
-                        kind != "prefLabel"
-                        and (item["value"], item["lang"]) in pref_values
-                    ):
-                        issues.append(
-                            self._skos_issue(
-                                "warning",
-                                "label_overlap",
-                                concept,
-                                f"'{item['value']}' is both a prefLabel and a "
-                                f"{kind} on '{name}'; the three label properties "
-                                "are pairwise disjoint (SKOS Reference S13)",
-                            )
+
+            # S13 makes the three label properties *pairwise* disjoint, so an
+            # altLabel matching a hiddenLabel is as much a clash as either
+            # matching a prefLabel. Grouping by literal catches all three pairs
+            # and reports each clashing literal once rather than once per kind.
+            #
+            # Keyed by (value, language): a language tag is part of an RDF
+            # literal's identity, so "Bank"@en and "Bank"@de are different
+            # objects and S13 is not engaged.
+            by_literal: dict[tuple[str, str], list[str]] = {}
+            for kind in self.SKOS_LABEL_KINDS:
+                for item in labels[kind]:
+                    if item["value"].strip():
+                        by_literal.setdefault((item["value"], item["lang"]), []).append(
+                            kind
                         )
+            for (value, lang), kinds in by_literal.items():
+                clashing = [k for k in self.SKOS_LABEL_KINDS if k in kinds]
+                if len(clashing) > 1:
+                    tagged = f"'{value}'@{lang}" if lang else f"'{value}'"
+                    issues.append(
+                        self._skos_issue(
+                            "warning",
+                            "label_overlap",
+                            concept,
+                            f"{tagged} on '{name}' is used as "
+                            f"{' and '.join(clashing)}; the three label "
+                            "properties are pairwise disjoint "
+                            "(SKOS Reference S13)",
+                        )
+                    )
 
             # Every notation, not ``graph.value``'s arbitrary one: a concept
             # carrying a correct typed notation alongside a language-tagged one

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -730,16 +730,72 @@ def render_skos_vocabulary():
 
     if _skos_tab == "SKOS Validation":
         st.subheader("SKOS Validation")
+        st.caption(
+            "Errors are conditions the SKOS Reference states outright. "
+            "Conventions are thesaurus practice; editorial checks are about "
+            "completeness. Both advisory tiers can be switched off, which is "
+            "what makes this usable on a large imported vocabulary."
+        )
+        _c1, _c2 = st.columns(2)
+        with _c1:
+            _conventions = st.checkbox(
+                "Conventions (warnings)", value=True, key="skos_check_conventions"
+            )
+        with _c2:
+            _editorial = st.checkbox(
+                "Editorial (info)", value=True, key="skos_check_editorial"
+            )
+
+        # Rendered from the engine's catalogue, not retyped here: a check code
+        # like `hierarchy_redundancy` means nothing on its own, and a reference
+        # maintained separately from the checks drifts from them.
+        with st.expander("What is checked", expanded=False):
+            for _sev, _title in (
+                ("error", "Errors — always checked"),
+                ("warning", "Conventions — the warnings checkbox"),
+                ("info", "Editorial — the info checkbox"),
+            ):
+                st.markdown(f"**{_title}**")
+                for _kind, _entry in ont.SKOS_CHECKS.items():
+                    if _entry["severity"] == _sev:
+                        st.markdown(
+                            f"- `{_kind}` — {_entry['summary']} "
+                            f"<span style='opacity:.6'>({_entry['source']})</span>",
+                            unsafe_allow_html=True,
+                        )
+
         if st.button("Run SKOS Validation", key="run_skos_validation"):
-            issues = ont.validate_skos()
-            if not issues:
+            st.session_state["_skos_issues"] = ont.validate_skos(
+                check_conventions=_conventions, check_editorial=_editorial
+            )
+
+        if (_issues := st.session_state.get("_skos_issues")) is not None:
+            if not _issues:
                 st.success("No SKOS issues found!")
             else:
-                for issue in issues:
-                    severity = issue["severity"]
-                    icon = {"error": "🔴", "warning": "🟡", "info": "🔵"}.get(
-                        severity, "⚪"
+                _icons = {"error": "🔴", "warning": "🟡", "info": "🔵"}
+                _counts: dict[str, int] = {}
+                for _issue in _issues:
+                    _counts[_issue["severity"]] = _counts.get(_issue["severity"], 0) + 1
+                st.write(
+                    " · ".join(
+                        f"{_icons[_sev]} {_counts[_sev]} "
+                        f"{_sev}{'s' if _counts[_sev] != 1 else ''}"
+                        for _sev in ("error", "warning", "info")
+                        if _counts.get(_sev)
                     )
-                    st.markdown(
-                        f"{icon} **{issue['type']}** — {issue['subject']}: {issue['message']}"
-                    )
+                )
+
+                # Grouped by check, not a flat list: a real vocabulary produces
+                # hundreds of issues and "37 concepts have no definition" is one
+                # decision, while thirty-seven lines of it is a wall.
+                _by_type: dict[str, list[dict[str, str]]] = {}
+                for _issue in _issues:
+                    _by_type.setdefault(_issue["type"], []).append(_issue)
+                for _kind, _group in _by_type.items():
+                    _sev = _group[0]["severity"]
+                    with st.expander(
+                        f"{_icons[_sev]} {_kind} — {len(_group)}", expanded=False
+                    ):
+                        for _issue in _group:
+                            st.markdown(f"- {_issue['message']}")

--- a/tests/test_skos.py
+++ b/tests/test_skos.py
@@ -217,6 +217,35 @@ class TestValidateSKOS:
                 om.graph.add((om._uri(f"c{i}"), SKOS.broader, om._uri(f"c{i - 1}")))
         assert not [i for i in om.validate_skos() if i["type"] == "broader_cycle"]
 
-    def test_valid_skos_no_issues(self, skos_om):
-        issues = skos_om.validate_skos()
-        assert len(issues) == 0
+    def test_valid_skos_no_errors(self, skos_om):
+        """The fixture is well-formed SKOS, so nothing is an error.
+
+        It is not fully *documented* SKOS: its labels carry no language tag and
+        its concepts have no definitions, which the convention and editorial
+        tiers rightly mention. Turning those off is what "is this valid?" means.
+        """
+        issues = skos_om.validate_skos(check_editorial=False, check_conventions=False)
+        assert issues == []
+
+    def test_a_fully_documented_vocabulary_is_silent_at_every_tier(self):
+        """The stronger guarantee: a vocabulary with nothing to say about it.
+
+        Worth having as well as the error-only check above, because most of the
+        new checks are advisory and a false positive in one of them would
+        otherwise only show up as noise on a real vocabulary.
+        """
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_concept_scheme("Scheme", label="Scheme")
+        om.add_concept("Animal", scheme="Scheme")
+        om.set_concept_label("Animal", "prefLabel", "Animal", lang="en")
+        om.set_concept_note("Animal", "definition", "A living organism", lang="en")
+        om.set_top_concept("Animal", "Scheme")
+        for name, label, text in (
+            ("Dog", "Dog", "A domesticated canine"),
+            ("Cat", "Cat", "A domesticated feline"),
+        ):
+            om.add_concept(name, scheme="Scheme", broader="Animal")
+            om.set_concept_label(name, "prefLabel", label, lang="en")
+            om.set_concept_note(name, "definition", text, lang="en")
+
+        assert om.validate_skos() == []

--- a/tests/test_skos_validation.py
+++ b/tests/test_skos_validation.py
@@ -1,0 +1,398 @@
+"""One test per SKOS validation check (WS-1).
+
+`validate_skos` used to check five things. These cover what it checks now, one
+fixture per `type` code, plus the tier gating and the shape of an issue.
+
+Each test asserts on the `type` rather than the message, so wording can change
+without churning the suite, and every fixture is built to trip exactly one
+check: a fixture that trips two makes it impossible to tell which one broke.
+"""
+
+import ast
+import pathlib
+
+import pytest
+from rdflib import Literal, URIRef
+from rdflib.namespace import SKOS
+
+from ontology_manager import OntologyManager
+
+
+@pytest.fixture
+def om():
+    return OntologyManager(base_uri="http://test.org/ont#")
+
+
+@pytest.fixture
+def vocab(om):
+    """A documented two-concept vocabulary that reports nothing.
+
+    Tests bend one thing about it and assert the one check that fires, so the
+    starting point has to be genuinely silent.
+    """
+    om.add_concept_scheme("Scheme", label="Scheme")
+    om.add_concept("Animal", scheme="Scheme")
+    om.set_concept_label("Animal", "prefLabel", "Animal", lang="en")
+    om.set_concept_note("Animal", "definition", "A living organism", lang="en")
+    om.set_top_concept("Animal", "Scheme")
+    om.add_concept("Dog", scheme="Scheme", broader="Animal")
+    om.set_concept_label("Dog", "prefLabel", "Dog", lang="en")
+    om.set_concept_note("Dog", "definition", "A domesticated canine", lang="en")
+    return om
+
+
+def _types(om, **kwargs):
+    return [i["type"] for i in om.validate_skos(**kwargs)]
+
+
+def _of_type(om, kind, **kwargs):
+    return [i for i in om.validate_skos(**kwargs) if i["type"] == kind]
+
+
+class TestBaseline:
+    def test_the_fixture_is_silent(self, vocab):
+        assert vocab.validate_skos() == []
+
+
+class TestLabelChecks:
+    def test_missing_pref_label(self, vocab):
+        vocab.add_concept("Cat", scheme="Scheme", broader="Animal")
+        vocab.set_concept_note("Cat", "definition", "A feline", lang="en")
+        assert "missing_prefLabel" in _types(vocab)
+
+    def test_missing_pref_label_is_an_error(self, vocab):
+        vocab.add_concept("Cat", scheme="Scheme", broader="Animal")
+        assert _of_type(vocab, "missing_prefLabel")[0]["severity"] == "error"
+
+    def test_two_pref_labels_in_one_language(self, vocab):
+        """S14 allows at most one per tag; only an import can produce two."""
+        vocab.graph.add(
+            (
+                URIRef("http://test.org/ont#Dog"),
+                SKOS.prefLabel,
+                Literal("Hound", lang="en"),
+            )
+        )
+        assert "multi_prefLabel_per_lang" in _types(vocab)
+
+    def test_pref_labels_in_different_languages_are_fine(self, vocab):
+        vocab.set_concept_label("Dog", "prefLabel", "Hund", lang="de")
+        assert "multi_prefLabel_per_lang" not in _types(vocab)
+
+    def test_empty_label(self, vocab):
+        vocab.graph.add(
+            (
+                URIRef("http://test.org/ont#Dog"),
+                SKOS.altLabel,
+                Literal("   ", lang="en"),
+            )
+        )
+        assert "empty_label" in _types(vocab)
+
+    def test_missing_language_tag(self, vocab):
+        vocab.set_concept_label("Dog", "altLabel", "Hound")
+        assert "missing_lang" in _types(vocab)
+
+    def test_a_malformed_tag_cannot_reach_the_graph(self, vocab):
+        """Why there is no `bad_lang` check.
+
+        rdflib validates the tag when the Literal is built, by the API and by
+        the parser alike, so a malformed one never lands in the graph for a
+        validator to find.
+        """
+        with pytest.raises(ValueError):
+            Literal("Hound", lang="en_GB")
+
+    def test_label_overlap_across_kinds(self, vocab):
+        """S13: the three label properties are pairwise disjoint."""
+        vocab.set_concept_label("Dog", "altLabel", "Dog", lang="en")
+        assert "label_overlap" in _types(vocab)
+
+    def test_notation_with_a_language_tag(self, vocab):
+        vocab.graph.add(
+            (
+                URIRef("http://test.org/ont#Dog"),
+                SKOS.notation,
+                Literal("636.7", lang="en"),
+            )
+        )
+        assert "notation_lang_tagged" in _types(vocab)
+
+    def test_notation_with_a_datatype_is_fine(self, vocab):
+        vocab.set_concept_notation("Dog", "636.7", datatype="http://example.org/ddc")
+        assert "notation_lang_tagged" not in _types(vocab)
+
+
+class TestRelationChecks:
+    def test_self_relation(self, vocab):
+        vocab.graph.add(
+            (
+                URIRef("http://test.org/ont#Dog"),
+                SKOS.related,
+                URIRef("http://test.org/ont#Dog"),
+            )
+        )
+        assert "self_relation" in _types(vocab)
+
+    def test_dangling_relation(self, vocab):
+        vocab.graph.add(
+            (
+                URIRef("http://test.org/ont#Dog"),
+                SKOS.related,
+                URIRef("http://test.org/ont#Ghost"),
+            )
+        )
+        assert "dangling_relation" in _types(vocab)
+
+    def test_a_mapping_to_another_vocabulary_is_not_dangling(self, vocab):
+        """Pointing outside the graph is what a mapping property is for."""
+        vocab.add_concept_mapping(
+            "Dog", "exactMatch", "http://www.wikidata.org/entity/Q144"
+        )
+        assert "dangling_relation" not in _types(vocab)
+
+    def test_related_to_an_ancestor(self, vocab):
+        """S27: skos:related is disjoint with skos:broaderTransitive."""
+        vocab.add_concept_relation("Dog", "related", "Animal")
+        assert "relation_clash" in _types(vocab)
+
+    def test_related_to_an_unrelated_concept_is_fine(self, vocab):
+        vocab.add_concept("Kennel", scheme="Scheme", broader="Animal")
+        vocab.set_concept_label("Kennel", "prefLabel", "Kennel", lang="en")
+        vocab.set_concept_note("Kennel", "definition", "A dog house", lang="en")
+        assert "relation_clash" not in _types(vocab)
+
+
+class TestHierarchyChecks:
+    def test_redundant_broader(self, vocab):
+        """A parent already reachable through another parent."""
+        vocab.add_concept("Pet", scheme="Scheme", broader="Animal")
+        vocab.set_concept_label("Pet", "prefLabel", "Pet", lang="en")
+        vocab.set_concept_note("Pet", "definition", "A kept animal", lang="en")
+        vocab.add_concept_relation(
+            "Dog", "broader", "Pet"
+        )  # Dog -> Animal and Dog -> Pet -> Animal
+        assert "hierarchy_redundancy" in _types(vocab)
+
+    def test_plain_poly_hierarchy_is_not_redundant(self, vocab):
+        vocab.add_concept("Pet", scheme="Scheme")
+        vocab.set_concept_label("Pet", "prefLabel", "Pet", lang="en")
+        vocab.set_concept_note("Pet", "definition", "A kept animal", lang="en")
+        vocab.set_top_concept("Pet", "Scheme")
+        vocab.add_concept_relation("Dog", "broader", "Pet")
+        assert "hierarchy_redundancy" not in _types(vocab)
+
+    def test_orphan(self, vocab):
+        vocab.add_concept("Loner", scheme="Scheme")
+        vocab.set_concept_label("Loner", "prefLabel", "Loner", lang="en")
+        vocab.set_concept_note("Loner", "definition", "Alone", lang="en")
+        assert "orphan" in _types(vocab)
+
+    def test_a_top_concept_is_not_an_orphan(self, vocab):
+        vocab.add_concept("Plant", scheme="Scheme")
+        vocab.set_concept_label("Plant", "prefLabel", "Plant", lang="en")
+        vocab.set_concept_note("Plant", "definition", "A living organism", lang="en")
+        vocab.set_top_concept("Plant", "Scheme")
+        assert "orphan" not in _types(vocab)
+
+    def test_top_concept_with_a_broader_in_the_same_scheme(self, vocab):
+        vocab.set_top_concept("Dog", "Scheme")  # Dog already has broader Animal
+        assert "top_with_broader" in _types(vocab)
+
+    def test_top_concept_with_a_broader_in_another_scheme_is_fine(self, vocab):
+        """Legitimate: a concept can head one scheme and sit under another."""
+        vocab.add_concept_scheme("Other", label="Other")
+        vocab.set_top_concept("Dog", "Other")
+        assert "top_with_broader" not in _types(vocab)
+
+
+class TestSchemeChecks:
+    def test_concept_in_no_scheme(self, vocab):
+        vocab.add_concept("Stray", broader="Animal")
+        vocab.set_concept_label("Stray", "prefLabel", "Stray", lang="en")
+        vocab.set_concept_note("Stray", "definition", "Unowned", lang="en")
+        assert "no_scheme" in _types(vocab)
+
+    def test_duplicate_pref_label_within_a_scheme(self, vocab):
+        vocab.add_concept("Hound", scheme="Scheme", broader="Animal")
+        vocab.set_concept_label("Hound", "prefLabel", "Dog", lang="en")
+        vocab.set_concept_note("Hound", "definition", "A dog", lang="en")
+        assert "duplicate_prefLabel" in _types(vocab)
+
+    def test_the_same_pair_is_not_also_reported_vocabulary_wide(self, vocab):
+        """Within-scheme and vocabulary-wide duplication are different problems;
+        one pair should not produce both."""
+        vocab.add_concept("Hound", scheme="Scheme", broader="Animal")
+        vocab.set_concept_label("Hound", "prefLabel", "Dog", lang="en")
+        vocab.set_concept_note("Hound", "definition", "A dog", lang="en")
+        assert "ambiguous_prefLabel" not in _types(vocab)
+
+    def test_ambiguous_pref_label_across_schemes(self, vocab):
+        vocab.add_concept_scheme("Other", label="Other")
+        vocab.add_concept("Hound", scheme="Other")
+        vocab.set_concept_label("Hound", "prefLabel", "Dog", lang="en")
+        vocab.set_concept_note("Hound", "definition", "A dog", lang="en")
+        vocab.set_top_concept("Hound", "Other")
+        assert "ambiguous_prefLabel" in _types(vocab)
+
+    def test_mapping_between_two_concepts_of_one_scheme(self, vocab):
+        vocab.add_concept_mapping("Dog", "exactMatch", "http://test.org/ont#Animal")
+        assert "mapping_within_scheme" in _types(vocab)
+
+
+class TestEditorialChecks:
+    def test_undocumented(self, vocab):
+        vocab.add_concept("Cat", scheme="Scheme", broader="Animal")
+        vocab.set_concept_label("Cat", "prefLabel", "Cat", lang="en")
+        assert "undocumented" in _types(vocab)
+
+    def test_a_scope_note_counts_as_documentation(self, vocab):
+        vocab.add_concept("Cat", scheme="Scheme", broader="Animal")
+        vocab.set_concept_label("Cat", "prefLabel", "Cat", lang="en")
+        vocab.set_concept_note("Cat", "scopeNote", "Domestic only", lang="en")
+        assert "undocumented" not in _types(vocab)
+
+    def test_valueless_association_between_siblings(self, vocab):
+        vocab.add_concept("Cat", scheme="Scheme", broader="Animal")
+        vocab.set_concept_label("Cat", "prefLabel", "Cat", lang="en")
+        vocab.set_concept_note("Cat", "definition", "A feline", lang="en")
+        vocab.add_concept_relation("Dog", "related", "Cat")
+        assert "valueless_association" in _types(vocab)
+
+    def test_disconnected_cluster(self, vocab):
+        for name in ("Rock", "Pebble"):
+            vocab.add_concept(name, scheme="Scheme")
+            vocab.set_concept_label(name, "prefLabel", name, lang="en")
+            vocab.set_concept_note(name, "definition", "A mineral", lang="en")
+        vocab.add_concept_relation("Pebble", "broader", "Rock")
+        vocab.set_top_concept("Rock", "Scheme")
+        found = _of_type(vocab, "disconnected_components")
+        assert len(found) == 1
+        assert "2 concepts" in found[0]["message"]
+
+    def test_one_connected_vocabulary_reports_no_clusters(self, vocab):
+        assert "disconnected_components" not in _types(vocab)
+
+
+class TestCycles:
+    def test_cycle_through_any_parent(self, vocab):
+        vocab.add_concept("Pet", scheme="Scheme", broader="Animal")
+        vocab.set_concept_label("Pet", "prefLabel", "Pet", lang="en")
+        vocab.set_concept_note("Pet", "definition", "A kept animal", lang="en")
+        vocab.graph.add(
+            (
+                URIRef("http://test.org/ont#Animal"),
+                SKOS.broader,
+                URIRef("http://test.org/ont#Pet"),
+            )
+        )
+        assert "broader_cycle" in _types(vocab)
+
+
+class TestTiers:
+    def test_errors_always_run(self, vocab):
+        vocab.add_concept("Cat", scheme="Scheme", broader="Animal")
+        types = _types(vocab, check_editorial=False, check_conventions=False)
+        assert types == ["missing_prefLabel"]
+
+    def test_conventions_can_be_switched_off(self, vocab):
+        vocab.set_concept_label("Dog", "altLabel", "Hound")  # untagged
+        assert "missing_lang" in _types(vocab)
+        assert "missing_lang" not in _types(vocab, check_conventions=False)
+
+    def test_editorial_can_be_switched_off(self, vocab):
+        vocab.add_concept("Cat", scheme="Scheme", broader="Animal")
+        vocab.set_concept_label("Cat", "prefLabel", "Cat", lang="en")
+        assert "undocumented" in _types(vocab)
+        assert "undocumented" not in _types(vocab, check_editorial=False)
+
+
+class TestIssueShape:
+    def test_every_issue_carries_a_subject_uri(self, vocab):
+        """The UI navigates by URI: a local name may name two concepts."""
+        vocab.add_concept("Cat", scheme="Scheme")
+        for issue in vocab.validate_skos():
+            assert issue["subject_uri"].startswith("http")
+            assert set(issue) == {
+                "severity",
+                "type",
+                "subject",
+                "subject_uri",
+                "message",
+            }
+
+    def test_errors_sort_before_warnings_before_info(self, vocab):
+        vocab.add_concept("Cat", scheme="Scheme")  # trips all three tiers
+        severities = [i["severity"] for i in vocab.validate_skos()]
+        assert severities == sorted(
+            severities, key=lambda s: {"error": 0, "warning": 1, "info": 2}[s]
+        )
+
+
+class TestCheckCatalogue:
+    """`SKOS_CHECKS` describes exactly the checks the validator can emit.
+
+    Read out of the source rather than out of a run: a check that only fires on
+    an exotic graph would otherwise drift out of the documentation unnoticed,
+    and the catalogue is what the page and the README both render.
+    """
+
+    @staticmethod
+    def _emitted() -> set:
+        source = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "orionbelt_ontology_builder"
+            / "ontology_manager.py"
+        )
+        pairs = set()
+        for node in ast.walk(ast.parse(source.read_text(encoding="utf-8"))):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "_skos_issue"
+                and len(node.args) >= 2
+            ):
+                continue
+            severity, kind = node.args[0], node.args[1]
+            assert isinstance(severity, ast.Constant) and isinstance(
+                kind, ast.Constant
+            ), "severity and type must be literals, or this test cannot read them"
+            pairs.add((kind.value, severity.value))
+        return pairs
+
+    def test_every_check_is_documented(self):
+        undocumented = {
+            kind
+            for kind, _ in self._emitted()
+            if kind not in OntologyManager.SKOS_CHECKS
+        }
+        assert not undocumented, (
+            f"emitted but not in SKOS_CHECKS: {sorted(undocumented)}"
+        )
+
+    def test_nothing_documented_is_unreachable(self):
+        emitted = {kind for kind, _ in self._emitted()}
+        stale = set(OntologyManager.SKOS_CHECKS) - emitted
+        assert not stale, f"in SKOS_CHECKS but never emitted: {sorted(stale)}"
+
+    def test_documented_severity_matches_what_is_emitted(self):
+        for kind, severity in sorted(self._emitted()):
+            assert OntologyManager.SKOS_CHECKS[kind]["severity"] == severity, (
+                f"{kind} is emitted as {severity} but documented as "
+                f"{OntologyManager.SKOS_CHECKS[kind]['severity']}"
+            )
+
+    def test_every_entry_is_complete(self):
+        for kind, entry in OntologyManager.SKOS_CHECKS.items():
+            assert set(entry) == {"severity", "summary", "source"}, kind
+            assert entry["summary"].endswith("."), (
+                f"{kind}: summary reads as a sentence"
+            )
+            assert entry["severity"] in {"error", "warning", "info"}, kind
+
+    def test_the_readme_documents_every_check(self):
+        readme = (pathlib.Path(__file__).resolve().parents[1] / "README.md").read_text(
+            encoding="utf-8"
+        )
+        missing = [k for k in OntologyManager.SKOS_CHECKS if f"`{k}`" not in readme]
+        assert not missing, f"not documented in README.md: {missing}"

--- a/tests/test_skos_validation.py
+++ b/tests/test_skos_validation.py
@@ -13,7 +13,7 @@ import pathlib
 
 import pytest
 from rdflib import Literal, URIRef
-from rdflib.namespace import SKOS
+from rdflib.namespace import RDF, SKOS
 
 from ontology_manager import OntologyManager
 
@@ -327,6 +327,84 @@ class TestIssueShape:
         assert severities == sorted(
             severities, key=lambda s: {"error": 0, "warning": 1, "info": 2}[s]
         )
+
+
+class TestOneDirectionalImports:
+    """A published vocabulary asserts one side of an inverse, not both.
+
+    SKOS declares broader/narrower inverses and related symmetric, but almost
+    every real file carries only ``B skos:broader A``. Our own writes
+    materialise both sides, so a validator that reads one direction works on a
+    graph this app built and quietly fails on an imported one, which is the
+    graph validation is actually for.
+    """
+
+    @staticmethod
+    def _seed(om, *names):
+        """Concepts written straight into the graph, no inverses materialised."""
+        base = "http://test.org/ont#"
+        om.add_concept_scheme("S")
+        for name in names:
+            uri = URIRef(base + name)
+            om.graph.add((uri, RDF.type, SKOS.Concept))
+            om.graph.add((uri, SKOS.inScheme, URIRef(base + "S")))
+            om.graph.add((uri, SKOS.prefLabel, Literal(name, lang="en")))
+            om.graph.add((uri, SKOS.definition, Literal("A definition", lang="en")))
+        return base
+
+    def test_a_parent_with_only_broader_asserted_is_not_an_orphan(self, om):
+        base = self._seed(om, "Animal", "Dog")
+        om.graph.add((URIRef(base + "Dog"), SKOS.broader, URIRef(base + "Animal")))
+        assert "orphan" not in _types(om)
+
+    def test_a_child_with_only_narrower_asserted_is_not_an_orphan(self, om):
+        base = self._seed(om, "Animal", "Dog")
+        om.graph.add((URIRef(base + "Animal"), SKOS.narrower, URIRef(base + "Dog")))
+        assert "orphan" not in _types(om)
+
+    def test_hierarchy_is_visible_through_a_narrower_only_import(self, om):
+        """S27 has to see the hierarchy however it was asserted."""
+        base = self._seed(om, "Animal", "Dog")
+        om.graph.add((URIRef(base + "Animal"), SKOS.narrower, URIRef(base + "Dog")))
+        om.graph.add((URIRef(base + "Dog"), SKOS.related, URIRef(base + "Animal")))
+        assert "relation_clash" in _types(om)
+
+    def test_a_cycle_asserted_only_as_narrower_is_found(self, om):
+        base = self._seed(om, "A", "B")
+        om.graph.add((URIRef(base + "A"), SKOS.narrower, URIRef(base + "B")))
+        om.graph.add((URIRef(base + "B"), SKOS.narrower, URIRef(base + "A")))
+        assert "broader_cycle" in _types(om)
+
+    def test_related_asserted_one_way_reaches_both_concepts(self, om):
+        base = self._seed(om, "Cat", "Dog")
+        om.graph.add((URIRef(base + "Cat"), SKOS.related, URIRef(base + "Dog")))
+        assert "orphan" not in _types(om)
+
+
+class TestLanguageIsPartOfLiteralIdentity:
+    def test_same_text_in_different_languages_is_not_an_overlap(self, vocab):
+        """S13 is about the same object, and a language tag is part of one."""
+        vocab.set_concept_label("Dog", "altLabel", "Dog", lang="de")
+        assert "label_overlap" not in _types(vocab)
+
+    def test_same_text_in_the_same_language_still_is(self, vocab):
+        vocab.set_concept_label("Dog", "altLabel", "Dog", lang="en")
+        assert "label_overlap" in _types(vocab)
+
+
+class TestEveryNotationIsChecked:
+    def test_a_tagged_notation_alongside_a_typed_one(self, vocab):
+        """``graph.value`` returns one arbitrary object, so this was a coin flip."""
+        dog = URIRef("http://test.org/ont#Dog")
+        vocab.graph.add(
+            (
+                dog,
+                SKOS.notation,
+                Literal("636.7", datatype=URIRef("http://example.org/ddc")),
+            )
+        )
+        vocab.graph.add((dog, SKOS.notation, Literal("bad", lang="en")))
+        assert "notation_lang_tagged" in _types(vocab)
 
 
 class TestCheckCatalogue:

--- a/tests/test_skos_validation.py
+++ b/tests/test_skos_validation.py
@@ -340,14 +340,20 @@ class TestOneDirectionalImports:
     """
 
     @staticmethod
-    def _seed(om, *names):
-        """Concepts written straight into the graph, no inverses materialised."""
+    def _seed(om, *names, in_scheme=True):
+        """Concepts written straight into the graph, no inverses materialised.
+
+        ``in_scheme=False`` omits the skos:inScheme triple, for the tests about
+        membership implied by a top-concept assertion: seeding it would mask
+        the very thing they check.
+        """
         base = "http://test.org/ont#"
         om.add_concept_scheme("S")
         for name in names:
             uri = URIRef(base + name)
             om.graph.add((uri, RDF.type, SKOS.Concept))
-            om.graph.add((uri, SKOS.inScheme, URIRef(base + "S")))
+            if in_scheme:
+                om.graph.add((uri, SKOS.inScheme, URIRef(base + "S")))
             om.graph.add((uri, SKOS.prefLabel, Literal(name, lang="en")))
             om.graph.add((uri, SKOS.definition, Literal("A definition", lang="en")))
         return base
@@ -374,6 +380,41 @@ class TestOneDirectionalImports:
         om.graph.add((URIRef(base + "A"), SKOS.narrower, URIRef(base + "B")))
         om.graph.add((URIRef(base + "B"), SKOS.narrower, URIRef(base + "A")))
         assert "broader_cycle" in _types(om)
+
+    def test_a_scheme_side_top_concept_is_not_an_orphan(self, om):
+        """``scheme skos:hasTopConcept concept`` with no concept-side triple."""
+        base = self._seed(om, "Animal")
+        om.graph.add((URIRef(base + "S"), SKOS.hasTopConcept, URIRef(base + "Animal")))
+        assert "orphan" not in _types(om)
+
+    def test_a_scheme_side_top_concept_is_in_that_scheme(self, om):
+        """skos:topConceptOf is a sub-property of skos:inScheme."""
+        base = self._seed(om, "Animal")
+        om.graph.add((URIRef(base + "S"), SKOS.hasTopConcept, URIRef(base + "Animal")))
+        assert "no_scheme" not in _types(om)
+        concept = next(c for c in om.get_concepts() if c["name"] == "Animal")
+        assert concept["top_of"] == ["S"]
+        assert concept["schemes"] == ["S"]
+
+    def test_a_scheme_side_top_concept_is_found_by_scheme_filter(self, om):
+        base = self._seed(om, "Animal", in_scheme=False)
+        om.graph.add((URIRef(base + "S"), SKOS.hasTopConcept, URIRef(base + "Animal")))
+        assert [c["name"] for c in om.get_concepts(scheme=base + "S")] == ["Animal"]
+        assert om.get_concept_schemes()[0]["concept_count"] == 1
+
+    def test_membership_is_not_double_counted(self, om):
+        """All three assertions at once still describe one membership."""
+        base = self._seed(om, "Animal", in_scheme=False)
+        for triple in (
+            (URIRef(base + "S"), SKOS.hasTopConcept, URIRef(base + "Animal")),
+            (URIRef(base + "Animal"), SKOS.topConceptOf, URIRef(base + "S")),
+            (URIRef(base + "Animal"), SKOS.inScheme, URIRef(base + "S")),
+        ):
+            om.graph.add(triple)
+        concept = next(c for c in om.get_concepts() if c["name"] == "Animal")
+        assert concept["top_of"] == ["S"]
+        assert concept["schemes"] == ["S"]
+        assert om.get_concept_schemes()[0]["concept_count"] == 1
 
     def test_related_asserted_one_way_reaches_both_concepts(self, om):
         base = self._seed(om, "Cat", "Dog")

--- a/tests/test_skos_validation.py
+++ b/tests/test_skos_validation.py
@@ -432,6 +432,28 @@ class TestLanguageIsPartOfLiteralIdentity:
         vocab.set_concept_label("Dog", "altLabel", "Dog", lang="en")
         assert "label_overlap" in _types(vocab)
 
+    def test_alt_and_hidden_clash_without_a_pref_label_involved(self, vocab):
+        """S13 makes the three *pairwise* disjoint, not each disjoint from
+        prefLabel: an altLabel matching a hiddenLabel is as much a clash."""
+        vocab.set_concept_label("Dog", "altLabel", "Alias", lang="en")
+        vocab.set_concept_label("Dog", "hiddenLabel", "Alias", lang="en")
+        found = _of_type(vocab, "label_overlap")
+        assert len(found) == 1
+        assert "altLabel and hiddenLabel" in found[0]["message"]
+
+    def test_one_literal_in_all_three_kinds_is_reported_once(self, vocab):
+        vocab.set_concept_label("Dog", "prefLabel", "Alias", lang="en")
+        vocab.set_concept_label("Dog", "altLabel", "Alias", lang="en")
+        vocab.set_concept_label("Dog", "hiddenLabel", "Alias", lang="en")
+        found = _of_type(vocab, "label_overlap")
+        assert len(found) == 1
+        assert "prefLabel and altLabel and hiddenLabel" in found[0]["message"]
+
+    def test_alt_and_hidden_in_different_languages_do_not_clash(self, vocab):
+        vocab.set_concept_label("Dog", "altLabel", "Alias", lang="en")
+        vocab.set_concept_label("Dog", "hiddenLabel", "Alias", lang="de")
+        assert "label_overlap" not in _types(vocab)
+
 
 class TestEveryNotationIsChecked:
     def test_a_tagged_notation_alongside_a_typed_one(self, vocab):

--- a/tests/test_skos_validation.py
+++ b/tests/test_skos_validation.py
@@ -531,9 +531,41 @@ class TestCheckCatalogue:
             )
             assert entry["severity"] in {"error", "warning", "info"}, kind
 
-    def test_the_readme_documents_every_check(self):
-        readme = (pathlib.Path(__file__).resolve().parents[1] / "README.md").read_text(
+    @staticmethod
+    def _readme() -> str:
+        return (pathlib.Path(__file__).resolve().parents[1] / "README.md").read_text(
             encoding="utf-8"
         )
+
+    def test_the_readme_documents_every_check(self):
+        readme = self._readme()
         missing = [k for k in OntologyManager.SKOS_CHECKS if f"`{k}`" not in readme]
         assert not missing, f"not documented in README.md: {missing}"
+
+    def test_the_readme_says_what_the_catalogue_says(self):
+        """The README table is generated from the catalogue but stored static.
+
+        Checking only that each check is *named* there let a description go two
+        revisions stale while the test stayed green. The wording is the part a
+        reader relies on, so it is the part worth pinning.
+        """
+        readme = self._readme()
+        stale = [
+            kind
+            for kind, entry in OntologyManager.SKOS_CHECKS.items()
+            if " ".join(entry["summary"].split()) not in readme
+        ]
+        assert not stale, (
+            "README.md describes these checks differently from SKOS_CHECKS, "
+            f"regenerate its table: {stale}"
+        )
+
+    def test_the_readme_cites_the_same_sources(self):
+        readme = self._readme()
+        for kind, entry in OntologyManager.SKOS_CHECKS.items():
+            summary = " ".join(entry["summary"].split())
+            row = next((line for line in readme.splitlines() if summary in line), None)
+            assert row is not None, kind
+            assert entry["source"] in row, (
+                f"{kind}: README cites something other than {entry['source']!r}"
+            )


### PR DESCRIPTION
Implements WS-1 from the SKOS improvement plan. `validate_skos` checked five things; it now runs **twenty checks in three tiers**, so a large imported vocabulary can be checked for real errors without drowning in advice.

| Tier | Gate | Checks |
|---|---|---|
| **error** | always | `missing_prefLabel` (raised from warning), `multi_prefLabel_per_lang`, `empty_label`, `self_relation`, `dangling_relation`, `relation_clash`, `broader_cycle` |
| **warning** | `check_conventions` | `missing_lang`, `label_overlap`, `duplicate_prefLabel`, `ambiguous_prefLabel`, `orphan`, `top_with_broader`, `hierarchy_redundancy`, `mapping_within_scheme`, `notation_lang_tagged` |
| **info** | `check_editorial` | `no_scheme`, `undocumented`, `valueless_association`, `disconnected_components` |

Every issue now carries `subject_uri` alongside `subject`, so the UI can navigate to the concept rather than resolve a local name through the base namespace, and issues come back sorted by severity.

## Documentation

`SKOS_CHECKS` is the single source of truth for the check list. The page renders its "What is checked" reference from it, the README table is generated from it, and tests fail if the validator emits a check the catalogue does not describe, describes one it cannot emit, or disagrees about a severity. Those tests read the emitted checks out of the source with an AST scan rather than from a run, so a check that only fires on an exotic graph cannot silently drift out of the docs.

Sources cite the SKOS Reference integrity condition where the condition is stated there, qSKOS where the check comes from that tool's published criteria, and say "practice" where it is thesaurus convention. Nothing invents a citation: `broader_cycle` is attributed to qSKOS, not to a Reference condition, because SKOS does not actually forbid a cycle.

## Four judgement calls

- **No `bad_lang` check**, though the plan called for one. rdflib validates the language tag when the `Literal` is constructed, by the API and by the parser alike, and it refuses exactly what `languages.py` refuses. A malformed tag cannot reach the graph, so the check could never fire. Shipping it would have been unreachable code with an unwritable test; a test pins the reasoning down instead.
- **`dangling_relation` excludes the mapping properties.** Pointing outside the graph is precisely what `exactMatch` and friends are for.
- **`top_with_broader` only fires when the broader is in the same scheme.** A concept heading one scheme while sitting under a parent in another is legitimate.
- **A pair reported as `duplicate_prefLabel` is not also reported as `ambiguous_prefLabel`.** Scheme-scoped and vocabulary-wide duplication are different problems, but a reader who has seen the first does not need the second about the same two concepts.

## Structure

One method per family of checks rather than growing one function past 300 lines. Each takes the already-fetched concept list, so `get_concepts()` is walked once, and returns issues rather than appending to shared state. Every index is keyed by URI, following the correction made late in #298.

## UI

A checkbox per advisory tier, a collapsible reference to what each check means, and results grouped by check with counts, because a real vocabulary produces hundreds of issues and "37 concepts have no definition" is one decision where thirty-seven lines is a wall.

## Testing

One fixture per check in `tests/test_skos_validation.py`, each built to trip exactly one so a failure names the check that broke, plus a fully documented vocabulary that must stay silent at every tier, which is the real guard against a check over-firing.

The pre-existing "valid SKOS" fixture is well-formed but undocumented (untagged labels, no definitions), so its zero-issues assertion is now scoped to errors and the stronger guarantee gets its own vocabulary.

1308 tests, ruff and mypy pass. The README guard was verified to fail when a check is renamed in the table. Validation page checked live in the running app.