### PR TITLE
feat(skos): read SKOS-XL labels instead of calling them missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ A dedicated page for building controlled vocabularies:
 
 #### What SKOS validation checks
 
-Twenty checks in three tiers. The page groups results by check and lets you
+21 checks in three tiers. The page groups results by check and lets you
 switch either advisory tier off, which is what makes it usable on a large
 imported vocabulary. `validate_skos()` returns the same list to Python callers,
 each issue carrying a stable `type`, a `severity`, the `subject` concept and its
@@ -145,6 +145,7 @@ each issue carrying a stable `type`, a `severity`, the `subject` concept and its
 | `no_scheme` | The concept belongs to no ConceptScheme. | Practice |
 | `undocumented` | The concept has neither a definition nor a scopeNote. | Practice |
 | `valueless_association` | Two concepts are skos:related and already share a parent, which relates them anyway. | qSKOS |
+| `skos_xl_labels` | The vocabulary uses SKOS-XL labels, which this editor shows but does not edit. | SKOS-XL |
 | `disconnected_components` | A cluster of concepts has no link to the main body of the vocabulary. | qSKOS |
 
 Sources cite the SKOS Reference integrity condition where the condition is

--- a/ontology_manager.py
+++ b/ontology_manager.py
@@ -14,6 +14,7 @@ from orionbelt_ontology_builder.ontology_manager import (  # noqa: F401
     IMPORT_MERGE,
     IMPORT_MERGE_OVERWRITE,
     IMPORT_REPLACE,
+    SKOSXL,
     OntologyManager,
     UndoManager,
 )

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -108,16 +108,7 @@ class OntologyManager:
         self.base_uri = base_uri
         self.namespace = Namespace(base_uri)
 
-        # Bind common prefixes
-        self.graph.bind("owl", OWL)
-        self.graph.bind("rdf", RDF)
-        self.graph.bind("rdfs", RDFS)
-        self.graph.bind("xsd", XSD)
-        self.graph.bind("skos", SKOS)
-        self.graph.bind("skosxl", SKOSXL)
-        self.graph.bind("dc", DC)
-        self.graph.bind("dcterms", DCTERMS)
-        self.graph.bind("", self.namespace)
+        self._bind_standard_prefixes()
 
         # Prefixes the user explicitly bound via add_prefix (prefix -> namespace).
         # Tracked so the creation picker offers them even when the name collides
@@ -3871,20 +3862,52 @@ class OntologyManager:
             stack.extend(parents.get(node, ()))
         return seen
 
+    @classmethod
+    def _effective_labels(
+        cls, concept: dict[str, Any]
+    ) -> dict[str, list[dict[str, str]]]:
+        """A concept's labels as the SKOS entailment regime sees them.
+
+        A ``skosxl:prefLabel`` whose label resource carries a ``literalForm``
+        entails the corresponding ``skos:prefLabel`` (SKOS Reference B.3.4.2),
+        so a SKOS-XL label takes part in every integrity condition a plain one
+        does: S13 disjointness, S14's one-per-language rule, and the duplicate
+        and ambiguous label checks. Suppressing ``missing_prefLabel`` for them
+        and stopping there left the rest as false negatives.
+
+        Deduplicated by (value, language), because that entailment means a
+        plain label and an XL label carrying the same literal are the same
+        statement, not two labels that clash with each other.
+
+        Validation-only. The editor keeps the two apart, since it can write
+        plain labels and not SKOS-XL ones.
+        """
+        merged: dict[str, list[dict[str, str]]] = {}
+        for kind in cls.SKOS_LABEL_KINDS:
+            seen: set[tuple[str, str]] = set()
+            values = []
+            for item in [*concept["labels"][kind], *concept["xl_labels"][kind]]:
+                key = (item["value"], item["lang"])
+                if key not in seen:
+                    seen.add(key)
+                    values.append(item)
+            merged[kind] = values
+        return merged
+
     def _skos_label_issues(
         self, concepts: list[dict[str, Any]]
     ) -> list[dict[str, str]]:
         """Labels: presence, language tagging, and the SKOS disjointness rules."""
         issues: list[dict[str, str]] = []
         for concept in concepts:
-            labels = concept["labels"]
+            labels = self._effective_labels(concept)
             name = concept["name"]
 
             # A SKOS-XL preferred label is a preferred label. Without this the
             # check fires on every concept of a SKOS-XL vocabulary, at the one
             # severity that cannot be switched off, and reports a valid file as
             # broken.
-            if not labels["prefLabel"] and not concept["xl_labels"]["prefLabel"]:
+            if not labels["prefLabel"]:
                 issues.append(
                     self._skos_issue(
                         "error",
@@ -4160,7 +4183,7 @@ class OntologyManager:
         for scheme in schemes:
             seen: dict[tuple[str, str], dict[str, Any]] = {}
             for concept in self.get_concepts(scheme=scheme["uri"]):
-                for item in concept["labels"]["prefLabel"]:
+                for item in self._effective_labels(concept)["prefLabel"]:
                     key = (item["lang"], item["value"])
                     tagged = (
                         f"'{item['value']}'@{item['lang']}"
@@ -4189,7 +4212,7 @@ class OntologyManager:
         # has seen the first does not need the second for the same two concepts.
         vocabulary: dict[tuple[str, str], dict[str, Any]] = {}
         for concept in concepts:
-            for item in concept["labels"]["prefLabel"]:
+            for item in self._effective_labels(concept)["prefLabel"]:
                 key = (item["lang"], item["value"])
                 tagged = (
                     f"'{item['value']}'@{item['lang']}"
@@ -5083,9 +5106,28 @@ class OntologyManager:
                 # Current bindings take precedence
                 self.graph.bind(prefix, ns, override=False)
 
+    def _bind_standard_prefixes(self):
+        """Bind the prefixes this app always wants readable in an export.
+
+        Called after every graph replacement, not only at construction: loading
+        a file swaps ``self.graph`` for a fresh one, and only the prefixes
+        rdflib auto-binds survive that. ``skosxl`` is not one of them, so a
+        loaded SKOS-XL vocabulary exported as ``ns1:`` until this ran again.
+        """
+        self.graph.bind("owl", OWL)
+        self.graph.bind("rdf", RDF)
+        self.graph.bind("rdfs", RDFS)
+        self.graph.bind("xsd", XSD)
+        self.graph.bind("skos", SKOS)
+        self.graph.bind("skosxl", SKOSXL)
+        self.graph.bind("dc", DC)
+        self.graph.bind("dcterms", DCTERMS)
+        self.graph.bind("", self.namespace)
+
     def _update_namespace_from_graph(self):
         """Update namespace based on loaded ontology."""
         found_ontology = False
+        # Rebound at the end of this method, once self.namespace is settled.
 
         # Try to find the ontology URI
         for ont in self.graph.subjects(RDF.type, OWL.Ontology):
@@ -5106,14 +5148,9 @@ class OntologyManager:
                 self.ontology_uri = URIRef(self.base_uri.rstrip("#").rstrip("/"))
                 self.graph.add((self.ontology_uri, RDF.type, OWL.Ontology))
 
-        # Re-bind prefixes
-        self.graph.bind("owl", OWL)
-        self.graph.bind("rdf", RDF)
-        self.graph.bind("rdfs", RDFS)
-        self.graph.bind("xsd", XSD)
-        self.graph.bind("skos", SKOS)
-        self.graph.bind("dc", DC)
-        self.graph.bind("dcterms", DCTERMS)
+        # One list, bound from one place. This block used to repeat the set
+        # from __init__ and had silently fallen a prefix behind it.
+        self._bind_standard_prefixes()
 
     def _detect_base_uri(self, uri_str: str) -> str:
         """Detect the base URI with separator from an ontology URI string."""

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -52,6 +52,13 @@ _Triple = tuple[Node, Node, Node]
 _TripleUpdates = list[tuple[_Triple, _Triple]]
 
 # domainIncludes/rangeIncludes from Schema.org and gist
+#: SKOS-XL, the W3C extension that makes a label a resource rather than a
+#: literal, so statements can be made about the label itself. rdflib has no
+#: built-in binding for it. This app authors plain SKOS labels only; SKOS-XL is
+#: read so an imported vocabulary is not shown as unlabelled, and reported so
+#: the user knows why those labels are not editable here.
+SKOSXL = Namespace("http://www.w3.org/2008/05/skos-xl#")
+
 _SCHEMA = Namespace("https://schema.org/")
 _GIST = Namespace("https://w3id.org/semanticarts/ns/ontology/gist/")
 _DOMAIN_INCLUDES = (_SCHEMA.domainIncludes, _GIST.domainIncludes)
@@ -107,6 +114,7 @@ class OntologyManager:
         self.graph.bind("rdfs", RDFS)
         self.graph.bind("xsd", XSD)
         self.graph.bind("skos", SKOS)
+        self.graph.bind("skosxl", SKOSXL)
         self.graph.bind("dc", DC)
         self.graph.bind("dcterms", DCTERMS)
         self.graph.bind("", self.namespace)
@@ -168,6 +176,9 @@ class OntologyManager:
         "rdfs",
         "xsd",
         "skos",
+        # SKOS-XL is a vocabulary this app reads, not one a user mints entities
+        # in, so it belongs here beside skos rather than in the creatable list.
+        "skosxl",
         "dc",
         "dcterms",
     }
@@ -2796,6 +2807,14 @@ class OntologyManager:
         "hiddenLabel": SKOS.hiddenLabel,
     }
 
+    #: The SKOS-XL counterpart of each label kind. Reading these is what keeps
+    #: an imported AGROVOC or EuroVoc from looking entirely unlabelled.
+    SKOS_XL_LABEL_KINDS: ClassVar[dict[str, URIRef]] = {
+        "prefLabel": SKOSXL.prefLabel,
+        "altLabel": SKOSXL.altLabel,
+        "hiddenLabel": SKOSXL.hiddenLabel,
+    }
+
     #: SKOS documentation properties. All are repeatable and language-tagged.
     SKOS_NOTE_KINDS: ClassVar[dict[str, URIRef]] = {
         "definition": SKOS.definition,
@@ -2954,6 +2973,14 @@ class OntologyManager:
             ),
             "source": "qSKOS",
         },
+        "skos_xl_labels": {
+            "severity": "info",
+            "summary": (
+                "The vocabulary uses SKOS-XL labels, which this editor shows "
+                "but does not edit."
+            ),
+            "source": "SKOS-XL",
+        },
         "disconnected_components": {
             "severity": "info",
             "summary": (
@@ -2986,6 +3013,21 @@ class OntologyManager:
             for o in self.graph.objects(uri, prop)
             if isinstance(o, Literal)
         ]
+        return sorted(values, key=lambda v: (v["lang"] != "", v["lang"], v["value"]))
+
+    def _xl_literals(self, uri: Node, prop: URIRef) -> list[dict[str, str]]:
+        """Label literals reached through a SKOS-XL label resource.
+
+        ``concept skosxl:prefLabel [ skosxl:literalForm "Dog"@en ]`` carries the
+        same information as ``skos:prefLabel "Dog"@en``, one indirection away.
+        A label resource without a ``literalForm`` contributes nothing, which is
+        why the value is filtered rather than rendered as an empty string.
+        """
+        values = []
+        for label in self.graph.objects(uri, prop):
+            for form in self.graph.objects(label, SKOSXL.literalForm):
+                if isinstance(form, Literal):
+                    values.append({"value": str(form), "lang": form.language or ""})
         return sorted(values, key=lambda v: (v["lang"] != "", v["lang"], v["value"]))
 
     @staticmethod
@@ -3204,7 +3246,19 @@ class OntologyManager:
                 kind: self._tagged_literals(uri, prop)
                 for kind, prop in self.SKOS_NOTE_KINDS.items()
             }
-            pref_label = self._flatten_literal(labels["prefLabel"])
+            # Kept in their own key rather than merged into ``labels``: the
+            # editor writes plain SKOS, so a SKOS-XL label offered in the same
+            # list would come with a delete button that silently does nothing.
+            xl_labels = {
+                kind: self._xl_literals(uri, prop)
+                for kind, prop in self.SKOS_XL_LABEL_KINDS.items()
+            }
+            # The flat key falls back to SKOS-XL so the graph, the dashboard and
+            # the concept list show a name for an imported vocabulary instead of
+            # a bare local name.
+            pref_label = self._flatten_literal(
+                labels["prefLabel"] or xl_labels["prefLabel"]
+            )
             definition = self._flatten_literal(notes["definition"])
             alt_labels = [v["value"] for v in labels["altLabel"]]
 
@@ -3281,6 +3335,7 @@ class OntologyManager:
                     # Structured, language-aware views. The flat keys above are
                     # computed from these and kept for existing readers.
                     "labels": labels,
+                    "xl_labels": xl_labels,
                     "notes": notes,
                     "notation": notation,
                     "top_of_uris": top_of_uris,
@@ -3825,7 +3880,11 @@ class OntologyManager:
             labels = concept["labels"]
             name = concept["name"]
 
-            if not labels["prefLabel"]:
+            # A SKOS-XL preferred label is a preferred label. Without this the
+            # check fires on every concept of a SKOS-XL vocabulary, at the one
+            # severity that cannot be switched off, and reports a valid file as
+            # broken.
+            if not labels["prefLabel"] and not concept["xl_labels"]["prefLabel"]:
                 issues.append(
                     self._skos_issue(
                         "error",
@@ -4191,7 +4250,35 @@ class OntologyManager:
                     )
 
         issues.extend(self._skos_component_issues(concepts))
+        issues.extend(self._skos_xl_issues(concepts))
         return issues
+
+    def _skos_xl_issues(self, concepts: list[dict[str, Any]]) -> list[dict[str, str]]:
+        """One notice that this vocabulary carries SKOS-XL labels.
+
+        Once for the vocabulary, not once per concept: it is a fact about the
+        file rather than a defect in each concept, and AGROVOC would otherwise
+        produce forty thousand identical lines. The count is what the user needs
+        in order to recognise the situation.
+        """
+        using = [
+            c
+            for c in concepts
+            if any(c["xl_labels"][kind] for kind in self.SKOS_XL_LABEL_KINDS)
+        ]
+        if not using:
+            return []
+        return [
+            self._skos_issue(
+                "info",
+                "skos_xl_labels",
+                using[0],
+                f"{len(using)} concept{'s' if len(using) != 1 else ''} in this "
+                "vocabulary carry SKOS-XL labels. They are shown but not "
+                "editable here, which edits plain SKOS labels; editing one "
+                "means adding a skos:prefLabel alongside it.",
+            )
+        ]
 
     def _skos_component_issues(
         self, concepts: list[dict[str, Any]]

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -901,8 +901,32 @@ def render_skos_literal_editor(ont, concept, ck):
                 _api(kind)[1](concept["uri"], kind, item["value"], item["lang"])
                 save_checkpoint(f"Delete {kind}")
                 st.rerun()
-    if not rows:
+    if not rows and not any(
+        concept["xl_labels"][kind] for kind in ont.SKOS_XL_LABEL_KINDS
+    ):
         st.caption("No labels or notes yet.")
+
+    # SKOS-XL labels are shown but not editable: this app writes plain SKOS, and
+    # a delete button next to one would silently do nothing. Rendering them at
+    # all is what keeps an imported AGROVOC or EuroVoc from looking unlabelled.
+    xl_rows = [
+        (kind, item)
+        for kind in ont.SKOS_XL_LABEL_KINDS
+        for item in concept["xl_labels"][kind]
+    ]
+    if xl_rows:
+        for kind, item in xl_rows:
+            col_kind, col_lang, col_text, _ = st.columns([2, 1, 5, 0.7])
+            with col_kind:
+                st.write(f"`skosxl:{kind}`")
+            with col_lang:
+                st.write(item["lang"] or "—")
+            with col_text:
+                st.write(item["value"])
+        st.caption(
+            "SKOS-XL labels are read-only here. To edit one, add a plain SKOS "
+            "label of the same kind below."
+        )
 
     col_kind, col_lang, col_text, col_add = st.columns([2, 1, 5, 0.7])
     with col_kind:

--- a/tests/test_skos_validation.py
+++ b/tests/test_skos_validation.py
@@ -597,7 +597,13 @@ class TestSkosXl:
         om.graph.add((concept, SKOS.inScheme, URIRef(cls.BASE + "S")))
         om.graph.add((concept, SKOS.definition, Literal("A definition", lang="en")))
         om.graph.add((label, RDF.type, SKOSXL.Label))
-        om.graph.add((label, SKOSXL.literalForm, Literal(text, lang=lang)))
+        om.graph.add(
+            (
+                label,
+                SKOSXL.literalForm,
+                Literal(text, lang=lang) if lang else Literal(text),
+            )
+        )
         om.graph.add((concept, OntologyManager.SKOS_XL_LABEL_KINDS[kind], label))
         return concept
 
@@ -664,6 +670,69 @@ class TestSkosXl:
         assert concept["xl_labels"]["altLabel"][0]["value"] == "XL altLabel"
         assert concept["xl_labels"]["hiddenLabel"][0]["value"] == "XL hiddenLabel"
 
+    # --- SKOS-XL labels take part in the integrity conditions -------------
+    #
+    # A skosxl:prefLabel with a literalForm entails the plain skos:prefLabel
+    # (SKOS Reference B.3.4.2), so it is subject to every rule a plain label
+    # is. Suppressing missing_prefLabel and stopping there left the rest as
+    # false negatives.
+
+    def test_two_xl_pref_labels_in_one_language_break_s14(self, om):
+        concept = self._xl_labelled(om, "A", text="One")
+        second = URIRef(self.BASE + "label_A_second")
+        om.graph.add((second, RDF.type, SKOSXL.Label))
+        om.graph.add((second, SKOSXL.literalForm, Literal("Two", lang="en")))
+        om.graph.add((concept, SKOSXL.prefLabel, second))
+        assert "multi_prefLabel_per_lang" in _types(om)
+
+    def test_duplicate_xl_pref_labels_in_a_scheme_are_found(self, om):
+        self._xl_labelled(om, "A", text="Same")
+        self._xl_labelled(om, "B", text="Same")
+        assert "duplicate_prefLabel" in _types(om)
+
+    def test_a_plain_pref_label_clashes_with_an_xl_alt_label(self, om):
+        """S13 disjointness does not care which spelling asserted the label."""
+        concept = self._xl_labelled(om, "A", kind="altLabel", text="Dog")
+        om.graph.add((concept, SKOS.prefLabel, Literal("Dog", lang="en")))
+        assert "label_overlap" in _types(om)
+
+    def test_an_xl_label_entailing_a_plain_one_is_not_a_clash(self, om):
+        """The entailment makes them the same statement, not two labels.
+
+        Without deduplication, spelling a label both ways would report S14 and
+        S13 violations against itself.
+        """
+        concept = self._xl_labelled(om, "A", text="Dog")
+        om.graph.add((concept, SKOS.prefLabel, Literal("Dog", lang="en")))
+        types = _types(om)
+        assert "multi_prefLabel_per_lang" not in types
+        assert "label_overlap" not in types
+
+    def test_an_untagged_xl_label_is_reported_like_a_plain_one(self, om):
+        self._xl_labelled(om, "A", text="Alpha", lang=None)
+        assert "missing_lang" in _types(om)
+
     def test_skosxl_is_not_offered_as_a_place_to_create_entities(self, om):
         """It is a vocabulary this app reads, not one the user mints in."""
         assert str(SKOSXL) not in om.get_creatable_namespaces()
+
+    def test_the_prefix_survives_a_load(self, om, tmp_path):
+        """Loading replaces the graph, and only rdflib's own defaults survive.
+
+        skosxl is not one of them, so an imported SKOS-XL vocabulary exported
+        as `ns1:` until the standard prefixes were rebound.
+        """
+        source = tmp_path / "xl.ttl"
+        source.write_text(
+            "<http://example.org/o#A> a "
+            "<http://www.w3.org/2004/02/skos/core#Concept> ;\n"
+            "  <http://www.w3.org/2008/05/skos-xl#prefLabel> "
+            "<http://example.org/o#lbl> .\n"
+            "<http://example.org/o#lbl> a "
+            "<http://www.w3.org/2008/05/skos-xl#Label> ;\n"
+            '  <http://www.w3.org/2008/05/skos-xl#literalForm> "Alpha"@en .\n',
+            encoding="utf-8",
+        )
+        om.load_from_file(str(source))
+        assert "skosxl" in {prefix for prefix, _ in om.graph.namespaces()}
+        assert "skosxl:" in om.graph.serialize(format="turtle")

--- a/tests/test_skos_validation.py
+++ b/tests/test_skos_validation.py
@@ -15,7 +15,7 @@ import pytest
 from rdflib import Literal, URIRef
 from rdflib.namespace import RDF, SKOS
 
-from ontology_manager import OntologyManager
+from ontology_manager import SKOSXL, OntologyManager
 
 
 @pytest.fixture
@@ -560,6 +560,12 @@ class TestCheckCatalogue:
             f"regenerate its table: {stale}"
         )
 
+    def test_the_readme_states_the_right_number_of_checks(self):
+        """A count in prose drifts the moment a check is added."""
+        readme = self._readme()
+        expected = f"{len(OntologyManager.SKOS_CHECKS)} checks in three tiers"
+        assert expected in readme, f"README.md should say {expected!r}"
+
     def test_the_readme_cites_the_same_sources(self):
         readme = self._readme()
         for kind, entry in OntologyManager.SKOS_CHECKS.items():
@@ -569,3 +575,95 @@ class TestCheckCatalogue:
             assert entry["source"] in row, (
                 f"{kind}: README cites something other than {entry['source']!r}"
             )
+
+
+class TestSkosXl:
+    """SKOS-XL labels are read, not authored.
+
+    Every fixture writes triples directly, because SKOS-XL only ever arrives by
+    import: this app has no way to author it, so a fixture built through the API
+    could not reach the case at all.
+    """
+
+    BASE = "http://test.org/ont#"
+
+    @classmethod
+    def _xl_labelled(cls, om, name, kind="prefLabel", text="Alpha", lang="en"):
+        """A concept whose only label of ``kind`` is a SKOS-XL one."""
+        concept = URIRef(cls.BASE + name)
+        label = URIRef(f"{cls.BASE}label_{name}_{kind}")
+        om.graph.add((URIRef(cls.BASE + "S"), RDF.type, SKOS.ConceptScheme))
+        om.graph.add((concept, RDF.type, SKOS.Concept))
+        om.graph.add((concept, SKOS.inScheme, URIRef(cls.BASE + "S")))
+        om.graph.add((concept, SKOS.definition, Literal("A definition", lang="en")))
+        om.graph.add((label, RDF.type, SKOSXL.Label))
+        om.graph.add((label, SKOSXL.literalForm, Literal(text, lang=lang)))
+        om.graph.add((concept, OntologyManager.SKOS_XL_LABEL_KINDS[kind], label))
+        return concept
+
+    def test_an_xl_pref_label_is_a_pref_label(self, om):
+        """Otherwise every concept of a SKOS-XL vocabulary is an error."""
+        self._xl_labelled(om, "A")
+        assert "missing_prefLabel" not in _types(om)
+
+    def test_a_concept_with_no_label_at_all_still_reports(self, om):
+        om.graph.add((URIRef(self.BASE + "S"), RDF.type, SKOS.ConceptScheme))
+        om.graph.add((URIRef(self.BASE + "A"), RDF.type, SKOS.Concept))
+        om.graph.add((URIRef(self.BASE + "A"), SKOS.inScheme, URIRef(self.BASE + "S")))
+        assert "missing_prefLabel" in _types(om)
+
+    def test_xl_labels_are_readable(self, om):
+        self._xl_labelled(om, "A")
+        concept = om.get_concepts()[0]
+        assert concept["xl_labels"]["prefLabel"] == [{"value": "Alpha", "lang": "en"}]
+
+    def test_xl_labels_are_not_mixed_into_the_editable_ones(self, om):
+        """The editor writes plain SKOS; merging them would give a SKOS-XL label
+        a delete button that does nothing."""
+        self._xl_labelled(om, "A")
+        assert om.get_concepts()[0]["labels"]["prefLabel"] == []
+
+    def test_the_flat_label_falls_back_to_xl(self, om):
+        """So the graph, the dashboard and the concept list show a name."""
+        self._xl_labelled(om, "A")
+        assert om.get_concepts()[0]["prefLabel"] == "Alpha"
+
+    def test_a_plain_label_wins_the_flat_key(self, om):
+        concept = self._xl_labelled(om, "A")
+        om.graph.add((concept, SKOS.prefLabel, Literal("Plain", lang="en")))
+        assert om.get_concepts()[0]["prefLabel"] == "Plain"
+
+    def test_a_label_resource_without_a_literal_form_contributes_nothing(self, om):
+        om.graph.add((URIRef(self.BASE + "S"), RDF.type, SKOS.ConceptScheme))
+        om.graph.add((URIRef(self.BASE + "A"), RDF.type, SKOS.Concept))
+        label = URIRef(self.BASE + "empty_label")
+        om.graph.add((label, RDF.type, SKOSXL.Label))
+        om.graph.add((URIRef(self.BASE + "A"), SKOSXL.prefLabel, label))
+        assert om.get_concepts()[0]["xl_labels"]["prefLabel"] == []
+        assert "missing_prefLabel" in _types(om)
+
+    def test_the_vocabulary_is_reported_once_not_once_per_concept(self, om):
+        """AGROVOC would otherwise produce one line per concept."""
+        for name in ("A", "B", "C"):
+            self._xl_labelled(om, name)
+        found = _of_type(om, "skos_xl_labels")
+        assert len(found) == 1
+        assert "3 concepts" in found[0]["message"]
+
+    def test_nothing_is_reported_for_a_plain_skos_vocabulary(self, vocab):
+        assert "skos_xl_labels" not in _types(vocab)
+
+    def test_the_notice_is_editorial(self, om):
+        self._xl_labelled(om, "A")
+        assert "skos_xl_labels" not in _types(om, check_editorial=False)
+
+    def test_alt_and_hidden_xl_labels_are_read_too(self, om):
+        for kind in ("altLabel", "hiddenLabel"):
+            self._xl_labelled(om, "A", kind=kind, text=f"XL {kind}")
+        concept = om.get_concepts()[0]
+        assert concept["xl_labels"]["altLabel"][0]["value"] == "XL altLabel"
+        assert concept["xl_labels"]["hiddenLabel"][0]["value"] == "XL hiddenLabel"
+
+    def test_skosxl_is_not_offered_as_a_place_to_create_entities(self, om):
+        """It is a vocabulary this app reads, not one the user mints in."""
+        assert str(SKOSXL) not in om.get_creatable_namespaces()


### PR DESCRIPTION
SKOS-XL makes a label a resource rather than a literal, so statements can be made *about the label* (who authored it, when it was deprecated, how it relates to other labels). **AGROVOC and EuroVoc both publish that way.**

This app read `skos:prefLabel` only. A SKOS-XL vocabulary therefore arrived with every concept apparently unlabelled, and `missing_prefLabel` reported for each of them at the one severity that cannot be switched off. A 40,000-concept import produced 40,000 errors, all wrong, about a perfectly valid file.

```turtle
# what the app understood                # what AGROVOC actually ships
:Dog skos:prefLabel "Dog"@en .           :Dog skosxl:prefLabel :lbl .
                                         :lbl a skosxl:Label ;
                                              skosxl:literalForm "Dog"@en .
```

## The line taken

The SKOS plan asked for SKOS-XL to be *detected* in validation and not offered as an editing mode, so this reads it without authoring it:

- `get_concepts()` gains `xl_labels`, read through `skosxl:literalForm`. **A separate key, not merged into `labels`** — the editor writes plain SKOS, so a SKOS-XL label in the same list would come with a delete button that silently did nothing.
- The flat `prefLabel` falls back to the SKOS-XL one, so the concept list, the graph and the dashboard show a name instead of a bare local name.
- `missing_prefLabel` accepts a SKOS-XL preferred label.
- A new `skos_xl_labels` info check reports **the vocabulary once, with a count**, not once per concept. It is a fact about the file rather than a defect in each concept, and per-concept would be the same flood one tier quieter.
- The editor renders SKOS-XL labels read-only, prefixed `skosxl:` and without a delete button, under a caption explaining how to override one.

## One thing the existing tests caught

Binding the `skosxl` prefix made it appear in `get_creatable_namespaces()`, offering it as somewhere to mint entities. It is a vocabulary this app reads, not one a user creates in, so it joins the standard prefixes beside `skos`. `test_namespace_create.py` failed on it immediately.

## Testing

12 new tests, all writing triples directly rather than through the API — SKOS-XL only ever arrives by import, and this app cannot author it, so an API-built fixture could not reach the case at all. They cover the label being read, the flood not firing, a plain label winning the flat key, a label resource with no `literalForm` contributing nothing, the notice being once-per-vocabulary and editorial-tier, and `skosxl` staying out of the creatable namespaces.

Verified end to end in the running app with a two-concept SKOS-XL vocabulary: concepts list as `Animal · Tier` and `Dog` rather than bare names, the notice appears once, and the read-only rows carry no delete button.

1338 tests, ruff, format and mypy pass.

Leaves the `broaderTransitive` S27 gap for a follow-up: it is rarer, the Reference discourages asserting those properties directly, and fixing it means separating "direct parents" from "ancestor reachability", which are currently one map.