### PR TITLE
feat(skos): autofix for seven validation checks (WS-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,32 @@ each issue carrying a stable `type`, a `severity`, the `subject` concept and its
 | `skos_xl_labels` | The vocabulary uses SKOS-XL labels, which this editor shows but does not edit. | SKOS-XL |
 | `disconnected_components` | A cluster of concepts has no link to the main body of the vocabulary. | qSKOS |
 
+#### Fixing what it finds
+
+7 of the checks can be repaired automatically. Each is its own button on
+the validation panel, and each lands in the undo stack as a checkpoint.
+
+| Check | The fix |
+|---|---|
+| `missing_lang` | Stamp a language tag on labels that carry none. |
+| `self_relation` | Remove the self-referential relation, and its inverse. |
+| `dangling_relation` | Remove relations pointing at something that is not a Concept here. |
+| `top_with_broader` | Retract topConceptOf where the concept has a broader in that scheme. |
+| `label_overlap` | Remove the duplicate of a label held under two kinds. |
+| `hierarchy_redundancy` | Remove a broader edge already implied by another parent. |
+| `broader_cycle` | Break each hierarchy cycle by removing one edge. |
+
+There is deliberately no "fix everything" button. Breaking a hierarchy cycle
+and dropping a redundant edge both discard something the author may have
+meant, so the choice belongs to them, one class at a time. The rest of the
+checks describe things only an author can settle, such as what a concept
+means or which scheme it belongs to, and guessing would be worse than
+reporting. SKOS-XL labels are never modified, since this editor writes plain
+SKOS and repairing one would mean editing a label resource it cannot author.
+
+From Python: `autofix_skos("missing_lang", lang="en")` returns how many
+issues it resolved.
+
 Sources cite the SKOS Reference integrity condition where the condition is
 stated there, [qSKOS](https://github.com/cmader/qSKOS) where the check comes
 from that tool's published quality criteria, and say "practice" where it is

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -4354,21 +4354,21 @@ class OntologyManager:
             for cluster in components[1:]
         ]
 
-    def _skos_cycle_issues(
-        self, concepts: list[dict[str, Any]]
-    ) -> list[dict[str, str]]:
-        """Every distinct ``skos:broader`` cycle, reported once.
+    def _skos_cycles(self, concepts: list[dict[str, Any]]) -> list[list[str]]:
+        """Every distinct ``skos:broader`` cycle, as a list of URIs each.
 
         An iterative three-colour DFS over *all* parents. Iterative because an
         imported vocabulary can be deeper than the recursion limit, over all
         parents because following only the first missed any cycle reachable
         through a second, and canonicalised by member set so a cycle is not
-        reported once per member.
+        found once per member.
+
+        Shared by the check and its autofix on purpose: a fixer that rederived
+        the cycles its own way could break an edge the check never complained
+        about, or leave the one it did.
         """
-        issues: list[dict[str, str]] = []
+        cycles: list[list[str]] = []
         parents = self._skos_parent_map(concepts)
-        shown = self._skos_display_names(concepts)
-        by_uri = {c["uri"]: c for c in concepts}
         WHITE, GREY, BLACK = 0, 1, 2
         colour = dict.fromkeys(parents, WHITE)
         seen_cycles: set[frozenset] = set()
@@ -4389,15 +4389,7 @@ class OntologyManager:
                         cycle = path[path.index(nxt) :]
                         if frozenset(cycle) not in seen_cycles:
                             seen_cycles.add(frozenset(cycle))
-                            issues.append(
-                                self._skos_issue(
-                                    "error",
-                                    "broader_cycle",
-                                    by_uri[cycle[0]],
-                                    "Broader/narrower cycle detected: "
-                                    + " -> ".join(shown[u] for u in [*cycle, nxt]),
-                                )
-                            )
+                            cycles.append(cycle)
                     elif colour.get(nxt, BLACK) == WHITE:
                         colour[nxt] = GREY
                         path.append(nxt)
@@ -4408,7 +4400,24 @@ class OntologyManager:
                     colour[node] = BLACK
                     stack.pop()
                     path.pop()
-        return issues
+        return cycles
+
+    def _skos_cycle_issues(
+        self, concepts: list[dict[str, Any]]
+    ) -> list[dict[str, str]]:
+        """One issue per distinct cycle found by :meth:`_skos_cycles`."""
+        shown = self._skos_display_names(concepts)
+        by_uri = {c["uri"]: c for c in concepts}
+        return [
+            self._skos_issue(
+                "error",
+                "broader_cycle",
+                by_uri[cycle[0]],
+                "Broader/narrower cycle detected: "
+                + " -> ".join(shown[u] for u in [*cycle, cycle[0]]),
+            )
+            for cycle in self._skos_cycles(concepts)
+        ]
 
     def validate_skos(
         self,
@@ -4457,6 +4466,211 @@ class OntologyManager:
         return sorted(
             issues, key=lambda i: (order[i["severity"]], i["type"], i["subject"])
         )
+
+    #: What :meth:`autofix_skos` can repair, keyed by the check ``type`` it
+    #: clears. Deliberately a subset: most checks describe something only the
+    #: author can decide (what a concept means, which scheme it belongs to), and
+    #: guessing would be worse than reporting.
+    SKOS_AUTOFIXES: ClassVar[dict[str, str]] = {
+        "missing_lang": "Stamp a language tag on labels that carry none.",
+        "self_relation": "Remove the self-referential relation, and its inverse.",
+        "dangling_relation": (
+            "Remove relations pointing at something that is not a Concept here."
+        ),
+        "top_with_broader": (
+            "Retract topConceptOf where the concept has a broader in that scheme."
+        ),
+        "label_overlap": "Remove the duplicate of a label held under two kinds.",
+        "hierarchy_redundancy": (
+            "Remove a broader edge already implied by another parent."
+        ),
+        "broader_cycle": "Break each hierarchy cycle by removing one edge.",
+    }
+
+    def autofix_skos(self, fix_type: str, *, lang: str | None = None) -> int:
+        """Repair one class of SKOS issue. Returns how many issues it resolved.
+
+        Counted in issues rather than triples, so the count matches what the
+        validation panel offered to fix. The two iterative fixers (cycles and
+        redundant edges) can resolve more than one reported issue per removal,
+        because one edge may close several cycles, so their count is what they
+        removed rather than what was reported.
+
+        One class at a time, never all of them: breaking a cycle and dropping a
+        redundant edge both discard something the author may have meant, so the
+        choice belongs to them, per issue class, with an undo checkpoint around
+        it.
+
+        Each fixer derives its targets from the same views the corresponding
+        check reads, rather than re-reading whichever property its author had in
+        mind. A fixer that disagreed with its check would either break an edge
+        nothing complained about or leave the one that did, and unlike a wrong
+        report a wrong repair is written into the user's graph.
+
+        SKOS-XL labels are never touched. This app writes plain SKOS, so
+        "repairing" one would mean editing a label resource it cannot author;
+        those issues are left for the author to resolve.
+        """
+        if fix_type not in self.SKOS_AUTOFIXES:
+            known = ", ".join(sorted(self.SKOS_AUTOFIXES))
+            raise ValueError(f"No autofix for '{fix_type}' (fixable: {known})")
+        fixer = getattr(self, f"_autofix_{fix_type}")
+        if fix_type == "missing_lang":
+            return fixer(lang)
+        return fixer()
+
+    def _autofix_missing_lang(self, lang: str | None) -> int:
+        """Re-tag untagged labels in ``lang``.
+
+        The tag is asked for rather than guessed: a vocabulary's labels are not
+        necessarily in the language of whoever is repairing it, and stamping the
+        wrong one is a lie the validator will then report as clean.
+        """
+        tag = self._checked_lang(lang)
+        if not tag:
+            raise ValueError("A language tag is required to fix untagged labels.")
+
+        fixed = 0
+        for concept in self.get_concepts():
+            uri = URIRef(concept["uri"])
+            for kind, prop in self.SKOS_LABEL_KINDS.items():
+                # Plain labels only: an untagged skosxl:literalForm would have to
+                # be edited on the label resource, which this app does not author.
+                for item in concept["labels"][kind]:
+                    if item["lang"] or not item["value"].strip():
+                        continue
+                    self.graph.remove((uri, prop, Literal(item["value"])))
+                    self.graph.add((uri, prop, Literal(item["value"], lang=tag)))
+                    fixed += 1
+        return fixed
+
+    def _autofix_self_relation(self) -> int:
+        fixed = 0
+        for concept in self.get_concepts():
+            uri = concept["uri"]
+            for kind in ("broader", "narrower", "related"):
+                if uri in concept[f"{kind}_uris"]:
+                    # Through the helper, so the auto-added inverse goes too.
+                    self.remove_concept_relation(uri, kind, uri)
+                    fixed += 1
+        return fixed
+
+    def _autofix_dangling_relation(self) -> int:
+        concepts = self.get_concepts()
+        known = {c["uri"] for c in concepts}
+        fixed = 0
+        for concept in concepts:
+            for kind in ("broader", "narrower", "related"):
+                for target in concept[f"{kind}_uris"]:
+                    if target not in known:
+                        self.remove_concept_relation(concept["uri"], kind, target)
+                        fixed += 1
+        return fixed
+
+    def _autofix_top_with_broader(self) -> int:
+        concepts = self.get_concepts()
+        parents, _children, _related = self._skos_link_maps(concepts)
+        fixed = 0
+        for concept in concepts:
+            uri = concept["uri"]
+            for scheme_uri in concept["top_of_uris"]:
+                in_scheme = self._skos_concepts_in_scheme(concepts, scheme_uri)
+                if set(parents[uri]) & in_scheme:
+                    # The broader is the assertion with content; being a top
+                    # concept is the one contradicted by it.
+                    self.set_top_concept(uri, scheme_uri, is_top=False)
+                    fixed += 1
+        return fixed
+
+    def _autofix_label_overlap(self) -> int:
+        """Drop the less specific of two label kinds holding one literal.
+
+        prefLabel is kept over altLabel, and altLabel over hiddenLabel: the
+        surviving one is the more visible, so the repair never hides a label
+        that was on show. A literal held by a SKOS-XL label is left alone, and
+        so is its plain counterpart, because removing either side of that pair
+        means guessing which spelling the author meant to keep.
+        """
+        precedence = list(self.SKOS_LABEL_KINDS)
+        fixed = 0
+        for concept in self.get_concepts():
+            uri = URIRef(concept["uri"])
+            xl_literals = {
+                (item["value"], item["lang"])
+                for kind in self.SKOS_XL_LABEL_KINDS
+                for item in concept["xl_labels"][kind]
+            }
+            by_literal: dict[tuple[str, str], list[str]] = {}
+            for kind in self.SKOS_LABEL_KINDS:
+                for item in concept["labels"][kind]:
+                    if item["value"].strip():
+                        by_literal.setdefault((item["value"], item["lang"]), []).append(
+                            kind
+                        )
+            for (value, tag), kinds in by_literal.items():
+                if (value, tag) in xl_literals:
+                    continue
+                clashing = [k for k in precedence if k in kinds]
+                if len(clashing) < 2:
+                    continue
+                for kind in clashing[1:]:
+                    self.graph.remove(
+                        (
+                            uri,
+                            self.SKOS_LABEL_KINDS[kind],
+                            Literal(value, lang=tag) if tag else Literal(value),
+                        )
+                    )
+                # One per clashing literal, matching how the check reports it:
+                # a literal held under all three kinds is one issue, not two.
+                fixed += 1
+        return fixed
+
+    def _autofix_hierarchy_redundancy(self) -> int:
+        """Remove a parent already reachable through another parent.
+
+        Recomputed after each removal: two redundant edges can each be implied
+        by the other, and removing both would detach the concept from a branch
+        it genuinely belongs to.
+        """
+        fixed = 0
+        while True:
+            concepts = self.get_concepts()
+            parents = self._skos_parent_map(concepts)
+            redundant = None
+            for concept in concepts:
+                uri = concept["uri"]
+                direct = parents.get(uri, [])
+                for parent in direct:
+                    via_others: set[str] = set()
+                    for other in direct:
+                        if other != parent:
+                            via_others |= self._skos_ancestors(parents, other)
+                    if parent in via_others:
+                        redundant = (uri, parent)
+                        break
+                if redundant:
+                    break
+            if not redundant:
+                return fixed
+            self.remove_concept_relation(redundant[0], "broader", redundant[1])
+            fixed += 1
+
+    def _autofix_broader_cycle(self) -> int:
+        """Break each cycle by removing the edge that closes it.
+
+        Recomputed after each break, because one edge can close more than one
+        cycle and removing it may resolve several at once.
+        """
+        fixed = 0
+        while True:
+            cycles = self._skos_cycles(self.get_concepts())
+            if not cycles:
+                return fixed
+            cycle = cycles[0]
+            # The closing edge: the last member's broader back to the first.
+            self.remove_concept_relation(cycle[-1], "broader", cycle[0])
+            fixed += 1
 
     # ==================== RELATIONS OPERATIONS ====================
 

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -4532,15 +4532,38 @@ class OntologyManager:
 
         fixed = 0
         for concept in self.get_concepts():
-            uri = URIRef(concept["uri"])
-            for kind, prop in self.SKOS_LABEL_KINDS.items():
+            effective = self._effective_labels(concept)
+            taken = {
+                (item["value"], item["lang"])
+                for kind in self.SKOS_LABEL_KINDS
+                for item in effective[kind]
+            }
+            pref_langs = {
+                item["lang"] for item in effective["prefLabel"] if item["lang"]
+            }
+            for kind in self.SKOS_LABEL_KINDS:
                 # Plain labels only: an untagged skosxl:literalForm would have to
                 # be edited on the label resource, which this app does not author.
                 for item in concept["labels"][kind]:
                     if item["lang"] or not item["value"].strip():
                         continue
-                    self.graph.remove((uri, prop, Literal(item["value"])))
-                    self.graph.add((uri, prop, Literal(item["value"], lang=tag)))
+                    # Refuse a re-tag that would trade this warning for a worse
+                    # problem: a second prefLabel in a language that already has
+                    # one breaks S14, and landing on a literal another kind holds
+                    # breaks S13. Both are left for the author.
+                    if kind == "prefLabel" and tag in pref_langs:
+                        continue
+                    if (item["value"], tag) in taken:
+                        continue
+                    # Through the helper, which matches the literal actually in
+                    # the graph. Rebuilding one with Literal(value) misses a
+                    # typed label such as "Dog"^^xsd:string, so the old literal
+                    # survived and a tagged duplicate was added beside it.
+                    self.remove_concept_label(concept["uri"], kind, item["value"])
+                    self.set_concept_label(concept["uri"], kind, item["value"], tag)
+                    taken.add((item["value"], tag))
+                    if kind == "prefLabel":
+                        pref_langs.add(tag)
                     fixed += 1
         return fixed
 
@@ -4594,7 +4617,6 @@ class OntologyManager:
         precedence = list(self.SKOS_LABEL_KINDS)
         fixed = 0
         for concept in self.get_concepts():
-            uri = URIRef(concept["uri"])
             xl_literals = {
                 (item["value"], item["lang"])
                 for kind in self.SKOS_XL_LABEL_KINDS
@@ -4614,13 +4636,10 @@ class OntologyManager:
                 if len(clashing) < 2:
                     continue
                 for kind in clashing[1:]:
-                    self.graph.remove(
-                        (
-                            uri,
-                            self.SKOS_LABEL_KINDS[kind],
-                            Literal(value, lang=tag) if tag else Literal(value),
-                        )
-                    )
+                    # The helper matches on (text, language) against the literal
+                    # in the graph, so a typed label is removed rather than
+                    # missed by a rebuilt plain one.
+                    self.remove_concept_label(concept["uri"], kind, value, tag)
                 # One per clashing literal, matching how the check reports it:
                 # a literal held under all three kinds is one issue, not two.
                 fixed += 1

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -821,18 +821,35 @@ def render_skos_vocabulary():
                                 except ValueError as exc:
                                     show_message(str(exc), "error")
                                 else:
-                                    save_checkpoint(f"Autofix: {_kind}")
-                                    st.session_state["_skos_issues"] = (
-                                        ont.validate_skos(
-                                            check_conventions=_conventions,
-                                            check_editorial=_editorial,
+                                    # A fixer can legitimately do nothing: every
+                                    # issue in the group may involve a SKOS-XL
+                                    # label, or be a re-tag that would break S14.
+                                    # Checkpointing an empty change and calling
+                                    # it success puts a no-op in the undo stack
+                                    # and leaves the group standing underneath a
+                                    # green message.
+                                    if not _n:
+                                        show_message(
+                                            f"Nothing to fix automatically in "
+                                            f"{_kind}. These need an editorial "
+                                            "decision: a SKOS-XL label this "
+                                            "editor cannot rewrite, or a repair "
+                                            "that would break another rule.",
+                                            "info",
                                         )
-                                    )
-                                    set_flash_message(
-                                        f"Fixed {_n} {_kind} issue"
-                                        f"{'s' if _n != 1 else ''}.",
-                                        "success",
-                                    )
-                                    st.rerun()
+                                    else:
+                                        save_checkpoint(f"Autofix: {_kind}")
+                                        st.session_state["_skos_issues"] = (
+                                            ont.validate_skos(
+                                                check_conventions=_conventions,
+                                                check_editorial=_editorial,
+                                            )
+                                        )
+                                        set_flash_message(
+                                            f"Fixed {_n} {_kind} issue"
+                                            f"{'s' if _n != 1 else ''}.",
+                                            "success",
+                                        )
+                                        st.rerun()
                         for _issue in _group:
                             st.markdown(f"- {_issue['message']}")

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -797,5 +797,42 @@ def render_skos_vocabulary():
                     with st.expander(
                         f"{_icons[_sev]} {_kind} — {len(_group)}", expanded=False
                     ):
+                        # One button per class, and no "fix everything": breaking
+                        # a cycle and dropping a redundant edge each discard
+                        # something the author may have meant, so the choice is
+                        # theirs one class at a time.
+                        if _fix := ont.SKOS_AUTOFIXES.get(_kind):
+                            st.caption(_fix)
+                            _lang = None
+                            if _kind == "missing_lang":
+                                # Asked for, not guessed: a vocabulary's labels
+                                # need not be in the repairer's language.
+                                _lang = language_selectbox(
+                                    "Tag these labels as",
+                                    key=f"autofix_lang_{_kind}",
+                                )
+                            if st.button(
+                                f"Fix {len(_group)} issue"
+                                f"{'s' if len(_group) != 1 else ''}",
+                                key=f"autofix_{_kind}",
+                            ):
+                                try:
+                                    _n = ont.autofix_skos(_kind, lang=_lang)
+                                except ValueError as exc:
+                                    show_message(str(exc), "error")
+                                else:
+                                    save_checkpoint(f"Autofix: {_kind}")
+                                    st.session_state["_skos_issues"] = (
+                                        ont.validate_skos(
+                                            check_conventions=_conventions,
+                                            check_editorial=_editorial,
+                                        )
+                                    )
+                                    set_flash_message(
+                                        f"Fixed {_n} {_kind} issue"
+                                        f"{'s' if _n != 1 else ''}.",
+                                        "success",
+                                    )
+                                    st.rerun()
                         for _issue in _group:
                             st.markdown(f"- {_issue['message']}")

--- a/tests/test_skos_autofix.py
+++ b/tests/test_skos_autofix.py
@@ -15,7 +15,7 @@ import pathlib
 
 import pytest
 from rdflib import Literal, URIRef
-from rdflib.namespace import RDF, SKOS
+from rdflib.namespace import RDF, SKOS, XSD
 
 from ontology_manager import SKOSXL, OntologyManager
 
@@ -67,6 +67,44 @@ def broken():
     return om
 
 
+@pytest.fixture
+def awkward():
+    """The shapes the first fixture could not reach.
+
+    Typed literals, a re-tag that would break S14, an untagged label whose text
+    already belongs to another kind, and a SKOS-XL label. Every one of these
+    slipped past the property tests below while `broken` was their only input,
+    which is the argument for having two.
+    """
+    om = OntologyManager(base_uri=BASE)
+    om.graph.add((_uri("S"), RDF.type, SKOS.ConceptScheme))
+
+    # A typed label reads as untagged and must still be replaced, not duplicated.
+    typed = _concept(om, "Typed", labelled=False)
+    om.graph.add((typed, SKOS.prefLabel, Literal("Typed", datatype=XSD.string)))
+    om.graph.add((typed, SKOS.altLabel, Literal("Typed", datatype=XSD.string)))
+
+    # Re-tagging this to en would put two prefLabels in one language.
+    clash = _concept(om, "Clash")
+    om.graph.add((clash, SKOS.prefLabel, Literal("Hund")))
+
+    # Re-tagging this to en would collide with its own prefLabel.
+    overlap = _concept(om, "Overlap")
+    om.graph.add((overlap, SKOS.altLabel, Literal("Overlap")))
+
+    # A SKOS-XL label, which no fixer may touch.
+    xl_concept = _concept(om, "Xl", labelled=False)
+    label = _uri("xl_label")
+    om.graph.add((label, RDF.type, SKOSXL.Label))
+    om.graph.add((label, SKOSXL.literalForm, Literal("Untagged")))
+    om.graph.add((xl_concept, SKOSXL.prefLabel, label))
+
+    for name in ("Typed", "Clash", "Overlap", "Xl"):
+        om.graph.add((_uri(name), SKOS.topConceptOf, _uri("S")))
+        om.graph.add((_uri("S"), SKOS.hasTopConcept, _uri(name)))
+    return om
+
+
 def _fix(om, kind):
     """Run one fixer, supplying the language the tag fixer needs."""
     if kind == "missing_lang":
@@ -91,16 +129,36 @@ class TestEveryFixerAgreesWithItsCheck:
         _fix(broken, kind)
         assert kind not in _counts(broken)
 
+    @pytest.mark.parametrize("fixture", ["broken", "awkward"])
     @pytest.mark.parametrize("kind", FIXABLE)
-    def test_no_other_class_of_issue_appears(self, broken, kind):
-        """A repair that trades one problem for another is not a repair."""
-        if kind == "broader_cycle":
-            broken.graph.add((_uri("Animal"), SKOS.broader, _uri("Dog")))
-        before = _counts(broken)
-        _fix(broken, kind)
-        after = _counts(broken)
+    def test_no_other_class_of_issue_appears(self, request, fixture, kind):
+        """A repair that trades one problem for another is not a repair.
+
+        Run over both fixtures: this property held on `broken` alone while the
+        fixers were still creating S14 violations out of untagged labels,
+        because that fixture had no concept where a re-tag could collide.
+        """
+        om = request.getfixturevalue(fixture)
+        if kind == "broader_cycle" and fixture == "broken":
+            om.graph.add((_uri("Animal"), SKOS.broader, _uri("Dog")))
+        before = _counts(om)
+        _fix(om, kind)
+        after = _counts(om)
         introduced = {k: after[k] for k in after if after[k] > before.get(k, 0)}
-        assert not introduced, f"{kind} introduced {introduced}"
+        assert not introduced, f"{kind} introduced {introduced} on {fixture}"
+
+    @pytest.mark.parametrize("fixture", ["broken", "awkward"])
+    @pytest.mark.parametrize("kind", FIXABLE)
+    def test_a_fixer_never_claims_more_than_it_did(self, request, fixture, kind):
+        """A count above zero has to mean the check reports fewer afterwards."""
+        om = request.getfixturevalue(fixture)
+        if kind == "broader_cycle" and fixture == "broken":
+            om.graph.add((_uri("Animal"), SKOS.broader, _uri("Dog")))
+        before = _counts(om).get(kind, 0)
+        if _fix(om, kind):
+            assert _counts(om).get(kind, 0) < before, (
+                f"{kind} reported work but {before} issues remain on {fixture}"
+            )
 
     @pytest.mark.parametrize("kind", FIXABLE)
     def test_running_it_twice_changes_nothing_the_second_time(self, broken, kind):
@@ -192,6 +250,67 @@ class TestSkosXlIsNeverTouched:
         before = len(xl.graph)
         assert xl.autofix_skos("label_overlap") == 0
         assert len(xl.graph) == before
+
+
+class TestLiteralIdentity:
+    """A label's datatype is part of the node, so a rebuilt literal misses it.
+
+    `_tagged_literals` reports a label as (value, language), which is all the
+    checks need. A fixer that turned that back into `Literal(value)` did not
+    match `"Dog"^^xsd:string` in the graph: the old literal survived, a tagged
+    one was added beside it, and the fixer reported success. Removals go through
+    `remove_concept_label`, which matches the node that is actually there.
+    """
+
+    @pytest.fixture
+    def typed(self):
+        om = OntologyManager(base_uri=BASE)
+        om.graph.add((_uri("S"), RDF.type, SKOS.ConceptScheme))
+        _concept(om, "A", labelled=False)
+        return om
+
+    def test_a_typed_label_is_replaced_not_duplicated(self, typed):
+        typed.graph.add(
+            (_uri("A"), SKOS.prefLabel, Literal("Dog", datatype=XSD.string))
+        )
+        assert typed.autofix_skos("missing_lang", lang="en") == 1
+        labels = list(typed.graph.objects(_uri("A"), SKOS.prefLabel))
+        assert len(labels) == 1
+        assert labels[0].language == "en"
+
+    def test_a_typed_label_clash_is_really_removed(self, typed):
+        for prop in (SKOS.prefLabel, SKOS.altLabel):
+            typed.graph.add((_uri("A"), prop, Literal("Dog", datatype=XSD.string)))
+        assert typed.autofix_skos("label_overlap") == 1
+        assert not [i for i in typed.validate_skos() if i["type"] == "label_overlap"]
+
+
+class TestARetagThatWouldBreakSomethingElseIsRefused:
+    """The fixer would rather leave a warning than create an error."""
+
+    @pytest.fixture
+    def om(self):
+        manager = OntologyManager(base_uri=BASE)
+        manager.graph.add((_uri("S"), RDF.type, SKOS.ConceptScheme))
+        _concept(manager, "A", labelled=False)
+        return manager
+
+    def test_a_second_pref_label_in_one_language_is_not_created(self, om):
+        om.graph.add((_uri("A"), SKOS.prefLabel, Literal("Dog", lang="en")))
+        om.graph.add((_uri("A"), SKOS.prefLabel, Literal("Hund")))
+        assert om.autofix_skos("missing_lang", lang="en") == 0
+        assert "multi_prefLabel_per_lang" not in [i["type"] for i in om.validate_skos()]
+
+    def test_an_overlap_is_not_created(self, om):
+        om.graph.add((_uri("A"), SKOS.prefLabel, Literal("Dog", lang="en")))
+        om.graph.add((_uri("A"), SKOS.altLabel, Literal("Dog")))
+        assert om.autofix_skos("missing_lang", lang="en") == 0
+        assert "label_overlap" not in [i["type"] for i in om.validate_skos()]
+
+    def test_a_re_tag_with_no_collision_still_happens(self, om):
+        om.graph.add((_uri("A"), SKOS.prefLabel, Literal("Dog", lang="en")))
+        om.graph.add((_uri("A"), SKOS.altLabel, Literal("Hound")))
+        assert om.autofix_skos("missing_lang", lang="en") == 1
 
 
 class TestLabelOverlapKeepsTheMoreVisibleLabel:

--- a/tests/test_skos_autofix.py
+++ b/tests/test_skos_autofix.py
@@ -1,0 +1,303 @@
+"""Tests for `autofix_skos` (WS-2).
+
+Fixtures write triples directly rather than going through the API. The API
+refuses several of the things a fixer exists to repair (it will not create a
+cycle, a self-relation or an untagged label where one already has a tag), so a
+fixture built through it could not reach the cases at all. This is also the
+shape a broken vocabulary actually arrives in: an imported file.
+
+The two tests that matter most are parametrized over every fixable type:
+a fixer must clear its own check, and must not introduce a different one.
+A wrong report is a nuisance; a wrong repair is written into the user's graph.
+"""
+
+import pathlib
+
+import pytest
+from rdflib import Literal, URIRef
+from rdflib.namespace import RDF, SKOS
+
+from ontology_manager import SKOSXL, OntologyManager
+
+BASE = "http://test.org/ont#"
+FIXABLE = sorted(OntologyManager.SKOS_AUTOFIXES)
+
+
+def _uri(name):
+    return URIRef(BASE + name)
+
+
+def _concept(om, name, *, labelled=True, documented=True):
+    uri = _uri(name)
+    om.graph.add((uri, RDF.type, SKOS.Concept))
+    om.graph.add((uri, SKOS.inScheme, _uri("S")))
+    if labelled:
+        om.graph.add((uri, SKOS.prefLabel, Literal(name, lang="en")))
+    if documented:
+        om.graph.add((uri, SKOS.definition, Literal("A definition", lang="en")))
+    return uri
+
+
+@pytest.fixture
+def broken():
+    """One vocabulary tripping every fixable check at once.
+
+    Deliberately not one fixture per fixer: running a fixer against a graph
+    that has other problems too is the real case, and it is how a fixer that
+    reaches too far shows up.
+    """
+    om = OntologyManager(base_uri=BASE)
+    om.graph.add((_uri("S"), RDF.type, SKOS.ConceptScheme))
+    animal = _concept(om, "Animal")
+    mammal = _concept(om, "Mammal")
+    dog = _concept(om, "Dog")
+    pet = _concept(om, "Pet")
+
+    om.graph.add((mammal, SKOS.broader, animal))
+    om.graph.add((dog, SKOS.broader, mammal))
+    om.graph.add((dog, SKOS.broader, animal))  # hierarchy_redundancy
+    om.graph.add((pet, SKOS.broader, animal))
+    om.graph.add((animal, SKOS.broader, _uri("Ghost")))  # dangling_relation
+    om.graph.add((pet, SKOS.related, pet))  # self_relation
+    om.graph.add((dog, SKOS.altLabel, Literal("Dog", lang="en")))  # label_overlap
+    om.graph.add((pet, SKOS.altLabel, Literal("Untagged")))  # missing_lang
+    om.graph.add((mammal, SKOS.topConceptOf, _uri("S")))  # top_with_broader
+    om.graph.add((_uri("S"), SKOS.hasTopConcept, mammal))
+    om.graph.add((animal, SKOS.topConceptOf, _uri("S")))
+    return om
+
+
+def _fix(om, kind):
+    """Run one fixer, supplying the language the tag fixer needs."""
+    if kind == "missing_lang":
+        return om.autofix_skos(kind, lang="en")
+    return om.autofix_skos(kind)
+
+
+def _counts(om):
+    counts: dict[str, int] = {}
+    for issue in om.validate_skos():
+        counts[issue["type"]] = counts.get(issue["type"], 0) + 1
+    return counts
+
+
+class TestEveryFixerAgreesWithItsCheck:
+    @pytest.mark.parametrize("kind", FIXABLE)
+    def test_the_check_stops_reporting(self, broken, kind):
+        """The invariant the whole workstream rests on."""
+        if kind == "broader_cycle":
+            broken.graph.add((_uri("Animal"), SKOS.broader, _uri("Dog")))
+        assert _counts(broken).get(kind), f"fixture does not trip {kind}"
+        _fix(broken, kind)
+        assert kind not in _counts(broken)
+
+    @pytest.mark.parametrize("kind", FIXABLE)
+    def test_no_other_class_of_issue_appears(self, broken, kind):
+        """A repair that trades one problem for another is not a repair."""
+        if kind == "broader_cycle":
+            broken.graph.add((_uri("Animal"), SKOS.broader, _uri("Dog")))
+        before = _counts(broken)
+        _fix(broken, kind)
+        after = _counts(broken)
+        introduced = {k: after[k] for k in after if after[k] > before.get(k, 0)}
+        assert not introduced, f"{kind} introduced {introduced}"
+
+    @pytest.mark.parametrize("kind", FIXABLE)
+    def test_running_it_twice_changes_nothing_the_second_time(self, broken, kind):
+        if kind == "broader_cycle":
+            broken.graph.add((_uri("Animal"), SKOS.broader, _uri("Dog")))
+        _fix(broken, kind)
+        assert _fix(broken, kind) == 0
+
+    @pytest.mark.parametrize("kind", FIXABLE)
+    def test_it_reports_how_much_it_did(self, broken, kind):
+        if kind == "broader_cycle":
+            broken.graph.add((_uri("Animal"), SKOS.broader, _uri("Dog")))
+        assert _fix(broken, kind) > 0
+
+    @pytest.mark.parametrize(
+        "kind",
+        [k for k in FIXABLE if k not in ("broader_cycle", "hierarchy_redundancy")],
+    )
+    def test_the_count_matches_what_was_reported(self, broken, kind):
+        """So the panel's "Fix 3 issues" is followed by "Fixed 3".
+
+        The two iterative fixers are excluded: removing one edge can clear
+        several reported cycles, and can make a second redundant edge no longer
+        redundant, so their count is what they removed rather than what was
+        reported.
+        """
+        expected = _counts(broken).get(kind, 0)
+        assert expected > 0, f"fixture does not trip {kind}"
+        assert _fix(broken, kind) == expected
+
+
+class TestInversesGoToo:
+    """`add_concept_relation` writes both directions, so a fixer that removed
+    one would leave a half-edge the UI cannot see or delete."""
+
+    def test_self_relation(self, broken):
+        broken.autofix_skos("self_relation")
+        pet = _uri("Pet")
+        assert (pet, SKOS.related, pet) not in broken.graph
+
+    def test_dangling_relation_takes_the_inverse(self, om_with_dangling_pair):
+        om = om_with_dangling_pair
+        om.autofix_skos("dangling_relation")
+        assert (_uri("Ghost"), SKOS.narrower, _uri("Animal")) not in om.graph
+
+    def test_hierarchy_redundancy(self, broken):
+        broken.autofix_skos("hierarchy_redundancy")
+        assert (_uri("Animal"), SKOS.narrower, _uri("Dog")) not in broken.graph
+
+    def test_broader_cycle(self, broken):
+        broken.graph.add((_uri("Animal"), SKOS.broader, _uri("Dog")))
+        broken.graph.add((_uri("Dog"), SKOS.narrower, _uri("Animal")))
+        broken.autofix_skos("broader_cycle")
+        assert not [i for i in broken.validate_skos() if i["type"] == "broader_cycle"]
+
+
+@pytest.fixture
+def om_with_dangling_pair():
+    om = OntologyManager(base_uri=BASE)
+    om.graph.add((_uri("S"), RDF.type, SKOS.ConceptScheme))
+    animal = _concept(om, "Animal")
+    om.graph.add((animal, SKOS.broader, _uri("Ghost")))
+    om.graph.add((_uri("Ghost"), SKOS.narrower, animal))
+    return om
+
+
+class TestSkosXlIsNeverTouched:
+    """This app writes plain SKOS. Repairing a SKOS-XL label would mean editing
+    a label resource it cannot author, so those issues are left alone."""
+
+    @pytest.fixture
+    def xl(self):
+        om = OntologyManager(base_uri=BASE)
+        om.graph.add((_uri("S"), RDF.type, SKOS.ConceptScheme))
+        concept = _concept(om, "A", labelled=False)
+        label = _uri("lbl")
+        om.graph.add((label, RDF.type, SKOSXL.Label))
+        om.graph.add((label, SKOSXL.literalForm, Literal("Untagged")))
+        om.graph.add((concept, SKOSXL.prefLabel, label))
+        return om
+
+    def test_an_untagged_xl_label_is_left_alone(self, xl):
+        assert xl.autofix_skos("missing_lang", lang="en") == 0
+        assert (_uri("lbl"), SKOSXL.literalForm, Literal("Untagged")) in xl.graph
+
+    def test_a_clash_involving_an_xl_label_is_left_alone(self, xl):
+        """Which spelling the author meant to keep is not ours to guess."""
+        xl.graph.add((_uri("A"), SKOS.altLabel, Literal("Untagged", lang="en")))
+        before = len(xl.graph)
+        assert xl.autofix_skos("label_overlap") == 0
+        assert len(xl.graph) == before
+
+
+class TestLabelOverlapKeepsTheMoreVisibleLabel:
+    @pytest.fixture
+    def om(self):
+        manager = OntologyManager(base_uri=BASE)
+        manager.graph.add((_uri("S"), RDF.type, SKOS.ConceptScheme))
+        _concept(manager, "A", labelled=False)
+        return manager
+
+    def test_pref_label_survives_alt_label(self, om):
+        for prop in (SKOS.prefLabel, SKOS.altLabel):
+            om.graph.add((_uri("A"), prop, Literal("Same", lang="en")))
+        om.autofix_skos("label_overlap")
+        assert (_uri("A"), SKOS.prefLabel, Literal("Same", lang="en")) in om.graph
+        assert (_uri("A"), SKOS.altLabel, Literal("Same", lang="en")) not in om.graph
+
+    def test_alt_label_survives_hidden_label(self, om):
+        for prop in (SKOS.altLabel, SKOS.hiddenLabel):
+            om.graph.add((_uri("A"), prop, Literal("Same", lang="en")))
+        om.autofix_skos("label_overlap")
+        assert (_uri("A"), SKOS.altLabel, Literal("Same", lang="en")) in om.graph
+        assert (_uri("A"), SKOS.hiddenLabel, Literal("Same", lang="en")) not in om.graph
+
+    def test_a_literal_in_all_three_leaves_only_the_pref_label(self, om):
+        for prop in (SKOS.prefLabel, SKOS.altLabel, SKOS.hiddenLabel):
+            om.graph.add((_uri("A"), prop, Literal("Same", lang="en")))
+        # One issue, not two: the check reports the literal once.
+        assert om.autofix_skos("label_overlap") == 1
+        assert (_uri("A"), SKOS.prefLabel, Literal("Same", lang="en")) in om.graph
+
+
+class TestHierarchyRedundancyDoesNotDetach:
+    def test_two_mutually_implying_edges_lose_only_one(self):
+        """Recomputing between removals is what keeps a concept attached."""
+        om = OntologyManager(base_uri=BASE)
+        om.graph.add((_uri("S"), RDF.type, SKOS.ConceptScheme))
+        for name in ("Animal", "Mammal", "Dog"):
+            _concept(om, name)
+        om.graph.add((_uri("Mammal"), SKOS.broader, _uri("Animal")))
+        om.graph.add((_uri("Dog"), SKOS.broader, _uri("Mammal")))
+        om.graph.add((_uri("Dog"), SKOS.broader, _uri("Animal")))
+
+        om.autofix_skos("hierarchy_redundancy")
+        dog = next(c for c in om.get_concepts() if c["name"] == "Dog")
+        assert dog["broader"] == ["Mammal"]
+
+
+class TestMissingLang:
+    def test_a_language_is_required(self, broken):
+        with pytest.raises(ValueError, match="language tag is required"):
+            broken.autofix_skos("missing_lang")
+
+    def test_a_malformed_tag_is_refused(self, broken):
+        with pytest.raises(ValueError):
+            broken.autofix_skos("missing_lang", lang="en_GB")
+
+    def test_already_tagged_labels_are_untouched(self, broken):
+        broken.autofix_skos("missing_lang", lang="de")
+        assert (_uri("Dog"), SKOS.prefLabel, Literal("Dog", lang="en")) in broken.graph
+
+    def test_the_tag_is_applied(self, broken):
+        broken.autofix_skos("missing_lang", lang="de")
+        assert (
+            _uri("Pet"),
+            SKOS.altLabel,
+            Literal("Untagged", lang="de"),
+        ) in broken.graph
+        assert (_uri("Pet"), SKOS.altLabel, Literal("Untagged")) not in broken.graph
+
+
+class TestTheCatalogue:
+    def test_every_fixable_type_is_a_real_check(self):
+        unknown = set(OntologyManager.SKOS_AUTOFIXES) - set(OntologyManager.SKOS_CHECKS)
+        assert not unknown, f"not a check type: {sorted(unknown)}"
+
+    def test_an_unknown_fix_names_the_alternatives(self, broken):
+        with pytest.raises(ValueError, match="fixable:"):
+            broken.autofix_skos("not_a_fix")
+
+    def test_a_check_that_is_not_fixable_is_refused(self, broken):
+        """`undocumented` needs an author, not an algorithm."""
+        with pytest.raises(ValueError, match="No autofix"):
+            broken.autofix_skos("undocumented")
+
+    def test_the_readme_documents_every_fix(self):
+        """Same guard as the check table: naming it is not documenting it."""
+        readme = (pathlib.Path(__file__).resolve().parents[1] / "README.md").read_text(
+            encoding="utf-8"
+        )
+        stale = [
+            kind
+            for kind, summary in OntologyManager.SKOS_AUTOFIXES.items()
+            if f"`{kind}`" not in readme or " ".join(summary.split()) not in readme
+        ]
+        assert not stale, f"README.md does not match SKOS_AUTOFIXES for: {stale}"
+
+    def test_the_readme_states_the_right_number_of_fixes(self):
+        """A count in prose drifts the moment a fixer is added."""
+        readme = (pathlib.Path(__file__).resolve().parents[1] / "README.md").read_text(
+            encoding="utf-8"
+        )
+        expected = f"{len(OntologyManager.SKOS_AUTOFIXES)} of the checks"
+        assert expected in readme, f"README.md should say {expected!r}"
+
+    def test_every_entry_describes_itself(self):
+        for kind, summary in OntologyManager.SKOS_AUTOFIXES.items():
+            assert summary.endswith("."), kind
+            assert len(summary) > 20, kind


### PR DESCRIPTION
Implements WS-2 from the SKOS improvement plan. `autofix_skos(fix_type)` repairs one class of issue and returns how many it resolved.

**7 of the 21 checks are fixable:** `missing_lang`, `self_relation`, `dangling_relation`, `top_with_broader`, `label_overlap`, `hierarchy_redundancy`, `broader_cycle`. The rest describe things only an author can settle, such as what a concept means or which scheme it belongs to, and guessing would be worse than reporting.

## The constraint that shaped it

A fixer must agree with its check. A wrong report is a nuisance; **a wrong repair is written into the user's graph.**

Four rounds of review on #300 and #301 all landed on the same failure: a fix addressed the instance in front of me rather than the rule it belonged to — one direction of an inverse pair, one side of a disjointness, one check out of the set an entailment touches. That is survivable in a validator and not in a repairer.

So every fixer derives its targets from the same views the corresponding check reads (`_effective_labels`, `_skos_link_maps`) rather than re-reading whichever property seemed relevant, and cycle detection was factored out into `_skos_cycles` so the check and the fixer cannot drift apart.

Three properties are tested **across every fixable type**, not spot-checked:

- the check stops reporting afterwards
- no *other* class of issue appears (a repair that trades one problem for another is not a repair)
- a second run changes nothing

## Decisions worth reviewing

- **No "fix everything" button.** Breaking a cycle and dropping a redundant edge each discard something the author may have meant, so the choice is theirs, one class at a time, with an undo checkpoint around it.
- **SKOS-XL labels are never touched.** This app writes plain SKOS, so repairing one would mean editing a label resource it cannot author. An untagged XL label, and a clash where one side is XL, are both left alone — which spelling the author meant to keep is not ours to guess.
- **`missing_lang` asks for the tag rather than guessing.** A vocabulary's labels need not be in the repairer's language, and stamping the wrong one is a lie the validator would then report as clean.
- **`label_overlap` keeps the more visible label**: prefLabel over altLabel, altLabel over hiddenLabel, so a repair never hides a label that was on show.
- **The two iterative fixers recompute between removals.** Two redundant edges can each be implied by the other, and removing both would detach a concept from a branch it genuinely belongs to. One edge can close several cycles.
- **Counts are issues, not triples**, so the panel's "Fix 3 issues" is followed by "Fixed 3". The two iterative fixers are documented as the exception.

## UI

A button per fixable class inside its group on the validation panel, with the fix described, and a language picker where one is needed. Each takes a checkpoint named for the fix, so it lands in the undo stack like any other edit.

## Testing

53 new tests. Fixtures write triples directly: the API refuses most of what these fixers repair (it will not create a cycle, a self-relation, or an untagged label beside a tagged one), so a fixture built through it could not reach the cases — and an imported file is the shape a broken vocabulary actually arrives in.

Verified end to end in the running app: fixing untagged labels without choosing a language reports the refusal in place rather than crashing, fixing with one clears the group and enables Undo, and Undo brings the issue back.

1397 tests, ruff, format and mypy pass. README documents the fix table, guarded by the same tests as the check table.