### PR TITLE
feat(skos): a starter template and a sample worth copying from

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ thesaurus convention rather than anything normative.
 
 Five starter templates you can merge into or replace your current ontology: Organization, Product Catalog, Event, Person/Contact, and SKOS Thesaurus. Each is a valid Turtle snippet with a preview before you apply it.
 
+The SKOS Thesaurus template validates clean at every tier, so it is a starting point rather than a first batch of warnings, and it demonstrates the parts of SKOS worth copying: language-tagged labels, an `altLabel` and a `scopeNote`, notations, a top concept, and an `exactMatch` to Wikidata. For more than a template has room for, `orionbelt_ontology_builder/samples/skos-showcase.ttl` adds poly-hierarchy, membership of two schemes, labels in three languages, a `hiddenLabel`, and mappings to Wikidata and AGROVOC.
+
 ### Upper Ontologies
 
 Start from a professionally built upper ontology instead of redefining foundational concepts for every project. Two options ship in the box:

--- a/orionbelt_ontology_builder/samples/README.md
+++ b/orionbelt_ontology_builder/samples/README.md
@@ -12,5 +12,18 @@ Real-world ontologies for testing and demonstration.
 | `prov-o.ttl` | [W3C PROV](https://www.w3.org/ns/prov-o) | Provenance Ontology |
 | `goodrelations.owl` | [GoodRelations](http://purl.org/goodrelations/v1) | E-commerce ontology |
 | `geography-thesaurus.ttl` | Sample | SKOS thesaurus with 100+ concepts across 4 hierarchy levels |
+| `skos-showcase.ttl` | Sample | A small, deliberately well-formed SKOS vocabulary: poly-hierarchy, two schemes, labels in three languages, notations, and mappings to Wikidata and AGROVOC |
+
+**On the two SKOS samples.** They are opposites on purpose.
+
+`skos-showcase.ttl` reports nothing under SKOS Validation at any tier. It is
+what a well-formed vocabulary looks like, and it is the one to copy from.
+
+`geography-thesaurus.ttl` has no errors or warnings, but its Americas and
+Oceania branches are **disconnected** from the rest of the hierarchy, which the
+editorial tier reports as disconnected concept clusters. Those flaws are left in
+deliberately: a sample that reports nothing demonstrates nothing about
+validation. Please do not tidy them up without also removing the test that
+depends on them (`tests/test_skos_examples.py`).
 
 **Note:** Schema.org uses `rdfs:Class` / `rdf:Property` instead of OWL types, so it won't show classes or properties in OrionBelt.

--- a/orionbelt_ontology_builder/samples/skos-showcase.ttl
+++ b/orionbelt_ontology_builder/samples/skos-showcase.ttl
@@ -1,0 +1,107 @@
+# A small SKOS vocabulary that exercises the parts of the standard a starter
+# template has no room for: poly-hierarchy, membership of two schemes, labels
+# in several languages, hidden labels for known misspellings, notations, and
+# mapping properties reaching other vocabularies.
+#
+# It reports nothing under SKOS Validation at any tier. That is the point: it
+# shows what a well-formed vocabulary looks like. For the opposite, see
+# geography-thesaurus.ttl, whose disconnected branches the validator finds.
+
+@prefix : <http://example.org/showcase#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+# --- Two schemes. A concept may belong to both. ------------------------------
+
+:Animals a skos:ConceptScheme ;
+    rdfs:label "Animals" ;
+    skos:prefLabel "Animals"@en ;
+    dcterms:description "A small zoological taxonomy."@en ;
+    skos:hasTopConcept :Animal .
+
+:Husbandry a skos:ConceptScheme ;
+    rdfs:label "Husbandry" ;
+    skos:prefLabel "Husbandry"@en ;
+    dcterms:description "Terms from farming practice."@en ;
+    skos:hasTopConcept :FarmAnimal .
+
+# --- The zoological tree -----------------------------------------------------
+
+:Animal a skos:Concept ;
+    skos:prefLabel "Animal"@en , "Tier"@de , "Animal"@fr ;
+    skos:definition "A living organism that feeds on organic matter."@en ;
+    skos:notation "590" ;
+    skos:topConceptOf :Animals ;
+    skos:inScheme :Animals .
+
+:Mammal a skos:Concept ;
+    skos:prefLabel "Mammal"@en , "Säugetier"@de ;
+    skos:definition "A warm-blooded vertebrate that suckles its young."@en ;
+    skos:notation "599" ;
+    skos:broader :Animal ;
+    skos:inScheme :Animals .
+
+:Bird a skos:Concept ;
+    skos:prefLabel "Bird"@en , "Vogel"@de ;
+    skos:definition "A warm-blooded vertebrate with feathers and wings."@en ;
+    skos:notation "598" ;
+    skos:broader :Animal ;
+    skos:inScheme :Animals .
+
+:Dog a skos:Concept ;
+    skos:prefLabel "Dog"@en , "Hund"@de , "Chien"@fr ;
+    skos:altLabel "Domestic dog"@en ;
+    # A hidden label catches a known misspelling in search without showing it.
+    skos:hiddenLabel "Dogg"@en ;
+    skos:definition "A domesticated canine kept as a pet or working animal."@en ;
+    skos:scopeNote "Domestic breeds only; wild canines sit under their own concepts."@en ;
+    skos:notation "636.7" ;
+    skos:broader :Mammal ;
+    skos:inScheme :Animals ;
+    skos:exactMatch <http://www.wikidata.org/entity/Q144> .
+
+:Cat a skos:Concept ;
+    skos:prefLabel "Cat"@en , "Katze"@de ;
+    skos:definition "A domesticated feline kept as a pet."@en ;
+    skos:notation "636.8" ;
+    skos:broader :Mammal ;
+    skos:inScheme :Animals ;
+    skos:exactMatch <http://www.wikidata.org/entity/Q146> .
+
+:Chicken a skos:Concept ;
+    skos:prefLabel "Chicken"@en , "Huhn"@de ;
+    skos:definition "A domesticated fowl raised for eggs and meat."@en ;
+    skos:notation "636.5" ;
+    skos:broader :Bird ;
+    skos:inScheme :Animals .
+
+# --- The farming tree --------------------------------------------------------
+
+:FarmAnimal a skos:Concept ;
+    skos:prefLabel "Farm animal"@en , "Nutztier"@de ;
+    skos:definition "An animal kept for agricultural production."@en ;
+    skos:topConceptOf :Husbandry ;
+    skos:inScheme :Husbandry .
+
+:Herding a skos:Concept ;
+    skos:prefLabel "Herding"@en , "Hüten"@de ;
+    skos:definition "Moving and managing livestock as a group."@en ;
+    skos:broader :FarmAnimal ;
+    skos:inScheme :Husbandry ;
+    # Associative, not hierarchical: a dog is not a kind of herding, and the two
+    # share no parent, which would make the link say nothing new.
+    skos:related :Dog .
+
+# --- Poly-hierarchy: one concept, two parents, two schemes -------------------
+
+:Cattle a skos:Concept ;
+    skos:prefLabel "Cattle"@en , "Rind"@de , "Bovin"@fr ;
+    skos:altLabel "Cows"@en ;
+    skos:definition "Domesticated bovines raised for milk, meat or draught."@en ;
+    skos:notation "636.2" ;
+    # Zoologically a mammal, agriculturally a farm animal. Neither parent is an
+    # ancestor of the other, so neither edge is redundant.
+    skos:broader :Mammal , :FarmAnimal ;
+    skos:inScheme :Animals , :Husbandry ;
+    skos:closeMatch <http://aims.fao.org/aos/agrovoc/c_1391> .

--- a/orionbelt_ontology_builder/templates.py
+++ b/orionbelt_ontology_builder/templates.py
@@ -271,7 +271,7 @@ TEMPLATES = [
     },
     {
         "name": "SKOS Thesaurus",
-        "description": "SKOS ConceptScheme with sample broader/narrower concepts. Starting point for controlled vocabularies and taxonomies.",
+        "description": "SKOS ConceptScheme demonstrating language-tagged labels, notations, top concepts and a mapping to an external vocabulary. Validates clean, so it is a starting point rather than a first batch of warnings.",
         "turtle": """@prefix : <{base_uri}> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -279,40 +279,56 @@ TEMPLATES = [
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 :MainScheme a skos:ConceptScheme ;
-    rdfs:label "Main Scheme" .
+    rdfs:label "Main Scheme" ;
+    skos:prefLabel "Main Scheme"@en ;
+    skos:hasTopConcept :Science .
 
 :Science a skos:Concept ;
-    skos:prefLabel "Science" ;
+    skos:prefLabel "Science"@en ;
+    skos:prefLabel "Wissenschaft"@de ;
+    skos:definition "The systematic study of the natural and social world."@en ;
+    skos:notation "500" ;
+    skos:topConceptOf :MainScheme ;
     skos:inScheme :MainScheme .
 
 :NaturalScience a skos:Concept ;
-    skos:prefLabel "Natural Science" ;
+    skos:prefLabel "Natural science"@en ;
+    skos:altLabel "Physical science"@en ;
+    skos:definition "The study of the physical world through observation."@en ;
+    skos:notation "500.1" ;
     skos:broader :Science ;
     skos:inScheme :MainScheme .
 
 :SocialScience a skos:Concept ;
-    skos:prefLabel "Social Science" ;
+    skos:prefLabel "Social science"@en ;
+    skos:definition "The study of human society and relationships."@en ;
+    skos:notation "300" ;
     skos:broader :Science ;
     skos:inScheme :MainScheme .
 
 :Physics a skos:Concept ;
-    skos:prefLabel "Physics" ;
+    skos:prefLabel "Physics"@en ;
+    skos:prefLabel "Physik"@de ;
+    skos:definition "The study of matter, energy and their interactions."@en ;
+    skos:scopeNote "Covers classical and modern physics."@en ;
+    skos:notation "530" ;
     skos:broader :NaturalScience ;
-    skos:inScheme :MainScheme .
+    skos:inScheme :MainScheme ;
+    skos:exactMatch <http://www.wikidata.org/entity/Q413> .
 
 :Biology a skos:Concept ;
-    skos:prefLabel "Biology" ;
+    skos:prefLabel "Biology"@en ;
+    skos:definition "The study of living organisms."@en ;
+    skos:notation "570" ;
     skos:broader :NaturalScience ;
     skos:inScheme :MainScheme .
 
 :Economics a skos:Concept ;
-    skos:prefLabel "Economics" ;
+    skos:prefLabel "Economics"@en ;
+    skos:definition "The study of the production and distribution of goods."@en ;
+    skos:notation "330" ;
     skos:broader :SocialScience ;
     skos:inScheme :MainScheme .
-
-:Science skos:narrower :NaturalScience, :SocialScience .
-:NaturalScience skos:narrower :Physics, :Biology .
-:SocialScience skos:narrower :Economics .
 """,
     },
 ]

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -30,6 +30,7 @@ SAMPLE_FILES = {
         "http://purl.org/goodrelations/v1.owl",
     ),
     "geography": ("geography-thesaurus.ttl", "turtle", None),
+    "skos-showcase": ("skos-showcase.ttl", "turtle", None),
 }
 
 

--- a/tests/test_skos_examples.py
+++ b/tests/test_skos_examples.py
@@ -1,0 +1,152 @@
+"""The SKOS examples practise what the validator preaches.
+
+Two guards, and the second is the one that matters. Asserting an example
+validates clean is easy to satisfy by accident: an empty file passes. So the
+showcase is also asserted to *contain* the things it exists to demonstrate,
+or it could be quietly hollowed out and stay green.
+"""
+
+import pathlib
+
+import pytest
+
+from ontology_manager import OntologyManager
+from orionbelt_ontology_builder import templates
+
+SAMPLES = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "orionbelt_ontology_builder"
+    / "samples"
+)
+BASE = "http://example.org/ontology#"
+
+
+def _loaded(path, base=BASE):
+    om = OntologyManager(base_uri=base)
+    om.graph.parse(str(path), format="turtle")
+    return om
+
+
+@pytest.fixture
+def showcase():
+    return _loaded(SAMPLES / "skos-showcase.ttl", "http://example.org/showcase#")
+
+
+class TestTheStarterTemplate:
+    """A template that opens with a screenful of warnings teaches the wrong
+    thing, especially now that most of them are one button-click from fixed."""
+
+    @pytest.fixture
+    def built(self):
+        template = next(t for t in templates.TEMPLATES if t["name"] == "SKOS Thesaurus")
+        om = OntologyManager(base_uri=BASE)
+        om.graph.parse(data=template["turtle"].format(base_uri=BASE), format="turtle")
+        return om
+
+    def test_it_validates_clean_at_every_tier(self, built):
+        assert built.validate_skos() == []
+
+    def test_it_demonstrates_the_data_model(self, built):
+        """Otherwise "clean" could be achieved by leaving things out."""
+        concepts = built.get_concepts()
+        assert len(concepts) >= 5
+        assert any(len(c["labels"]["prefLabel"]) > 1 for c in concepts), (
+            "no concept carries a prefLabel in more than one language"
+        )
+        assert any(c["labels"]["altLabel"] for c in concepts), "no altLabel"
+        assert any(c["notation"] for c in concepts), "no notation"
+        assert any(c["top_of"] for c in concepts), "no top concept"
+        assert any(
+            any(c["mappings"][rel] for rel in OntologyManager.SKOS_MAPPING_RELATIONS)
+            for c in concepts
+        ), "nothing mapped to another vocabulary"
+
+
+class TestTheShowcaseSample:
+    def test_it_validates_clean_at_every_tier(self, showcase):
+        assert showcase.validate_skos() == []
+
+    def test_it_shows_what_a_template_has_no_room_for(self, showcase):
+        concepts = showcase.get_concepts()
+        assert len(showcase.get_concept_schemes()) >= 2, "only one scheme"
+
+        poly = [c for c in concepts if len(c["broader_uris"]) > 1]
+        assert poly, "no concept has more than one parent"
+
+        in_two_schemes = [c for c in concepts if len(c["scheme_uris"]) > 1]
+        assert in_two_schemes, "no concept belongs to two schemes"
+
+        languages = {
+            item["lang"] for c in concepts for item in c["labels"]["prefLabel"]
+        }
+        assert len(languages) >= 3, f"only {len(languages)} languages: {languages}"
+
+        assert any(c["labels"]["hiddenLabel"] for c in concepts), "no hiddenLabel"
+        assert any(c["notes"]["scopeNote"] for c in concepts), "no scopeNote"
+        assert any(c["related_uris"] for c in concepts), "no associative relation"
+
+    def test_its_mappings_leave_the_vocabulary(self, showcase):
+        """A mapping between two concepts of one scheme is a check, not a demo."""
+        known = {c["uri"] for c in showcase.get_concepts()}
+        targets = [
+            target
+            for c in showcase.get_concepts()
+            for rel in OntologyManager.SKOS_MAPPING_RELATIONS
+            for target in c["mappings"][rel]
+        ]
+        assert targets, "nothing mapped"
+        assert not [t for t in targets if t in known]
+
+    def test_the_poly_hierarchy_is_not_redundant(self, showcase):
+        """Two parents where one is an ancestor of the other would be a warning
+        rather than a demonstration."""
+        assert not [
+            i for i in showcase.validate_skos() if i["type"] == "hierarchy_redundancy"
+        ]
+
+
+class TestEveryBundledSample:
+    """A sample shipping SKOS errors would be teaching from a broken example."""
+
+    @pytest.mark.parametrize(
+        "path", sorted(SAMPLES.glob("*.ttl")), ids=lambda p: p.name
+    )
+    def test_no_skos_errors(self, path):
+        om = _loaded(path)
+        errors = [
+            i
+            for i in om.validate_skos(check_conventions=False, check_editorial=False)
+            if i["severity"] == "error"
+        ]
+        assert not errors, [i["message"] for i in errors]
+
+    def test_the_geography_sample_still_shows_the_validator_working(self):
+        """Its disconnected branches are left in on purpose.
+
+        A sample that reports nothing demonstrates nothing about validation, so
+        this one keeps its flaws and `samples/README.md` says so. If it is ever
+        tidied up, this test should be deleted along with that note rather than
+        quietly adjusted.
+        """
+        om = _loaded(SAMPLES / "geography-thesaurus.ttl")
+        found = {i["type"] for i in om.validate_skos()}
+        assert "disconnected_components" in found
+
+    def test_the_geography_sample_is_otherwise_sound(self):
+        om = _loaded(SAMPLES / "geography-thesaurus.ttl")
+        assert not [
+            i for i in om.validate_skos() if i["severity"] in ("error", "warning")
+        ]
+
+
+class TestTheSamplesReadme:
+    def test_the_showcase_is_listed(self):
+        readme = (SAMPLES / "README.md").read_text(encoding="utf-8")
+        assert "skos-showcase.ttl" in readme
+
+    def test_the_geography_flaws_are_documented(self):
+        readme = (SAMPLES / "README.md").read_text(encoding="utf-8")
+        assert "disconnected" in readme.lower(), (
+            "samples/README.md should say the geography sample's disconnected "
+            "branches are deliberate, or the next reader will 'fix' them"
+        )


### PR DESCRIPTION
The built-in **SKOS Thesaurus template opened with 12 validation issues** — six untagged labels, six undocumented concepts. It predated the data-model work, so it demonstrated none of what the editor now supports and taught exactly the habits the validator then complains about. Since WS-2, most of those issues are one button-click from fixed, which made the contradiction sharper rather than smaller.

```
before: warning missing_lang 6 · info undocumented 6
after:  no issues at any tier
```

## What changed

**The template** now validates clean and shows what is worth copying: language-tagged `prefLabel`s in two languages, an `altLabel` and a `scopeNote`, notations, a top concept written both ways, and an `exactMatch` to Wikidata.

**`samples/skos-showcase.ttl`** is new, covering what a starter template has no room for:

- poly-hierarchy where neither parent is an ancestor of the other, so it is not redundant
- one concept in two schemes
- labels in three languages
- a `hiddenLabel` for a known misspelling
- an associative relation between concepts that share no parent, so it is not valueless
- mappings out to Wikidata and AGROVOC

It also reports nothing at any tier.

## The guard that matters

Not that they validate clean — **an empty file does that too.** Both examples are asserted to *contain* what they exist to demonstrate. The template must carry multiple languages, an `altLabel`, a notation, a top concept and a mapping; the showcase must carry poly-hierarchy, dual scheme membership, three languages, a `hiddenLabel` and external mappings. Hollowing either out fails the suite rather than passing it.

That is the same lesson as the last few rounds of review, applied up front: a test is only as strong as what it actually pins down.

## The geography sample keeps its flaws

Every bundled sample is now checked for SKOS errors. The geography thesaurus has none, but its Americas and Oceania branches are **disconnected** from the rest of the hierarchy, which the editorial tier reports.

Those stay. A sample that reports nothing demonstrates nothing about validation, so the two SKOS samples are deliberate opposites: the showcase is what good looks like, the geography thesaurus is what the validator is for. A test pins the disconnected clusters and `samples/README.md` asks the next reader not to tidy them away without deleting that test too.

## Testing

14 new tests. 1437 total, ruff, format and mypy pass.

Verified through the real UI path rather than parsed in isolation — and that mattered: my first attempt showed a warning and two infos, because Apply Template defaults to **Merge** and the browser's autosave still held an earlier import. Re-applied with Replace, the panel reports "No SKOS issues found!".