### PR TITLE
feat(skos): Dublin Core metadata on concept schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,39 @@ A dedicated page for building controlled vocabularies:
 - An edge that would make a concept its own ancestor is refused as you save it
 - Hierarchy tree view, filterable by scheme
 
+#### Concept scheme metadata
+
+A published vocabulary carries Dublin Core terms on its ConceptScheme, and
+consumers rely on them: AGROVOC, EuroVoc and LCSH all do this. The Concept
+Schemes page edits them, and `set_scheme_metadata()` writes them from Python.
+
+| Field | Property | Written as |
+|---|---|---|
+| `title` | `dcterms:title` | language-tagged text, one per language |
+| `description` | `dcterms:description` | language-tagged text, one per language |
+| `creator` | `dcterms:creator` | a name, or an IRI identifying one; repeatable |
+| `publisher` | `dcterms:publisher` | a name, or an IRI identifying one; repeatable |
+| `contributor` | `dcterms:contributor` | a name, or an IRI identifying one; repeatable |
+| `created` | `dcterms:created` | `YYYY`, `YYYY-MM` or `YYYY-MM-DD`, typed by precision |
+| `issued` | `dcterms:issued` | `YYYY`, `YYYY-MM` or `YYYY-MM-DD`, typed by precision |
+| `modified` | `dcterms:modified` | `YYYY`, `YYYY-MM` or `YYYY-MM-DD`, typed by precision |
+| `license` | `dcterms:license` | an absolute IRI |
+| `source` | `dcterms:source` | an absolute IRI |
+| `rights` | `dcterms:rights` | language-tagged text, one per language |
+| `versionInfo` | `owl:versionInfo` | plain text |
+
+The shapes matter. A date is typed by how much of it was given, so a
+vocabulary that records only `2019` is not forced to invent a month and a
+day. A licence is stored as a resource rather than as text about one, so a
+consumer can follow it. A creator may be either a name or an identifier such
+as an ORCID, and is stored as whichever it is.
+
+`versionInfo` is `owl:versionInfo` rather than a Dublin Core term: nothing in
+DC is used for a vocabulary version in practice.
+
 #### What SKOS validation checks
 
-21 checks in three tiers. The page groups results by check and lets you
+22 checks in three tiers. The page groups results by check and lets you
 switch either advisory tier off, which is what makes it usable on a large
 imported vocabulary. `validate_skos()` returns the same list to Python callers,
 each issue carrying a stable `type`, a `severity`, the `subject` concept and its
@@ -143,6 +173,7 @@ each issue carrying a stable `type`, a `severity`, the `subject` concept and its
 | Check | What it means | Source |
 |---|---|---|
 | `no_scheme` | The concept belongs to no ConceptScheme. | Practice |
+| `scheme_untitled` | A ConceptScheme has neither a dcterms:title nor an rdfs:label, leaving a consumer only its URI. | Practice |
 | `undocumented` | The concept has neither a definition nor a scopeNote. | Practice |
 | `valueless_association` | Two concepts are skos:related and already share a parent, which relates them anyway. | qSKOS |
 | `skos_xl_labels` | The vocabulary uses SKOS-XL labels, which this editor shows but does not edit. | SKOS-XL |

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2,6 +2,7 @@
 OntologyManager - Core class for managing OWL ontologies using rdflib.
 """
 
+import datetime
 import logging
 import os
 import re
@@ -3157,13 +3158,37 @@ class OntologyManager:
                 return URIRef(text)
             return Literal(text)
         if kind == "date":
-            for pattern, datatype in self._DATE_PRECISION:
-                if re.match(pattern, text):
-                    return Literal(text, datatype=datatype)
+            return self._typed_date(field, text)
+        return Literal(text)
+
+    def _typed_date(self, field: str, text: str) -> Literal:
+        """A date literal typed by its precision, refused if it is not a date.
+
+        Matching the shape is not enough. "2019-13" and "2019-02-31" both look
+        like dates and neither exists, and rdflib stores such a literal happily,
+        complaining only later when something tries to read its value — by which
+        point it is in the user's file. So the range check belongs here.
+
+        February is why this uses the calendar rather than a table of month
+        lengths: 2020-02-29 is a date and 2019-02-29 is not.
+        """
+        for pattern, datatype in self._DATE_PRECISION:
+            if re.match(pattern, text):
+                break
+        else:
             raise ValueError(
                 f"{field} must be a date as YYYY, YYYY-MM or YYYY-MM-DD, got: {text}"
             )
-        return Literal(text)
+
+        parts = [int(part) for part in text.split("-")]
+        try:
+            if datatype == XSD.gYearMonth and not 1 <= parts[1] <= 12:
+                raise ValueError(text)
+            if datatype == XSD.date:
+                datetime.date(*parts)
+        except ValueError:
+            raise ValueError(f"{field} is not a real date: {text}") from None
+        return Literal(text, datatype=datatype)
 
     def set_scheme_metadata(
         self, scheme: str, field: str, value: str, lang: str | None = None

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -2951,6 +2951,14 @@ class OntologyManager:
             "summary": "The concept belongs to no ConceptScheme.",
             "source": "Practice",
         },
+        "scheme_untitled": {
+            "severity": "info",
+            "summary": (
+                "A ConceptScheme has neither a dcterms:title nor an "
+                "rdfs:label, leaving a consumer only its URI."
+            ),
+            "source": "Practice",
+        },
         "undocumented": {
             "severity": "info",
             "summary": "The concept has neither a definition nor a scopeNote.",
@@ -3048,6 +3056,193 @@ class OntologyManager:
             or (scheme, SKOS.hasTopConcept, concept) in self.graph
         )
 
+    #: Metadata a published vocabulary carries on its ConceptScheme, keyed by
+    #: the short name the UI and the API use.
+    #:
+    #: Mostly Dublin Core Terms, which is what AGROVOC, EuroVoc and LCSH all
+    #: use for this. ``versionInfo`` is OWL rather than DC, included because a
+    #: vocabulary without a version is hard to cite and nothing in DC is used
+    #: for it in practice.
+    #:
+    #: ``kind`` says how a value is written, because these are not all strings:
+    #:
+    #: - ``text``   language-tagged literal, one per language
+    #: - ``agent``  a name, or an IRI identifying one; repeatable
+    #: - ``date``   typed by precision: gYear, gYearMonth or date
+    #: - ``iri``    a resource, such as the licence a vocabulary is issued under
+    #: - ``plain``  an untagged string
+    SCHEME_METADATA: ClassVar[dict[str, dict[str, Any]]] = {
+        "title": {"property": DCTERMS.title, "kind": "text", "single": True},
+        "description": {
+            "property": DCTERMS.description,
+            "kind": "text",
+            "single": True,
+        },
+        "creator": {"property": DCTERMS.creator, "kind": "agent", "single": False},
+        "publisher": {
+            "property": DCTERMS.publisher,
+            "kind": "agent",
+            "single": False,
+        },
+        "contributor": {
+            "property": DCTERMS.contributor,
+            "kind": "agent",
+            "single": False,
+        },
+        "created": {"property": DCTERMS.created, "kind": "date", "single": True},
+        "issued": {"property": DCTERMS.issued, "kind": "date", "single": True},
+        "modified": {"property": DCTERMS.modified, "kind": "date", "single": True},
+        "license": {"property": DCTERMS.license, "kind": "iri", "single": True},
+        "source": {"property": DCTERMS.source, "kind": "iri", "single": True},
+        "rights": {"property": DCTERMS.rights, "kind": "text", "single": True},
+        "versionInfo": {
+            "property": OWL.versionInfo,
+            "kind": "plain",
+            "single": True,
+        },
+    }
+
+    #: How much of a date was given, and the datatype that says so. A
+    #: vocabulary that records only ``"2019"`` should not be forced to invent a
+    #: month and a day, and typing it as xsd:date would be a false precision.
+    _DATE_PRECISION: ClassVar[tuple[tuple[str, URIRef], ...]] = (
+        (r"^\d{4}$", XSD.gYear),
+        (r"^\d{4}-\d{2}$", XSD.gYearMonth),
+        (r"^\d{4}-\d{2}-\d{2}$", XSD.date),
+    )
+
+    def _scheme_field(self, field: str) -> dict[str, Any]:
+        """Resolve a metadata field, or say which fields exist."""
+        entry = self.SCHEME_METADATA.get(field)
+        if entry is None:
+            known = ", ".join(self.SCHEME_METADATA)
+            raise ValueError(
+                f"Unknown scheme metadata field: {field} (expected one of {known})"
+            )
+        return entry
+
+    def _scheme_uri(self, scheme: str) -> URIRef:
+        """A scheme's URI, resolved by URI or by local name.
+
+        Prefers an exact URI match, so two schemes sharing a local name across
+        namespaces do not collapse into whichever the store yields first.
+        """
+        candidate = self._uri(scheme)
+        if (candidate, RDF.type, SKOS.ConceptScheme) in self.graph:
+            return candidate
+        for existing in self.graph.subjects(RDF.type, SKOS.ConceptScheme):
+            if isinstance(existing, URIRef) and self._local_name(existing) == scheme:
+                return existing
+        return candidate
+
+    def _scheme_metadata_node(self, field: str, value: str, lang: str | None):
+        """The RDF term for one metadata value, by the field's kind."""
+        entry = self._scheme_field(field)
+        kind = entry["kind"]
+        text = self._literal_text(value, field)
+
+        if kind == "text":
+            tag = self._checked_lang(lang)
+            return Literal(text, lang=tag) if tag else Literal(text)
+        if kind == "iri":
+            if not self._IRI_SCHEME_RE.match(text):
+                raise ValueError(f"{field} must be an absolute IRI, got: {text}")
+            if reason := self.invalid_uri_reason(text):
+                raise ValueError(reason)
+            return URIRef(text)
+        if kind == "agent":
+            # A name or an IRI identifying one. Both are used in the wild, and
+            # an IRI stored as a string would not resolve for a consumer.
+            if self._IRI_SCHEME_RE.match(text) and not self.invalid_uri_reason(text):
+                return URIRef(text)
+            return Literal(text)
+        if kind == "date":
+            for pattern, datatype in self._DATE_PRECISION:
+                if re.match(pattern, text):
+                    return Literal(text, datatype=datatype)
+            raise ValueError(
+                f"{field} must be a date as YYYY, YYYY-MM or YYYY-MM-DD, got: {text}"
+            )
+        return Literal(text)
+
+    def set_scheme_metadata(
+        self, scheme: str, field: str, value: str, lang: str | None = None
+    ) -> None:
+        """Set a Dublin Core (or versionInfo) value on a ConceptScheme.
+
+        Single-valued fields replace what is there, per language for the
+        language-tagged ones: a scheme has one title in English, not a list of
+        them. Repeatable fields append, since a vocabulary may have several
+        creators.
+        """
+        entry = self._scheme_field(field)
+        uri = self._scheme_uri(scheme)
+        node = self._scheme_metadata_node(field, value, lang)
+
+        if entry["single"]:
+            if entry["kind"] == "text":
+                tag = (lang or "").strip()
+                for existing in list(self.graph.objects(uri, entry["property"])):
+                    if (
+                        isinstance(existing, Literal)
+                        and (existing.language or "") == tag
+                    ):
+                        self.graph.remove((uri, entry["property"], existing))
+            else:
+                self.graph.remove((uri, entry["property"], None))
+        self.graph.add((uri, entry["property"], node))
+
+    def remove_scheme_metadata(
+        self, scheme: str, field: str, value: str | None = None, lang: str | None = None
+    ) -> bool:
+        """Remove one metadata value, or every value of that field.
+
+        Matches the term actually in the graph rather than rebuilding one, so a
+        typed date or an IRI-valued creator is removed rather than missed.
+        """
+        entry = self._scheme_field(field)
+        uri = self._scheme_uri(scheme)
+        if value is None:
+            removed = (uri, entry["property"], None) in self.graph
+            self.graph.remove((uri, entry["property"], None))
+            return removed
+
+        target_lang = (lang or "").strip()
+        removed = False
+        for existing in list(self.graph.objects(uri, entry["property"])):
+            if str(existing) != value:
+                continue
+            if (
+                isinstance(existing, Literal)
+                and (existing.language or "") != target_lang
+            ):
+                continue
+            self.graph.remove((uri, entry["property"], existing))
+            removed = True
+        return removed
+
+    def _scheme_metadata(self, uri: Node) -> dict[str, list[dict[str, Any]]]:
+        """Every metadata value on a scheme, keyed by field name.
+
+        ``is_iri`` is a bool rather than text, so the UI can render a resource
+        as one instead of as a string that happens to look like a URL.
+        """
+        found: dict[str, list[dict[str, Any]]] = {}
+        for field, entry in self.SCHEME_METADATA.items():
+            values = []
+            for obj in self.graph.objects(uri, entry["property"]):
+                values.append(
+                    {
+                        "value": str(obj),
+                        "lang": obj.language or "" if isinstance(obj, Literal) else "",
+                        "is_iri": isinstance(obj, URIRef),
+                    }
+                )
+            found[field] = sorted(
+                values, key=lambda v: (v["lang"] != "", v["lang"], v["value"])
+            )
+        return found
+
     def add_concept_scheme(
         self, name: str, label: str | None = None, comment: str | None = None
     ) -> URIRef:
@@ -3085,6 +3280,7 @@ class OntologyManager:
                     "label": label,
                     "comment": comment,
                     "concept_count": concept_count,
+                    "metadata": self._scheme_metadata(uri),
                 }
             )
         return sorted(schemes, key=lambda s: s["name"])
@@ -4140,6 +4336,18 @@ class OntologyManager:
         """Scheme membership, label clashes, and cross-scheme mapping misuse."""
         issues: list[dict[str, str]] = []
         shown = self._skos_display_names(concepts)
+
+        for scheme in schemes:
+            if not scheme["metadata"]["title"] and not scheme["label"]:
+                issues.append(
+                    self._skos_issue(
+                        "info",
+                        "scheme_untitled",
+                        scheme,
+                        f"ConceptScheme '{scheme['name']}' has no dcterms:title "
+                        "or rdfs:label, so a consumer has only its URI to go on",
+                    )
+                )
 
         for concept in concepts:
             if not concept["scheme_uris"] and schemes:

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -859,6 +859,103 @@ def render_language_pack_sidebar() -> None:
     persist_language_packs()
 
 
+def _clearing_key(base: str) -> str:
+    """A widget key that changes once :func:`_clear_input` is called on it.
+
+    Popping a widget's key from ``session_state`` does not reset the widget:
+    Streamlit restores the value from its own widget store when a widget with
+    the same key is created again. Changing the key makes a different widget,
+    which starts empty. Used so an add row does not keep the text just added
+    and invite adding it twice.
+    """
+    return f"{base}_{st.session_state.get(f'{base}__gen', 0)}"
+
+
+def _clear_input(base: str) -> None:
+    """Retire the current widget behind ``base`` so the next one starts empty."""
+    generation = st.session_state.get(f"{base}__gen", 0)
+    st.session_state.pop(f"{base}_{generation}", None)
+    st.session_state[f"{base}__gen"] = generation + 1
+
+
+def render_scheme_metadata_editor(ont, scheme, sk):
+    """Rows of Dublin Core metadata on a ConceptScheme, with add and delete.
+
+    Outside the scheme form, for the same reason the concept label editor is:
+    a button inside a form cannot act until the form is submitted.
+
+    The fields are not all strings, so the add row changes shape with the one
+    picked: a language for the language-tagged ones, none for a date or an IRI.
+    Offering a language box beside a licence URL would invite tagging it.
+    """
+    rows = [
+        (field, item)
+        for field in ont.SCHEME_METADATA
+        for item in scheme["metadata"][field]
+    ]
+    for i, (field, item) in enumerate(rows):
+        col_field, col_lang, col_value, col_del = st.columns([2, 1, 5, 0.7])
+        with col_field:
+            st.write(f"`{field}`")
+        with col_lang:
+            st.write(item["lang"] or "—")
+        with col_value:
+            st.write(f"<{item['value']}>" if item["is_iri"] else item["value"])
+        with col_del:
+            if st.button("🗑️", key=f"del_meta_{sk}_{i}", help=f"Delete this {field}"):
+                ont.remove_scheme_metadata(
+                    scheme["uri"], field, item["value"], item["lang"]
+                )
+                save_checkpoint(f"Delete scheme {field}")
+                st.rerun()
+    if not rows:
+        st.caption("No metadata yet.")
+
+    col_field, col_lang, col_value, col_add = st.columns([2, 1, 5, 0.7])
+    with col_field:
+        new_field = st.selectbox(
+            "Field",
+            list(ont.SCHEME_METADATA),
+            key=f"add_meta_field_{sk}",
+            label_visibility="collapsed",
+        )
+    entry = ont.SCHEME_METADATA[new_field]
+    with col_lang:
+        if entry["kind"] == "text":
+            new_lang = language_selectbox(
+                "Language",
+                key=f"add_meta_lang_{sk}",
+                label_visibility="collapsed",
+            )
+        else:
+            new_lang = None
+            st.write("—")
+    placeholder = {
+        "date": "2026, 2026-08 or 2026-08-20",
+        "iri": "https://creativecommons.org/licenses/by/4.0/",
+        "agent": "A name, or an IRI identifying one",
+    }.get(entry["kind"], f"New {new_field}…")
+    with col_value:
+        new_value = st.text_input(
+            "Value",
+            key=_clearing_key(f"add_meta_value_{sk}"),
+            placeholder=placeholder,
+            label_visibility="collapsed",
+        )
+    with col_add:
+        if st.button("➕", key=f"add_meta_btn_{sk}", help=f"Set this {new_field}"):
+            try:
+                ont.set_scheme_metadata(
+                    scheme["uri"], new_field, new_value, new_lang or None
+                )
+            except ValueError as exc:
+                show_message(str(exc), "error")
+            else:
+                save_checkpoint(f"Set scheme {new_field}")
+                _clear_input(f"add_meta_value_{sk}")
+                st.rerun()
+
+
 def render_skos_literal_editor(ont, concept, ck):
     """One table of a concept's labels and notes, with add and delete.
 
@@ -944,7 +1041,7 @@ def render_skos_literal_editor(ont, concept, ck):
     with col_text:
         new_text = st.text_input(
             "Text",
-            key=f"add_lit_text_{ck}",
+            key=_clearing_key(f"add_lit_text_{ck}"),
             placeholder="New label or note…",
             label_visibility="collapsed",
         )
@@ -959,7 +1056,7 @@ def render_skos_literal_editor(ont, concept, ck):
                 # Clear the text but keep the kind and the language: adding
                 # several values in one language is the common case, and a
                 # value left in the box invites adding it twice.
-                st.session_state.pop(f"add_lit_text_{ck}", None)
+                _clear_input(f"add_lit_text_{ck}")
                 st.rerun()
 
 

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -20,6 +20,7 @@ from ..ui import (
     language_selectbox,
     language_tag_error,
     missing_required,
+    render_scheme_metadata_editor,
     render_skos_literal_editor,
     required_selectbox,
     save_checkpoint,
@@ -119,6 +120,10 @@ def render_skos_vocabulary():
                         st.write(f"**Label:** {scheme['label'] or '—'}")
                         st.write(f"**Comment:** {scheme['comment'] or '—'}")
                         st.write(f"**Concepts:** {scheme['concept_count']}")
+                        for _field in ont.SCHEME_METADATA:
+                            _values = scheme["metadata"][_field]
+                            if _values:
+                                st.write(f"**{_field}:** {_fmt_tagged(_values)}")
 
                     if confirm_delete(scheme["uri"], "scheme", f"scheme_{_sk}"):
                         ont.delete_concept_scheme(scheme["uri"])
@@ -129,6 +134,15 @@ def render_skos_vocabulary():
                         st.rerun()
 
                     if _is_open("scheme", _sk, "edit"):
+                        st.divider()
+                        st.markdown("**Metadata**")
+                        st.caption(
+                            "Dublin Core terms a published vocabulary is "
+                            "expected to carry. `versionInfo` is OWL rather "
+                            "than DC; nothing in DC is used for it in practice."
+                        )
+                        render_scheme_metadata_editor(ont, scheme, _sk)
+
                         st.divider()
                         with st.form(f"edit_scheme_form_{_sk}"):
                             new_name = st.text_input(

--- a/tests/test_scheme_metadata.py
+++ b/tests/test_scheme_metadata.py
@@ -9,6 +9,7 @@ about one, and a creator may be either. Storing all of them as plain literals
 would round-trip fine and be wrong.
 """
 
+import datetime
 import pathlib
 
 import pytest
@@ -82,9 +83,37 @@ class TestDatesAreTypedByPrecision:
     @pytest.mark.parametrize(
         "value", ["yesterday", "01-03-2019", "2019-3-1", "20190301"]
     )
-    def test_a_value_that_is_not_a_date_is_refused(self, om, value):
+    def test_a_value_that_is_not_shaped_like_a_date_is_refused(self, om, value):
         with pytest.raises(ValueError, match="YYYY"):
             om.set_scheme_metadata("Animals", "created", value)
+
+    @pytest.mark.parametrize(
+        "value", ["2019-13", "2019-00", "2019-02-31", "2019-04-31", "2019-02-29"]
+    )
+    def test_a_date_that_does_not_exist_is_refused(self, om, value):
+        """Shape is not enough. rdflib stores a literal like this without
+        complaint and only objects later, when something reads its value, by
+        which point it is in the user's file."""
+        with pytest.raises(ValueError, match="not a real date"):
+            om.set_scheme_metadata("Animals", "created", value)
+
+    def test_a_leap_day_is_a_date_in_a_leap_year(self, om):
+        """Why this uses the calendar and not a table of month lengths."""
+        om.set_scheme_metadata("Animals", "created", "2020-02-29")
+        assert [v["value"] for v in _meta(om, "created")] == ["2020-02-29"]
+
+    def test_the_end_of_a_long_month_is_accepted(self, om):
+        om.set_scheme_metadata("Animals", "created", "2019-12-31")
+        assert [v["value"] for v in _meta(om, "created")] == ["2019-12-31"]
+
+    def test_a_stored_date_reads_back_as_a_date(self, om):
+        """The value round-trips through rdflib rather than only looking right.
+
+        A literal that fails to convert is exactly what this check keeps out.
+        """
+        om.set_scheme_metadata("Animals", "created", "2019-03-01")
+        stored = _objects(om, DCTERMS.created)[0]
+        assert stored.toPython() == datetime.date(2019, 3, 1)
 
     def test_a_new_date_replaces_the_old_one(self, om):
         om.set_scheme_metadata("Animals", "modified", "2019")

--- a/tests/test_scheme_metadata.py
+++ b/tests/test_scheme_metadata.py
@@ -1,0 +1,246 @@
+"""Dublin Core metadata on a ConceptScheme.
+
+`add_concept_scheme` took a label and a comment, while every published
+vocabulary carries a title, a creator, a licence and dates on its scheme.
+
+The point of these tests is that the fields are not all strings. A date is
+typed by how much of it was given, a licence is a resource rather than text
+about one, and a creator may be either. Storing all of them as plain literals
+would round-trip fine and be wrong.
+"""
+
+import pathlib
+
+import pytest
+from rdflib import Literal, URIRef
+from rdflib.namespace import DCTERMS, OWL, RDF, SKOS, XSD
+
+from ontology_manager import OntologyManager
+
+BASE = "http://test.org/ont#"
+CC_BY = "https://creativecommons.org/licenses/by/4.0/"
+ORCID = "https://orcid.org/0000-0002-1825-0097"
+
+
+@pytest.fixture
+def om():
+    manager = OntologyManager(base_uri=BASE)
+    manager.add_concept_scheme("Animals")
+    return manager
+
+
+def _meta(om, field):
+    return om.get_concept_schemes()[0]["metadata"][field]
+
+
+def _objects(om, prop):
+    return list(om.graph.objects(URIRef(BASE + "Animals"), prop))
+
+
+class TestTextFields:
+    def test_a_title_per_language(self, om):
+        om.set_scheme_metadata("Animals", "title", "Animal Thesaurus", lang="en")
+        om.set_scheme_metadata("Animals", "title", "Tierthesaurus", lang="de")
+        assert [v["value"] for v in _meta(om, "title")] == [
+            "Tierthesaurus",
+            "Animal Thesaurus",
+        ]
+
+    def test_a_second_title_in_one_language_replaces_the_first(self, om):
+        """A scheme has one title in English, not a list of them."""
+        om.set_scheme_metadata("Animals", "title", "First", lang="en")
+        om.set_scheme_metadata("Animals", "title", "Second", lang="en")
+        assert [v["value"] for v in _meta(om, "title")] == ["Second"]
+
+    def test_a_malformed_language_tag_is_refused(self, om):
+        with pytest.raises(ValueError):
+            om.set_scheme_metadata("Animals", "title", "Title", lang="en_GB")
+
+    def test_a_blank_value_is_refused(self, om):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            om.set_scheme_metadata("Animals", "title", "   ", lang="en")
+
+
+class TestDatesAreTypedByPrecision:
+    """A vocabulary that records only the year should not have to invent a day,
+    and typing "2019" as xsd:date would claim a precision it does not have."""
+
+    @pytest.mark.parametrize(
+        ("value", "datatype"),
+        [
+            ("2019", XSD.gYear),
+            ("2019-03", XSD.gYearMonth),
+            ("2019-03-01", XSD.date),
+        ],
+    )
+    def test_precision(self, om, value, datatype):
+        om.set_scheme_metadata("Animals", "created", value)
+        stored = _objects(om, DCTERMS.created)[0]
+        assert stored.datatype == datatype
+        assert str(stored) == value
+
+    @pytest.mark.parametrize(
+        "value", ["yesterday", "01-03-2019", "2019-3-1", "20190301"]
+    )
+    def test_a_value_that_is_not_a_date_is_refused(self, om, value):
+        with pytest.raises(ValueError, match="YYYY"):
+            om.set_scheme_metadata("Animals", "created", value)
+
+    def test_a_new_date_replaces_the_old_one(self, om):
+        om.set_scheme_metadata("Animals", "modified", "2019")
+        om.set_scheme_metadata("Animals", "modified", "2026-08-20")
+        assert len(_objects(om, DCTERMS.modified)) == 1
+
+
+class TestResourceFields:
+    def test_a_licence_is_a_resource_not_a_string(self, om):
+        """A consumer follows a licence IRI; it cannot follow text about one."""
+        om.set_scheme_metadata("Animals", "license", CC_BY)
+        stored = _objects(om, DCTERMS.license)[0]
+        assert isinstance(stored, URIRef)
+        assert str(stored) == CC_BY
+
+    def test_a_licence_must_be_an_absolute_iri(self, om):
+        with pytest.raises(ValueError, match="absolute IRI"):
+            om.set_scheme_metadata("Animals", "license", "CC-BY-4.0")
+
+    def test_a_licence_that_cannot_be_serialised_is_refused(self, om):
+        with pytest.raises(ValueError, match="no spaces"):
+            om.set_scheme_metadata(
+                "Animals", "license", "https://example.org/a licence"
+            )
+
+
+class TestAgentFields:
+    """Both spellings are used in the wild, and an IRI stored as a string does
+    not resolve for a consumer."""
+
+    def test_a_name_is_stored_as_text(self, om):
+        om.set_scheme_metadata("Animals", "creator", "RALFORION d.o.o.")
+        assert isinstance(_objects(om, DCTERMS.creator)[0], Literal)
+
+    def test_an_identifier_is_stored_as_a_resource(self, om):
+        om.set_scheme_metadata("Animals", "creator", ORCID)
+        assert isinstance(_objects(om, DCTERMS.creator)[0], URIRef)
+
+    def test_creators_are_repeatable(self, om):
+        om.set_scheme_metadata("Animals", "creator", "A Person")
+        om.set_scheme_metadata("Animals", "creator", "Another Person")
+        assert len(_meta(om, "creator")) == 2
+
+    def test_the_reader_says_which_is_which(self, om):
+        om.set_scheme_metadata("Animals", "creator", "A Person")
+        om.set_scheme_metadata("Animals", "creator", ORCID)
+        by_value = {v["value"]: v["is_iri"] for v in _meta(om, "creator")}
+        assert by_value == {"A Person": False, ORCID: True}
+
+
+class TestRemoval:
+    def test_one_value(self, om):
+        om.set_scheme_metadata("Animals", "creator", "A Person")
+        om.set_scheme_metadata("Animals", "creator", "Another Person")
+        assert om.remove_scheme_metadata("Animals", "creator", "A Person")
+        assert [v["value"] for v in _meta(om, "creator")] == ["Another Person"]
+
+    def test_a_typed_date_is_really_removed(self, om):
+        """The stored term is typed, so a rebuilt plain literal would miss it."""
+        om.set_scheme_metadata("Animals", "created", "2019")
+        assert om.remove_scheme_metadata("Animals", "created", "2019")
+        assert _meta(om, "created") == []
+
+    def test_an_iri_valued_creator_is_really_removed(self, om):
+        om.set_scheme_metadata("Animals", "creator", ORCID)
+        assert om.remove_scheme_metadata("Animals", "creator", ORCID)
+        assert _meta(om, "creator") == []
+
+    def test_language_is_matched(self, om):
+        om.set_scheme_metadata("Animals", "title", "Same", lang="en")
+        om.set_scheme_metadata("Animals", "title", "Same", lang="de")
+        om.remove_scheme_metadata("Animals", "title", "Same", "en")
+        assert [v["lang"] for v in _meta(om, "title")] == ["de"]
+
+    def test_clearing_a_field(self, om):
+        om.set_scheme_metadata("Animals", "creator", "A Person")
+        om.set_scheme_metadata("Animals", "creator", "Another Person")
+        assert om.remove_scheme_metadata("Animals", "creator")
+        assert _meta(om, "creator") == []
+
+    def test_removing_what_is_not_there(self, om):
+        assert not om.remove_scheme_metadata("Animals", "creator", "Nobody")
+
+
+class TestTheCatalogue:
+    def test_an_unknown_field_names_the_alternatives(self, om):
+        with pytest.raises(ValueError, match="title"):
+            om.set_scheme_metadata("Animals", "notAField", "x")
+
+    def test_version_info_is_owl_not_dublin_core(self, om):
+        """Recorded because it is the one field that is not DC."""
+        om.set_scheme_metadata("Animals", "versionInfo", "1.2.0")
+        assert _objects(om, OWL.versionInfo) == [Literal("1.2.0")]
+
+    def test_the_readme_documents_every_field(self):
+        """Same guard as the check table: naming it is not documenting it."""
+        readme = (pathlib.Path(__file__).resolve().parents[1] / "README.md").read_text(
+            encoding="utf-8"
+        )
+        missing = [f for f in OntologyManager.SCHEME_METADATA if f"`{f}`" not in readme]
+        assert not missing, f"not documented in README.md: {missing}"
+
+    def test_every_entry_is_complete(self):
+        for field, entry in OntologyManager.SCHEME_METADATA.items():
+            assert set(entry) == {"property", "kind", "single"}, field
+            assert entry["kind"] in {"text", "agent", "date", "iri", "plain"}, field
+
+
+class TestSchemesAreAddressedByUri:
+    """Two schemes can share a local name across namespaces (issue #87 part B)."""
+
+    def test_metadata_lands_on_the_right_scheme(self, om):
+        other = "http://other.example/ns#Animals"
+        om.graph.add((URIRef(other), RDF.type, SKOS.ConceptScheme))
+        om.set_scheme_metadata(other, "title", "The other one", lang="en")
+
+        titles = {
+            s["uri"]: [v["value"] for v in s["metadata"]["title"]]
+            for s in om.get_concept_schemes()
+        }
+        assert titles[other] == ["The other one"]
+        assert titles[BASE + "Animals"] == []
+
+
+class TestValidation:
+    def test_a_scheme_with_no_title_is_reported(self, om):
+        assert "scheme_untitled" in {i["type"] for i in om.validate_skos()}
+
+    def test_a_title_settles_it(self, om):
+        om.set_scheme_metadata("Animals", "title", "Animals", lang="en")
+        assert "scheme_untitled" not in {i["type"] for i in om.validate_skos()}
+
+    def test_an_rdfs_label_settles_it_too(self):
+        """The check is about a consumer having something to show, not about
+        which vocabulary supplied it."""
+        manager = OntologyManager(base_uri=BASE)
+        manager.add_concept_scheme("Animals", label="Animals")
+        assert "scheme_untitled" not in {i["type"] for i in manager.validate_skos()}
+
+    def test_it_is_editorial(self, om):
+        assert "scheme_untitled" not in {
+            i["type"] for i in om.validate_skos(check_editorial=False)
+        }
+
+
+class TestRoundTrip:
+    def test_metadata_survives_turtle(self, om):
+        om.set_scheme_metadata("Animals", "title", "Animal Thesaurus", lang="en")
+        om.set_scheme_metadata("Animals", "creator", ORCID)
+        om.set_scheme_metadata("Animals", "license", CC_BY)
+        om.set_scheme_metadata("Animals", "created", "2019")
+        om.set_scheme_metadata("Animals", "versionInfo", "1.2.0")
+
+        from rdflib import Graph
+
+        reparsed = Graph().parse(
+            data=om.graph.serialize(format="turtle"), format="turtle"
+        )
+        assert set(reparsed) == set(om.graph)


### PR DESCRIPTION
`add_concept_scheme` took a label and a comment. Every published vocabulary carries more than that on its scheme, and consumers rely on it — AGROVOC, EuroVoc and LCSH all publish `dcterms:title`, `creator`, `license` and dates there.

Twelve fields, catalogued in `SCHEME_METADATA` with the property and the shape each is written in.

## The shapes are the point

Storing all of these as plain literals would round-trip cleanly and be wrong:

- **A date is typed by how much of it was given.** `"2019"` becomes `xsd:gYear`, `"2019-03"` `xsd:gYearMonth`, `"2019-03-01"` `xsd:date`. A vocabulary that recorded only a year should not be forced to invent a month and a day, and calling it `xsd:date` would claim a precision it does not have.
- **A licence is a resource**, not text about one, so a consumer can follow it.
- **A creator may be a name or an identifier** such as an ORCID, and is stored as whichever it is. An IRI kept as a string does not resolve.
- **Titles and descriptions are language-tagged, one per language**, like `prefLabel`: a scheme has one title in English, not a list of them.

```turtle
dcterms:created "2019"^^xsd:gYear ;
dcterms:creator <https://orcid.org/0000-0002-1825-0097>, "RALFORION d.o.o." ;
dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
dcterms:title "Tierthesaurus"@de, "Animal Thesaurus"@en ;
owl:versionInfo "1.2.0" .
```

`versionInfo` is `owl:versionInfo` rather than a DC term, because nothing in DC is used for a vocabulary version in practice. Called out in the catalogue, the README and the UI rather than left to be discovered.

## Validation

Adds `scheme_untitled`, an editorial check for a scheme carrying neither a title nor an `rdfs:label`, leaving a consumer only its URI. That is the 22nd check; the README table and its guards regenerated, and the doc guards caught the omission before I thought about it.

## A bug this work exposed

The add row in the **concept label editor** was supposed to clear its text after a successful add, and never did. Popping a widget's key from `session_state` does not reset it — Streamlit restores the value from its own widget store when a widget with that key is created again.

I claimed that fix in the WS-3 commit message and never re-verified it. Both add rows now use a key that changes on success, so the next widget starts empty, and both were checked in the running app this time.

## Testing

35 new tests, covering each shape, removal matching the term actually stored (a typed date or an IRI-valued creator), schemes addressed by URI so two sharing a local name do not collapse, and a Turtle round-trip.

1458 tests, ruff, format and mypy pass.

Verified live: picking a date field replaces the language box and offers the date formats, `yesterday` is refused in place with the accepted formats, and `2019` is accepted and shown.