### PR TITLE
fix(skos): S27 sees a directly asserted broaderTransitive

### DIFF
--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -4087,11 +4087,15 @@ class OntologyManager:
         edges: dict[str, set[str]] = {uri: set(parents.get(uri, ())) for uri in known}
         for concept in concepts:
             subject = URIRef(concept["uri"])
+            # ``isinstance`` before the membership test, as every other relation
+            # read here does. A literal whose text spells a concept's URI is not
+            # that concept, and comparing lexical forms would make one look like
+            # a hierarchy edge.
             for target in self.graph.objects(subject, SKOS.broaderTransitive):
-                if str(target) in known:
+                if isinstance(target, URIRef) and str(target) in known:
                     edges[concept["uri"]].add(str(target))
             for target in self.graph.objects(subject, SKOS.narrowerTransitive):
-                if str(target) in known:
+                if isinstance(target, URIRef) and str(target) in known:
                     edges[str(target)].add(concept["uri"])
 
         closure: dict[str, set[str]] = {}

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -4061,6 +4061,52 @@ class OntologyManager:
             {uri: sorted(v) for uri, v in related.items()},
         )
 
+    def _skos_ancestor_closure(
+        self, concepts: list[dict[str, Any]]
+    ) -> dict[str, set[str]]:
+        """Everything above each concept, for the checks that need reachability.
+
+        Deliberately not the map :meth:`_skos_link_maps` returns. That one is
+        *direct* parents, which is what ``hierarchy_redundancy`` needs: an edge
+        is redundant only when another direct edge already implies it. This one
+        is reachability, and it additionally follows ``skos:broaderTransitive``
+        and ``skos:narrowerTransitive`` where a vocabulary asserts them, because
+        S27 is stated in terms of ``skos:broaderTransitive`` rather than of
+        ``skos:broader``.
+
+        Keeping them apart is the whole point. Feeding transitive edges into the
+        direct map would make ``hierarchy_redundancy`` report them, and such an
+        edge is *meant* to skip levels.
+
+        The Reference discourages asserting the transitive properties directly,
+        treating them as something to infer, so this is an uncommon shape. It is
+        still a vocabulary a consumer can hand us.
+        """
+        known = {c["uri"] for c in concepts}
+        parents, _children, _related = self._skos_link_maps(concepts)
+        edges: dict[str, set[str]] = {uri: set(parents.get(uri, ())) for uri in known}
+        for concept in concepts:
+            subject = URIRef(concept["uri"])
+            for target in self.graph.objects(subject, SKOS.broaderTransitive):
+                if str(target) in known:
+                    edges[concept["uri"]].add(str(target))
+            for target in self.graph.objects(subject, SKOS.narrowerTransitive):
+                if str(target) in known:
+                    edges[str(target)].add(concept["uri"])
+
+        closure: dict[str, set[str]] = {}
+        for start in known:
+            seen: set[str] = set()
+            stack = list(edges.get(start, ()))
+            while stack:
+                node = stack.pop()
+                if node in seen:
+                    continue
+                seen.add(node)
+                stack.extend(edges.get(node, ()))
+            closure[start] = seen
+        return closure
+
     @classmethod
     def _skos_parent_map(cls, concepts: list[dict[str, Any]]) -> dict[str, list[str]]:
         """URI -> its broader URIs, from both asserted directions."""
@@ -4236,7 +4282,9 @@ class OntologyManager:
         """Semantic relations: self-links, dangling targets, and S27 clashes."""
         issues: list[dict[str, str]] = []
         shown = self._skos_display_names(concepts)
-        parents, _children, related_map = self._skos_link_maps(concepts)
+        _parents, _children, related_map = self._skos_link_maps(concepts)
+        # Reachability, not direct parents: S27 is about broaderTransitive.
+        ancestors = self._skos_ancestor_closure(concepts)
         known = set(shown)
 
         for concept in concepts:
@@ -4267,11 +4315,10 @@ class OntologyManager:
                             )
                         )
 
-            ancestry = self._skos_ancestors(parents, uri)
             for target in related_map[uri]:
                 if target not in known or target == uri:
                     continue
-                if target in ancestry or uri in self._skos_ancestors(parents, target):
+                if target in ancestors[uri] or uri in ancestors[target]:
                     issues.append(
                         self._skos_issue(
                             "error",

--- a/tests/test_skos_validation.py
+++ b/tests/test_skos_validation.py
@@ -470,6 +470,77 @@ class TestEveryNotationIsChecked:
         assert "notation_lang_tagged" in _types(vocab)
 
 
+class TestTheTransitiveProperties:
+    """S27 makes `skos:related` disjoint with `skos:broaderTransitive`.
+
+    The check walks `skos:broader`, which is the closure in every ordinary
+    vocabulary, because SKOS entails the transitive property from the direct
+    one. A vocabulary may also assert `skos:broaderTransitive` outright, and
+    then the hierarchy is only visible through it. The Reference discourages
+    that, treating those properties as something to infer, but it is still a
+    file a consumer can hand us.
+    """
+
+    @staticmethod
+    def _seed(om, *names):
+        base = "http://test.org/ont#"
+        om.graph.add((URIRef(base + "S"), RDF.type, SKOS.ConceptScheme))
+        om.graph.add((URIRef(base + "S"), SKOS.prefLabel, Literal("S", lang="en")))
+        for name in names:
+            uri = URIRef(base + name)
+            om.graph.add((uri, RDF.type, SKOS.Concept))
+            om.graph.add((uri, SKOS.inScheme, URIRef(base + "S")))
+            om.graph.add((uri, SKOS.prefLabel, Literal(name, lang="en")))
+            om.graph.add((uri, SKOS.definition, Literal("A definition", lang="en")))
+        return base
+
+    def test_related_to_an_asserted_broader_transitive(self, om):
+        base = self._seed(om, "A", "B")
+        om.graph.add((URIRef(base + "A"), SKOS.broaderTransitive, URIRef(base + "B")))
+        om.graph.add((URIRef(base + "A"), SKOS.related, URIRef(base + "B")))
+        assert "relation_clash" in _types(om)
+
+    def test_narrower_transitive_is_read_as_the_inverse(self, om):
+        base = self._seed(om, "A", "B")
+        om.graph.add((URIRef(base + "B"), SKOS.narrowerTransitive, URIRef(base + "A")))
+        om.graph.add((URIRef(base + "A"), SKOS.related, URIRef(base + "B")))
+        assert "relation_clash" in _types(om)
+
+    def test_a_chain_mixing_direct_and_transitive_edges(self, om):
+        base = self._seed(om, "A", "B", "C")
+        om.graph.add((URIRef(base + "A"), SKOS.broader, URIRef(base + "B")))
+        om.graph.add((URIRef(base + "B"), SKOS.broaderTransitive, URIRef(base + "C")))
+        om.graph.add((URIRef(base + "A"), SKOS.related, URIRef(base + "C")))
+        assert "relation_clash" in _types(om)
+
+    def test_a_transitive_edge_is_not_hierarchy_redundancy(self, om):
+        """The reason reachability and direct parents stay separate maps.
+
+        `A broaderTransitive C` alongside `A broader B broader C` is the
+        entailment written down, not a redundant edge. Folding transitive edges
+        into the direct parent map would report it as one.
+        """
+        base = self._seed(om, "A", "B", "C")
+        om.graph.add((URIRef(base + "A"), SKOS.broader, URIRef(base + "B")))
+        om.graph.add((URIRef(base + "B"), SKOS.broader, URIRef(base + "C")))
+        om.graph.add((URIRef(base + "A"), SKOS.broaderTransitive, URIRef(base + "C")))
+        assert "hierarchy_redundancy" not in _types(om)
+
+    def test_a_redundant_direct_edge_is_still_reported(self, om):
+        base = self._seed(om, "A", "B", "C")
+        om.graph.add((URIRef(base + "A"), SKOS.broader, URIRef(base + "B")))
+        om.graph.add((URIRef(base + "B"), SKOS.broader, URIRef(base + "C")))
+        om.graph.add((URIRef(base + "A"), SKOS.broader, URIRef(base + "C")))
+        assert "hierarchy_redundancy" in _types(om)
+
+    def test_a_transitive_edge_does_not_make_a_concept_look_stranded(self, om):
+        """Reachability feeds S27; orphan still asks about direct links."""
+        base = self._seed(om, "A", "B")
+        om.graph.add((URIRef(base + "A"), SKOS.broader, URIRef(base + "B")))
+        om.graph.add((URIRef(base + "A"), SKOS.broaderTransitive, URIRef(base + "B")))
+        assert "orphan" not in _types(om)
+
+
 class TestCheckCatalogue:
     """`SKOS_CHECKS` describes exactly the checks the validator can emit.
 

--- a/tests/test_skos_validation.py
+++ b/tests/test_skos_validation.py
@@ -533,6 +533,32 @@ class TestTheTransitiveProperties:
         om.graph.add((URIRef(base + "A"), SKOS.broader, URIRef(base + "C")))
         assert "hierarchy_redundancy" in _types(om)
 
+    def test_a_literal_spelling_a_uri_is_not_that_concept(self, om):
+        """RDF distinguishes a resource from text that looks like one.
+
+        Every other relation read here filters to URIRef before comparing. This
+        path did not, so a literal whose lexical form happened to spell a
+        concept's URI was treated as a hierarchy edge to it, and S27 fired on a
+        relation that does not exist.
+        """
+        base = self._seed(om, "A", "B")
+        om.graph.add((URIRef(base + "A"), SKOS.broaderTransitive, Literal(base + "B")))
+        om.graph.add((URIRef(base + "A"), SKOS.related, URIRef(base + "B")))
+        assert "relation_clash" not in _types(om)
+
+    def test_the_same_target_as_a_resource_does_clash(self, om):
+        """The other half: the guard must not suppress the real case."""
+        base = self._seed(om, "A", "B")
+        om.graph.add((URIRef(base + "A"), SKOS.broaderTransitive, URIRef(base + "B")))
+        om.graph.add((URIRef(base + "A"), SKOS.related, URIRef(base + "B")))
+        assert "relation_clash" in _types(om)
+
+    def test_a_literal_on_the_inverse_property_too(self, om):
+        base = self._seed(om, "A", "B")
+        om.graph.add((URIRef(base + "B"), SKOS.narrowerTransitive, Literal(base + "A")))
+        om.graph.add((URIRef(base + "A"), SKOS.related, URIRef(base + "B")))
+        assert "relation_clash" not in _types(om)
+
     def test_a_transitive_edge_does_not_make_a_concept_look_stranded(self, om):
         """Reachability feeds S27; orphan still asks about direct links."""
         base = self._seed(om, "A", "B")


### PR DESCRIPTION
The last deliberate deferral from the WS-1 review, closed.

SKOS Reference **S27** makes `skos:related` disjoint with `skos:broaderTransitive`. The check walked `skos:broader`, which *is* that closure in every ordinary vocabulary, because SKOS entails the transitive property from the direct one. But a vocabulary may assert `skos:broaderTransitive` outright, and then the hierarchy is only visible through it:

```
asserted broaderTransitive  → relation_clash False   (expected True)
asserted narrowerTransitive → relation_clash False   (expected True)
mixed broader + transitive  → relation_clash False   (expected True)
```

## The fix is the one the deferral predicted

The problem was that "direct parents" and "ancestor reachability" were **one map**. They are now two:

- **`_skos_link_maps`** stays direct parents, and is what `hierarchy_redundancy` reads — an edge is redundant only when another *direct* edge implies it.
- **`_skos_ancestor_closure`** is reachability, and additionally follows `broaderTransitive` and `narrowerTransitive` where a vocabulary asserts them.

Folding transitive edges into the direct map instead — the obvious one-line version — would have made `hierarchy_redundancy` report this:

```turtle
:A skos:broader :B .   :B skos:broader :C .
:A skos:broaderTransitive :C .   # the entailment written down, not a redundant edge
```

Two of the new tests pin that separation. They pass before the change as well as after, which is what a regression guard on a fix looks like rather than a test of the bug.

## Incidentally faster

The closure is computed once per validation run, where the code it replaces walked ancestors per concept *and* again per related target.

## Testing

6 new tests; 3 fail without the change. 1486 total, ruff, format and mypy pass.

## Scope note

The Reference discourages asserting the transitive properties at all, treating them as something to infer, so this is an uncommon shape — which is why it was deferred rather than fixed during WS-1. It is still a vocabulary a consumer can hand us, and the check now reads it correctly.

Cycle detection and the `orphan` check deliberately keep reading direct edges only: a loop through transitive assertions alone is not a `skos:broader` cycle, and a concept reachable only by an entailed edge has no direct link to show a user.