### PR TITLE
fix(viz): the focus switch sits outside the panel it swaps

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -54,6 +54,7 @@ from .ui import (  # noqa: F401
     SEARCH_PAD_WIDTH,
     VIZ_FILE_STATE_KEY,
     VIZ_FILE_STATE_MAX_FILES,
+    VIZ_NODE_PANEL,
     VIZ_SETTINGS_KEY,
     _apply_annotation_edit,
     _apply_class_edit,

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -144,7 +144,7 @@ _CUSTOM_CSS = """
        in the browser: this recovers ~270px, enough for the whole sidebar to
        fit without scrolling.
        NOTE: internal DOM again — re-verify on a Streamlit bump. */
-    /* The "what is hidden" note, which rides on the Filter Nodes label as
+    /* The "what is hidden" note, which rides on the Node options label as
        generated content — not as part of the label text, which would force the
        expander shut on every filter edit (see viz_hidden_note_style, #267).
        Quieter than the label it follows, and gone once the expander is open:
@@ -1224,7 +1224,7 @@ def viz_focus_toggle():
     first use, not something reapplied over a choice you have already made.
 
     That also decouples the two controls: after you have expressed a preference,
-    the focus seeds are their own list rather than a function of Filter Nodes.
+    the focus seeds are their own list rather than a function of Node options.
     An empty selection still falls back to the first node, downstream.
     """
     if _viz_widget_missing("viz_focus_mode"):
@@ -3704,6 +3704,12 @@ def _download_or_save(label, data, file_name, mime="text/plain", key=None):
 
 LIST_PAGE_SIZE = 50
 GRAPH_MAX_NODES = 500
+#: The label on the graph's node panel. Named once because it is spoken about
+#: elsewhere: the cap and focus notices tell the user to open it by name, and a
+#: rename that missed them left the guidance pointing at a panel that no longer
+#: existed under that name (review of PR #307).
+VIZ_NODE_PANEL = "Node options"
+
 FOCUS_BUILD_MAX_NODES = 5000
 
 
@@ -4994,7 +5000,7 @@ def viz_hidden_caption(
 
 
 def viz_hidden_note_style(note: str) -> str:
-    """A ``<style>`` block that writes ``note`` onto the Filter Nodes label.
+    """A ``<style>`` block that writes ``note`` onto the Node options label.
 
     The note cannot simply be appended to the expander's label text: Streamlit's
     expander resets its open/closed state to the ``expanded`` argument whenever

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -10,6 +10,7 @@ from ..ui import (
     _PRECISE_NAV_TYPES,
     GRAPH_MAX_NODES,
     PKG_DIR,
+    VIZ_NODE_PANEL,
     _build_name_collision_set,
     _disambiguated_name,
     _edge_id,
@@ -602,7 +603,7 @@ def render_visualization():
         _hidden_note = st.session_state.get("_viz_hidden_note") or ""
         with (
             _filter_col.container(key="viz_filter_nodes"),
-            st.expander("Node options", expanded=False),
+            st.expander(VIZ_NODE_PANEL, expanded=False),
         ):
             st.html(viz_hidden_note_style(_hidden_note))
             if focus_mode and focus_targets:
@@ -1575,7 +1576,7 @@ def render_visualization():
                 graph_notice = (
                     f"{_cut_classes} of {len(visible_class_uris)} classes are not "
                     f"drawn: the graph stops at {max_nodes} nodes. Hide some in "
-                    f"Filter Nodes, or focus on one node, to see the rest."
+                    f"{VIZ_NODE_PANEL}, or focus on one node, to see the rest."
                 )
 
             # Focus mode: keep only the seed nodes' neighbourhood within
@@ -1675,7 +1676,8 @@ def render_visualization():
                         f"Nothing to focus on: this ontology is past the "
                         f"{max_nodes} nodes the graph builds at once, and the "
                         f"node you picked is not among them. Hide some classes "
-                        f"or individuals in Filter Nodes to bring it into range."
+                        f"or individuals in {VIZ_NODE_PANEL} to bring it into "
+                        f"range."
                     )
 
             # Spread parallel edges so they don't overlap
@@ -1753,7 +1755,7 @@ def render_visualization():
         # the cached graph is reused.
         if gdata and gdata.get("notice"):
             status.warning(gdata["notice"], icon="⚠️")
-        # Recompute the note for the Filter Nodes label now that the focus
+        # Recompute the note for the Node options label now that the focus
         # controls have rendered and the prune has run. One rerun when it
         # actually changes, so the label is never a step behind what the graph
         # is showing; it converges because the note is derived from settings,

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -517,7 +517,17 @@ def render_visualization():
         # does not run and the page crashed reading this further down (P1).
         focus_seeds: list = []
         focus_depth = 0
-        _find_col, _filter_col = st.columns([1, 3])
+        # Find, the mode switch, then the panel the mode chooses the contents
+        # of. Focus is not a node filter: turning it on *replaces* the filter
+        # controls with its own (see the branch below), so the switch belongs
+        # outside the panel it swaps, next to Find — the two are a pair, one
+        # picking an entity and the other narrowing to it. It used to sit inside
+        # that panel, one click deep, while ten display toggles that matter far
+        # less sat in the open (issue #305).
+        # The mode column is sized to the checkbox, not to an even third: the
+        # spare width goes to the panel, whose collapsed label carries the note
+        # about what the view is holding back.
+        _find_col, _mode_col, _filter_col = st.columns([1, 0.5, 2.5])
         with _find_col:
             if focus_targets:
                 _find_choice = st.selectbox(
@@ -574,12 +584,7 @@ def render_visualization():
         # string: Streamlit's expander snaps back to `expanded` whenever its
         # label changes, so a note that moves with the filter closed the panel
         # under the user on every edit (issue #267).
-        _hidden_note = st.session_state.get("_viz_hidden_note") or ""
-        with (
-            _filter_col.container(key="viz_filter_nodes"),
-            st.expander("Filter Nodes", expanded=False),
-        ):
-            st.html(viz_hidden_note_style(_hidden_note))
+        with _mode_col:
             focus_mode = st.checkbox(
                 "Focus on one node",
                 key="viz_focus_mode",
@@ -589,9 +594,17 @@ def render_visualization():
                     "N hops, across all node types — handy for large ontologies "
                     "where showing everything at once is overwhelming. "
                     "Annotations come along with whatever is shown; the "
-                    "Annotations checkbox above still turns them off."
+                    "Annotations checkbox above still turns them off. "
+                    "The panel beside this switches to the focus controls."
                 ),
             )
+
+        _hidden_note = st.session_state.get("_viz_hidden_note") or ""
+        with (
+            _filter_col.container(key="viz_filter_nodes"),
+            st.expander("Node options", expanded=False),
+        ):
+            st.html(viz_hidden_note_style(_hidden_note))
             if focus_mode and focus_targets:
                 focus_labels = list(focus_targets.keys())
                 label_set = set(focus_labels)

--- a/tests/test_viz_filter_expander.py
+++ b/tests/test_viz_filter_expander.py
@@ -6,6 +6,8 @@ panel shut after every class you added or removed. The note now reaches the
 label as generated content and the label string never moves.
 """
 
+import pathlib
+
 from streamlit.testing.v1 import AppTest
 
 from orionbelt_ontology_builder import app
@@ -86,6 +88,35 @@ def test_the_focus_switch_is_not_inside_the_panel_it_controls():
         if c.label == "Focus on one node"
     ]
     assert not inside, "the focus switch is back inside the panel it swaps"
+
+
+def test_the_panel_is_named_from_one_place():
+    """The label is spoken about elsewhere, so it cannot be a loose string.
+
+    Two graph notices tell the user to open the panel by name. Renaming the
+    expander without them left that guidance pointing at a panel no longer
+    called that (review of PR #307). Both now interpolate the constant, and
+    this fails if a stale spelling comes back.
+    """
+    source = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "orionbelt_ontology_builder"
+        / "views"
+        / "visualization.py"
+    ).read_text(encoding="utf-8")
+    assert "st.expander(VIZ_NODE_PANEL" in source, (
+        "the expander should take its label from the constant"
+    )
+    assert "Filter Nodes" not in source, (
+        "a stale spelling of the panel name is back in the view"
+    )
+
+
+def test_the_notices_name_the_panel_the_user_can_see(monkeypatch):
+    """The cap and focus notices have to match the label on screen."""
+    at = _rendered()
+    labels = [e.label for e in at.expander]
+    assert app.VIZ_NODE_PANEL in labels
 
 
 def test_entity_names_cannot_break_out_of_the_stylesheet():

--- a/tests/test_viz_filter_expander.py
+++ b/tests/test_viz_filter_expander.py
@@ -1,4 +1,4 @@
-"""The Filter Nodes panel must stay open while you edit the filter (issue #267).
+"""The node options panel must stay open while you edit the filter (issue #267).
 
 Streamlit's expander resets its open/closed state to the ``expanded`` argument
 whenever its *label* changes, so the "what is hidden" note used to snap the
@@ -44,7 +44,10 @@ def _rendered():
 def test_the_hidden_note_never_reaches_the_expander_label():
     at = _rendered()
     labels = [e.label for e in at.expander]
-    assert "Filter Nodes" in labels
+    # Named for what it holds in both modes: focus mode replaces the filter
+    # controls with its own, so "Filter Nodes" described only half of it
+    # (issue #305).
+    assert "Node options" in labels
     assert not [
         label for label in labels if "hidden" in label or label != label.strip()
     ], labels
@@ -64,6 +67,25 @@ def test_no_note_renders_nothing():
     assert app.viz_hidden_note_style("") == (
         '<style>.st-key-viz_filter_nodes { --viz-hidden-note: ""; }</style>'
     )
+
+
+def test_the_focus_switch_is_not_inside_the_panel_it_controls():
+    """It swaps the panel's contents, so it cannot live in the panel.
+
+    A checkbox reachable only by opening a collapsed expander, while ten
+    display toggles that matter far less sit in the open (issue #305).
+    """
+    at = _rendered()
+    assert [c for c in at.checkbox if c.label == "Focus on one node"], (
+        "the focus switch is missing"
+    )
+    inside = [
+        c
+        for expander in at.expander
+        for c in expander.checkbox
+        if c.label == "Focus on one node"
+    ]
+    assert not inside, "the focus switch is back inside the panel it swaps"
 
 
 def test_entity_names_cannot_break_out_of_the_stylesheet():

--- a/tests/test_viz_node_cap.py
+++ b/tests/test_viz_node_cap.py
@@ -211,7 +211,7 @@ def test_a_seed_past_the_assembly_cap_says_why_the_graph_is_empty(
 
     assert nodes == [] and edges == []
     assert "Nothing to focus on" in notice
-    assert "Filter Nodes" in notice
+    assert "Node options" in notice
 
 
 def test_the_assembly_cap_is_only_raised_for_focus():


### PR DESCRIPTION
Closes #305.

`Focus on one node` was inside the collapsed `Filter Nodes` expander, one click deep — while **ten display toggles that matter far less** sat in the open: Classes, Obj Props, Data Props, Annotations, Individuals, SKOS, Ind. Edges, Triples, Fit to window, Highlight Issues. Its own help text calls it the control for large ontologies, which is exactly when a user is least likely to go hunting for it.

## The stronger reason the issue doesn't state

**It is not a node filter.** Turning it on *replaces* the filter controls — the panel branches on it:

```python
if focus_mode and focus_targets:  → focus seeds + hop depth
elif focus_mode:                  → "Enable Classes… to pick focus nodes"
else:                             → the per-kind filter UI
```

A switch that decides what a container holds does not belong inside that container. And its natural partner, `Find and centre on an entity`, was already outside in the adjacent column — the pair was split by the expander wall.

So the switch moves next to Find, and the panel becomes `Node options`, which covers what it holds in both modes.

Worth noting there was a second way in, equally hidden: the Details panel mentions *"Alt-click focuses on it alone."*

## Deliberately not a rewrite

The checkbox keeps its **widget type, its key and its callback**. Nothing about how the state is stored, restored, or reached from an Alt-click on a node changes — only where it renders. That area has history (#56, #196, #234, #267) and the state machine is worth leaving alone.

The label is renamed once in the source and never at runtime: a label that changes while the app runs snaps the expander back open, which is what #267 was. Flipping the mode changes the panel's *contents* and not its label, so it stays open.

## Verified live

- The switch reads as one row with Find and the panel
- Enabling it swaps the panel to `Focus node(s)` + `Depth (hops)`
- Disabling it restores the kind filters
- The panel stays open across the flip — no #267 regression

## Tests

The existing #267 guard asserted the old label, and is **updated rather than loosened**. A new test asserts the switch is not inside the expander; verified it fails when the checkbox is put back.

1490 tests, ruff, format and mypy pass.