### PR TITLE
fix(viz): pin the graph status bar and un-red the options toggle

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -207,6 +207,12 @@ _BRAND_CSS = f"""
         background-color: {_BRAND} !important;
         border-color: {_BRAND} !important;
     }}
+    /* Toggle track when on. st.toggle shares stCheckbox's testid; what tells
+       them apart is the mark: a checkbox renders a <span>, a toggle a <div>
+       track wrapping the knob. */
+    [data-testid="stCheckbox"] label[data-baseweb="checkbox"]:has(input:checked) > div:first-child {{
+        background-color: {_BRAND} !important;
+    }}
     /* Selected radio (its control circle; not the label wrapper) */
     [data-testid="stRadio"] label[data-baseweb="radio"]:has(input:checked) > div:first-child {{
         background-color: {_BRAND} !important;

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -2085,9 +2085,28 @@ def render_visualization():
                         "Alt-click to focus on it alone"
                     )
 
-                # Inject CSS to remove gap between status bar columns
+                # Inject CSS to remove gap between status bar columns, and pin
+                # the bar to the bottom of the scroll port. The bar reports the
+                # node you just clicked, so it has to stay in view while you
+                # work the graph; with the display options open it otherwise
+                # sits below the fold. A sticky element can only travel inside
+                # its own parent, so every wrapper Streamlit puts between the
+                # bar and the page column gets the rule — the one with room to
+                # move is the one that ends up sticking, and which that is
+                # differs between the two layouts below (the button row is
+                # wrapped, the lone markdown block is not). Streamlit also
+                # collapses that block to a text line's height, which would
+                # leave the 36px bar hanging past the sticky edge, so pin it.
                 st.markdown(
                     """<style>
+            div[data-testid="stLayoutWrapper"]:has(#graph-status-bar),
+            div[data-testid="stHorizontalBlock"]:has(#graph-status-bar),
+            div[data-testid="stElementContainer"]:has(#graph-status-bar) {
+                position: sticky !important; bottom: 0.75rem; z-index: 20;
+            }
+            div[data-testid="stElementContainer"]:has(#graph-status-bar) {
+                height: 36px !important;
+            }
             div[data-testid="stHorizontalBlock"]:has(#graph-status-bar) { gap: 0 !important; }
             div[data-testid="stHorizontalBlock"]:has(#graph-status-bar) [data-testid="stBaseButton-secondary"] button,
             div[data-testid="stHorizontalBlock"]:has(#graph-status-bar) button[kind] ,

--- a/tests/test_brand_theme.py
+++ b/tests/test_brand_theme.py
@@ -19,6 +19,7 @@ def test_brand_css_forces_the_brand_colour_on_every_accent_widget():
     required_hooks = [
         'data-testid="stBaseButton-primary"',  # primary buttons
         'data-testid="stCheckbox"',  # checked checkbox
+        "> div:first-child",  # the toggle track (st.toggle reuses stCheckbox)
         'data-testid="stRadio"',  # selected radio
         'data-testid="stSlider"',  # slider thumb
         'data-testid="stSliderThumbValue"',  # slider value label

--- a/tests/test_brand_theme.py
+++ b/tests/test_brand_theme.py
@@ -19,7 +19,12 @@ def test_brand_css_forces_the_brand_colour_on_every_accent_widget():
     required_hooks = [
         'data-testid="stBaseButton-primary"',  # primary buttons
         'data-testid="stCheckbox"',  # checked checkbox
-        "> div:first-child",  # the toggle track (st.toggle reuses stCheckbox)
+        # The toggle track. st.toggle reuses stCheckbox's testid, so only the
+        # full selector tells its rule apart from the checkbox's.
+        (
+            '[data-testid="stCheckbox"] label[data-baseweb="checkbox"]'
+            ":has(input:checked) > div:first-child"
+        ),
         'data-testid="stRadio"',  # selected radio
         'data-testid="stSlider"',  # slider thumb
         'data-testid="stSliderThumbValue"',  # slider value label


### PR DESCRIPTION
Two visualization fixes reported from the hosted app.

## The status bar scrolled out of view

The bar under the interactive graph reports the node you just clicked, but it rode the page flow: opening the display options band pushed it below the fold, so the thing you clicked to read was no longer readable.

It is now sticky against the bottom of the scroll port.

A sticky element can only travel inside its own parent, and the two status bar layouts nest differently: the bar-plus-button row sits in a layout wrapper that hugs it exactly, leaving no room to move, while the lone markdown block sits straight in the page column. The rule names every wrapper between the bar and the column, and whichever one has slack does the sticking. The markdown block also collapses to a text line's height, which left the 36px bar hanging past the sticky edge, so its height is pinned to match.

## The Display options toggle was red

Streamlit's theme presets drop the configured brand primaryColor, which is why the app re-forces the navy with CSS. `st.toggle` shares `stCheckbox`'s testid, so the existing checkbox rule looked like it should cover it, but a toggle renders its mark as a `div` track instead of a `span` and the rule missed. Added a selector that keys on the track, plus a hook in `test_brand_theme.py` so it cannot be dropped silently.

## Verification

Both layouts checked in the running app at 1400x600 (small enough to force scrolling): the bar and the "Open full editor" button stay pinned together 12px above the viewport bottom while the graph scrolls underneath, and the toggle track renders navy.

pytest (1492 passed), ruff format/check, and mypy all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)