### PR TITLE
fix(viz): the pinned status bar was eating the canvas's height reserve

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -108,7 +108,45 @@ var fsDetachTimer = null;   // timer that detaches fsResizeHandler
 // not change when the graph is resized, so the two cannot chase each other.
 var AUTOFIT_MAX_RESERVE = 220;
 
+// The status bar is sticky, so it stays readable while the page scrolls. A
+// pinned sticky element's rect reports where it is *painted*, though, not where
+// it sits in the layout — and once pinned that is level with the window bottom,
+// above the graph's own edge, so the measurement below reserved nothing and the
+// canvas grew until the bar covered it. Un-pin it for the length of the
+// measurement: it all happens in one task, so nothing repaints in between.
+function unpinStickies() {
+    var undo = [];
+    try {
+        var doc = window.parent.document;
+        var el = doc.getElementById('graph-status-bar');
+        for (; el && el !== doc.body; el = el.parentElement) {
+            if (window.parent.getComputedStyle(el).position !== 'sticky') continue;
+            undo.push([el, el.style.getPropertyValue('position'),
+                       el.style.getPropertyPriority('position')]);
+            el.style.setProperty('position', 'static', 'important');
+        }
+    } catch (e) { /* cross-origin, or no bar on screen: nothing to un-pin */ }
+    return function () {
+        for (var i = 0; i < undo.length; i++) {
+            if (undo[i][1]) {
+                undo[i][0].style.setProperty('position', undo[i][1], undo[i][2]);
+            } else {
+                undo[i][0].style.removeProperty('position');
+            }
+        }
+    };
+}
+
 function autofitReserve() {
+    var repin = unpinStickies();
+    try {
+        return measureReserve();
+    } finally {
+        repin();
+    }
+}
+
+function measureReserve() {
     var node = window.frameElement;
     while (node && node.getAttribute
            && node.getAttribute('data-testid') !== 'stElementContainer') {

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -117,6 +117,21 @@ _CUSTOM_CSS = """
         border-radius: 4px;
         color: #721c24;
     }
+    /* The browser-storage component has nothing to show, but Streamlit still
+       lays its iframe out — a 26px band, plus the column's 16px gap, wherever
+       the write happens to be called (on the graph page, right above the
+       canvas). Take it out of the flow rather than hiding it: a display:none
+       or visibility:hidden iframe is a document that may never run, and this
+       one has a write to localStorage to perform. */
+    [data-testid="stElementContainer"]:has(
+        iframe[src*="streamlit_local_storage"]
+    ) {
+        position: absolute !important;
+        width: 0 !important;
+        height: 0 !important;
+        overflow: hidden !important;
+        pointer-events: none;
+    }
     /* Reduce margin/padding. The side gutters are Streamlit's own 80px, which
        on a wide screen is 160px the graph could be using; 2rem still keeps text
        pages off the window edge. */

--- a/tests/test_viz_autofit_sticky.py
+++ b/tests/test_viz_autofit_sticky.py
@@ -1,0 +1,52 @@
+"""The autofit measurement and the sticky status bar must not fight (PR #309).
+
+Neither is observable outside a real browser. The status bar pins itself to the
+bottom of the window so it stays readable while the page scrolls; autofit sizes
+the canvas from the rect of whatever follows it. A pinned element's rect reports
+where it is *painted*, which once pinned is above the canvas's own edge — so
+measuring it while pinned reserves nothing and the canvas grows until the bar
+covers it. The measurement therefore has to un-pin first.
+"""
+
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+_VIEWER = _PKG / "lib" / "graph_viewer" / "index.html"
+_VIZ = _PKG / "views" / "visualization.py"
+
+
+def _function_body(src: str, name: str) -> str:
+    """The text between the braces of ``function <name>(...) { ... }``."""
+    start = src.index(f"function {name}(")
+    depth = 0
+    out: list[str] = []
+    for i in range(src.index("{", start), len(src)):
+        ch = src[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return "".join(out)
+        out.append(ch)
+    raise AssertionError(f"unbalanced braces in {name}")
+
+
+def test_the_status_bar_is_pinned():
+    """The premise of the guard below: the bar really is sticky."""
+    assert "position: sticky" in _VIZ.read_text()
+
+
+def test_reserve_measurement_unpins_before_it_measures():
+    body = _function_body(_VIEWER.read_text(), "autofitReserve")
+    assert "unpinStickies()" in body, "autofitReserve no longer un-pins"
+    assert "measureReserve()" in body
+    # The measuring itself must stay in measureReserve, i.e. inside the un-pin:
+    # a rect read here would be back to reading painted positions.
+    assert "getBoundingClientRect" not in body
+
+
+def test_unpinning_is_reversible():
+    body = _function_body(_VIEWER.read_text(), "unpinStickies")
+    assert "'static'" in body  # what it forces while measuring
+    assert "removeProperty" in body  # and puts back afterwards


### PR DESCRIPTION
Follow-up to #308, which pinned the graph status bar to the bottom of the window.

## The canvas grew until the bar covered it

Autofit sizes the canvas by measuring the lowest edge of whatever follows the graph, and the status bar is the thing that follows it. Pinning the bar broke that measurement: a stuck sticky element's rect reports where it is *painted*, which is level with the window bottom and therefore above the canvas's own edge. The reserve came out as zero, so the canvas grew past the window and the bar was drawn on top of the graph.

The measurement now un-pins the bar first and puts it back afterwards. It all happens inside one task, so nothing repaints in between.

With "Fit to window" on, collapsing the display options now hands the reclaimed height to the graph and the bar stays put at the bottom. With it off the canvas keeps the height the slider asks for, and the bar rides above it as a pinned readout.

## A leftover band above the canvas

The browser-storage component has nothing to show, but Streamlit still lays its iframe out, so a settings write left a 26px band plus the column's 16px gap right above the graph. It is now out of the layout flow.

Out of flow rather than `display: none`: a hidden iframe is a document that may never run, and this one has a write to localStorage to perform. Verified in the running app that the write still lands (the saved payload reflects a setting changed while the component was out of flow).

## Verification

Checked in the running app at 1400x900 across the four states: fit on with the options open and collapsed, fit off, and the details panel open. The canvas ends where the bar begins in every one, and the page no longer scrolls when the graph is fit to it.

`tests/test_viz_autofit_sticky.py` pins the pairing at the source level, the way `test_viz_fullscreen.py` does for fullscreen: neither half is observable outside a browser, and breaking either silently brings the overlap back.

pytest (1495 passed), ruff format/check, and mypy are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)