### PR TITLE
feat(viz): the graph's panels float over the canvas

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -117,6 +117,17 @@ _CUSTOM_CSS = """
         border-radius: 4px;
         color: #721c24;
     }
+    /* CSS injected through st.markdown leaves an empty element behind, which
+       is invisible but still takes a slot in the page column's 16px gap grid.
+       Four of them ride above the graph, so the canvas started ~64px lower than
+       it had to. Nothing to show, so take them out of the flow. */
+    [data-testid="stElementContainer"]:has(
+        > [data-testid="stMarkdown"]
+        > [data-testid="stMarkdownContainer"]
+        > style:only-child
+    ) {
+        display: none !important;
+    }
     /* The browser-storage component has nothing to show, but Streamlit still
        lays its iframe out — a 26px band, plus the column's 16px gap, wherever
        the write happens to be called (on the graph page, right above the
@@ -134,10 +145,17 @@ _CUSTOM_CSS = """
     }
     /* Reduce margin/padding. The side gutters are Streamlit's own 80px, which
        on a wide screen is 160px the graph could be using; 2rem still keeps text
-       pages off the window edge. */
+       pages off the window edge.
+
+       The top has a floor: Streamlit's header is an opaque 60px bar painted at
+       z-index 999990, so anything above 3.75rem is painted over rather than
+       scrolled under. 4rem clears it with a little air. It used to be 2.5rem
+       and looked fine only because the CSS blocks above the title were each
+       taking a 16px slot in the column; once those went out of the flow, the
+       first line of the page slid under the header. */
     .block-container, .stMainBlockContainer,
     [data-testid="stAppViewBlockContainer"] {
-        padding-top: 2.5rem !important;
+        padding-top: 4rem !important;
         padding-bottom: 0 !important;
         padding-left: 2rem !important;
         padding-right: 2rem !important;

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -90,7 +90,13 @@ def graph_overlay_css(dark: bool) -> str:
     edge = "rgba(250,250,250,0.2)" if dark else "rgba(49,51,63,0.15)"
     shadow = "0 8px 28px rgba(0,0,0,0.55)" if dark else "0 8px 28px rgba(0,0,0,0.16)"
     return f"""<style>
-    {_GRAPH_ROW} {{ position: relative; }}
+    {_GRAPH_ROW} {{
+        position: relative;
+        /* No column gap above the canvas. Every other row on this page is a
+           control that reads as its own line; the canvas is the page, and the
+           strip of empty graph above its legend already reads as a margin. */
+        margin-top: -12px;
+    }}
     /* The canvas takes the whole row, panel open or not. */
     {_GRAPH_ROW} > [data-testid="stColumn"]:has(.st-key-graph_viewer) {{
         flex: 1 1 100% !important;

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -63,6 +63,67 @@ from ..ui import (
 
 logger = logging.getLogger(__name__)
 
+# The row that holds the canvas and both of its overlays, keyed off the graph
+# component itself — nothing else on the page carries that key.
+_GRAPH_ROW = '[data-testid="stHorizontalBlock"]:has(.st-key-graph_viewer)'
+
+
+def graph_overlay_css(dark: bool) -> str:
+    """CSS that floats the graph page's panels over the canvas.
+
+    The details panel used to take a quarter of the row's width, the reopen
+    toggle a sliver of it, and the Node options picker pushed the graph down
+    far enough to squeeze it to its floor. All three now sit on top of the
+    canvas, so the graph keeps its size whatever is open.
+
+    Solid cards, not translucent ones: chips and labels read over a busy graph
+    are unreadable. Colours follow the graph's own two themes.
+    """
+    bg = "#262730" if dark else "#ffffff"
+    edge = "rgba(250,250,250,0.2)" if dark else "rgba(49,51,63,0.15)"
+    shadow = "0 8px 28px rgba(0,0,0,0.55)" if dark else "0 8px 28px rgba(0,0,0,0.16)"
+    return f"""<style>
+    {_GRAPH_ROW} {{ position: relative; }}
+    /* The canvas takes the whole row, panel open or not. */
+    {_GRAPH_ROW} > [data-testid="stColumn"]:has(.st-key-graph_viewer) {{
+        flex: 1 1 100% !important;
+        width: 100% !important;
+    }}
+    /* The details panel, as a card over the right of the canvas. Both edges are
+       pinned so `max-height` has a length to resolve against, and a long editor
+       scrolls inside the card instead of running past the graph. */
+    {_GRAPH_ROW} > [data-testid="stColumn"]:has(.st-key-viz_hide_panel) {{
+        position: absolute; top: 0; bottom: 0; right: 0; z-index: 20;
+        width: 21rem; max-width: 45%;
+        height: fit-content; max-height: 100%; overflow-y: auto;
+        padding: 0.6rem 0.9rem 0.9rem;
+        background: {bg};
+        border: 1px solid {edge};
+        border-radius: 10px;
+        box-shadow: {shadow};
+    }}
+    /* Panel closed: the reopen toggle alone, in the same corner. */
+    {_GRAPH_ROW} > [data-testid="stColumn"]:has(.st-key-viz_show_panel) {{
+        position: absolute; top: 0; right: 0; z-index: 20;
+        width: auto;
+    }}
+    /* Node options drops over the canvas rather than shoving it down. The card
+       hangs off the bottom edge of its own summary, so the picker still reads
+       as part of the control it opened from. Above the details panel: it is
+       the thing the click just opened. */
+    .st-key-viz_filter_nodes {{ position: relative; z-index: 25; }}
+    .st-key-viz_filter_nodes details[open] > [data-testid="stExpanderDetails"] {{
+        position: absolute; top: 100%; left: 0; right: 0;
+        max-height: 60vh; overflow-y: auto;
+        padding: 0.25rem 1rem 1rem;
+        background: {bg};
+        border: 1px solid {edge};
+        border-top: none;
+        border-radius: 0 0 10px 10px;
+        box-shadow: {shadow};
+    }}
+    </style>"""
+
 
 def _add_annotation_nodes(net, ont, subject_uri, subject_node_id, room):
     """Hang ``subject_uri``'s annotations off its node, at most ``room`` of them.
@@ -1836,6 +1897,12 @@ def render_visualization():
                     st.session_state.pop("_viz_dropped_selection", None)
             _prev_sel = st.session_state.get("_viz_last_selection")
             _prev_has_sel = isinstance(_prev_sel, dict) and _prev_sel.get("selected")
+
+            # Everything that opens on this page used to be paid for out of
+            # the canvas: the details panel took a quarter of the width, the
+            # reopen toggle took a sliver of it, and the Node options picker
+            # pushed the graph down far enough to squeeze it to its floor.
+            st.markdown(graph_overlay_css(_gv_dark), unsafe_allow_html=True)
 
             _panel_on = bool(st.session_state.get("_viz_cfg_details_panel", True))
             if _panel_on:

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -109,7 +109,14 @@ def graph_overlay_css(dark: bool) -> str:
         position: absolute; top: {_TOOLBAR_CLEARANCE}; bottom: 0; right: 0;
         z-index: 20;
         width: 21rem; max-width: 45%;
-        height: fit-content; max-height: 100%; overflow-y: auto;
+        /* The cap has to pay for the offset too: the card starts a toolbar's
+           height down, so a full-height one would hang that far past the
+           canvas and over the status bar. Border-box so its padding is inside
+           the cap rather than added to it. */
+        box-sizing: border-box;
+        height: fit-content;
+        max-height: calc(100% - {_TOOLBAR_CLEARANCE});
+        overflow-y: auto;
         padding: 0.6rem 0.9rem 0.9rem;
         background: {bg};
         border: 1px solid {edge};

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -67,6 +67,13 @@ logger = logging.getLogger(__name__)
 # component itself — nothing else on the page carries that key.
 _GRAPH_ROW = '[data-testid="stHorizontalBlock"]:has(.st-key-graph_viewer)'
 
+# The canvas keeps its own download and fullscreen buttons in its top-right
+# corner (see the graph viewer's #download-btn / #fullscreen-btn: 8px down,
+# 32px tall). The overlays claim that same corner, and being outside the iframe
+# they win every hit test, so they start below the toolbar instead of on top of
+# it. test_viz_overlays.py keeps this in step with the buttons' own CSS.
+_TOOLBAR_CLEARANCE = "2.75rem"
+
 
 def graph_overlay_css(dark: bool) -> str:
     """CSS that floats the graph page's panels over the canvas.
@@ -93,7 +100,8 @@ def graph_overlay_css(dark: bool) -> str:
        pinned so `max-height` has a length to resolve against, and a long editor
        scrolls inside the card instead of running past the graph. */
     {_GRAPH_ROW} > [data-testid="stColumn"]:has(.st-key-viz_hide_panel) {{
-        position: absolute; top: 0; bottom: 0; right: 0; z-index: 20;
+        position: absolute; top: {_TOOLBAR_CLEARANCE}; bottom: 0; right: 0;
+        z-index: 20;
         width: 21rem; max-width: 45%;
         height: fit-content; max-height: 100%; overflow-y: auto;
         padding: 0.6rem 0.9rem 0.9rem;
@@ -104,7 +112,7 @@ def graph_overlay_css(dark: bool) -> str:
     }}
     /* Panel closed: the reopen toggle alone, in the same corner. */
     {_GRAPH_ROW} > [data-testid="stColumn"]:has(.st-key-viz_show_panel) {{
-        position: absolute; top: 0; right: 0; z-index: 20;
+        position: absolute; top: {_TOOLBAR_CLEARANCE}; right: 0; z-index: 20;
         width: auto;
     }}
     /* Node options drops over the canvas rather than shoving it down. The card
@@ -112,6 +120,14 @@ def graph_overlay_css(dark: bool) -> str:
        as part of the control it opened from. Above the details panel: it is
        the thing the click just opened. */
     .st-key-viz_filter_nodes {{ position: relative; z-index: 25; }}
+    /* Streamlit animates an expander open by running a height animation on the
+       <details> from JavaScript. It measures the body, which is out of the flow
+       here, so the graph slid down by the height of a card that was never in
+       the flow and snapped back when the animation ended. An !important
+       declaration outranks a script animation, and with the body absolute the
+       natural height is the summary — which is what it should have been all
+       along. */
+    .st-key-viz_filter_nodes details {{ height: auto !important; }}
     .st-key-viz_filter_nodes details[open] > [data-testid="stExpanderDetails"] {{
         position: absolute; top: 100%; left: 0; right: 0;
         max-height: 60vh; overflow-y: auto;

--- a/tests/test_viz_overlays.py
+++ b/tests/test_viz_overlays.py
@@ -7,6 +7,7 @@ canvas, or an invisible component reappears as a band above it — so the hooks
 are pinned here instead.
 """
 
+import re
 from pathlib import Path
 
 from orionbelt_ontology_builder import ui
@@ -37,6 +38,42 @@ def test_the_cards_are_opaque():
     assert "box-shadow:" in light and "box-shadow:" in dark
 
 
+def test_the_picker_cannot_animate_the_canvas_around():
+    """Streamlit opens an expander with a JS height animation on the <details>.
+
+    It animates towards the height of a body that is out of the flow here, so
+    the graph slid down by the height of a card that was never in the flow and
+    snapped back when the animation ended. Only an !important declaration
+    outranks a script animation.
+    """
+    css = graph_overlay_css(dark=False)
+    assert ".st-key-viz_filter_nodes details {" in css
+    rule = css[css.index(".st-key-viz_filter_nodes details {") :]
+    assert "height: auto !important" in rule[: rule.index("}")]
+
+
+def test_css_only_markdown_is_taken_out_of_the_flow():
+    """An st.markdown carrying only a <style> still takes a slot in the page
+    column's 16px gap grid. Four of them ride above the graph."""
+    assert "> style:only-child" in ui._CUSTOM_CSS
+
+
+def test_the_page_starts_below_streamlit_s_header():
+    """The header is an opaque bar painted over the page, not behind it.
+
+    Hiding the CSS-only elements above the title moved the first line of the
+    page up under it, which clipped the breadcrumb. The top padding is what
+    keeps them apart, so it may not drop below the header's 60px.
+    """
+    rule = ui._CUSTOM_CSS[
+        ui._CUSTOM_CSS.index(".block-container, .stMainBlockContainer") :
+    ]
+    rule = rule[: rule.index("}")]
+    padding = re.search(r"padding-top:\s*([\d.]+)rem", rule)
+    assert padding, "the page no longer sets its own top padding"
+    assert float(padding.group(1)) * 16 >= 60
+
+
 def test_the_storage_component_rule_names_the_package_that_is_imported():
     """The invisible browser-storage iframe is hidden by its served URL.
 
@@ -46,3 +83,33 @@ def test_the_storage_component_rule_names_the_package_that_is_imported():
     """
     assert 'iframe[src*="streamlit_local_storage"]' in ui._CUSTOM_CSS
     assert "from streamlit_local_storage import" in (_PKG / "ui.py").read_text()
+
+
+def _toolbar_bottom_px(viewer: str) -> int:
+    """How far down the canvas its own toolbar reaches, from the buttons' CSS."""
+    bottoms = []
+    for button in ("#download-btn", "#fullscreen-btn"):
+        rule = viewer[viewer.index(button + " {") :]
+        rule = rule[: rule.index("}")]
+        top = re.search(r"top:\s*(\d+)px", rule)
+        height = re.search(r"height:\s*(\d+)px", rule)
+        assert top and height, f"{button} no longer sizes itself in px"
+        bottoms.append(int(top.group(1)) + int(height.group(1)))
+    return max(bottoms)
+
+
+def test_the_overlays_clear_the_canvas_toolbar():
+    """The canvas keeps download and fullscreen in the corner the cards use.
+
+    The overlays live outside the iframe, so they win every hit test over those
+    buttons — covering one is enough to make it unclickable, with nothing on
+    screen to say why. They start below the toolbar instead.
+    """
+    viewer = (_PKG / "lib" / "graph_viewer" / "index.html").read_text()
+    css = graph_overlay_css(dark=False)
+    offsets = re.findall(r"top:\s*([\d.]+)rem", css)
+    assert offsets, "the overlays no longer offset themselves from the top"
+    clearance = min(float(o) for o in offsets) * 16  # rem at Streamlit's root size
+    assert clearance >= _toolbar_bottom_px(viewer), (
+        "an overlay now starts over the canvas's own toolbar buttons"
+    )

--- a/tests/test_viz_overlays.py
+++ b/tests/test_viz_overlays.py
@@ -38,6 +38,14 @@ def test_the_cards_are_opaque():
     assert "box-shadow:" in light and "box-shadow:" in dark
 
 
+def test_the_canvas_does_not_pay_for_the_column_gap():
+    """Every row on this page is separated by the column's 16px gap. Above the
+    canvas that gap reads as a band, because the canvas already opens with a
+    strip of empty graph above its legend."""
+    css = graph_overlay_css(dark=False)
+    assert "margin-top: -12px" in css
+
+
 def test_the_picker_cannot_animate_the_canvas_around():
     """Streamlit opens an expander with a JS height animation on the <details>.
 

--- a/tests/test_viz_overlays.py
+++ b/tests/test_viz_overlays.py
@@ -11,7 +11,10 @@ import re
 from pathlib import Path
 
 from orionbelt_ontology_builder import ui
-from orionbelt_ontology_builder.views.visualization import graph_overlay_css
+from orionbelt_ontology_builder.views.visualization import (
+    _TOOLBAR_CLEARANCE,
+    graph_overlay_css,
+)
 
 _PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
 
@@ -36,6 +39,16 @@ def test_the_cards_are_opaque():
     assert "background: #ffffff" in light
     assert "background: #262730" in dark  # the app's own dark surface, not black
     assert "box-shadow:" in light and "box-shadow:" in dark
+
+
+def test_the_panel_cap_pays_for_its_own_offset():
+    """The card starts a toolbar's height down the canvas, so a cap of the full
+    row height would let a long editor hang that far past the canvas and over
+    the status bar. The cap has to subtract the same offset."""
+    css = graph_overlay_css(dark=False)
+    assert f"max-height: calc(100% - {_TOOLBAR_CLEARANCE})" in css
+    # ...and the padding has to sit inside that cap, not on top of it.
+    assert "box-sizing: border-box" in css
 
 
 def test_the_canvas_does_not_pay_for_the_column_gap():

--- a/tests/test_viz_overlays.py
+++ b/tests/test_viz_overlays.py
@@ -1,0 +1,48 @@
+"""Guards for the graph page's CSS hooks into Streamlit's DOM.
+
+None of this is observable outside a browser, and all of it is keyed off markup
+Streamlit generates rather than markup this app writes. A hook that stops
+matching fails silently — the panel goes back to taking a column out of the
+canvas, or an invisible component reappears as a band above it — so the hooks
+are pinned here instead.
+"""
+
+from pathlib import Path
+
+from orionbelt_ontology_builder import ui
+from orionbelt_ontology_builder.views.visualization import graph_overlay_css
+
+_PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+
+
+def test_every_overlay_is_taken_out_of_the_row():
+    """The three panels that used to cost the canvas space must all float."""
+    css = graph_overlay_css(dark=False)
+    for hook, what in [
+        (".st-key-viz_hide_panel", "the details panel"),
+        (".st-key-viz_show_panel", "the reopen toggle"),
+        (".st-key-viz_filter_nodes", "the Node options picker"),
+    ]:
+        assert hook in css, f"{what} no longer floats over the canvas"
+    # Their positioning context, and the canvas claiming the freed width.
+    assert '[data-testid="stHorizontalBlock"]:has(.st-key-graph_viewer)' in css
+    assert "flex: 1 1 100% !important" in css
+
+
+def test_the_cards_are_opaque():
+    """Chips and labels over a busy graph need something solid behind them."""
+    light, dark = graph_overlay_css(dark=False), graph_overlay_css(dark=True)
+    assert "background: #ffffff" in light
+    assert "background: #262730" in dark  # the app's own dark surface, not black
+    assert "box-shadow:" in light and "box-shadow:" in dark
+
+
+def test_the_storage_component_rule_names_the_package_that_is_imported():
+    """The invisible browser-storage iframe is hidden by its served URL.
+
+    Streamlit serves a component from ``/component/<module>.<name>/``, so the
+    rule keys on the module the app imports. Renaming the dependency without
+    updating the rule would put its 26px band back above the canvas.
+    """
+    assert 'iframe[src*="streamlit_local_storage"]' in ui._CUSTOM_CSS
+    assert "from streamlit_local_storage import" in (_PKG / "ui.py").read_text()


### PR DESCRIPTION
Everything that opened on the graph page was paid for out of the canvas: the details panel took a quarter of the row's width, the reopen toggle took a sliver of it, and the Node options picker pushed the graph down far enough to squeeze it to its 300px floor. Opening a panel to read one node cost you the view you opened it from.

All three now sit on top of the canvas as solid cards, and the canvas claims the whole row whatever is open.

## Details

**Solid, not translucent.** Chips and labels read over a busy graph are unreadable. The two card palettes follow the graph's own light/dark themes.

**The details panel** pins both its edges, so `max-height` has a length to resolve against and a long editor scrolls inside the card instead of running past the graph. It sizes to its content, so a two-line panel is a two-line card.

**Node options** hangs off the bottom edge of its own summary, so the picker still reads as part of the control that opened it. It sits above the details panel: it is the thing the click just opened. Its multiselect dropdown renders in a body-level portal, so the card's `overflow-y` does not clip it (checked in the browser).

**The reopen toggle** floats in the same corner as the panel it reopens, so the canvas does not change width when you open or close the panel.

## Testing

The CSS moved out of the render path into `graph_overlay_css()` so the hooks can be tested. Every hook is Streamlit's markup rather than this app's, and one that stops matching fails silently, so `tests/test_viz_overlays.py` pins them.

That file also back-fills a guard for the browser-storage rule from #309. A review suggested that rule's `streamlit_local_storage` substring never matches because the component is declared as `st_local_storage`. It does match: Streamlit serves a component from `/component/<module>.<name>/`, so the live URL is `/component/streamlit_local_storage.st_local_storage/index.html` and contains both names. Confirmed against the running app, where the selector matches exactly one element and its container computes to `position: absolute; height: 0`. The new test ties the substring to the module the app imports, which is the part that could actually drift.

## Verification

Driven in the running app at 1400x900: panel open and closed, Node options open over both, a node selected with the status bar and its "Open full editor" button, and fullscreen (the row is now a positioning context, but the canvas goes `position: fixed` in fullscreen and still covers the viewport).

pytest (1498 passed), ruff format/check, and mypy are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)