### PR TITLE
chore: release 1.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.22.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.23.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -31,7 +31,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.22.0"
+APP_VERSION = "1.23.0"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.22.0"
+version = "1.23.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -786,7 +786,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.22.0"
+version = "1.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },


### PR DESCRIPTION
Twelve commits since v1.22.0. Minor bump: new features, no breaking API changes.

## What is in it

**SKOS** — the workstreams, complete:
- Validation depth (#300) and autofix for seven checks (#302)
- Language-aware, multi-valued concept editing (#298)
- SKOS-XL labels read instead of reported missing (#301)
- A starter template and a sample worth copying from (#303)
- Dublin Core metadata on concept schemes (#304)
- S27 sees a directly asserted broaderTransitive (#306)

**The graph page:**
- Panels float over the canvas instead of taking width from it: details panel, reopen toggle, and the Node options picker (#310)
- The status bar stays in view while you work the graph, and no longer eats the canvas's height reserve (#308, #309)
- The focus switch sits outside the panel it swaps (#307)

**Compatibility:**
- The Python floor is 3.12 (#299). Worth calling out in the release notes: 3.11 is no longer supported.

## The bump

The version lives in `pyproject.toml`, `APP_VERSION` in `orionbelt_ontology_builder/ui.py`, and the README's Docker pin; `uv.lock` carries it as well. Grepped the whole repo for the old string afterwards, no stragglers.

pytest (1504 passed), ruff format/check, and mypy are clean.

## After merging

Tag `v1.23.0`, then **Manage app -> Reboot** at share.streamlit.io: the push webhook does not fire reliably, and the hosted app is still serving the pre-#308 layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)