### PR TITLE
fix(viz): the details panel's link points at the whole value

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -180,6 +180,7 @@ from .ui import (  # noqa: F401
     log_error,
     maybe_restore_autosave,
     missing_required,
+    panel_heading_markdown,
     panel_subject_uri,
     parent_option_index,
     parse_filter_text,

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -180,7 +180,7 @@ from .ui import (  # noqa: F401
     log_error,
     maybe_restore_autosave,
     missing_required,
-    panel_heading_markdown,
+    panel_heading_html,
     panel_subject_uri,
     parent_option_index,
     parse_filter_text,

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -70,7 +70,8 @@ function sendFindSelection(id) {
         if (nd) {
             sendToStreamlit("streamlit:setComponentValue", {
                 value: {nodeId: id, ntype: nd.ntype || null, ename: nd.ename || null,
-                        label: nd.label, title: nd.title || '', selected: true}
+                        label: nd.label, flabel: nd.flabel || null,
+                        title: nd.title || '', selected: true}
             });
         }
     } catch (e) {}
@@ -1071,7 +1072,9 @@ function renderGraph(args) {
         var nd = nodes.get(params.nodes[0]);
         hlJustSelected = true;
         applyNeighbourHighlight(params.nodes[0]);
-        sendSelection({nodeId: params.nodes[0], ntype: nd.ntype || null, ename: nd.ename || null, label: nd.label, title: nd.title || '', selected: true});
+        // flabel is the untruncated label for nodes whose drawn label is cut to
+        // fit (annotation values, literals); the details panel shows that one.
+        sendSelection({nodeId: params.nodes[0], ntype: nd.ntype || null, ename: nd.ename || null, label: nd.label, flabel: nd.flabel || null, title: nd.title || '', selected: true});
     });
     network.on('selectEdge', function(params) {
         if (params.nodes.length === 0 && params.edges.length > 0) {

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -14,6 +14,7 @@ compatibility shims address them by.
 """
 
 import hashlib
+import html
 import json
 import logging
 import re
@@ -2935,27 +2936,29 @@ def _panel_add_parent(classes, ntype, ename):
     return None
 
 
-#: Everything markdown would read as syntax in a heading built from user text.
-_MD_SPECIALS = re.compile(r"([\\`*_\[\]<>])")
-
-
-def panel_heading_markdown(shown: str, full: str) -> str:
+def panel_heading_html(shown: str, full: str) -> str:
     """The details panel's heading: a node's label, linking to its whole value.
 
     A node draws a label cut to fit on it, and the heading is that label. As
     plain text Streamlit linkifies a URL in it, so a cut URL became a link to
-    the cut URL and clicking it opened the wrong page (issue #313). Written as
-    an explicit link instead: the text stays as short as the node drew it, the
-    destination is the value in full, and markdown does not linkify inside a
-    link's own text, so nothing rewrites it back.
+    the cut URL and clicking it opened the wrong page (issue #313) — and a value
+    that merely *starts* with a URL has the same problem with no whole URL to
+    link to.
+
+    So the heading is written as one HTML block, which markdown copies through
+    raw: nothing in it is linkified, and the only link is the one built here,
+    around the text the node drew and pointing at the value in full. Inline HTML
+    would not do — markdown still parses the text between inline tags, and the
+    linkifier put its own <a> inside ours.
     """
-    text = _MD_SPECIALS.sub(r"\\\1", shown or full)
+    text = html.escape(shown or full)
     is_url = full.startswith(("http://", "https://")) and not any(
         c.isspace() for c in full
     )
     if not is_url:
-        return f"**{text}**"
-    return f"**[{text}](<{full.replace('>', '%3E')}>)**"
+        return f"<p><strong>{text}</strong></p>"
+    href = html.escape(full, quote=True)
+    return f'<p><strong><a href="{href}" target="_blank">{text}</a></strong></p>'
 
 
 def panel_subject_uri(ntype, ename, classes, object_props, data_props, individuals):

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -2935,6 +2935,29 @@ def _panel_add_parent(classes, ntype, ename):
     return None
 
 
+#: Everything markdown would read as syntax in a heading built from user text.
+_MD_SPECIALS = re.compile(r"([\\`*_\[\]<>])")
+
+
+def panel_heading_markdown(shown: str, full: str) -> str:
+    """The details panel's heading: a node's label, linking to its whole value.
+
+    A node draws a label cut to fit on it, and the heading is that label. As
+    plain text Streamlit linkifies a URL in it, so a cut URL became a link to
+    the cut URL and clicking it opened the wrong page (issue #313). Written as
+    an explicit link instead: the text stays as short as the node drew it, the
+    destination is the value in full, and markdown does not linkify inside a
+    link's own text, so nothing rewrites it back.
+    """
+    text = _MD_SPECIALS.sub(r"\\\1", shown or full)
+    is_url = full.startswith(("http://", "https://")) and not any(
+        c.isspace() for c in full
+    )
+    if not is_url:
+        return f"**{text}**"
+    return f"**[{text}](<{full.replace('>', '%3E')}>)**"
+
+
 def panel_subject_uri(ntype, ename, classes, object_props, data_props, individuals):
     """The URI of the selected node, when it is something to hang more off.
 

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -44,7 +44,7 @@ from ..ui import (
     follow_renamed_node_ids,
     graph_node_cap,
     local_store,
-    panel_heading_markdown,
+    panel_heading_html,
     panel_subject_uri,
     parse_filter_text,
     prioritise_find_target,
@@ -2143,7 +2143,8 @@ def render_visualization():
                         # full, not the cut text (issue #313).
                         _shown = _sel.get("label", "")
                         st.markdown(
-                            panel_heading_markdown(_shown, _sel.get("flabel") or _shown)
+                            panel_heading_html(_shown, _sel.get("flabel") or _shown),
+                            unsafe_allow_html=True,
                         )
                         # What was selected, not merely that it was an edge:
                         # relations, restrictions and object properties are all

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -44,6 +44,7 @@ from ..ui import (
     follow_renamed_node_ids,
     graph_node_cap,
     local_store,
+    panel_heading_markdown,
     panel_subject_uri,
     parse_filter_text,
     prioritise_find_target,
@@ -193,6 +194,10 @@ def _add_annotation_nodes(net, ont, subject_uri, subject_node_id, room):
             font={"size": 10, "color": "#f0f0f0"},
             ntype="Annotation",
             ename=ann_ename,
+            # The drawn label is cut to fit the node; the details panel wants the
+            # whole value. A cut URL there rendered as a link to the cut URL,
+            # which opens the wrong page (issue #313).
+            flabel=ann["value"],
         )
         net.add_edge(
             subject_node_id,
@@ -1642,6 +1647,7 @@ def render_visualization():
                                 shape="box",
                                 size=8,
                                 font={"size": 9, "color": "#333333"},
+                                flabel=o_str,
                             )
                             _triple_new += 1
                             node_count += 1
@@ -2132,7 +2138,13 @@ def render_visualization():
                         )
                         _render_panel_add_buttons(classes, None, None, None)
                     else:
-                        st.markdown(f"**{_sel.get('label', '')}**")
+                        # The node's own label reads best here, but it is cut
+                        # to fit the node — so the link under it is the value in
+                        # full, not the cut text (issue #313).
+                        _shown = _sel.get("label", "")
+                        st.markdown(
+                            panel_heading_markdown(_shown, _sel.get("flabel") or _shown)
+                        )
                         # What was selected, not merely that it was an edge:
                         # relations, restrictions and object properties are all
                         # drawn as edges and want telling apart (issue #152).

--- a/tests/test_viz_details_link.py
+++ b/tests/test_viz_details_link.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from streamlit.testing.v1 import AppTest
 
-from orionbelt_ontology_builder.app import panel_heading_markdown
+from orionbelt_ontology_builder.app import panel_heading_html
 
 URL = "https://webeep.polimi.it/course/view.php?id=123456"
 CUT = URL[:30] + "..."
@@ -108,7 +108,7 @@ def test_every_node_selection_the_viewer_sends_carries_it():
 
 
 def _heading(at):
-    headings = [m.value for m in at.markdown if m.value.startswith("**")]
+    headings = [m.value for m in at.markdown if m.value.startswith("<p>")]
     assert headings, "the details panel drew no heading"
     return headings[0]
 
@@ -116,28 +116,55 @@ def _heading(at):
 def test_the_heading_links_the_cut_text_to_the_whole_url():
     """The regression: the heading was the cut label as plain text, which
     Streamlit linkified — href and all — to ``https://webeep.polimi.it/cours``.
-    An explicit link keeps the short text and lands on the whole URL, and
-    markdown does not linkify inside a link's own text."""
-    assert _heading(_run(select=True)) == f"**[{CUT}](<{URL}>)**"
+    The link is built here now: short text, whole destination."""
+    assert _heading(_run(select=True)) == (
+        f'<p><strong><a href="{URL}" target="_blank">{CUT}</a></strong></p>'
+    )
 
 
 def test_a_value_that_was_never_cut_reads_the_same():
     short = "https://ex.org/a"
-    assert _heading(_run(select=True, value=short)) == f"**[{short}](<{short}>)**"
+    assert _heading(_run(select=True, value=short)) == (
+        f'<p><strong><a href="{short}" target="_blank">{short}</a></strong></p>'
+    )
+
+
+def test_a_value_that_only_starts_with_a_url_is_not_linked_at_all():
+    """Prose beginning with a URL has no whole URL to link to, and cutting it
+    leaves the same bare-URL text that started this. It is a block of HTML, and
+    markdown copies a block through raw — so Streamlit's linkifier never sees
+    it. Inline HTML would not do: markdown parses the text between inline tags,
+    and the linkifier put its own <a> inside ours."""
+    prose = f"{URL} notes"
+    heading = _heading(_run(select=True, value=prose))
+    assert heading == f"<p><strong>{prose[:30]}...</strong></p>"
+    assert "<a" not in heading
+
+
+def test_the_heading_is_a_block_so_markdown_leaves_it_alone():
+    """The whole guard rests on this: an HTML block starts the line."""
+    for heading in (
+        panel_heading_html("x", "x"),
+        panel_heading_html("x", "https://ex.org/x"),
+    ):
+        assert heading.startswith("<p>")
+        assert "\n" not in heading
 
 
 def test_a_plain_label_is_not_a_link():
-    assert panel_heading_markdown("Course", "Course") == "**Course**"
+    assert panel_heading_html("Course", "Course") == "<p><strong>Course</strong></p>"
 
 
-def test_a_label_that_reads_as_markdown_is_escaped():
-    """The label is the user's own text, and it is markdown now."""
-    assert panel_heading_markdown("a_b*c", "a_b*c") == "**a\\_b\\*c**"
-    assert panel_heading_markdown("[x](y)", "[x](y)") == "**\\[x\\](y)**"
+def test_a_label_is_escaped_not_rendered():
+    """The label is the user's own text, and it lands in HTML."""
+    assert panel_heading_html("<i>x</i>", "<i>x</i>") == (
+        "<p><strong>&lt;i&gt;x&lt;/i&gt;</strong></p>"
+    )
+    quoted = panel_heading_html("cut", 'https://ex.org/"onmouseover=alert(1)')
+    assert '"onmouseover' not in quoted
 
 
 def test_only_web_urls_become_links():
-    """A value that merely starts like a URL but carries spaces is prose, and
-    ``javascript:`` is not a destination this heading ever offers."""
-    assert "](" not in panel_heading_markdown("see", "see https://ex.org/a")
-    assert "](" not in panel_heading_markdown("x", "javascript:alert(1)")
+    """``javascript:`` is not a destination this heading ever offers."""
+    assert "<a" not in panel_heading_html("x", "javascript:alert(1)")
+    assert "<a" not in panel_heading_html("x", "ftp://ex.org/x")

--- a/tests/test_viz_details_link.py
+++ b/tests/test_viz_details_link.py
@@ -1,0 +1,143 @@
+"""The details panel's heading links to the whole value (issue #313).
+
+An annotation node draws a label cut to 30 characters so it fits on the node.
+The panel headed with that cut label as plain markdown, and Streamlit linkifies
+a bare URL — so a cut URL became a link to the cut URL, which opens the wrong
+page. The heading text may still be short; the link under it must not be.
+
+The AppTest half uses the same harness as ``test_viz_focus_annotations``: the
+real page, seeded through the environment because ``AppTest.from_function`` runs
+the script source in a fresh namespace.
+"""
+
+import json
+import os
+import re
+from pathlib import Path
+
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder.app import panel_heading_markdown
+
+URL = "https://webeep.polimi.it/course/view.php?id=123456"
+CUT = URL[:30] + "..."
+
+_VIEWER = (
+    Path(__file__).resolve().parent.parent
+    / "orionbelt_ontology_builder"
+    / "lib"
+    / "graph_viewer"
+    / "index.html"
+)
+
+
+def _script():
+    import os
+
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Course")
+        om.add_annotation("Course", "webeep", os.environ["ANN_VALUE"])
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        # The cross-session settings restore mounts the localStorage component,
+        # which blocks forever without a browser to answer it. Mark it done, and
+        # pin the panel open rather than inheriting whoever ran the tests.
+        st.session_state["_viz_settings_restored"] = True
+        st.session_state["_viz_cfg_details_panel"] = True
+        st.session_state["_viz_cfg_show_annotations"] = True
+        if os.environ["SELECT"] == "1":
+            ann = next(
+                a
+                for a in om.get_annotations(om.namespace + "Course")
+                if a["predicate"] == "webeep"
+            )
+            value = ann["value"]
+            st.session_state["_viz_last_selection"] = {
+                "selected": True,
+                "ntype": "Annotation",
+                "ename": app.annotation_ename(om.namespace + "Course", ann),
+                "label": value[:30] + "..." if len(value) > 30 else value,
+                "flabel": value,
+                "title": f"webeep: {value}",
+            }
+
+    app.render_visualization()
+
+
+def _run(select=False, value=URL):
+    os.environ["ANN_VALUE"] = value
+    os.environ["SELECT"] = "1" if select else "0"
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    return at
+
+
+# --- the node carries what the panel needs ----------------------------------
+
+
+def test_the_node_keeps_the_whole_value_behind_its_cut_label():
+    nodes = json.loads(_run().session_state["last_graph_data"]["nodes"])
+    node = next(n for n in nodes if n.get("ntype") == "Annotation")
+    assert node["label"] == CUT
+    assert node["flabel"] == URL
+
+
+def test_every_node_selection_the_viewer_sends_carries_it():
+    """A click and a Find & centre both fill the panel, so both payloads need
+    it: whichever one forgot would put the cut link back."""
+    src = _VIEWER.read_text(encoding="utf-8")
+    sites = list(re.finditer(r"(?<!f)label: nd\.label", src))
+    assert len(sites) == 2, (
+        f"expected 2 node selection payloads, found {len(sites)} — "
+        "a new one must send flabel too (issue #313)"
+    )
+    for site in sites:
+        assert "flabel: nd.flabel" in src[site.start() : site.start() + 200], (
+            "a selection payload sends the drawn label without the whole one"
+        )
+
+
+# --- the heading ------------------------------------------------------------
+
+
+def _heading(at):
+    headings = [m.value for m in at.markdown if m.value.startswith("**")]
+    assert headings, "the details panel drew no heading"
+    return headings[0]
+
+
+def test_the_heading_links_the_cut_text_to_the_whole_url():
+    """The regression: the heading was the cut label as plain text, which
+    Streamlit linkified — href and all — to ``https://webeep.polimi.it/cours``.
+    An explicit link keeps the short text and lands on the whole URL, and
+    markdown does not linkify inside a link's own text."""
+    assert _heading(_run(select=True)) == f"**[{CUT}](<{URL}>)**"
+
+
+def test_a_value_that_was_never_cut_reads_the_same():
+    short = "https://ex.org/a"
+    assert _heading(_run(select=True, value=short)) == f"**[{short}](<{short}>)**"
+
+
+def test_a_plain_label_is_not_a_link():
+    assert panel_heading_markdown("Course", "Course") == "**Course**"
+
+
+def test_a_label_that_reads_as_markdown_is_escaped():
+    """The label is the user's own text, and it is markdown now."""
+    assert panel_heading_markdown("a_b*c", "a_b*c") == "**a\\_b\\*c**"
+    assert panel_heading_markdown("[x](y)", "[x](y)") == "**\\[x\\](y)**"
+
+
+def test_only_web_urls_become_links():
+    """A value that merely starts like a URL but carries spaces is prose, and
+    ``javascript:`` is not a destination this heading ever offers."""
+    assert "](" not in panel_heading_markdown("see", "see https://ex.org/a")
+    assert "](" not in panel_heading_markdown("x", "javascript:alert(1)")


### PR DESCRIPTION
Fixes the clickable link in the graph's Details panel (issue #313).

## The bug

An annotation node draws a label cut to 30 characters so it fits on the node, and the details panel headed with that label as plain text. Streamlit linkifies a bare URL, so a cut URL became a link to the cut URL: clicking it opened `https://webeep.polimi.it/cours` instead of the page the annotation names.

## The fix

- The node carries its whole value (`flabel`) alongside the drawn label, for annotation nodes and for literal nodes in the triple view.
- The viewer sends it with the selection, on a click and on a Find & centre alike.
- The heading is an explicit link: the text stays as short as the node drew it, the destination is the value in full. Markdown does not linkify inside a link's own text, so nothing rewrites it back. Labels that are not URLs are unlinked, and markdown syntax in a label is escaped rather than rendered.

## Verified

`pytest` (1511 passing, 7 new), ruff, mypy, plus a live run: clicking the annotation node yields one anchor with text `https://webeep.polimi.it/cours...` and href `https://webeep.polimi.it/course/view.php?id=123456`.

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)