### PR TITLE
fix(viz): a dropdown in a floating panel opens below its input

### DIFF
--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -124,6 +124,18 @@ def graph_overlay_css(dark: bool) -> str:
         border-radius: 10px;
         box-shadow: {shadow};
     }}
+    /* A dropdown inside a card opens into the card's own scrollport, and with
+       no room left below the input BaseWeb flips the list upwards — over the
+       input being typed into and the controls above it (issue #315). The list
+       is portaled out of the card anyway, so while one is open the card stops
+       scrolling and the list hangs past its edge instead. */
+    {_GRAPH_ROW} > [data-testid="stColumn"]:has(.st-key-viz_hide_panel):has(
+        [aria-expanded="true"]
+    ),
+    .st-key-viz_filter_nodes details[open]
+        > [data-testid="stExpanderDetails"]:has([aria-expanded="true"]) {{
+        overflow: visible;
+    }}
     /* Panel closed: the reopen toggle alone, in the same corner. */
     {_GRAPH_ROW} > [data-testid="stColumn"]:has(.st-key-viz_show_panel) {{
         position: absolute; top: {_TOOLBAR_CLEARANCE}; right: 0; z-index: 20;

--- a/tests/test_viz_overlays.py
+++ b/tests/test_viz_overlays.py
@@ -51,6 +51,29 @@ def test_the_panel_cap_pays_for_its_own_offset():
     assert "box-sizing: border-box" in css
 
 
+def test_an_open_dropdown_stops_the_card_scrolling():
+    """A card that scrolls is the boundary a dropdown is placed inside, and with
+    no room below the input BaseWeb flips the list up over the input and the
+    controls above it (issue #315). Both scrolling cards have to let go while a
+    list is open — it is portaled out of them anyway."""
+    css = graph_overlay_css(dark=False)
+    escapes = re.findall(
+        r"([^{}]*:has\(\s*\[aria-expanded=\"true\"\]\s*\)[^{}]*)\{([^}]*)\}", css
+    )
+    assert escapes, "nothing lets a dropdown out of the cards"
+    selectors, body = escapes[0]
+    assert "overflow: visible" in body
+    assert ".st-key-viz_hide_panel" in selectors, "the details panel still scrolls"
+    assert ".st-key-viz_filter_nodes" in selectors, "Node options still scrolls"
+
+
+def test_the_cards_scroll_when_no_dropdown_is_open():
+    """The escape hatch is only that: a long panel still scrolls inside its card
+    rather than running past the canvas."""
+    css = graph_overlay_css(dark=False)
+    assert css.count("overflow-y: auto") == 2
+
+
 def test_the_canvas_does_not_pay_for_the_column_gap():
     """Every row on this page is separated by the column's 16px gap. Above the
     canvas that gap reads as a band, because the canvas already opens with a


### PR DESCRIPTION
Fixes the class selector covering the panel when it is focused (issue #315).

## The bug

Since PR #310 the graph's panels float over the canvas, capped with `max-height` and `overflow-y: auto`. That scrollport is the boundary BaseWeb measures a dropdown against. The class picker sits near the bottom of Node options, leaving about 80px below it inside the card, so the list flipped upwards: over the box being typed into and over the segmented control above it.

Confirmed in the running app by toggling each candidate container in the live DOM:

| card overflow | multiselect chip box | list opens |
| --- | --- | --- |
| `auto` (shipped) | as shipped | above the input, over the panel |
| `auto` | freed | above the input, over the panel |
| freed | as shipped | below the input |

So the card's scrollport is the cause on its own; the multiselect's own chip box is not.

## The fix

While a list is open (`:has([aria-expanded="true"])`) the card stops scrolling. The list is portaled out to the document anyway, so it can hang past the card's edge and open below its input the way it does everywhere else. Both floating cards get it: the details panel has the same scrollport and the same selectboxes.

The cap itself is untouched, so a long panel still scrolls inside its card whenever no list is open.

## Verified

In the running app, and with the shipped CSS rather than an injected probe:

- Node options, class picker: list opens below the input, over the canvas; nothing covers the input or the control above it.
- Details panel, Parent selectbox: opens below when the viewport has room, and above the input (not over it) when it does not, which is ordinary behaviour.
- With nothing open, neither card matches the escape hatch and both still scroll.

`pytest` (1515 passing, 2 new in `tests/test_viz_overlays.py`), ruff, mypy.

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)