### PR TITLE
fix(viz): adding to the graph no longer zooms out to the whole ontology

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -852,8 +852,18 @@ function renderGraph(args) {
                 pinnedIds.push(n.id);
             }
         });
+        // Nothing went away, so everything the camera was framing is still
+        // there, pinned where it was: keep the view instead of letting vis
+        // re-frame the whole graph once physics settles. Adding a subclass to
+        // the class you are looking at otherwise zoomed out to the whole
+        // ontology every time, which is the one thing you were not looking at
+        // (issue #314). When nodes *did* go away the old frame can hold nothing
+        // at all — a filter swapped for another set places every node afresh —
+        // so there vis still re-frames.
+        var _keptAll = Object.keys(_raw.pos).length === pinnedIds.length;
+        var _hold = !!savedView && _keptAll;
         var iters2 = Math.min(Math.max(nCount * 3, 150), 500);
-        options.physics.stabilization = { enabled: true, iterations: Math.max(iters2 - 40, 80), updateInterval: 50, fit: !_pin };
+        options.physics.stabilization = { enabled: true, iterations: Math.max(iters2 - 40, 80), updateInterval: 50, fit: !_pin && !_hold };
     } else {
         // Fresh layout (Render, or nothing cached): deterministic thanks to the
         // pinned randomSeed set in Python (issue #141).

--- a/tests/test_viz_camera_hold.py
+++ b/tests/test_viz_camera_hold.py
@@ -1,0 +1,57 @@
+"""The camera holds still when the graph only gains nodes (issue #314).
+
+Adding a subclass rebuilds the graph with the same layout generation, so the
+nodes already placed keep their positions — but vis re-frames the whole graph
+once physics settles, and the view zoomed out to the whole ontology every time.
+Building one subclass after another, the class you are working on is the one
+thing you stop being able to see.
+
+None of it is observable outside a browser, so the invariant is pinned at the
+source level the way test_viz_fullscreen.py pins the fullscreen ones. Verified
+by hand in the running app: at scale 1.016 on FOAF, adding a subclass used to
+leave the graph at 0.484 and now leaves it at 1.016, with the new node in view;
+turning a node type off (nodes go away) still re-frames.
+"""
+
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+_VIEWER = _PKG / "lib" / "graph_viewer" / "index.html"
+
+
+def _viewer() -> str:
+    return _VIEWER.read_text(encoding="utf-8")
+
+
+def _rebuild_branch(src: str) -> str:
+    """The branch that runs when the node set changed under the same seq."""
+    start = src.index("// Same render generation but a changed node set")
+    return src[start : src.index("var nodes = new vis.DataSet", start)]
+
+
+def test_a_grown_graph_keeps_the_view_it_had():
+    """vis's post-stabilization fit is what moved the camera, so the branch that
+    restores a saved viewport has to switch it off."""
+    branch = _rebuild_branch(_viewer())
+    assert "fit: !_pin && !_hold" in branch, (
+        "the rebuild re-frames the graph even when it is holding a saved view"
+    )
+    assert "_hold = !!savedView" in branch, "the hold is not tied to a saved view"
+
+
+def test_the_hold_needs_every_node_that_was_placed():
+    """A view is only worth keeping while what it framed is still on screen. A
+    filter swapped for another set places every node afresh, and the old frame
+    would hold nothing at all — so that case still re-frames."""
+    branch = _rebuild_branch(_viewer())
+    assert "Object.keys(_raw.pos).length === pinnedIds.length" in branch, (
+        "the hold no longer checks that nothing was dropped from the graph"
+    )
+
+
+def test_a_fresh_layout_still_frames_the_graph():
+    """Nothing to hold on a Render click or a first visit: the fit is what puts
+    the graph on screen at all."""
+    src = _viewer()
+    fresh = src[src.index("// Fresh layout (Render, or nothing cached)") :]
+    assert "fit: !_pin" in fresh[: fresh.index("var nodes = new vis.DataSet")]


### PR DESCRIPTION
Keeps the view where it was when the graph only gains nodes (issue #314).

## The bug

Adding a class from the panel rebuilds the graph under the same layout generation, so every node already placed keeps its position and is pinned. The rebuild then handed vis `stabilization.fit: true`, which frames the whole graph once physics settles — undoing the saved viewport the same branch had just restored. Building one subclass after another, the class being worked on is the one thing that stops being visible.

Measured in the running app on FOAF, zoomed to scale 1.016 on Person:

| | before | after |
| --- | --- | --- |
| add a subclass | scale 0.484, view jumped | scale 1.016, new node in view |
| turn a node type off (nodes go away) | re-frames | re-frames (1.636 to 0.958) |

## The fix

The camera holds its view when nothing was dropped from the graph: everything it was framing is still there, in the same place, and the new node settles next to its parent. When nodes did go away the old frame can hold nothing at all (a filter swapped for another set places every node afresh), so that case still re-frames, as does a Render click and a first visit.

## Verified

In the running app, with the numbers in the table above, plus `pytest` (1518 passing, 3 new pinning the JS invariant since none of it is observable from Python), ruff, mypy.

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)