### PR TITLE
feat(viz): clicking the graph closes the Node options card

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -59,6 +59,21 @@ function sendToStreamlit(type, data) {
     window.parent.postMessage(Object.assign({isStreamlitMessage: true, type: type}, data || {}), "*");
 }
 
+// Close the Node options card when something in the graph is selected. The card
+// floats over the top of the canvas, so a click means the user has moved on to
+// the graph itself and the card is now in the way — the details panel beside it
+// is where the click's answer appears. Closed the way the user would close it,
+// by clicking the expander's own summary, so Streamlit's state follows and the
+// card does not spring back open on the next rerun. The parent document is the
+// same origin (see measureReserve); if it ever is not, the card simply stays.
+function closeNodeOptions() {
+    try {
+        var summary = window.parent.document.querySelector(
+            '.st-key-viz_filter_nodes details[open] > summary');
+        if (summary) summary.click();
+    } catch (e) { /* cross-origin: leave the card as it is */ }
+}
+
 // Report a Find-selected node to Streamlit, matching the selectNode payload, so
 // the details/status panel reflects the found node. selectNodes() alone does not
 // fire selectNode, so a Find focus would otherwise leave the panel out of sync
@@ -1071,6 +1086,7 @@ function renderGraph(args) {
     network.on('selectNode', function(params) {
         var nd = nodes.get(params.nodes[0]);
         hlJustSelected = true;
+        closeNodeOptions();
         applyNeighbourHighlight(params.nodes[0]);
         // flabel is the untruncated label for nodes whose drawn label is cut to
         // fit (annotation values, literals); the details panel shows that one.
@@ -1080,6 +1096,7 @@ function renderGraph(args) {
         if (params.nodes.length === 0 && params.edges.length > 0) {
             // An edge-only selection means no node is selected, and vis does not
             // fire deselectNode on the way there.
+            closeNodeOptions();
             clearNeighbourHighlight();
             var ed = edges.get(params.edges[0]);
             sendSelection({ntype: ed.ntype || null, ename: ed.ename || null, label: ed.label || '', title: ed.title || '', selected: true, isEdge: true});

--- a/tests/test_viz_node_options_autoclose.py
+++ b/tests/test_viz_node_options_autoclose.py
@@ -1,0 +1,63 @@
+"""Node options gets out of the way when the graph is clicked.
+
+The card floats over the top of the canvas (PR #310), so after a click it covers
+the very graph the click was about, while the answer appears in the details panel
+beside it. Selecting a node or an edge therefore closes it.
+
+Closed by clicking the expander's own summary rather than by setting anything:
+the expander is uncontrolled from Python — Streamlit only re-applies ``expanded``
+when the label changes, and moving the label is what closed the panel under the
+user in issue #267. None of it is observable outside a browser, so the wiring is
+pinned here the way test_viz_fullscreen.py pins the fullscreen invariants.
+"""
+
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+_VIEWER = _PKG / "lib" / "graph_viewer" / "index.html"
+
+
+def _viewer() -> str:
+    return _VIEWER.read_text(encoding="utf-8")
+
+
+def _handler(src: str, event: str) -> str:
+    """The body of ``network.on('<event>', ...)``."""
+    start = src.index(f"network.on('{event}'")
+    depth = 0
+    for i in range(src.index("{", start), len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"unbalanced braces in the {event} handler")
+
+
+def test_selecting_a_node_or_an_edge_closes_the_card():
+    src = _viewer()
+    for event in ("selectNode", "selectEdge"):
+        assert "closeNodeOptions()" in _handler(src, event), (
+            f"a {event} leaves Node options covering the graph"
+        )
+
+
+def test_clicking_empty_canvas_leaves_it_alone():
+    """A deselect is not a reason to close a card the user opened: nothing new
+    is being shown beside it."""
+    assert "closeNodeOptions()" not in _handler(_viewer(), "deselectNode")
+
+
+def test_the_card_is_closed_the_way_a_user_closes_it():
+    """Through the summary, so Streamlit's own expander state follows and the
+    card does not spring back open on the next rerun. Setting ``open`` on the
+    <details> would look right and then reopen."""
+    src = _viewer()
+    body = src[src.index("function closeNodeOptions()") :]
+    body = body[: body.index("\n}\n")]
+    assert "details[open] > summary" in body
+    assert "summary.click()" in body, "the card is closed without clicking its summary"
+    assert ".open = false" not in body
+    # The parent document is another frame's: unreachable one day, unimportant.
+    assert "catch" in body


### PR DESCRIPTION
Requested while testing the graph panels: the Node options card should get out of the way once you go back to the graph.

## Why

The card floats over the top of the canvas (PR #310). Click a node and the card is covering the very graph the click was about, while the answer to the click appears in the details panel beside it. Working through a graph, that means closing the card by hand after every click.

## What

Selecting a node or an edge closes the card. Clicking empty canvas leaves it open: a deselect shows nothing new beside it, so there is no reason to undo something the user opened.

It is closed by clicking the expander's own summary, the way a user would. The expander is uncontrolled from Python: Streamlit only re-applies `expanded` when the label changes, and deliberately moving the label is exactly what closed the panel under the user in issue #267. Setting `open` on the `<details>` directly would look right and then spring back on the next rerun. The parent document is same-origin, as the autofit measurement already relies on; if it ever is not, the card simply stays as it is.

## Verified

In the running app:

- clicking a node closes the card, and it stays closed through the rerun the click causes
- the details panel fills in with the clicked entity, with the whole graph now visible
- the card reopens on its summary as before
- a click on empty canvas leaves it open

`pytest` (1518 passing, 3 new pinning the wiring, since none of it is observable from Python), ruff, mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)