### PR TITLE
test(theme): pin that a missing config.json follows the OS like an empty one

### DIFF
--- a/tests/test_local_store.py
+++ b/tests/test_local_store.py
@@ -154,6 +154,27 @@ def test_resolved_startup_base_prefers_pin(home, monkeypatch):
     assert local_store.resolved_startup_base() == "dark"
 
 
+@pytest.mark.parametrize("write_config", [False, True])
+def test_an_absent_config_follows_the_os_like_an_empty_one(
+    home, monkeypatch, write_config
+):
+    """Issue #139 reported that the OS theme was only followed once a (even
+    empty) config.json existed. It is not what decides: a missing file and an
+    empty one both load as ``{}``, so neither pins a theme and both fall
+    through to the OS. What decides is whether ``darkdetect`` can be imported,
+    which is to say whether the app was installed with one of the extras that
+    ships it. Pinned here so the reported quirk cannot become true later.
+    """
+    fake = types.ModuleType("darkdetect")
+    fake.theme = lambda: "Dark"
+    monkeypatch.setitem(sys.modules, "darkdetect", fake)
+    if write_config:
+        local_store.config_file().write_text("{}", encoding="utf-8")
+    assert local_store.config_file().exists() is write_config
+    assert local_store.load_config() == {}
+    assert local_store.resolved_startup_base() == "dark"
+
+
 def test_resolved_startup_base_falls_back_to_system(home, monkeypatch):
     fake = types.ModuleType("darkdetect")
     fake.theme = lambda: "Dark"


### PR DESCRIPTION
Follow-up to #139, which I could not reproduce. Adds the regression test rather than a fix, since there is nothing to fix.

## What #139 reported

That auto light/dark theming only worked once a `config.json` existed in `~/.orionbelt_ontology_builder`, even an empty one.

## What actually decides

Nothing in the code looks at whether that file exists. `load_config()` returns `{}` for a missing file and for an empty one alike, so `get_theme_base()` answers `None` either way and `resolved_startup_base()` falls through to `detect_system_base()`.

What decides is whether `darkdetect` can be imported, which is to say whether the app was installed with one of the extras that ships it (`desktop`, `qt`, `gtk`). Without it, detection returns `None`, no `--theme.base` is passed at launch, and the choice is left to the browser or webview, which the code already notes does not report the system colour scheme reliably. That matches what the maintainer diagnosed on the issue, and the reporter confirmed `darkdetect` works on their machine.

## How I verified it

Resolved the startup theme under a temp `HOME`, with the `desktop` extra installed, once with no `config.json` and once with an empty one:

```
=== HOME=a (no config.json)
  config exists: False
  startup base : light
=== HOME=b (empty config.json)
  config exists: True
  startup base : light
```

Identical, and matching the machine's actual appearance. Without the extra both cases answer `None` instead, again identically, which is the real mechanism.

## What this adds

One parametrized test in `tests/test_local_store.py` asserting that a missing and an empty config both load as `{}` and both follow the detected OS theme, so the reported quirk cannot quietly become true later. No production code changes.

1595 tests, ruff and mypy green.