### PR TITLE
chore: release 1.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.23.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.24.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -32,7 +32,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.23.0"
+APP_VERSION = "1.24.0"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.23.0"
+version = "1.24.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/uv.lock
+++ b/uv.lock
@@ -795,7 +795,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.23.0"
+version = "1.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },


### PR DESCRIPTION
Version bump only. No behaviour changes of its own.

## Why minor, not patch

Three user-facing features have landed since v1.23.0:

- #320 copy what is selected, from the canvas or the status bar
- #283 (PR #323) paste / copy for the focus nodes
- #194 (PR #322) the `Show new (N)` offer and the "created but hidden" toast

And #194 changes existing behaviour on purpose: a class created while the node filter is narrowed no longer pushes itself into that view. Someone relying on the old behaviour will notice, which is not something a patch release should carry.

## What is in 1.24.0

Features:
- #320 copy what is selected, from the canvas or the status bar
- #319 clicking the graph closes the Node options card
- #283 paste / copy for the focus nodes
- #194 new entities auto-show only when the filter shows everything, with a toast and a one-click way in when one lands outside a narrowed filter

Fixes:
- #318 adding to the graph no longer zooms out to the whole ontology
- #317 a dropdown in a floating panel opens below its input
- #316 the details panel's link points at the whole value
- keeping a renamed entity in a narrowed filter, and both paste boxes no longer losing what a paste dropped (found while reviewing #322 and #323)

Also: #321 dependency bumps, #324 a regression test pinning the theming behaviour investigated in #139.

## The bump

Four files, all agreeing, with `tests/test_version_consistency.py` guarding the first three:

- `pyproject.toml`
- `orionbelt_ontology_builder/ui.py` (`APP_VERSION`)
- `README.md` (the Docker pin example)
- `uv.lock` (regenerated by `uv sync`)

1595 tests, ruff and mypy green.

## After merging

Tag and release are not done here. Note that the Streamlit Cloud push webhook does not fire reliably, so a manual **Manage app > Reboot** at share.streamlit.io is part of releasing, and the sidebar version is what confirms the hosted app actually picked it up.