### PR TITLE
fix(viz): keep the camera and the node in place across a rename

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -229,6 +229,7 @@ from .ui import (  # noqa: F401
     viz_node_id,
     viz_note_rename,
     viz_ontology_was_replaced,
+    viz_rename_map,
     viz_sync,
 )
 

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -919,6 +919,32 @@ function renderGraph(args) {
     var _raw = null;
     try { _raw = JSON.parse(sessionStorage.getItem('viz_pos') || 'null'); } catch (e) {}
 
+    // A rename mints a new URI, so the entity comes back as a node the cached
+    // layout has never seen: its old id went away, the "nothing went away" test
+    // below fails, and vis re-frames the whole graph — zooming out of the very
+    // class you were renaming (issue #329). Python sends where each renamed node
+    // went, so move its cached position over to the id it now has. The hash is
+    // recomputed over the same key set it was first taken from, so a render whose
+    // only change is the rename lands on the exact-restore path below. Written
+    // back to sessionStorage because a later re-mount reads the cache afresh.
+    var _renames = {};
+    var _carried = false;
+    try { _renames = JSON.parse(args.renames || '{}') || {}; } catch (e) {}
+    if (_raw && _raw.pos) {
+        Object.keys(_renames).forEach(function (oldId) {
+            var newId = _renames[oldId];
+            if (newId === oldId ||
+                !Object.prototype.hasOwnProperty.call(_raw.pos, oldId)) { return; }
+            _raw.pos[newId] = _raw.pos[oldId];
+            delete _raw.pos[oldId];
+            _carried = true;
+        });
+        if (_carried) {
+            _raw.hash = _hash(Object.keys(_raw.pos).sort().join('|'));
+            try { sessionStorage.setItem('viz_pos', JSON.stringify(_raw)); } catch (e) {}
+        }
+    }
+
     var usedSaved = false;
     if (_raw && _raw.seq === args.seq && _raw.hash === nodeHash && _raw.pos) {
         // Exact same graph: restore every position with physics off — no
@@ -952,8 +978,16 @@ function renderGraph(args) {
         // (issue #314). When nodes *did* go away the old frame can hold nothing
         // at all — a filter swapped for another set places every node afresh —
         // so there vis still re-frames.
+        // A rename is a substitution, not a change of subject: this is the graph
+        // you were already looking at, with one entity under a new name. The
+        // renamed node's own position was carried across above, but everything
+        // else keyed off its URI — its annotation nodes — comes back under new
+        // ids too, which fails that same test and re-frames the graph regardless
+        // (issue #329). So a render that carried a rename holds the camera on
+        // what it was framing and lets physics settle the re-keyed nodes around
+        // their pinned subject.
         var _keptAll = Object.keys(_raw.pos).length === pinnedIds.length;
-        var _hold = !!savedView && _keptAll;
+        var _hold = !!savedView && (_keptAll || _carried);
         var iters2 = Math.min(Math.max(nCount * 3, 150), 500);
         options.physics.stabilization = { enabled: true, iterations: Math.max(iters2 - 40, 80), updateInterval: 50, fit: !_pin && !_hold };
     } else {

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1358,6 +1358,26 @@ def _renamed_node_id(node_id, renames):
     return node_id
 
 
+def viz_rename_map(renames):
+    """The recorded renames flattened to one ``old id -> where it is now`` map.
+
+    The notes are left one rename at a time (see :func:`viz_note_rename`), so an
+    entity renamed twice before the next Visualization render is recorded as a
+    chain (A->B, B->C). The graph component needs a single hop per id to carry a
+    cached node position across a rename (issue #329), so the chain is walked
+    here. A rename back to an earlier name leaves the id where it started and is
+    dropped, since there is nothing to carry.
+    """
+    if not renames:
+        return {}
+    moved = {}
+    for old in renames:
+        final = _renamed_node_id(old, renames)
+        if final != old:
+            moved[old] = final
+    return moved
+
+
 def follow_renamed_node_ids(node_ids, renames):
     """Where ``node_ids`` ended up after the recorded renames (issue #275).
 
@@ -1732,16 +1752,35 @@ def show_message(message: str, type: str = "info"):
         st.info(message)
 
 
-def set_flash_message(message: str, type: str = "info"):
-    """Set a flash message to be displayed after rerun."""
-    st.session_state.flash_message = {"message": message, "type": type}
+#: Icons for the toast form of a flash message, by message type.
+_FLASH_TOAST_ICON = {"success": "✅", "warning": "⚠️", "error": "🚫", "info": "ℹ️"}
+
+
+def set_flash_message(message: str, type: str = "info", toast: bool = False):
+    """Set a flash message to be displayed after rerun.
+
+    ``toast`` floats the message over the page instead of drawing it as a banner.
+    The banner goes above the whole page body, so a confirmation for an edit made
+    further down — the details panel, a row editor — pushes everything the user
+    is looking at out from under the cursor (issue #330). Use it for the short
+    confirmations that say only that the edit landed; anything worth reading
+    twice, such as a bulk-add summary or an error, stays a banner (issue #114).
+    """
+    st.session_state.flash_message = {
+        "message": message,
+        "type": type,
+        "toast": toast,
+    }
 
 
 def display_flash_message():
     """Display and clear any pending flash message."""
     if st.session_state.get("flash_message"):
         msg = st.session_state.flash_message
-        show_message(msg["message"], msg["type"])
+        if msg.get("toast"):
+            st.toast(msg["message"], icon=_FLASH_TOAST_ICON.get(msg["type"]))
+        else:
+            show_message(msg["message"], msg["type"])
         st.session_state.flash_message = None
 
 
@@ -2782,7 +2821,7 @@ def render_annotation_form(
         save_checkpoint("Delete annotation")
         if on_close is not None:
             on_close()
-        set_flash_message("Annotation deleted!", "success")
+        set_flash_message("Annotation deleted!", "success", toast=True)
         st.rerun()
     if saved:
         if _missing := missing_required(On=new_subject):
@@ -2806,7 +2845,7 @@ def render_annotation_form(
             save_checkpoint("Update annotation")
             if on_close is not None:
                 on_close()
-            set_flash_message("Annotation updated!", "success")
+            set_flash_message("Annotation updated!", "success", toast=True)
             st.rerun()
 
 
@@ -3517,7 +3556,7 @@ def _panel_delete_entity(ont, kind, entity) -> None:
         }[kind](entity["uri"])
         save_checkpoint(f"Delete {kind}")
         _panel_drop_selection()
-        set_flash_message(f"{entity['name']} deleted!", "success")
+        set_flash_message(f"{entity['name']} deleted!", "success", toast=True)
 
     _panel_confirm_dialog(
         ont.format_delete_impact(ont.get_delete_impact(entity["uri"], kind)),
@@ -3556,7 +3595,7 @@ def _panel_delete_edge(ont, label, key_suffix, delete) -> None:
         if changed:
             save_checkpoint(f"Delete {label}")
             _panel_drop_selection()
-            set_flash_message(f"{label.capitalize()} deleted!", "success")
+            set_flash_message(f"{label.capitalize()} deleted!", "success", toast=True)
         else:
             set_flash_message(f"This {label} is no longer in the ontology.", "error")
 
@@ -4384,7 +4423,7 @@ def render_restriction_form(ont, rest, form_key, classes, properties, on_close=N
                 save_checkpoint("Edit restriction")
                 if on_close is not None:
                     on_close()
-                set_flash_message("Restriction updated!", "success")
+                set_flash_message("Restriction updated!", "success", toast=True)
                 st.rerun()
             else:
                 show_message(
@@ -4721,7 +4760,7 @@ def render_relation_form(ont, rel, form_key, spec, on_close=None):
                 save_checkpoint(f"Edit {spec['label']}")
                 if on_close is not None:
                     on_close()
-                set_flash_message("Relation updated!", "success")
+                set_flash_message("Relation updated!", "success", toast=True)
                 st.rerun()
             else:
                 # The row was deleted or edited elsewhere since this list

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -65,6 +65,7 @@ from ..ui import (
     viz_new_hidden_message,
     viz_node_id,
     viz_ontology_was_replaced,
+    viz_rename_map,
     viz_sync,
 )
 
@@ -718,6 +719,11 @@ def render_visualization():
             # whatever happens to hold that URI now, which is the very thing the
             # reuse prune below exists to stop (issue #180).
             _renames = None
+        # The graph component carries a renamed node's cached position over to
+        # the id it now has, so the render it lands on stays where it was
+        # instead of re-framing the whole graph (issue #329). Flattened here
+        # because the component applies one hop per id.
+        _viz_renames = viz_rename_map(_renames)
         if _renames and "_viz_cfg_focus_seeds" in st.session_state:
             (
                 st.session_state["_viz_cfg_focus_seeds"],
@@ -2241,6 +2247,10 @@ def render_visualization():
                     # On desktop the webview can't download; the component sends
                     # the PNG back for us to save instead (#86).
                     web_download=not local_store.local_persist_enabled(),
+                    # Where entities renamed since the last render went, so the
+                    # cached layout follows them and a rename doesn't zoom the
+                    # graph out (issue #329).
+                    renames=json.dumps(_viz_renames),
                     seq=st.session_state.viz_render_seq,
                     key="graph_viewer",
                     default=None,

--- a/tests/test_flash_toast.py
+++ b/tests/test_flash_toast.py
@@ -1,0 +1,84 @@
+"""Edit confirmations must not shove the page around (issue #330).
+
+A flash message is drawn above the whole page body, so "Relation updated!" for
+an edit made further down — in the details panel, or a row editor near the
+bottom of a long list — inserted a banner at the top and pushed everything the
+user was looking at out from under the cursor. Those confirmations say only that
+the edit landed, so they float over the page instead.
+
+Messages worth reading twice stay banners: a bulk-add summary names every row
+that failed (issue #114), and an error has to survive longer than a toast.
+"""
+
+import pytest
+
+from orionbelt_ontology_builder import ui
+
+
+class _State(dict):
+    """Stand-in for ``st.session_state``, which is read and written both ways."""
+
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+
+
+@pytest.fixture
+def flash(monkeypatch):
+    """Record what the flash was rendered as, without a Streamlit runtime."""
+    state = _State()
+    shown: list[tuple[str, str]] = []
+    monkeypatch.setattr(ui.st, "session_state", state)
+    monkeypatch.setattr(
+        ui.st, "toast", lambda message, icon=None: shown.append(("toast", message))
+    )
+    for kind in ("success", "warning", "error", "info"):
+        monkeypatch.setattr(
+            ui.st, kind, lambda message, k=kind: shown.append((k, message))
+        )
+    return state, shown
+
+
+def test_a_plain_flash_is_still_a_banner(flash):
+    state, shown = flash
+    ui.set_flash_message("Created 2 class(es). 1 row failed", "warning")
+
+    ui.display_flash_message()
+
+    assert shown == [("warning", "Created 2 class(es). 1 row failed")]
+    assert state["flash_message"] is None
+
+
+def test_a_toast_flash_floats_over_the_page(flash):
+    state, shown = flash
+    ui.set_flash_message("Relation updated!", "success", toast=True)
+
+    ui.display_flash_message()
+
+    assert shown == [("toast", "Relation updated!")]
+    assert state["flash_message"] is None
+
+
+def test_nothing_pending_renders_nothing(flash):
+    _state, shown = flash
+    ui.display_flash_message()
+    assert shown == []
+
+
+def test_the_editor_confirmations_are_the_ones_that_float():
+    """The confirmations that follow an in-place edit — the ones the issue is
+    about — ask for a toast; everything else keeps its banner."""
+    import inspect
+
+    src = inspect.getsource(ui)
+    for message in (
+        '"Relation updated!", "success"',
+        '"Restriction updated!", "success"',
+        '"Annotation updated!", "success"',
+        '"Annotation deleted!", "success"',
+    ):
+        assert f"set_flash_message({message}, toast=True)" in src, message
+    # An error the user has to act on is not a toast.
+    assert (
+        'set_flash_message(f"This {label} is no longer in the ontology.", "error")'
+        in src
+    )

--- a/tests/test_viz_rename_view_hold.py
+++ b/tests/test_viz_rename_view_hold.py
@@ -1,0 +1,206 @@
+"""A rename must not zoom the graph out (issue #329).
+
+Renaming an entity mints a new URI, and its graph node is keyed by a hash of
+that URI — so to the layout cache the entity you renamed went away and a
+stranger arrived. The cache then failed its "nothing went away" test (issue
+#314) and vis re-framed the whole graph, zooming out of the very class you were
+renaming.
+
+The render hands the component where each renamed node went, so the cached
+position is carried across to the new id and the camera stays put. The Python
+half is tested here; the component half is pinned at the source level, the way
+test_viz_camera_hold.py pins the invariant it builds on.
+"""
+
+from pathlib import Path
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import app
+
+NS = "http://test.org/ont#"
+
+_VIEWER = (
+    Path(__file__).resolve().parent.parent
+    / "orionbelt_ontology_builder"
+    / "lib"
+    / "graph_viewer"
+    / "index.html"
+)
+
+
+@pytest.fixture
+def session(monkeypatch):
+    state: dict = {}
+    monkeypatch.setattr(app.st, "session_state", state)
+    return state
+
+
+def _id(name):
+    return app.viz_node_id("class", NS + name)
+
+
+# --- the map the component is given -----------------------------------------
+
+
+def test_no_renames_is_an_empty_map(session):
+    """Every render but the one right after a rename."""
+    assert app.viz_rename_map(None) == {}
+    assert app.viz_rename_map({}) == {}
+
+
+def test_a_rename_maps_the_old_node_id_to_the_new_one(session):
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+
+    assert app.viz_rename_map(session["_viz_pending_renames"]) == {
+        _id("Person"): _id("Human")
+    }
+
+
+def test_a_chain_of_renames_collapses_to_one_hop(session):
+    """The notes are left one rename at a time, but the component applies a
+    single hop per id — an intermediate name is not where the node ended up."""
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+    app.viz_note_rename("class", NS + "Human", NS + "Being")
+
+    assert app.viz_rename_map(session["_viz_pending_renames"]) == {
+        _id("Person"): _id("Being"),
+        _id("Human"): _id("Being"),
+    }
+
+
+def test_a_rename_back_to_the_old_name_carries_nothing(session):
+    """Renamed and renamed back before the next render: the node is under the
+    id it already had, so there is nothing to move. An id mapped to itself would
+    tell the component the node set changed when it did not."""
+    app.viz_note_rename("class", NS + "Person", NS + "Human")
+    app.viz_note_rename("class", NS + "Human", NS + "Person")
+
+    assert app.viz_rename_map(session["_viz_pending_renames"]) == {}
+
+
+def test_the_map_is_in_node_ids_not_uris(session):
+    """Individuals and properties carry a prefix; the component matches against
+    the ids the graph actually uses."""
+    app.viz_note_rename("individual", NS + "alice", NS + "alicia")
+
+    assert app.viz_rename_map(session["_viz_pending_renames"]) == {
+        app.viz_node_id("individual", NS + "alice"): app.viz_node_id(
+            "individual", NS + "alicia"
+        )
+    }
+
+
+# --- the render actually hands it over ---------------------------------------
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app as _app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Person")
+        om.add_class("Organization")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["_viz_settings_restored"] = True
+    if st.session_state.pop("_test_rename", False):
+        om = st.session_state.ontology
+        old_uri = next(c["uri"] for c in om.get_classes() if c["name"] == "Person")
+        om.rename_class(old_uri, "Human")
+        new_uri = next(c["uri"] for c in om.get_classes() if c["name"] == "Human")
+        _app.viz_note_rename("class", old_uri, new_uri)
+        st.session_state["_test_renamed"] = (old_uri, new_uri)
+    _app.render_visualization()
+
+
+@pytest.fixture
+def graph_args(monkeypatch):
+    """Capture the kwargs the page hands the graph component."""
+    seen: list[dict] = []
+
+    def _declare(name, path=None, **kwargs):
+        def _component(**call_kwargs):
+            seen.append(call_kwargs)
+
+        return _component
+
+    monkeypatch.setattr("streamlit.components.v1.declare_component", _declare)
+    return seen
+
+
+def _run(at):
+    """Run the page again. A single-select ``st.segmented_control`` reads back
+    as a plain string, which Streamlit refuses when replaying widget state, so
+    each button group is handed the list form first (see
+    test_viz_new_class_hidden.py)."""
+    for group in at.get("button_group"):
+        value = group.value
+        if not isinstance(value, list):
+            group.set_value([value])
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    return at
+
+
+def test_an_ordinary_render_carries_no_renames(graph_args):
+    at = AppTest.from_function(_script, default_timeout=300).run(timeout=300)
+    assert not at.exception, at.exception
+
+    assert graph_args, "the graph component was never rendered"
+    assert graph_args[-1]["renames"] == "{}"
+
+
+def test_the_render_after_a_rename_carries_where_the_node_went(graph_args):
+    import json
+
+    at = AppTest.from_function(_script, default_timeout=300).run(timeout=300)
+    assert not at.exception, at.exception
+    at.session_state["_test_rename"] = True
+    _run(at)
+
+    old_uri, new_uri = at.session_state["_test_renamed"]
+    assert json.loads(graph_args[-1]["renames"]) == {
+        app.viz_node_id("class", old_uri): app.viz_node_id("class", new_uri)
+    }
+
+
+# --- the component half ------------------------------------------------------
+
+
+def _viewer() -> str:
+    return _VIEWER.read_text(encoding="utf-8")
+
+
+def test_the_viewer_carries_a_renamed_node_position_to_its_new_id():
+    """Without the carry the renamed node is placed afresh by physics, and the
+    cached layout is one node short of the graph it is restoring."""
+    src = _viewer()
+    start = src.index("var _renames = {};")
+    block = src[start : src.index("var usedSaved = false;", start)]
+    assert "JSON.parse(args.renames" in block, "the viewer ignores the rename map"
+    assert "_raw.pos[newId] = _raw.pos[oldId]" in block, (
+        "the cached position is not moved to the id the node now has"
+    )
+    assert "delete _raw.pos[oldId]" in block, (
+        "the old id is left behind, so the cache no longer matches the graph"
+    )
+    assert "sessionStorage.setItem('viz_pos'" in block, (
+        "the rewritten cache is not persisted, so a re-mount reads the old ids"
+    )
+
+
+def test_a_rename_render_holds_the_camera():
+    """Anything else keyed off the old URI — the entity's annotation nodes —
+    also comes back under a new id, so the "nothing went away" test fails even
+    with the position carried. A rename is still the same graph, so hold."""
+    src = _viewer()
+    start = src.index("// Same render generation but a changed node set")
+    branch = src[start : src.index("var nodes = new vis.DataSet", start)]
+    assert "_hold = !!savedView && (_keptAll || _carried)" in branch, (
+        "a rename render still lets vis re-frame the whole graph"
+    )


### PR DESCRIPTION
Closes #329
Closes #330

## #329 - renaming zoomed the graph out

A rename mints a new URI, and a graph node is keyed by a hash of that URI, so the layout cache read the rename as "one node went away, a stranger arrived". That failed the "nothing went away" test added for #314, and vis re-framed the whole graph: renaming a class at scale 2.4 dropped the view back to 1.0, zooming out of the very thing being renamed.

The render already knows about renames (the note left for #275, used to keep the focus seeds pointed at the entity). It now hands that to the graph component too, flattened to one hop per id, and the component:

- moves the renamed node's cached position over to the id it now has, and recomputes the cache hash over the same key set it was first taken from, so a render whose only change is the rename lands on the exact-restore path;
- holds the camera for a render that carried a rename. Anything else keyed off the old URI, such as the entity's annotation nodes, comes back under a new id too and would fail the same test even with the position carried.

## #330 - the `Relation updated` banner moved the window

A flash message is drawn above the whole page body, so a confirmation for an edit made further down (the details panel, a row editor near the bottom of a long list) inserted a banner at the top and pushed everything the user was looking at out from under the cursor.

`set_flash_message` takes a `toast` flag, and the confirmations that say only that the edit landed float over the page instead: relation, restriction and annotation updates, and the panel deletes. Messages worth reading twice keep their banner - a bulk-add summary names every row that failed (#114), and an error has to outlive a toast.

## Verified in the running app

Sample ontology, Visualization page, class renamed from the details panel at scale 2.4:

| | before | after |
| --- | --- | --- |
| scale after rename | 1.0 (full re-frame) | 2.4 |
| renamed node position | placed afresh by physics | (-86, 182), where it was |

And on the Relations page, saving a relation edit leaves the `All Relations` heading at the same offset it had, with the confirmation rendered outside the page body.

## Tests

- `tests/test_viz_rename_view_hold.py` - the flattened rename map (single rename, chain, rename-and-back, prefixed node kinds), an AppTest that the page actually hands the map to the component, and source-level pins on the component half alongside the existing `test_viz_camera_hold.py` ones.
- `tests/test_flash_toast.py` - banner vs toast routing, and that the editor confirmations are the ones that float while the "no longer in the ontology" error stays a banner.

Full suite, ruff and mypy are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
