### PR TITLE
feat(viz): "Auto-show new" toggle for the node filter

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -218,6 +218,7 @@ from .ui import (  # noqa: F401
     set_active_language_pack,
     set_flash_message,
     show_message,
+    viz_auto_show_new_toggled,
     viz_drop_focus_seeds,
     viz_filter_changed,
     viz_find_changed,

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -5246,7 +5246,8 @@ def reconcile_filter_selection(
       belongs (issue #194) — unless ``auto_show_new`` says otherwise, in which
       case they are added to a narrowed filter too (issue #326);
     - the rest of the selection is left as-is, so a deliberately emptied filter
-      stays empty (nothing is "new" when the user clears it).
+      stays empty (nothing is "new" when the user clears it), which
+      ``auto_show_new`` does not override.
 
     Auto-adding into a narrowed filter used to be unconditional. It is right for
     the default view and wrong for a curated one: a filter narrowed to a handful
@@ -5296,10 +5297,18 @@ def reconcile_filter_selection(
         selected_set = all_set
     else:
         selected_set = set(selected) & all_set
-        if auto_show_new:
+        if auto_show_new and selected:
             # Everything the previous render had never seen is new, and the
             # setting says new content joins the view rather than queueing up
             # behind "Show new" (issue #326).
+            #
+            # Not into a filter the user cleared, though. Empty is a view too,
+            # and the one auto-add could never be undone from: every entity
+            # created afterwards would walk straight back into it, so there
+            # would be no way to keep an empty canvas while building. Clearing
+            # it stays the deliberate act the rule above describes, and what is
+            # created lands behind "Show new" the way it does with the setting
+            # off.
             selected_set |= all_set - known
     ordered = [u for u in all_uris if u in selected_set]
     return ordered, all_set

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -52,6 +52,7 @@ _VIZ_PERSIST_KEYS = (
     "node_spacing",
     "fit",
     "highlight_issues",
+    "auto_show_new",
     "details_panel",
     "focus_mode",
     "focus_depth",
@@ -620,14 +621,27 @@ def _persist_viz_settings() -> None:
     Gated on an explicit change (the dirty flag set by the settings callbacks),
     not merely on the page rendering: otherwise a cloud reload could write the
     starting defaults back over a saved set before localStorage had answered
-    (PR #142 review P1). No-ops when nothing changed since the last write.
+    (PR #142 review P1).
+
+    Only the disk write is finished by the time this returns, and only it is
+    recorded as saved. The browser one is a component render, and a pass that
+    ends in ``st.rerun()`` is discarded along with everything it drew — which
+    is the usual pass here, because changing a setting often moves the
+    hidden-note count and that recompute reruns the page. Recording it as saved
+    there made the loss permanent: the next pass found the payload already
+    saved and never rendered the component again, so the setting was gone on
+    the next reload. So the browser path re-offers the payload until a pass
+    survives to carry it. The component is keyed by the payload's hash, so
+    those are all the same component writing the same value, not a queue of
+    writes (issue #326: turning "Auto-show new" on takes in what was queued,
+    which moves that count, so the very first use hit this every time).
     """
     if not st.session_state.get("_viz_settings_dirty"):
         return
     payload = _viz_settings_payload()
-    if payload == st.session_state.get("_viz_settings_saved_json"):
-        return
     if local_store.local_persist_enabled():
+        if payload == st.session_state.get("_viz_settings_saved_json"):
+            return
         try:
             cfg = local_store.load_config()
             cfg["viz_settings"] = json.loads(payload)
@@ -635,15 +649,13 @@ def _persist_viz_settings() -> None:
         except OSError as e:
             log_error(e, context="Viz settings save")
             return
-    else:
-        ls = _get_local_storage()
-        if ls is None:
-            return
-        h = _content_hash(payload)
-        ls.setItem(
-            VIZ_SETTINGS_KEY, payload, key=f"orionbelt_viz_settings_set_{h[:12]}"
-        )
-    st.session_state["_viz_settings_saved_json"] = payload
+        st.session_state["_viz_settings_saved_json"] = payload
+        return
+    ls = _get_local_storage()
+    if ls is None:
+        return
+    h = _content_hash(payload)
+    ls.setItem(VIZ_SETTINGS_KEY, payload, key=f"orionbelt_viz_settings_set_{h[:12]}")
 
 
 def custom_language_packs() -> dict[str, list[dict]]:
@@ -1213,6 +1225,36 @@ def viz_filter_changed(kind_key, uri_by_display):
     st.session_state[f"_viz_cfg_selected_{kind_key}_uris"] = [
         uri_by_display[d] for d in picked if d in uri_by_display
     ]
+
+
+def viz_auto_show_new_toggled():
+    """Persist "Auto-show new", and on switching it on let in what is queued.
+
+    The filter may already be holding entities back behind "Show new (N)" when
+    the setting is turned on. Leaving them there would break the half of the
+    promise the user can see: those are precisely the ones it says should have
+    come in. The reconcile cannot do it — by now they are in ``known``, so it no
+    longer reads them as new — so they are folded into the selection here, the
+    same merge the button does.
+
+    Order is not preserved and does not need to be: the next render's
+    :func:`reconcile_filter_selection` returns the selection in entity-list
+    order, and the queued list prunes itself the moment its entries are shown.
+    """
+    viz_sync("_viz_cfg_auto_show_new", "viz_auto_show_new")
+    if not st.session_state.get("_viz_cfg_auto_show_new"):
+        return
+    for kind in _FILTER_KINDS:
+        key = kind["key"]
+        pending = st.session_state.get(f"_viz_new_hidden_{key}") or []
+        if not pending:
+            continue
+        selected = st.session_state.get(f"_viz_cfg_selected_{key}_uris") or []
+        seen = set(selected)
+        st.session_state[f"_viz_cfg_selected_{key}_uris"] = [
+            *selected,
+            *(uri for uri in pending if uri not in seen),
+        ]
 
 
 def focus_seeds_from_selection(selected_classes, class_count):
@@ -5189,7 +5231,9 @@ def follow_filter_renames(all_uris, selected, known, renames, node_kind):
     )
 
 
-def reconcile_filter_selection(all_uris, selected, known, replaced=False):
+def reconcile_filter_selection(
+    all_uris, selected, known, replaced=False, auto_show_new=False
+):
     """Reconcile one Visualization filter's selection with the ontology.
 
     Diffs the current URIs against those seen on the previous render (``known``)
@@ -5199,7 +5243,8 @@ def reconcile_filter_selection(all_uris, selected, known, replaced=False):
     - entities deleted since last render drop out of the selection;
     - entities created since last render are added *only while the filter is
       showing everything*, which is where "new content is shown by default"
-      belongs (issue #194);
+      belongs (issue #194) — unless ``auto_show_new`` says otherwise, in which
+      case they are added to a narrowed filter too (issue #326);
     - the rest of the selection is left as-is, so a deliberately emptied filter
       stays empty (nothing is "new" when the user clears it).
 
@@ -5211,6 +5256,13 @@ def reconcile_filter_selection(all_uris, selected, known, replaced=False):
     ``set(selected) == known`` already means "was showing everything". The
     caller pairs this with :func:`newly_hidden_uris` so a creation that lands
     outside the filter is announced rather than silently dropped.
+
+    Which of the two a user wants turns out to depend on the ontology, not on
+    taste: curating a handful of key classes out of five hundred, a new class
+    forcing its way in is noise; building a small one class by class, being
+    told each time that what you just made is not on the canvas is friction.
+    ``auto_show_new`` is that choice, off by default so the shipped behaviour
+    is unchanged (issue #326).
 
     ``replaced`` marks that the whole ontology was swapped (load/import/new/undo)
     rather than incrementally edited. Diffing must not run then: an unrelated
@@ -5244,6 +5296,11 @@ def reconcile_filter_selection(all_uris, selected, known, replaced=False):
         selected_set = all_set
     else:
         selected_set = set(selected) & all_set
+        if auto_show_new:
+            # Everything the previous render had never seen is new, and the
+            # setting says new content joins the view rather than queueing up
+            # behind "Show new" (issue #326).
+            selected_set |= all_set - known
     ordered = [u for u in all_uris if u in selected_set]
     return ordered, all_set
 

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -56,6 +56,7 @@ from ..ui import (
     prune_reused_focus_seeds,
     reconcile_filter_selection,
     seed_filter_from_saved,
+    viz_auto_show_new_toggled,
     viz_filter_changed,
     viz_find_changed,
     viz_focus_toggle,
@@ -365,6 +366,10 @@ def render_visualization():
             "fit": True,
             "details_panel": False,
             "highlight_issues": False,
+            # Off keeps the shipped behaviour: a narrowed filter is a view the
+            # user built, and a class created afterwards waits behind "Show
+            # new" rather than pushing into it (issues #194, #326).
+            "auto_show_new": False,
             "focus_mode": False,
             "focus_depth": 1,
             "options_open": True,
@@ -534,6 +539,7 @@ def render_visualization():
         node_spacing = _cfg["_viz_cfg_node_spacing"]
         fit = _cfg["_viz_cfg_fit"]
         highlight_issues = _cfg["_viz_cfg_highlight_issues"]
+        auto_show_new = _cfg["_viz_cfg_auto_show_new"]
 
         validation_subjects = set()
         if highlight_issues:
@@ -601,6 +607,7 @@ def render_visualization():
                 _prev_sel,
                 _prev_known,
                 replaced=replaced,
+                auto_show_new=auto_show_new,
             )
             st.session_state[f"_viz_cfg_selected_{_key}_uris"] = _sel_uris
             st.session_state[f"_viz_cfg_known_{_key}_uris"] = _known_uris
@@ -1160,6 +1167,23 @@ def render_visualization():
                                 language=None,
                                 wrap_lines=True,
                             )
+                    # Which behaviour a narrowed filter should have is a
+                    # property of the ontology you are working on, so it is a
+                    # setting rather than a fixed rule (issue #326). It sits
+                    # here, under the "Show new" button it replaces, because
+                    # this is where the behaviour is visible; it governs every
+                    # filterable kind, not just the segment on screen, so the
+                    # label names none of them.
+                    st.checkbox(
+                        "Auto-show new",
+                        key="viz_auto_show_new",
+                        on_change=viz_auto_show_new_toggled,
+                        help="Let entities created from now on join a narrowed "
+                        "filter by themselves, instead of being held back and "
+                        "offered as 'Show new'. Turning it on also lets in "
+                        "whatever is queued there now. Applies to every "
+                        "filterable kind.",
+                    )
                 # Authoritative regardless of which segment is on screen: the
                 # class filter still applies while you are editing another kind.
                 selected_classes = selected_classes_list

--- a/tests/test_viz_auto_show_new.py
+++ b/tests/test_viz_auto_show_new.py
@@ -1,0 +1,211 @@
+"""Choosing whether new entities join a narrowed filter (issue #326).
+
+A narrowed filter is a view the user built, so an entity created afterwards
+waits behind "Show new" rather than pushing into it (issue #194). Which of the
+two is wanted turns out to depend on the ontology rather than on taste: curating
+a handful of key classes out of five hundred, a new class forcing its way in is
+noise; building a small ontology class by class, being told every time that what
+you just made is not on the canvas is friction. "Auto-show new" is that choice.
+
+The default is off, so everything test_viz_new_class_hidden.py pins still holds.
+"""
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import app, ui
+
+NS = "http://test.org/ont#"
+
+
+# --- the reconcile itself ----------------------------------------------------
+
+
+def _uris(*names):
+    return [NS + n for n in names]
+
+
+def test_off_keeps_a_new_entity_out_of_a_narrowed_filter():
+    """Issue #194's behaviour, which stays the default."""
+    selected, known = app.reconcile_filter_selection(
+        _uris("Shown", "Hidden", "Bicycle"),
+        _uris("Shown"),
+        set(_uris("Shown", "Hidden")),
+    )
+    assert selected == _uris("Shown")
+    assert known == set(_uris("Shown", "Hidden", "Bicycle"))
+
+
+def test_on_lets_a_new_entity_into_a_narrowed_filter():
+    selected, _known = app.reconcile_filter_selection(
+        _uris("Shown", "Hidden", "Bicycle"),
+        _uris("Shown"),
+        set(_uris("Shown", "Hidden")),
+        auto_show_new=True,
+    )
+    # In entity-list order, and the class deselected on purpose stays out: only
+    # what the previous render had never seen is let in.
+    assert selected == _uris("Shown", "Bicycle")
+
+
+def test_on_still_drops_what_was_deleted():
+    selected, _known = app.reconcile_filter_selection(
+        _uris("Shown"),
+        _uris("Shown", "Gone"),
+        set(_uris("Shown", "Gone")),
+        auto_show_new=True,
+    )
+    assert selected == _uris("Shown")
+
+
+def test_on_leaves_a_deliberately_emptied_filter_empty():
+    """Nothing is "new" when the user clears the filter, and an empty view is a
+    view — the setting must not quietly refill it."""
+    selected, _known = app.reconcile_filter_selection(
+        _uris("Shown", "Hidden"),
+        [],
+        set(_uris("Shown", "Hidden")),
+        auto_show_new=True,
+    )
+    assert selected == []
+
+
+def test_on_does_not_change_a_replacement():
+    """A load/import/undo shows everything either way."""
+    for auto in (False, True):
+        selected, _known = app.reconcile_filter_selection(
+            _uris("A", "B"),
+            _uris("A"),
+            set(_uris("A", "B")),
+            replaced=True,
+            auto_show_new=auto,
+        )
+        assert selected == _uris("A", "B"), auto
+
+
+# --- switching it on lets in what is already queued --------------------------
+
+
+class _State(dict):
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+
+
+@pytest.fixture
+def session(monkeypatch):
+    state = _State()
+    monkeypatch.setattr(ui.st, "session_state", state)
+    return state
+
+
+def test_switching_it_on_takes_in_what_show_new_was_offering(session):
+    """Those are exactly the entities the setting says should have come in, and
+    the reconcile can no longer see them as new — it has them in ``known``."""
+    session["viz_auto_show_new"] = True
+    session["_viz_cfg_selected_class_uris"] = _uris("Shown")
+    session["_viz_new_hidden_class"] = _uris("Bicycle")
+    session["_viz_cfg_selected_ind_uris"] = _uris("alice")
+    session["_viz_new_hidden_ind"] = _uris("bob")
+
+    app.viz_auto_show_new_toggled()
+
+    assert session["_viz_cfg_auto_show_new"] is True
+    assert set(session["_viz_cfg_selected_class_uris"]) == set(
+        _uris("Shown", "Bicycle")
+    )
+    # Every filterable kind, not just the segment that happened to be on screen.
+    assert set(session["_viz_cfg_selected_ind_uris"]) == set(_uris("alice", "bob"))
+
+
+def test_switching_it_off_changes_no_selection(session):
+    """Off is only a statement about entities created from now on; it must not
+    retract anything already on the canvas."""
+    session["viz_auto_show_new"] = False
+    session["_viz_cfg_selected_class_uris"] = _uris("Shown", "Bicycle")
+    session["_viz_new_hidden_class"] = _uris("Bicycle")
+
+    app.viz_auto_show_new_toggled()
+
+    assert session["_viz_cfg_auto_show_new"] is False
+    assert session["_viz_cfg_selected_class_uris"] == _uris("Shown", "Bicycle")
+
+
+def test_switching_it_on_with_nothing_queued_is_a_no_op(session):
+    session["viz_auto_show_new"] = True
+    session["_viz_cfg_selected_class_uris"] = _uris("Shown")
+
+    app.viz_auto_show_new_toggled()
+
+    assert session["_viz_cfg_selected_class_uris"] == _uris("Shown")
+
+
+def test_a_missing_widget_is_not_read_as_unticked(session):
+    """The page was not rendered, so the callback has nothing to sync — reading
+    the absent key as False would silently turn the setting off (issue #219's
+    failure mode)."""
+    session["_viz_cfg_auto_show_new"] = True
+    app.viz_auto_show_new_toggled()
+    assert session["_viz_cfg_auto_show_new"] is True
+
+
+# --- end to end on the page --------------------------------------------------
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app as _app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Shown")
+        om.add_class("Hidden")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["_viz_settings_restored"] = True
+        uris = [c["uri"] for c in om.get_classes()]
+        st.session_state["_viz_cfg_selected_class_uris"] = [
+            u for u in uris if u.endswith("Shown")
+        ]
+        st.session_state["_viz_cfg_known_class_uris"] = set(uris)
+    if st.session_state.pop("_test_add_class", False):
+        st.session_state.ontology.add_class("Bicycle")
+    _app.render_visualization()
+
+
+def _rerun(at):
+    for group in at.get("button_group"):
+        value = group.value
+        if not isinstance(value, list):
+            group.set_value([value])
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    return at
+
+
+def _selected(at):
+    return [
+        u.rsplit("#", 1)[-1] for u in at.session_state["_viz_cfg_selected_class_uris"]
+    ]
+
+
+def test_the_page_defaults_to_holding_new_classes_back():
+    at = AppTest.from_function(_script).run(timeout=300)
+    assert not at.exception, at.exception
+    assert at.session_state["_viz_cfg_auto_show_new"] is False
+
+
+def test_with_the_setting_on_a_new_class_appears_and_nothing_is_announced():
+    at = AppTest.from_function(_script).run(timeout=300)
+    assert not at.exception, at.exception
+    at.session_state["_viz_cfg_auto_show_new"] = True
+    at.session_state["_test_add_class"] = True
+    _rerun(at)
+
+    assert _selected(at) == ["Bicycle", "Shown"]
+    # Nothing was held back, so there is nothing to say and nothing to offer.
+    assert not [t for t in at.toast if "hidden by your class filter" in t.value]
+    assert not [b for b in at.button if b.label.startswith("Show new")]
+    # The class deselected on purpose is still deselected.
+    assert "Hidden" not in _selected(at)

--- a/tests/test_viz_auto_show_new.py
+++ b/tests/test_viz_auto_show_new.py
@@ -59,15 +59,51 @@ def test_on_still_drops_what_was_deleted():
 
 
 def test_on_leaves_a_deliberately_emptied_filter_empty():
-    """Nothing is "new" when the user clears the filter, and an empty view is a
-    view — the setting must not quietly refill it."""
+    """An empty view is a view, and the one auto-add could never be undone from:
+    every entity created afterwards would walk straight back into it.
+
+    The new entity has to be in ``all_uris`` for this to test anything — with
+    nothing new to add, the setting has no way to refill the filter and the
+    assertion holds whatever the rule is (Codex review of PR #332).
+    """
     selected, _known = app.reconcile_filter_selection(
-        _uris("Shown", "Hidden"),
+        _uris("Shown", "Hidden", "Bicycle"),
         [],
         set(_uris("Shown", "Hidden")),
         auto_show_new=True,
     )
     assert selected == []
+
+
+def test_an_emptied_filter_still_queues_what_was_created():
+    """It degrades to the setting-off behaviour rather than swallowing the
+    creation: "Show new" is still the way in."""
+    all_uris = _uris("Shown", "Hidden", "Bicycle")
+    selected, _known = app.reconcile_filter_selection(
+        all_uris, [], set(_uris("Shown", "Hidden")), auto_show_new=True
+    )
+    assert app.newly_hidden_uris(all_uris, selected, set(_uris("Shown", "Hidden"))) == [
+        NS + "Bicycle"
+    ]
+
+
+def test_taking_the_queue_in_makes_the_filter_non_empty_again():
+    """And then it is a narrowed filter like any other, so the next creation
+    joins it: emptiness is a state, not a permanent opt-out."""
+    selected, known = app.reconcile_filter_selection(
+        _uris("Shown", "Hidden", "Bicycle"),
+        _uris("Bicycle"),
+        set(_uris("Shown", "Hidden", "Bicycle")),
+        auto_show_new=True,
+    )
+    assert selected == _uris("Bicycle")
+    selected, _known = app.reconcile_filter_selection(
+        _uris("Shown", "Hidden", "Bicycle", "Wheel"),
+        selected,
+        known,
+        auto_show_new=True,
+    )
+    assert selected == _uris("Bicycle", "Wheel")
 
 
 def test_on_does_not_change_a_replacement():

--- a/tests/test_viz_settings.py
+++ b/tests/test_viz_settings.py
@@ -25,12 +25,14 @@ class _FakeLS:
     def __init__(self, value=None):
         self._value = value
         self.saved = None
+        self.writes: list = []
 
     def getItem(self, _key):
         return self._value
 
     def setItem(self, _key, value, key=None):
         self.saved = value
+        self.writes.append((value, key))
 
 
 def test_apply_validates_types_and_clamps_ints(monkeypatch, patch_ui):
@@ -151,6 +153,46 @@ def test_browser_dirty_change_is_saved(monkeypatch, patch_ui):
     app._persist_viz_settings()
     assert ls.saved is not None
     assert json.loads(ls.saved)["show_skos"] is False
+
+
+def test_browser_save_is_re_offered_until_a_pass_survives(monkeypatch, patch_ui):
+    """A pass that ends in ``st.rerun()`` is discarded along with everything it
+    drew, and the browser save is a component render — so a save made on such a
+    pass never reaches the browser. Recording it as saved made that permanent:
+    the next pass found nothing to do and the setting was gone on reload. It has
+    to keep being offered (issue #326 hit this on the toggle's very first use,
+    because taking in the queued entities moves the hidden-note count and that
+    recompute reruns the page).
+    """
+    ls = _FakeLS(None)
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
+    patch_ui("_get_local_storage", lambda: ls)
+    state: dict = {"_viz_settings_dirty": True, "_viz_cfg_show_skos": False}
+    monkeypatch.setattr(app.st, "session_state", state)
+
+    app._persist_viz_settings()
+    app._persist_viz_settings()
+
+    assert len(ls.writes) == 2, "the payload was offered once and then dropped"
+    # The same component writing the same value, not a queue of writes: the key
+    # is the payload's hash, so the browser sees one localStorage entry.
+    assert ls.writes[0] == ls.writes[1]
+
+
+def test_disk_save_still_happens_once(monkeypatch, patch_ui, tmp_path):
+    """The disk write is finished by the time it returns, so it keeps its
+    no-op — nothing there can discard it."""
+    cfg_file = tmp_path / "config.json"
+    monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
+    monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
+    state: dict = {"_viz_settings_dirty": True, "_viz_cfg_fit": False}
+    monkeypatch.setattr(app.st, "session_state", state)
+
+    app._persist_viz_settings()
+    assert state["_viz_settings_saved_json"] == json.dumps({"fit": False})
+    first = cfg_file.stat().st_mtime_ns
+    app._persist_viz_settings()
+    assert cfg_file.stat().st_mtime_ns == first
 
 
 def test_restore_defers_to_in_progress_changes(monkeypatch, patch_ui):


### PR DESCRIPTION
Closes #326

## Credit

The line that does the work is @SuperCowProducts', from the last patch in #326:

```python
selected_set = set(selected) & all_set | (all_set - known)
```

This PR keeps that expression and puts it behind a setting, since unconditionally it reverses #194 for everyone. The rest here is the setting, its persistence, the checkbox, and the tests. Commit carries a `Co-authored-by` trailer.

## What changes

A narrowed node filter is a view the user built, so an entity created afterwards waits behind "Show new" rather than pushing into it (#194). @SuperCowProducts' point in #326 is that which behaviour is wanted depends on the ontology rather than on taste: curating a handful of key classes out of five hundred, a new class forcing its way in is noise; building a small ontology class by class, being told every time that what you just made is not on the canvas is friction.

So it becomes a setting: **Auto-show new**, a checkbox in the Node options panel, directly under the "Show new" button it replaces. It governs every filterable kind (classes and individuals), which is why the label names neither.

**Off (the default, so nothing changes for anyone on upgrade):** a new class stays out, the page says so, and the panel offers "Show new (1)".

**On:** entities created from then on join the selection by themselves. Nothing is announced, no button appears. Entities deselected on purpose stay out.

A filter the user *cleared* is the one exception: empty is a view too, and the one auto-add could never be undone from, since every entity created afterwards would walk straight back into it. There, creations queue behind "Show new" the way they do with the setting off. Taking that queue in makes the filter non-empty again, after which the next creation joins it like any other narrowing.

Switching it on also takes in whatever "Show new" was already offering. The reconcile cannot do that for itself: by then those entities are in `known` and no longer read as new, so the toggle's callback folds them in, which is the same merge the button does.

The setting persists across sessions with the other display preferences (#142).

## Live check

Nine classes, filter narrowed to seven, one class (`Saddle`) created while narrowed:

| | off (default) | on |
| --- | --- | --- |
| filter | Classes 7/9 | Classes 8/9 |
| `Saddle` | held back | on the canvas |
| buttons | `Select all (9)` `Show new (1)` `Paste / copy` | `Select all (9)` `Paste / copy` |
| deselected class | still out | still out |

Ticking the box, then reloading the page: it comes back ticked.

## A settings write that could be lost

Turning the toggle on takes in the queued entities, which moves the hidden-note count, and that recompute reruns the page. That surfaced a pre-existing bug in the #142 persistence path.

Only the disk save is finished by the time `_persist_viz_settings` returns. The browser one is a component render, and a pass that ends in `st.rerun()` is discarded along with everything it drew - the same rule the codebase already documents for toasts. Recording it as saved made the loss permanent: the next pass found the payload already saved and never rendered the component again, so the setting was gone on the next reload.

The browser path now re-offers the payload until a pass survives. The component is keyed by the payload's hash, so those are all the same component writing the same value, not a queue of writes. The disk path keeps its no-op, since nothing there can discard it.

This is reachable without the new toggle - any setting change that also moves the hidden note, such as "Focus on one node" - so it is worth having fixed on its own.

## Tests

- `tests/test_viz_auto_show_new.py` - the reconcile with the flag on and off (new entity in, deleted entity out, emptied filter left empty, replacement unaffected), the toggle callback across both filterable kinds, and an end-to-end AppTest of the page in both states.
- `tests/test_viz_settings.py` - the browser save is re-offered until a pass survives, and the disk save still happens once.

Full suite (1621), ruff and mypy are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
