### PR TITLE
docs: acknowledge SuperCowProducts in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,18 @@ Not implemented yet, listed here so it is clear what the workbench does *not* do
 
 An ontology-based MCP server that analyzes relational database schemas (PostgreSQL, Snowflake, Dremio) and generates RDF/OWL ontologies with embedded SQL mappings. Together with the Ontology Builder, they form a toolkit for ontology-driven data modeling.
 
+## Acknowledgements
+
+[@SuperCowProducts](https://github.com/SuperCowProducts) has filed the large
+majority of this project's issue reports, and much of the Visualization page as
+it stands was shaped by them: the node filter, focus mode, the details panel and
+the graph's camera behaviour all came out of their reports. They also wrote the
+filter reconcile that the "Auto-show new" setting turns on
+([#326](https://github.com/ralforion/orionbelt-ontology-builder/issues/326)).
+
+Thanks also to everyone else who files a bug, sends a patch, or tells us what
+does not work.
+
 ## License
 
 Copyright 2025–2026 [RALFORION d.o.o.](https://ralforion.com)


### PR DESCRIPTION
Adds an **Acknowledgements** section above the licence, naming [@SuperCowProducts](https://github.com/SuperCowProducts).

## Why

A `Co-authored-by` trailer (added on #332) does not reach GitHub's contributors list, which is built from commit author and committer only. So nothing in the repository said any of this.

The numbers, checked rather than guessed:

- **92 of this repo's 112 issues** are theirs, 84 already closed.
- **10 of the 12 currently open issues** are theirs.
- Of 19 Visualization issues sampled, **17** are theirs: the node filter (#179, #180, #196, #267), focus mode (#56, #272, #275, #305), the details panel (#222, #312, #313), find and centre (#144, #195, #234), and the graph's camera behaviour (#141, #314, #329).
- The filter reconcile that "Auto-show new" turns on (#326) is their code.

## Note

This does not put them in GitHub's contributors list, and nothing short of rewriting `main` would. The realistic route there is them opening a PR directly, which also settles the CLA under its own terms. Worth inviting on #327 or #328, both small and both theirs.

No code changes. Full suite (1623), ruff and `git diff --check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
