### PR TITLE
feat(viz): a modifier-click on a focused node undoes itself

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -218,6 +218,7 @@ from .ui import (  # noqa: F401
     set_active_language_pack,
     set_flash_message,
     show_message,
+    viz_apply_focus_click,
     viz_auto_show_new_toggled,
     viz_drop_focus_seeds,
     viz_filter_changed,

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1275,11 +1275,11 @@ def focus_seeds_from_selection(selected_classes, class_count):
     return labels
 
 
-def focus_seeds_after_request(seeds, label, replace=False):
+def focus_seeds_after_request(seeds, label, replace=False, focus_on=False):
     """What a modifier-click on a graph node leaves the focus as.
 
-    Returns ``(seeds, focus_on)`` — the new seed list and whether focus mode
-    should still be on.
+    ``focus_on`` is whether focus mode is on *now*; returns ``(seeds, focus_on)``
+    — the new seed list and whether it should be on after the click.
 
     Ctrl/Cmd-click adds the node to whatever is focused already (issue #56),
     which is what building a neighbourhood up out of several nodes needs.
@@ -1289,7 +1289,16 @@ def focus_seeds_after_request(seeds, label, replace=False):
 
     Clicking a node that is *already* focused used to do nothing at all, which
     left no way back out of focus mode except reaching for the checkbox. Each
-    modifier now undoes its own action instead (issue #328):
+    modifier now undoes its own action instead (issue #328), but only while the
+    mode is on: the seeds outlive it on purpose (see the Alt-click note below),
+    so a seed sitting in the list is not the same thing as a node the user can
+    see focused. With the mode off there is nothing on screen to undo, and a
+    modifier-click is what it always was, an instruction to start focusing.
+    Inferring the mode from the seed list instead made Alt-clicking the node you
+    had just left refuse to focus it again, and Ctrl-clicking it drop it from a
+    focus that was not running (Codex review of PR #334).
+
+    While the mode is on:
 
     - Ctrl/Cmd-click adds, so on a node that is already a seed it removes it.
       Taking the last one out leaves nothing to focus on, so the mode goes off
@@ -1309,6 +1318,14 @@ def focus_seeds_after_request(seeds, label, replace=False):
     graph to a class the user never picked.
     """
     seeds = list(seeds or [])
+    if not focus_on:
+        # Nothing running to undo: start the focus. The seeds kept from last
+        # time come back around it, the same restore ticking the checkbox does.
+        if replace:
+            return [label], True
+        if label not in seeds:
+            seeds.append(label)
+        return seeds, True
     if replace:
         if seeds == [label]:
             return seeds, False
@@ -1318,6 +1335,34 @@ def focus_seeds_after_request(seeds, label, replace=False):
         return seeds, bool(seeds)
     seeds.append(label)
     return seeds, True
+
+
+def viz_apply_focus_click(label, replace=False):
+    """Apply a modifier-click on ``label`` to the focus state in session.
+
+    Returns the ``(seeds, focus_on)`` it wrote, so the caller can word the
+    toast. Split out from the page so the state it touches can be tested: the
+    click arrives through the graph component, which does not render under
+    AppTest, so nothing else can reach this path.
+
+    Mode and seeds are written together, never across renders: focus mode with
+    no seeds backfills an arbitrary first label, so a pass through that state
+    would jump the graph to a class nobody picked (issue #328).
+    """
+    seeds = list(st.session_state.get("_viz_cfg_focus_seeds") or [])
+    mode_before = bool(st.session_state.get("_viz_cfg_focus_mode"))
+    seeds, focus_on = focus_seeds_after_request(
+        seeds, label, replace=replace, focus_on=mode_before
+    )
+    st.session_state["_viz_cfg_focus_mode"] = focus_on
+    st.session_state["_viz_cfg_focus_seeds"] = seeds
+    if focus_on != mode_before:
+        # focus_mode is a persisted display setting (#142) and the save is gated
+        # on the dirty flag the widget callbacks set. Switching the mode from the
+        # canvas has to lift the same gate, or what is saved goes stale against
+        # what is on screen (Codex review of PR #334).
+        st.session_state["_viz_settings_dirty"] = True
+    return seeds, focus_on
 
 
 def viz_focus_toggle():

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1276,7 +1276,10 @@ def focus_seeds_from_selection(selected_classes, class_count):
 
 
 def focus_seeds_after_request(seeds, label, replace=False):
-    """The focus seeds a modifier-click in the graph leaves behind.
+    """What a modifier-click on a graph node leaves the focus as.
+
+    Returns ``(seeds, focus_on)`` — the new seed list and whether focus mode
+    should still be on.
 
     Ctrl/Cmd-click adds the node to whatever is focused already (issue #56),
     which is what building a neighbourhood up out of several nodes needs.
@@ -1284,15 +1287,37 @@ def focus_seeds_after_request(seeds, label, replace=False):
     time is the common case, and it otherwise means emptying the picker by hand
     between hops.
 
-    Clicking a node that is already a seed changes nothing either way, rather
-    than duplicating it in the multiselect.
+    Clicking a node that is *already* focused used to do nothing at all, which
+    left no way back out of focus mode except reaching for the checkbox. Each
+    modifier now undoes its own action instead (issue #328):
+
+    - Ctrl/Cmd-click adds, so on a node that is already a seed it removes it.
+      Taking the last one out leaves nothing to focus on, so the mode goes off
+      with it.
+    - Alt-click sets the focus to exactly one node, so on a node that is
+      *already* the only seed it turns the mode off. The seeds are kept, so
+      switching focus back on returns you to where you were (issue #235). On one
+      of several seeds it still means "now just this one", which is a narrowing
+      the user can still want.
+
+    Every behaviour that changes here was a no-op before, so nothing that did
+    something does something else now.
+
+    The mode has to go off in the same breath as the seeds empty, never on a
+    later render: focus mode with no seeds backfills an arbitrary first node
+    (see render_visualization), so passing through that state would jump the
+    graph to a class the user never picked.
     """
-    if replace:
-        return [label]
     seeds = list(seeds or [])
-    if label not in seeds:
-        seeds.append(label)
-    return seeds
+    if replace:
+        if seeds == [label]:
+            return seeds, False
+        return [label], True
+    if label in seeds:
+        seeds.remove(label)
+        return seeds, bool(seeds)
+    seeds.append(label)
+    return seeds, True
 
 
 def viz_focus_toggle():

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -2311,19 +2311,26 @@ def render_visualization():
                     _focus_label = _id_to_label.get(selection.get("nodeId"))
                     if _focus_label:
                         _replace = bool(selection.get("replace"))
-                        st.session_state["_viz_cfg_focus_mode"] = True
-                        st.session_state["_viz_cfg_focus_seeds"] = (
-                            focus_seeds_after_request(
-                                st.session_state.get("_viz_cfg_focus_seeds"),
-                                _focus_label,
-                                replace=_replace,
+                        _was = list(st.session_state.get("_viz_cfg_focus_seeds") or [])
+                        _seeds, _focus_on = focus_seeds_after_request(
+                            _was, _focus_label, replace=_replace
+                        )
+                        # Both together, never across renders: focus mode with
+                        # no seeds backfills an arbitrary first node further up,
+                        # so a pass through that state would jump the graph to a
+                        # class nobody picked (issue #328).
+                        st.session_state["_viz_cfg_focus_mode"] = _focus_on
+                        st.session_state["_viz_cfg_focus_seeds"] = _seeds
+                        if not _focus_on:
+                            _note = "Focus off"
+                        elif _focus_label not in _seeds:
+                            # Ctrl/Cmd-click took it out and left others behind.
+                            _note = f"Dropped {_focus_label} from the focus"
+                        else:
+                            _note = f"Focusing on {_focus_label}" + (
+                                " only" if _replace else ""
                             )
-                        )
-                        st.toast(
-                            f"Focusing on {_focus_label}"
-                            + (" only" if _replace else ""),
-                            icon="🎯",
-                        )
+                        st.toast(_note, icon="🎯")
                         st.rerun()
                     else:
                         st.toast(

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -41,7 +41,6 @@ from ..ui import (
     build_filter_entries,
     build_focus_seed_entries,
     filter_entry_token,
-    focus_seeds_after_request,
     focus_seeds_from_selection,
     follow_filter_renames,
     follow_focus_seed_renames,
@@ -56,6 +55,7 @@ from ..ui import (
     prune_reused_focus_seeds,
     reconcile_filter_selection,
     seed_filter_from_saved,
+    viz_apply_focus_click,
     viz_auto_show_new_toggled,
     viz_filter_changed,
     viz_find_changed,
@@ -2311,16 +2311,9 @@ def render_visualization():
                     _focus_label = _id_to_label.get(selection.get("nodeId"))
                     if _focus_label:
                         _replace = bool(selection.get("replace"))
-                        _was = list(st.session_state.get("_viz_cfg_focus_seeds") or [])
-                        _seeds, _focus_on = focus_seeds_after_request(
-                            _was, _focus_label, replace=_replace
+                        _seeds, _focus_on = viz_apply_focus_click(
+                            _focus_label, replace=_replace
                         )
-                        # Both together, never across renders: focus mode with
-                        # no seeds backfills an arbitrary first node further up,
-                        # so a pass through that state would jump the graph to a
-                        # class nobody picked (issue #328).
-                        st.session_state["_viz_cfg_focus_mode"] = _focus_on
-                        st.session_state["_viz_cfg_focus_seeds"] = _seeds
                         if not _focus_on:
                             _note = "Focus off"
                         elif _focus_label not in _seeds:

--- a/tests/test_viz_focus_click.py
+++ b/tests/test_viz_focus_click.py
@@ -1,53 +1,93 @@
-"""What a modifier-click on a graph node does to the focus seeds.
+"""What a modifier-click on a graph node does to the focus.
 
 Ctrl/Cmd-click adds the node to the focus (issue #56); Alt-click focuses on it
-alone (issue #276), because wanting one node at a time is the common case and
-it otherwise means emptying the picker by hand between hops.
+alone (issue #276), because wanting one node at a time is the common case and it
+otherwise means emptying the picker by hand between hops.
+
+Clicking a node that is *already* focused used to do nothing at all, leaving no
+way out of focus mode except the checkbox. Each modifier now undoes its own
+action (issue #328): ctrl/cmd-click removes what it would have added, alt-click
+switches the mode off when the focus is already exactly that node. Every case
+that changed was a no-op before.
 """
 
 from orionbelt_ontology_builder import app
 
+PERSON = "Class: Person"
+ORG = "Class: Org"
+ROLE = "Class: Role"
+
+
+# --- what each modifier does on a node that is not focused yet ---------------
+
 
 def test_ctrl_click_adds_to_what_is_already_focused():
     """Building a neighbourhood up out of several nodes."""
-    assert app.focus_seeds_after_request(["Class: Person"], "Class: Org") == [
-        "Class: Person",
-        "Class: Org",
-    ]
+    assert app.focus_seeds_after_request([PERSON], ORG) == ([PERSON, ORG], True)
 
 
 def test_alt_click_focuses_on_that_node_alone():
     """The point of issue #276."""
-    assert app.focus_seeds_after_request(
-        ["Class: Person", "Class: Org"], "Class: Role", replace=True
-    ) == ["Class: Role"]
-
-
-def test_ctrl_clicking_a_node_that_is_already_focused_changes_nothing():
-    """Not a duplicate entry in the multiselect."""
-    seeds = ["Class: Person", "Class: Org"]
-    assert app.focus_seeds_after_request(seeds, "Class: Person") == seeds
-
-
-def test_alt_clicking_the_only_focused_node_changes_nothing():
-    """Idempotent, so hopping back onto the node you are on is not a special
-    case the caller has to think about."""
-    assert app.focus_seeds_after_request(["Class: Person"], "Class: Person", True) == [
-        "Class: Person"
-    ]
+    assert app.focus_seeds_after_request([PERSON, ORG], ROLE, replace=True) == (
+        [ROLE],
+        True,
+    )
 
 
 def test_a_first_click_starts_the_focus_either_way():
     """Nothing focused yet, whichever modifier switched the mode on."""
-    assert app.focus_seeds_after_request(None, "Class: Person") == ["Class: Person"]
-    assert app.focus_seeds_after_request([], "Class: Person", replace=True) == [
-        "Class: Person"
-    ]
+    assert app.focus_seeds_after_request(None, PERSON) == ([PERSON], True)
+    assert app.focus_seeds_after_request([], PERSON, replace=True) == ([PERSON], True)
+
+
+# --- and on a node that is already focused (issue #328) ----------------------
+
+
+def test_ctrl_clicking_a_focused_node_drops_it():
+    """Ctrl/cmd-click adds, so on a node it already added it takes it back out.
+    The others stay, and the mode stays on with them."""
+    assert app.focus_seeds_after_request([PERSON, ORG], PERSON) == ([ORG], True)
+
+
+def test_ctrl_clicking_the_last_focused_node_turns_the_mode_off():
+    """Nothing left to focus on. The mode has to go off in the same breath: with
+    it on and no seeds, the page backfills an arbitrary first node, so the graph
+    would jump to a class nobody picked."""
+    assert app.focus_seeds_after_request([PERSON], PERSON) == ([], False)
+
+
+def test_alt_clicking_the_only_focused_node_turns_the_mode_off():
+    """Alt-click sets the focus to exactly one node, so on the node it is
+    already set to, it is the way back out."""
+    assert app.focus_seeds_after_request([PERSON], PERSON, replace=True) == (
+        [PERSON],
+        False,
+    )
+
+
+def test_the_alt_click_exit_keeps_the_seeds():
+    """So switching focus back on returns you where you were, rather than to a
+    node derived from the class selection (issue #235)."""
+    seeds, focus_on = app.focus_seeds_after_request([PERSON], PERSON, replace=True)
+    assert (seeds, focus_on) == ([PERSON], False)
+
+
+def test_alt_clicking_one_of_several_still_narrows():
+    """Not an exit: the focus is not already *exactly* that node, so "now just
+    this one" is still what the user asked for and still what they get."""
+    assert app.focus_seeds_after_request([PERSON, ORG], PERSON, replace=True) == (
+        [PERSON],
+        True,
+    )
+
+
+# --- and the invariant that made this safe to change -------------------------
 
 
 def test_the_caller_s_list_is_not_mutated():
-    """The seeds come out of session state; adding to that list in place would
-    edit the stored value before the assignment that is meant to."""
-    seeds = ["Class: Person"]
-    app.focus_seeds_after_request(seeds, "Class: Org")
-    assert seeds == ["Class: Person"]
+    """The seeds come out of session state; editing that list in place would
+    change the stored value before the assignment that is meant to."""
+    seeds = [PERSON, ORG]
+    app.focus_seeds_after_request(seeds, ORG)
+    app.focus_seeds_after_request(seeds, PERSON, replace=True)
+    assert seeds == [PERSON, ORG]

--- a/tests/test_viz_focus_click.py
+++ b/tests/test_viz_focus_click.py
@@ -11,7 +11,9 @@ switches the mode off when the focus is already exactly that node. Every case
 that changed was a no-op before.
 """
 
-from orionbelt_ontology_builder import app
+import pytest
+
+from orionbelt_ontology_builder import app, ui
 
 PERSON = "Class: Person"
 ORG = "Class: Org"
@@ -23,15 +25,17 @@ ROLE = "Class: Role"
 
 def test_ctrl_click_adds_to_what_is_already_focused():
     """Building a neighbourhood up out of several nodes."""
-    assert app.focus_seeds_after_request([PERSON], ORG) == ([PERSON, ORG], True)
+    assert app.focus_seeds_after_request([PERSON], ORG, focus_on=True) == (
+        [PERSON, ORG],
+        True,
+    )
 
 
 def test_alt_click_focuses_on_that_node_alone():
     """The point of issue #276."""
-    assert app.focus_seeds_after_request([PERSON, ORG], ROLE, replace=True) == (
-        [ROLE],
-        True,
-    )
+    assert app.focus_seeds_after_request(
+        [PERSON, ORG], ROLE, replace=True, focus_on=True
+    ) == ([ROLE], True)
 
 
 def test_a_first_click_starts_the_focus_either_way():
@@ -46,39 +50,77 @@ def test_a_first_click_starts_the_focus_either_way():
 def test_ctrl_clicking_a_focused_node_drops_it():
     """Ctrl/cmd-click adds, so on a node it already added it takes it back out.
     The others stay, and the mode stays on with them."""
-    assert app.focus_seeds_after_request([PERSON, ORG], PERSON) == ([ORG], True)
+    assert app.focus_seeds_after_request([PERSON, ORG], PERSON, focus_on=True) == (
+        [ORG],
+        True,
+    )
 
 
 def test_ctrl_clicking_the_last_focused_node_turns_the_mode_off():
     """Nothing left to focus on. The mode has to go off in the same breath: with
     it on and no seeds, the page backfills an arbitrary first node, so the graph
     would jump to a class nobody picked."""
-    assert app.focus_seeds_after_request([PERSON], PERSON) == ([], False)
+    assert app.focus_seeds_after_request([PERSON], PERSON, focus_on=True) == ([], False)
 
 
 def test_alt_clicking_the_only_focused_node_turns_the_mode_off():
     """Alt-click sets the focus to exactly one node, so on the node it is
     already set to, it is the way back out."""
-    assert app.focus_seeds_after_request([PERSON], PERSON, replace=True) == (
-        [PERSON],
-        False,
-    )
+    assert app.focus_seeds_after_request(
+        [PERSON], PERSON, replace=True, focus_on=True
+    ) == ([PERSON], False)
 
 
 def test_the_alt_click_exit_keeps_the_seeds():
     """So switching focus back on returns you where you were, rather than to a
     node derived from the class selection (issue #235)."""
-    seeds, focus_on = app.focus_seeds_after_request([PERSON], PERSON, replace=True)
+    seeds, focus_on = app.focus_seeds_after_request(
+        [PERSON], PERSON, replace=True, focus_on=True
+    )
     assert (seeds, focus_on) == ([PERSON], False)
 
 
 def test_alt_clicking_one_of_several_still_narrows():
     """Not an exit: the focus is not already *exactly* that node, so "now just
     this one" is still what the user asked for and still what they get."""
-    assert app.focus_seeds_after_request([PERSON, ORG], PERSON, replace=True) == (
+    assert app.focus_seeds_after_request(
+        [PERSON, ORG], PERSON, replace=True, focus_on=True
+    ) == ([PERSON], True)
+
+
+# --- with the mode off, a click just starts focusing (Codex review of #334) --
+
+
+def test_alt_clicking_the_node_you_just_left_focuses_it_again():
+    """The Alt-click exit keeps the seed, so the seed list still says
+    "Person" while the mode is off. Reading focus from the seeds made the
+    obvious next click refuse to do anything."""
+    assert app.focus_seeds_after_request(
+        [PERSON], PERSON, replace=True, focus_on=False
+    ) == ([PERSON], True)
+
+
+def test_ctrl_clicking_a_retained_seed_with_the_mode_off_focuses_it():
+    """Not a removal: there is no focus on screen for it to be the undo of."""
+    assert app.focus_seeds_after_request([PERSON], PERSON, focus_on=False) == (
         [PERSON],
         True,
     )
+
+
+def test_ctrl_clicking_with_the_mode_off_keeps_the_seeds_it_finds():
+    """Turning focus back on from the canvas restores what was kept, the same
+    way ticking the checkbox does (issue #235), and adds the node clicked."""
+    assert app.focus_seeds_after_request([PERSON], ORG, focus_on=False) == (
+        [PERSON, ORG],
+        True,
+    )
+
+
+def test_alt_clicking_with_the_mode_off_still_means_only_this_one():
+    assert app.focus_seeds_after_request(
+        [PERSON, ORG], ROLE, replace=True, focus_on=False
+    ) == ([ROLE], True)
 
 
 # --- and the invariant that made this safe to change -------------------------
@@ -88,6 +130,68 @@ def test_the_caller_s_list_is_not_mutated():
     """The seeds come out of session state; editing that list in place would
     change the stored value before the assignment that is meant to."""
     seeds = [PERSON, ORG]
-    app.focus_seeds_after_request(seeds, ORG)
-    app.focus_seeds_after_request(seeds, PERSON, replace=True)
+    app.focus_seeds_after_request(seeds, ORG, focus_on=True)
+    app.focus_seeds_after_request(seeds, PERSON, replace=True, focus_on=True)
     assert seeds == [PERSON, ORG]
+
+
+# --- and what the page writes when that click arrives ------------------------
+
+
+class _State(dict):
+    """Stand-in for ``st.session_state``, which is read and written both ways."""
+
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+
+
+@pytest.fixture
+def session(monkeypatch):
+    state = _State()
+    monkeypatch.setattr(ui.st, "session_state", state)
+    return state
+
+
+def test_the_click_writes_the_mode_and_the_seeds_together(session):
+    """Never one render apart: focus mode with no seeds backfills an arbitrary
+    first label, so the graph would jump to a class nobody picked."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+
+    seeds, focus_on = ui.viz_apply_focus_click(PERSON)
+
+    assert (seeds, focus_on) == ([], False)
+    assert session["_viz_cfg_focus_seeds"] == []
+    assert session["_viz_cfg_focus_mode"] is False
+
+
+def test_switching_the_mode_from_the_canvas_marks_the_settings_dirty(session):
+    """focus_mode is persisted (#142) and the save is gated on that flag, which
+    only the widget callbacks used to set. Without it, exiting focus by
+    modifier-click left the saved settings stale across a reload."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+
+    ui.viz_apply_focus_click(PERSON, replace=True)
+
+    assert session["_viz_cfg_focus_mode"] is False
+    assert session["_viz_settings_dirty"] is True
+
+
+def test_turning_the_mode_on_from_the_canvas_marks_it_dirty_too(session):
+    session["_viz_cfg_focus_mode"] = False
+    ui.viz_apply_focus_click(PERSON)
+    assert session["_viz_cfg_focus_mode"] is True
+    assert session["_viz_settings_dirty"] is True
+
+
+def test_a_click_that_leaves_the_mode_alone_does_not_mark_it_dirty(session):
+    """Adding a second seed changes the seeds, which are saved against the
+    linked file rather than with the display settings."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+
+    ui.viz_apply_focus_click(ORG)
+
+    assert session["_viz_cfg_focus_seeds"] == [PERSON, ORG]
+    assert "_viz_settings_dirty" not in session


### PR DESCRIPTION
Closes #328

Ctrl/Cmd-click adds a node to the focus (#56) and Alt-click focuses on it alone (#276), but clicking a node that was *already* focused did nothing at all, so there was no way out of focus mode except reaching for the checkbox.

## The rule

Each modifier undoes its own action. Only the bold cells change, and **every one of them was a no-op before**, so nothing that did something now does something else.

| | not a seed | one of several seeds | the only seed |
| --- | --- | --- | --- |
| **Ctrl/Cmd-click** (*add*) | add, mode on | **remove it** | **remove it, mode off** |
| **Alt-click** (*set to exactly this*) | focus on it alone | focus on it alone | **mode off, seeds kept** |

Alt-click is deliberately not a general toggle. It is a statement of the target state rather than an accumulate, so turning it into one outside the already-exactly-this-node case would make the outcome depend on state the user cannot see. In the one case it does fire, the graph is visibly showing that node's neighbourhood, so which way the click will go is on screen.

The Alt-click exit keeps the seeds, so re-ticking the checkbox returns you where you were (#235: a focus worth setting is worth keeping). The Ctrl-click removal empties them, because you said remove it.

## The trap this had to avoid

`render_visualization` backfills an arbitrary first label when focus mode is on with no seeds:

```python
if not saved_seeds:
    saved_seeds = [focus_labels[0]]
```

So the mode has to go off in the same breath as the seeds empty. Passing through that state on any later render would jump the graph to a class nobody picked. `focus_seeds_after_request` now returns `(seeds, focus_on)` and the caller sets both together.

## Live check

Driven through the component's own click handler in the running app:

| step | focus mode | seeds |
| --- | --- | --- |
| ctrl-click Person | on | Human |
| ctrl-click Organization | on | Human, Organization |
| ctrl-click Human again | on | Organization |
| ctrl-click Organization (last) | **off** | emptied, nothing backfilled |
| alt-click Role | on | Role |
| alt-click Role again | **off** | kept |
| re-tick the checkbox | on | Role |

## Note on the issue

@SuperCowProducts' follow-up comment suggested making ctrl *and* alt per-node toggles, with a keyboard shortcut for the mode. This takes the ctrl half, keeps alt as the "exactly this" gesture for the reason above, and leaves the shortcut to #288 (hotkeys), which is the better home for it.

Tests rewritten in `tests/test_viz_focus_click.py` (9). Full suite (1626), ruff and mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
