### PR TITLE
fix(viz): no more standing in a first entity for an empty focus

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -223,6 +223,7 @@ from .ui import (  # noqa: F401
     viz_drop_focus_seeds,
     viz_filter_changed,
     viz_find_changed,
+    viz_focus_seeds_changed,
     viz_focus_toggle,
     viz_hidden_caption,
     viz_hidden_note_style,

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -227,6 +227,7 @@ from .ui import (  # noqa: F401
     viz_focus_toggle,
     viz_hidden_caption,
     viz_hidden_note_style,
+    viz_leave_empty_focus,
     viz_mark_ontology_seen,
     viz_new_hidden_message,
     viz_node_id,

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -234,6 +234,7 @@ from .ui import (  # noqa: F401
     viz_note_rename,
     viz_ontology_was_replaced,
     viz_rename_map,
+    viz_set_focus_seeds,
     viz_sync,
 )
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1355,7 +1355,7 @@ def viz_apply_focus_click(label, replace=False):
         seeds, label, replace=replace, focus_on=mode_before
     )
     st.session_state["_viz_cfg_focus_mode"] = focus_on
-    st.session_state["_viz_cfg_focus_seeds"] = seeds
+    viz_set_focus_seeds(seeds)
     if focus_on != mode_before:
         # focus_mode is a persisted display setting (#142) and the save is gated
         # on the dirty flag the widget callbacks set. Switching the mode from the
@@ -1389,6 +1389,31 @@ def viz_focus_toggle():
             st.session_state.get("_viz_cfg_selected_classes") or [],
             st.session_state.get("_viz_cfg_class_count") or 0,
         )
+
+
+def viz_set_focus_seeds(seeds) -> None:
+    """Store the focus seeds, keeping the label -> id map to just those.
+
+    That map is what :func:`prune_reused_focus_seeds` compares against to tell a
+    label that has come to name a *different* entity from one that still names
+    the same (issue #180). An entry left behind for a label that is no longer a
+    seed outlives the entity it described: clear the focus, import an ontology
+    that also has a ``Bicycle``, pick it again, and the stale id says it is a
+    different Bicycle, so it is pruned and the focus ends before it starts (the
+    Codex review of PR #336).
+
+    Trimming rather than clearing outright, so the labels that *are* still seeds
+    keep the identity they were last seen under. A seed with no entry is one the
+    user has just picked, which the prune keeps.
+    """
+    seeds = list(seeds or [])
+    st.session_state["_viz_cfg_focus_seeds"] = seeds
+    ids = st.session_state.get("_viz_cfg_focus_seed_ids_by_label")
+    if ids:
+        kept = set(seeds)
+        st.session_state["_viz_cfg_focus_seed_ids_by_label"] = {
+            label: node_id for label, node_id in ids.items() if label in kept
+        }
 
 
 def viz_leave_empty_focus() -> None:
@@ -1439,9 +1464,8 @@ def viz_focus_seeds_changed():
     """
     if _viz_widget_missing("viz_focus_seeds"):
         return
-    seeds = st.session_state["viz_focus_seeds"] or []
-    st.session_state["_viz_cfg_focus_seeds"] = seeds
-    if not seeds:
+    viz_set_focus_seeds(st.session_state["viz_focus_seeds"])
+    if not st.session_state["_viz_cfg_focus_seeds"]:
         viz_leave_empty_focus()
 
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1385,9 +1385,18 @@ def viz_focus_toggle():
     st.session_state["_viz_cfg_focus_mode"] = on
     st.session_state["_viz_settings_dirty"] = True
     if on and not st.session_state.get("_viz_cfg_focus_seeds"):
-        st.session_state["_viz_cfg_focus_seeds"] = focus_seeds_from_selection(
-            st.session_state.get("_viz_cfg_selected_classes") or [],
-            st.session_state.get("_viz_cfg_class_count") or 0,
+        # Forgotten wholesale rather than trimmed: these labels are derived
+        # from the class selection, not picked by the user as seeds, so an id on
+        # file against one describes whatever was loaded before rather than the
+        # entity now carrying that name. Trimming would keep such an entry,
+        # since the label *is* a seed again, and the next prune would drop the
+        # seed as a swapped label (the Codex review of PR #336).
+        st.session_state.pop("_viz_cfg_focus_seed_ids_by_label", None)
+        viz_set_focus_seeds(
+            focus_seeds_from_selection(
+                st.session_state.get("_viz_cfg_selected_classes") or [],
+                st.session_state.get("_viz_cfg_class_count") or 0,
+            )
         )
 
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1391,6 +1391,39 @@ def viz_focus_toggle():
         )
 
 
+def viz_focus_seeds_changed():
+    """Persist the focus seeds, and leave focus mode when the last one goes.
+
+    Focus mode is "show me this node's neighbourhood", so it has nothing to mean
+    with nothing picked. Emptying the picker was undone on the spot by the
+    backfill downstream, which put the first class back in and made the list
+    impossible to clear at all (issue #335). Clearing it now leaves the mode
+    instead, which is where the last Ctrl/Cmd-click on the canvas already lands
+    (issue #328), so both ways out of a focus agree.
+
+    Leaving the mode rather than allowing an empty focus is also what keeps the
+    node cap honest: focus mode is allowed to assemble more nodes than can be
+    drawn only because the prune cuts it back to the seeds' neighbourhood
+    afterwards, and with no seeds nothing prunes (see :func:`graph_node_cap`).
+    An empty focus would have handed the browser the whole ontology, which is
+    the opposite of what clearing the box looks like it should do.
+
+    Switching the mode back on re-derives the seeds from the class selection
+    (see :func:`viz_focus_toggle`), which is the "start over" the request was
+    after.
+    """
+    if _viz_widget_missing("viz_focus_seeds"):
+        return
+    seeds = st.session_state["viz_focus_seeds"] or []
+    st.session_state["_viz_cfg_focus_seeds"] = seeds
+    if not seeds and st.session_state.get("_viz_cfg_focus_mode"):
+        st.session_state["_viz_cfg_focus_mode"] = False
+        # focus_mode is a persisted display setting and the save is gated on the
+        # dirty flag (#142) — the same gate the canvas click had to lift (the
+        # Codex review of PR #334), for the same reason.
+        st.session_state["_viz_settings_dirty"] = True
+
+
 def viz_find_changed():
     """Bump a sequence so the graph re-centres on the picked entity only when the
     Find selection changes — not on every rerun or drag, which would keep yanking

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1391,6 +1391,31 @@ def viz_focus_toggle():
         )
 
 
+def viz_leave_empty_focus() -> None:
+    """Switch focus mode off because there is nothing left to focus on.
+
+    The one landing every route out of a focus shares: the last Ctrl/Cmd-click
+    on the canvas (issue #328), clearing the picker, and a focus whose seeds
+    have all gone — an entity deleted, or its whole type switched off.
+
+    It replaces standing in an arbitrary first entity, which is what made the
+    picker impossible to clear and moved a focus onto a stranger behind the
+    user's back (issue #335). Nothing here picks *for* the user; it just stops
+    pretending a focus is running.
+
+    Also lifts the persisted-settings gate, since ``focus_mode`` is a saved
+    display setting and the save is gated on that flag (#142, and the Codex
+    review of PR #334).
+    """
+    if not st.session_state.get("_viz_cfg_focus_mode"):
+        return
+    st.session_state["_viz_cfg_focus_mode"] = False
+    # The config key only: the next render copies it into the checkbox's widget
+    # key, and writing that here raises once the checkbox has been instantiated
+    # — which it has, by the time the panel below it finds the focus empty.
+    st.session_state["_viz_settings_dirty"] = True
+
+
 def viz_focus_seeds_changed():
     """Persist the focus seeds, and leave focus mode when the last one goes.
 
@@ -1416,12 +1441,8 @@ def viz_focus_seeds_changed():
         return
     seeds = st.session_state["viz_focus_seeds"] or []
     st.session_state["_viz_cfg_focus_seeds"] = seeds
-    if not seeds and st.session_state.get("_viz_cfg_focus_mode"):
-        st.session_state["_viz_cfg_focus_mode"] = False
-        # focus_mode is a persisted display setting and the save is gated on the
-        # dirty flag (#142) — the same gate the canvas click had to lift (the
-        # Codex review of PR #334), for the same reason.
-        st.session_state["_viz_settings_dirty"] = True
+    if not seeds:
+        viz_leave_empty_focus()
 
 
 def viz_find_changed():

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -901,6 +901,9 @@ def render_visualization():
                     # swap back to the node filter; it converges because the
                     # mode is off on the next pass, so this branch is not taken.
                     viz_leave_empty_focus()
+                    # Queued, not raised here: this pass reruns, and a toast
+                    # drawn before a rerun goes with the rest of its output.
+                    st.session_state["_viz_focus_left_note"] = True
                     st.rerun()
                 st.session_state["_viz_cfg_focus_seeds"] = saved_seeds
                 st.session_state["viz_focus_seeds"] = saved_seeds
@@ -2160,6 +2163,17 @@ def render_visualization():
             st.session_state.pop("_viz_new_hidden_announce", None) or []
         ):
             st.toast(_announcement, icon="🙈")
+        # Focus mode ended itself because nothing was left to focus on — the
+        # entity went, its type was switched off, or there was nothing to derive
+        # a first seed from. Silently un-ticking the box is the confusing half of
+        # not standing an arbitrary entity in (issue #335), so say so, and say
+        # what starts a focus instead.
+        if st.session_state.pop("_viz_focus_left_note", False):
+            st.toast(
+                "Focus off: nothing left to focus on. Ctrl/Cmd-click a node to "
+                "start a new one.",
+                icon="🎯",
+            )
         # Say what is being held back, small, right above the canvas: a focus or
         # a narrowed filter is otherwise invisible, and an entity that isn't
         # drawn looks lost rather than filtered (issue #222 follow-up).

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -749,10 +749,16 @@ def render_visualization():
         # render belong to an ontology that has since been swapped out, so drop
         # them before anything reads or persists them.
         if "_viz_cfg_focus_seeds" in st.session_state:
-            st.session_state["_viz_cfg_focus_seeds"] = prune_reused_focus_seeds(
-                st.session_state["_viz_cfg_focus_seeds"],
-                st.session_state.get("_viz_cfg_focus_seed_ids_by_label"),
-                focus_targets,
+            # Through the setter, so an id recorded for a label the prune has
+            # just dropped goes with it. This runs whether or not focus mode is
+            # on, and it is the path that empties the seeds while the mode is
+            # off — where nothing else trims the map (Codex review of PR #336).
+            viz_set_focus_seeds(
+                prune_reused_focus_seeds(
+                    st.session_state["_viz_cfg_focus_seeds"],
+                    st.session_state.get("_viz_cfg_focus_seed_ids_by_label"),
+                    focus_targets,
+                )
             )
 
         # Seeds saved for this linked file are stored as node ids (#164); turn
@@ -770,7 +776,7 @@ def render_visualization():
                 _label_by_id[i] for i in _pending_seed_ids if i in _label_by_id
             ]
             if _restored_seeds:
-                st.session_state["_viz_cfg_focus_seeds"] = _restored_seeds
+                viz_set_focus_seeds(_restored_seeds)
 
         # Find & centre on a specific entity (issue #144). Independent of focus
         # mode: picking an entity here selects and camera-centres it in the graph
@@ -840,9 +846,7 @@ def render_visualization():
                                 st.session_state.get("_viz_cfg_focus_seeds") or []
                             )
                             if _find_choice not in _seeds:
-                                st.session_state["_viz_cfg_focus_seeds"] = _seeds + [
-                                    _find_choice
-                                ]
+                                viz_set_focus_seeds(_seeds + [_find_choice])
                                 _reveal_rerun = True
                         if _reveal_rerun:
                             st.rerun()
@@ -978,7 +982,7 @@ def render_visualization():
                         # page and takes anything drawn on that pass with it.
                         st.session_state["_viz_focus_paste_unknown"] = _funknown
                         if _fpasted:
-                            st.session_state["_viz_cfg_focus_seeds"] = _fpasted
+                            viz_set_focus_seeds(_fpasted)
                             st.rerun()
                         elif not _funknown:
                             st.info("Paste one or more entity names first.")

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -69,6 +69,7 @@ from ..ui import (
     viz_node_id,
     viz_ontology_was_replaced,
     viz_rename_map,
+    viz_set_focus_seeds,
     viz_sync,
 )
 
@@ -897,7 +898,7 @@ def render_visualization():
                 # re-deriving from the class selection, find them invalid again,
                 # and turn straight off — a focus that can never be switched on
                 # again (the Codex review of PR #336).
-                st.session_state["_viz_cfg_focus_seeds"] = saved_seeds
+                viz_set_focus_seeds(saved_seeds)
                 if not saved_seeds:
                     # Nothing left to focus on. This used to stand in an
                     # arbitrary first entity, which is how the picker became

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -59,6 +59,7 @@ from ..ui import (
     viz_auto_show_new_toggled,
     viz_filter_changed,
     viz_find_changed,
+    viz_focus_seeds_changed,
     viz_focus_toggle,
     viz_hidden_caption,
     viz_hidden_note_style,
@@ -905,8 +906,7 @@ def render_visualization():
                         "Focus node(s)",
                         options=focus_labels,
                         key="viz_focus_seeds",
-                        on_change=viz_sync,
-                        args=("_viz_cfg_focus_seeds", "viz_focus_seeds"),
+                        on_change=viz_focus_seeds_changed,
                         help="Classes, individuals or SKOS concepts to centre on. "
                         "The neighbourhood grows from all of them. Starts from "
                         "the classes you had filtered down to, or from one when "

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -63,6 +63,7 @@ from ..ui import (
     viz_focus_toggle,
     viz_hidden_caption,
     viz_hidden_note_style,
+    viz_leave_empty_focus,
     viz_mark_ontology_seen,
     viz_new_hidden_message,
     viz_node_id,
@@ -891,7 +892,16 @@ def render_visualization():
                     )
                 saved_seeds = [s for s in saved_seeds if s in label_set]
                 if not saved_seeds:
-                    saved_seeds = [focus_labels[0]]
+                    # Nothing left to focus on. This used to stand in an
+                    # arbitrary first entity, which is how the picker became
+                    # impossible to clear and how a focus whose entity type was
+                    # switched off silently moved to a stranger (issue #335).
+                    # Leave the mode instead, the one landing every route out of
+                    # a focus now shares (issue #328). Reruns so the panel can
+                    # swap back to the node filter; it converges because the
+                    # mode is off on the next pass, so this branch is not taken.
+                    viz_leave_empty_focus()
+                    st.rerun()
                 st.session_state["_viz_cfg_focus_seeds"] = saved_seeds
                 st.session_state["viz_focus_seeds"] = saved_seeds
                 # Remember what each label resolved to, so the next render can

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -891,6 +891,13 @@ def render_visualization():
                         len(all_class_names),
                     )
                 saved_seeds = [s for s in saved_seeds if s in label_set]
+                # Written before the branch below reruns. Labels that have just
+                # resolved to nothing must not survive as "the seeds to restore":
+                # they are still truthy, so switching focus back on would skip
+                # re-deriving from the class selection, find them invalid again,
+                # and turn straight off — a focus that can never be switched on
+                # again (the Codex review of PR #336).
+                st.session_state["_viz_cfg_focus_seeds"] = saved_seeds
                 if not saved_seeds:
                     # Nothing left to focus on. This used to stand in an
                     # arbitrary first entity, which is how the picker became
@@ -905,7 +912,6 @@ def render_visualization():
                     # drawn before a rerun goes with the rest of its output.
                     st.session_state["_viz_focus_left_note"] = True
                     st.rerun()
-                st.session_state["_viz_cfg_focus_seeds"] = saved_seeds
                 st.session_state["viz_focus_seeds"] = saved_seeds
                 # Remember what each label resolved to, so the next render can
                 # tell a label that has come to name a different entity from one

--- a/tests/test_viz_focus_clear.py
+++ b/tests/test_viz_focus_clear.py
@@ -188,6 +188,44 @@ def test_the_render_says_why_it_ended_the_focus():
     assert "_viz_focus_left_note" not in at.session_state
 
 
+def test_a_focus_ended_by_the_render_can_be_switched_back_on():
+    """The seeds that just resolved to nothing must not survive the exit.
+
+    They are still truthy, so viz_focus_toggle would skip re-deriving from the
+    class selection, the next render would find them invalid again and turn the
+    mode straight back off: a focus that can never be switched on again. The
+    write has to happen before the branch reruns (the Codex review of PR #336).
+    """
+    from streamlit.testing.v1 import AppTest
+
+    def _script():
+        import streamlit as st
+
+        from orionbelt_ontology_builder import app
+        from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+        if "ontology" not in st.session_state:
+            om = OntologyManager()
+            om.add_class("Bicycle")
+            om.add_class("Wheel")
+            st.session_state.ontology = om
+            st.session_state["_autosave_restored"] = True
+            st.session_state["_viz_settings_restored"] = True
+            st.session_state["_local_storage"] = None
+            st.session_state["_viz_cfg_focus_mode"] = True
+            # A seed whose entity is gone: deleted, or its type switched off.
+            st.session_state["_viz_cfg_focus_seeds"] = ["Class: Deleted"]
+        app.render_visualization()
+
+    at = AppTest.from_function(_script).run(timeout=120)
+    assert not at.exception, at.exception
+
+    assert at.session_state["_viz_cfg_focus_mode"] is False
+    assert at.session_state["_viz_cfg_focus_seeds"] == [], (
+        "the labels that resolved to nothing survived as the seeds to restore"
+    )
+
+
 def test_the_render_no_longer_stands_in_a_first_entity():
     """The backfill itself is gone, not merely unreachable from the picker:
     every route to an empty focus now ends the mode instead."""

--- a/tests/test_viz_focus_clear.py
+++ b/tests/test_viz_focus_clear.py
@@ -1,0 +1,122 @@
+"""Clearing the "Focus node(s)" picker leaves focus mode (issue #335).
+
+The picker could not be emptied: with the mode on and no seeds, the render
+backfilled the first class, so pressing Clear all put an arbitrary entity
+straight back. Focus mode is "show me this node's neighbourhood" and has nothing
+to mean with nothing picked, so clearing the last seed now leaves the mode
+instead, which is where the last Ctrl/Cmd-click on the canvas already lands
+(issue #328). Both ways out of a focus agree.
+
+Leaving the mode rather than allowing an empty focus is also what keeps the node
+cap honest (issue #216): focus mode may assemble more nodes than can be drawn
+only because the prune cuts it back afterwards, and with no seeds nothing
+prunes, so an empty focus would draw the whole ontology.
+"""
+
+import pytest
+
+from orionbelt_ontology_builder import ui
+
+PERSON = "Class: Person"
+ORG = "Class: Org"
+
+
+class _State(dict):
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+
+
+@pytest.fixture
+def session(monkeypatch):
+    state = _State()
+    monkeypatch.setattr(ui.st, "session_state", state)
+    return state
+
+
+def test_clearing_the_picker_leaves_focus_mode(session):
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    session["viz_focus_seeds"] = []
+
+    ui.viz_focus_seeds_changed()
+
+    assert session["_viz_cfg_focus_seeds"] == []
+    assert session["_viz_cfg_focus_mode"] is False
+
+
+def test_clearing_the_picker_marks_the_settings_dirty(session):
+    """focus_mode is persisted and the save is dirty-gated, the same gate the
+    canvas click had to lift (the Codex review of PR #334)."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    session["viz_focus_seeds"] = []
+
+    ui.viz_focus_seeds_changed()
+
+    assert session["_viz_settings_dirty"] is True
+
+
+def test_removing_one_of_several_keeps_the_mode(session):
+    """Only the last one out ends the focus."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON, ORG]
+    session["viz_focus_seeds"] = [ORG]
+
+    ui.viz_focus_seeds_changed()
+
+    assert session["_viz_cfg_focus_seeds"] == [ORG]
+    assert session["_viz_cfg_focus_mode"] is True
+    assert "_viz_settings_dirty" not in session
+
+
+def test_picking_seeds_persists_them(session):
+    """The everyday case the old viz_sync callback handled."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    session["viz_focus_seeds"] = [PERSON, ORG]
+
+    ui.viz_focus_seeds_changed()
+
+    assert session["_viz_cfg_focus_seeds"] == [PERSON, ORG]
+    assert session["_viz_cfg_focus_mode"] is True
+
+
+def test_a_missing_widget_is_not_read_as_cleared(session):
+    """The page was not rendered, so there is nothing to sync. Reading the
+    absent key as an empty pick would wipe the seeds and drop the mode
+    (issue #219's failure mode)."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+
+    ui.viz_focus_seeds_changed()
+
+    assert session["_viz_cfg_focus_seeds"] == [PERSON]
+    assert session["_viz_cfg_focus_mode"] is True
+
+
+def test_clearing_with_the_mode_already_off_touches_nothing(session):
+    """Nothing to leave, so nothing to save either."""
+    session["_viz_cfg_focus_mode"] = False
+    session["viz_focus_seeds"] = []
+
+    ui.viz_focus_seeds_changed()
+
+    assert session["_viz_cfg_focus_seeds"] == []
+    assert "_viz_settings_dirty" not in session
+
+
+def test_turning_the_mode_back_on_starts_over_from_the_selection(session):
+    """The "start over" the request asked for: re-ticking the checkbox after a
+    clear derives fresh seeds rather than restoring what was cleared."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    session["viz_focus_seeds"] = []
+    ui.viz_focus_seeds_changed()
+
+    session["_viz_cfg_selected_classes"] = ["Person", "Org"]
+    session["_viz_cfg_class_count"] = 5
+    session["viz_focus_mode"] = True
+    ui.viz_focus_toggle()
+
+    assert session["_viz_cfg_focus_mode"] is True
+    assert session["_viz_cfg_focus_seeds"] == [PERSON, ORG]

--- a/tests/test_viz_focus_clear.py
+++ b/tests/test_viz_focus_clear.py
@@ -305,3 +305,72 @@ def test_a_canvas_click_trims_the_ids_too(session):
 
     assert session["_viz_cfg_focus_seeds"] == []
     assert session["_viz_cfg_focus_seed_ids_by_label"] == {}
+
+
+def test_a_focus_left_off_does_not_poison_the_next_one(session):
+    """The reviewer's route, and the one nothing else trimmed: with the mode
+    off, the render's own prune is what empties the seeds, and the derivation
+    that refills them runs from the checkbox. Both wrote the seeds directly, so
+    the old ids sat there through the whole cycle and pruned the fresh seed."""
+    # Focus was left off with its seeds kept (the Alt-click exit, issue #328).
+    session["_viz_cfg_focus_mode"] = False
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    session["_viz_cfg_focus_seed_ids_by_label"] = {PERSON: "old_uid"}
+
+    # An ontology is loaded in which that label names a different entity, so the
+    # render's prune drops the seed. That write has to take the id with it.
+    ui.viz_set_focus_seeds(
+        ui.prune_reused_focus_seeds(
+            session["_viz_cfg_focus_seeds"],
+            session["_viz_cfg_focus_seed_ids_by_label"],
+            {PERSON: "new_uid"},
+        )
+    )
+    assert session["_viz_cfg_focus_seeds"] == []
+    assert session["_viz_cfg_focus_seed_ids_by_label"] == {}
+
+    # Ticking focus back on derives fresh seeds, which must survive the prune.
+    session["_viz_cfg_selected_classes"] = ["Person"]
+    session["_viz_cfg_class_count"] = 5
+    session["viz_focus_mode"] = True
+    ui.viz_focus_toggle()
+
+    assert session["_viz_cfg_focus_seeds"] == [PERSON]
+    assert ui.prune_reused_focus_seeds(
+        session["_viz_cfg_focus_seeds"],
+        session.get("_viz_cfg_focus_seed_ids_by_label"),
+        {PERSON: "new_uid"},
+    ) == [PERSON]
+
+
+def test_deriving_seeds_drops_ids_left_from_before(session):
+    """The derivation half on its own: what it produces are labels the user has
+    not picked yet, so no identity on file for them can be theirs."""
+    session["_viz_cfg_focus_seeds"] = []
+    session["_viz_cfg_focus_seed_ids_by_label"] = {PERSON: "old_uid"}
+    session["_viz_cfg_selected_classes"] = ["Person"]
+    session["_viz_cfg_class_count"] = 5
+    session["viz_focus_mode"] = True
+
+    ui.viz_focus_toggle()
+
+    assert session["_viz_cfg_focus_seeds"] == [PERSON]
+    assert "_viz_cfg_focus_seed_ids_by_label" not in session
+
+
+def test_every_way_of_storing_focus_seeds_goes_through_the_setter():
+    """Five call sites reached the seeds directly and two of them left the map
+    behind. Pinning it, since the next one added would too."""
+    from pathlib import Path
+
+    pkg = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+    src = (pkg / "ui.py").read_text(encoding="utf-8") + (
+        pkg / "views" / "visualization.py"
+    ).read_text(encoding="utf-8")
+    direct = [
+        line
+        for line in src.splitlines()
+        if '["_viz_cfg_focus_seeds"] =' in line and "viz_set_focus_seeds" not in line
+    ]
+    # The setter itself, and the rename follow, which writes the pair together.
+    assert len(direct) == 1, direct

--- a/tests/test_viz_focus_clear.py
+++ b/tests/test_viz_focus_clear.py
@@ -105,6 +105,29 @@ def test_clearing_with_the_mode_already_off_touches_nothing(session):
     assert "_viz_settings_dirty" not in session
 
 
+def test_a_focus_whose_seeds_have_all_gone_leaves_the_mode(session):
+    """The other route to an empty focus, and the one no callback sees: the
+    entity was deleted, or its whole type was switched off, so the saved labels
+    resolve to nothing on the next render. That used to move the focus onto an
+    arbitrary first entity behind the user's back."""
+    session["_viz_cfg_focus_mode"] = True
+
+    ui.viz_leave_empty_focus()
+
+    assert session["_viz_cfg_focus_mode"] is False
+    assert session["_viz_settings_dirty"] is True
+
+
+def test_leaving_a_focus_that_is_already_off_changes_nothing(session):
+    """So a render that finds no seeds with the mode already off does not
+    keep marking the settings dirty on every pass."""
+    session["_viz_cfg_focus_mode"] = False
+
+    ui.viz_leave_empty_focus()
+
+    assert "_viz_settings_dirty" not in session
+
+
 def test_turning_the_mode_back_on_starts_over_from_the_selection(session):
     """The "start over" the request asked for: re-ticking the checkbox after a
     clear derives fresh seeds rather than restoring what was cleared."""
@@ -120,3 +143,20 @@ def test_turning_the_mode_back_on_starts_over_from_the_selection(session):
 
     assert session["_viz_cfg_focus_mode"] is True
     assert session["_viz_cfg_focus_seeds"] == [PERSON, ORG]
+
+
+def test_the_render_no_longer_stands_in_a_first_entity():
+    """The backfill itself is gone, not merely unreachable from the picker:
+    every route to an empty focus now ends the mode instead."""
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parent.parent
+        / "orionbelt_ontology_builder"
+        / "views"
+        / "visualization.py"
+    ).read_text(encoding="utf-8")
+    assert "focus_labels[0]" not in src, (
+        "an empty focus is being filled with an arbitrary first entity again"
+    )
+    assert "viz_leave_empty_focus()" in src

--- a/tests/test_viz_focus_clear.py
+++ b/tests/test_viz_focus_clear.py
@@ -241,3 +241,67 @@ def test_the_render_no_longer_stands_in_a_first_entity():
         "an empty focus is being filled with an arbitrary first entity again"
     )
     assert "viz_leave_empty_focus()" in src
+
+
+# --- the label -> id map must not outlive the seeds ---------------------------
+
+
+def test_clearing_the_picker_drops_the_recorded_ids(session):
+    """The map is what tells a label that has come to name a different entity
+    from one that still names the same (issue #180). Left behind for a label
+    that is no longer a seed, it outlives the entity it described."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    session["_viz_cfg_focus_seed_ids_by_label"] = {PERSON: "old_uid"}
+    session["viz_focus_seeds"] = []
+
+    ui.viz_focus_seeds_changed()
+
+    assert session["_viz_cfg_focus_seed_ids_by_label"] == {}
+
+
+def test_a_seed_picked_again_after_a_swap_is_not_pruned(session):
+    """The failure the stale map caused: clear the focus, import an ontology
+    that also has a Bicycle, pick it again, and the old id says it is a
+    different Bicycle — so it was pruned and the focus ended before it started
+    (the Codex review of PR #336)."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    session["_viz_cfg_focus_seed_ids_by_label"] = {PERSON: "old_uid"}
+    session["viz_focus_seeds"] = []
+    ui.viz_focus_seeds_changed()
+
+    # The label now resolves to a different entity in the ontology just loaded.
+    kept = ui.prune_reused_focus_seeds(
+        [PERSON],
+        session["_viz_cfg_focus_seed_ids_by_label"],
+        {PERSON: "new_uid"},
+    )
+
+    assert kept == [PERSON]
+
+
+def test_the_ids_of_seeds_that_remain_are_kept(session):
+    """Trimmed, not cleared: a label that is still a seed keeps the identity it
+    was last seen under, so a genuine swap under it is still caught."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON, ORG]
+    session["_viz_cfg_focus_seed_ids_by_label"] = {PERSON: "p_uid", ORG: "o_uid"}
+    session["viz_focus_seeds"] = [ORG]
+
+    ui.viz_focus_seeds_changed()
+
+    assert session["_viz_cfg_focus_seed_ids_by_label"] == {ORG: "o_uid"}
+
+
+def test_a_canvas_click_trims_the_ids_too(session):
+    """The other route that empties the seeds: Ctrl/Cmd-click on the last one
+    (issue #328)."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    session["_viz_cfg_focus_seed_ids_by_label"] = {PERSON: "old_uid"}
+
+    ui.viz_apply_focus_click(PERSON)
+
+    assert session["_viz_cfg_focus_seeds"] == []
+    assert session["_viz_cfg_focus_seed_ids_by_label"] == {}

--- a/tests/test_viz_focus_clear.py
+++ b/tests/test_viz_focus_clear.py
@@ -145,6 +145,49 @@ def test_turning_the_mode_back_on_starts_over_from_the_selection(session):
     assert session["_viz_cfg_focus_seeds"] == [PERSON, ORG]
 
 
+def test_the_render_says_why_it_ended_the_focus():
+    """Un-ticking the box with no explanation is the confusing half of not
+    standing an arbitrary entity in: ticking focus with nothing to derive a
+    first seed from would otherwise just appear not to work.
+
+    Driven through the page rather than asserted at the source, because the note
+    has to survive the reruns between being queued and being raised — the pass
+    that ends the focus reruns, and so does the hidden-note recompute after it,
+    and anything drawn on a pass that reruns goes with it.
+    """
+    from streamlit.testing.v1 import AppTest
+
+    def _script():
+        import streamlit as st
+
+        from orionbelt_ontology_builder import app
+        from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+        if "ontology" not in st.session_state:
+            om = OntologyManager()
+            om.add_class("Bicycle")
+            om.add_class("Wheel")
+            st.session_state.ontology = om
+            st.session_state["_autosave_restored"] = True
+            # Mounting the localStorage component blocks with no browser to
+            # answer it, and ending a focus lifts the save's dirty gate.
+            st.session_state["_viz_settings_restored"] = True
+            st.session_state["_local_storage"] = None
+            st.session_state["_viz_cfg_focus_mode"] = True
+            st.session_state["_viz_cfg_focus_seeds"] = []
+        app.render_visualization()
+
+    at = AppTest.from_function(_script).run(timeout=120)
+    assert not at.exception, at.exception
+
+    assert at.session_state["_viz_cfg_focus_mode"] is False
+    assert [t.value for t in at.toast] == [
+        "Focus off: nothing left to focus on. Ctrl/Cmd-click a node to start a new one."
+    ]
+    # Consumed, so it is not raised again on every later render.
+    assert "_viz_focus_left_note" not in at.session_state
+
+
 def test_the_render_no_longer_stands_in_a_first_entity():
     """The backfill itself is gone, not merely unreachable from the picker:
     every route to an empty focus now ends the mode instead."""

--- a/tests/test_viz_render_matrix.py
+++ b/tests/test_viz_render_matrix.py
@@ -49,8 +49,12 @@ def _script():
         st.session_state.ontology = om
         st.session_state["_autosave_restored"] = True
         # The cross-session restore mounts the localStorage component, which
-        # blocks forever without a browser to answer it.
+        # blocks forever without a browser to answer it. The *save* mounts it
+        # too, and a render can now lift the dirty gate by itself — leaving a
+        # focus whose seeds have all gone (issue #335) — so the handle is nulled
+        # rather than only the restore being skipped.
         st.session_state["_viz_settings_restored"] = True
+        st.session_state["_local_storage"] = None
         for key, value in json.loads(os.environ["VIZ_MATRIX_SETTINGS"]).items():
             if value == "__all__":
                 value = {c["uri"] for c in om.get_classes()}


### PR DESCRIPTION
Closes #335

"Focus node(s)" could not be emptied. With the mode on and no seeds, the render stood in the first class, so Clear all put an arbitrary entity straight back:

```
seeds before Clear all:  ["Class: Bicycle", "Class: Role"]
seeds after  Clear all:  ["Class: Bicycle"]      <- refilled
```

And that was only the visible half. The same backfill fired whenever the saved seeds resolved to nothing on a render: the entity deleted, renamed away, or its whole type switched off. Focus a data property, untick "Data Props", and the focus silently moved onto the first class, from a route no callback sees.

## The change

`focus_labels[0]` is gone. Every route to an empty focus now ends the mode, through one `viz_leave_empty_focus`:

- the last Ctrl/Cmd-click on the canvas (#328, already did this),
- clearing the picker,
- and now the render finding nothing left to focus on.

Nothing picks for the user any more; it just stops pretending a focus is running. Switching the mode back on re-derives from the class selection (`viz_focus_toggle`), which is the "start over" the request was after.

## Why the mode ends rather than an empty focus being allowed

Focus mode with no seeds does not draw nothing today, it draws **everything**:

```python
focus_pruning = bool(focus_mode and focus_seed_ids)
```

and `graph_node_cap` says so outright:

> Going past what can be drawn is only safe because focus mode prunes back to the seeds' neighbourhood afterwards... With the mode on but every seed cleared nothing prunes, and the browser would be handed the lot.

So the backfill was what made that state unreachable and kept the #216 allowance safe. Deleting it alone would have made Clear all dump the whole ontology past the draw cap. Ending the mode keeps the empty-focus state unreachable, so `focus_pruning`, `graph_node_cap` and the #216 allowance are untouched.

## Two implementation notes

`viz_leave_empty_focus` writes only the config key, never the checkbox's widget key. By the time the panel finds the focus empty, the checkbox has been instantiated, and Streamlit raises on a write to an instantiated widget's key; the next render copies config into widget as it always does.

It also lifts the persisted-settings dirty gate, for the same reason the canvas click had to in the review of #334. That has a consequence for tests: the render matrix harness already skipped the cross-session *restore* because mounting the localStorage component blocks with no browser to answer it, and a render can now lift that gate by itself, so the *save* mounts it too. Two matrix cases hung until the harness nulled its localStorage handle.

## Live check, both routes

| | before | after |
| --- | --- | --- |
| Clear all on a sole seed | refilled `Class: Bicycle`, 1 node | focus off, whole graph (13 nodes) |
| focus a data property, untick Data Props | focus moved to `Class: Bicycle` | focus off, whole graph (10 nodes) |

10 tests in `tests/test_viz_focus_clear.py`, verified to fail when the guard is removed. Full suite (1644), ruff and mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
