### PR TITLE
chore: carry the licences for everything this wheel redistributes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
+include THIRD_PARTY_NOTICES.md
 include README.md
 include CLA.md
 include MANIFEST.in

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,61 @@
+# Third-party notices
+
+OrionBelt Ontology Builder is distributed under the [Business Source License 1.1](LICENSE).
+It redistributes the third-party works below. Each is listed with its upstream source, the
+licence it is offered under, and where the licence text lives in this repository.
+
+Licence texts are in `orionbelt_ontology_builder/licenses/`, except where a work already
+carries its own file next to the data (gist and gUFO do). Everything listed here ships in the
+wheel; nothing here is a build-time or development-only dependency.
+
+## Bundled software
+
+| Shipped as | Upstream | Version | Licence | Text |
+|---|---|---|---|---|
+| `orionbelt_ontology_builder/lib/graph_viewer/vis-network.min.js` | [vis-network](https://visjs.github.io/vis-network/) | 9.1.2 | MIT | [`licenses/MIT-vis-network.txt`](orionbelt_ontology_builder/licenses/MIT-vis-network.txt) |
+
+vis-network is offered under Apache-2.0 **or** MIT, at the recipient's choice. We take MIT.
+Copyright (c) 2011-2017 Almende B.V.; (c) 2017-2019 visjs contributors.
+
+## Bundled ontologies and vocabularies
+
+These are sample and reference vocabularies loaded from the Import/Export page. They are
+third-party works redistributed unmodified.
+
+| Shipped as | Upstream | Licence | Text |
+|---|---|---|---|
+| `samples/foaf.rdf` | [FOAF](http://xmlns.com/foaf/spec/) | CC BY 1.0 | [`licenses/CC-BY-1.0.txt`](orionbelt_ontology_builder/licenses/CC-BY-1.0.txt) |
+| `samples/goodrelations.owl` | [GoodRelations](http://purl.org/goodrelations/v1) | CC BY 3.0 | [`licenses/CC-BY-3.0.txt`](orionbelt_ontology_builder/licenses/CC-BY-3.0.txt) |
+| `samples/pizza.owl` | [Stanford/Manchester pizza](https://protege.stanford.edu/ontologies/pizza/pizza.owl) | CC BY 3.0 | [`licenses/CC-BY-3.0.txt`](orionbelt_ontology_builder/licenses/CC-BY-3.0.txt) |
+| `samples/prov-o.ttl` | [W3C PROV-O](https://www.w3.org/TR/prov-o/) | W3C Document License | [`licenses/W3C-Document-License.txt`](orionbelt_ontology_builder/licenses/W3C-Document-License.txt) |
+| `samples/wine.owl` | [W3C OWL Guide](https://www.w3.org/TR/owl-guide/) | W3C Document License | [`licenses/W3C-Document-License.txt`](orionbelt_ontology_builder/licenses/W3C-Document-License.txt) |
+| `samples/gist/*.ttl` | [Semantic Arts gist](https://github.com/semanticarts/gist) | CC BY 4.0 | `samples/gist/LICENSE-CC-BY-4.0.txt` |
+| `samples/gufo/gufo.ttl` | [gUFO](https://nemo-ufes.github.io/gufo/) | CC BY 4.0 | `samples/gufo/LICENSE-CC-BY-4.0.txt` |
+
+Copyright notices, as stated by the works themselves:
+
+- **FOAF** — Copyright © 2000-2014 Dan Brickley and Libby Miller.
+- **GoodRelations** — `dcterms:license` in the file names CC BY 3.0.
+- **pizza.owl** — `dcterms:license` in the file reads "Creative Commons Attribution 3.0 (CC BY 3.0)".
+- **PROV-O** — Copyright © 2011-2013 W3C® (MIT, ERCIM, Keio, Beihang).
+- **wine.owl** — published with the OWL Guide, Copyright © 2004 W3C® (MIT, ERCIM, Keio).
+
+`samples/geography-thesaurus.ttl` and `samples/skos-showcase.ttl` are our own work and are
+covered by this project's licence.
+
+## Where these terms came from
+
+`foaf.rdf`, `prov-o.ttl` and `wine.owl` state no licence inside the file, so their terms are
+taken from the publisher's specification page rather than from the artifact. The FOAF
+specification states CC BY 1.0 directly. PROV-O and the OWL Guide carry the standard W3C
+document-use rules, which is the W3C Document License. The other files state their licence in
+their own metadata, and gist and gUFO ship their licence text alongside the data.
+
+Verified 2026-08-29.
+
+## Python dependencies
+
+Runtime dependencies (streamlit, rdflib, owlrl, networkx, streamlit-local-storage) are
+declared in `pyproject.toml` and installed from PyPI. They are not redistributed here, so
+their licences are not reproduced. That changes if a bundle ever ships them inside an
+artifact, such as the PyInstaller build in issue #54, and this file should be revisited then.

--- a/orionbelt_ontology_builder/licenses/CC-BY-1.0.txt
+++ b/orionbelt_ontology_builder/licenses/CC-BY-1.0.txt
@@ -1,0 +1,193 @@
+Creative Commons Attribution 1.0 Generic (CC BY 1.0)
+https://creativecommons.org/licenses/by/1.0/
+
+Retrieved 2026-08-29 from https://creativecommons.org/licenses/by/1.0/legalcode
+See THIRD_PARTY_NOTICES.md for which bundled files this applies to.
+
+------------------------------------------------------------------------------
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
+COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY
+COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
+AUTHORIZED UNDER THIS LICENSE IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE TO BE
+BOUND BY THE TERMS OF THIS LICENSE. THE LICENSOR GRANTS YOU THE RIGHTS
+CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS.
+
+1. Definitions
+
+  - "Collective Work" means a work, such as a periodical issue, anthology or
+    encyclopedia, in which the Work in its entirety in unmodified form, along
+    with a number of other contributions, constituting separate and
+    independent works in themselves, are assembled into a collective whole. A
+    work that constitutes a Collective Work will not be considered a
+    Derivative Work (as defined below) for the purposes of this License.
+
+  - "Derivative Work" means a work based upon the Work or upon the Work and
+    other pre-existing works, such as a translation, musical arrangement,
+    dramatization, fictionalization, motion picture version, sound recording,
+    art reproduction, abridgment, condensation, or any other form in which the
+    Work may be recast, transformed, or adapted, except that a work that
+    constitutes a Collective Work will not be considered a Derivative Work for
+    the purpose of this License.
+
+  - "Licensor" means the individual or entity that offers the Work under the
+    terms of this License.
+
+  - "Original Author" means the individual or entity who created the Work.
+
+  - "Work" means the copyrightable work of authorship offered under the terms
+    of this License.
+
+  - "You" means an individual or entity exercising rights under this License
+    who has not previously violated the terms of this License with respect to
+    the Work, or who has received express permission from the Licensor to
+    exercise rights under this License despite a previous violation.
+
+2. Fair Use Rights. Nothing in this license is intended to reduce, limit, or
+restrict any rights arising from fair use, first sale or other limitations on
+the exclusive rights of the copyright owner under copyright law or other
+applicable laws.
+
+3. License Grant. Subject to the terms and conditions of this License,
+Licensor hereby grants You a worldwide, royalty-free, non-exclusive, perpetual
+(for the duration of the applicable copyright) license to exercise the rights
+in the Work as stated below:
+
+  - to reproduce the Work, to incorporate the Work into one or more Collective
+    Works, and to reproduce the Work as incorporated in the Collective Works;
+
+  - to create and reproduce Derivative Works;
+
+  - to distribute copies or phonorecords of, display publicly, perform
+    publicly, and perform publicly by means of a digital audio transmission
+    the Work including as incorporated in Collective Works;
+
+  - to distribute copies or phonorecords of, display publicly, perform
+    publicly, and perform publicly by means of a digital audio transmission
+    Derivative Works;
+
+The above rights may be exercised in all media and formats whether now known
+or hereafter devised. The above rights include the right to make such
+modifications as are technically necessary to exercise the rights in other
+media and formats. All rights not expressly granted by Licensor are hereby
+reserved.
+
+4. Restrictions. The license granted in Section 3 above is expressly made
+subject to and limited by the following restrictions:
+
+  - You may distribute, publicly display, publicly perform, or publicly
+    digitally perform the Work only under the terms of this License, and You
+    must include a copy of, or the Uniform Resource Identifier for, this
+    License with every copy or phonorecord of the Work You distribute,
+    publicly display, publicly perform, or publicly digitally perform. You may
+    not offer or impose any terms on the Work that alter or restrict the terms
+    of this License or the recipients' exercise of the rights granted
+    hereunder. You may not sublicense the Work. You must keep intact all
+    notices that refer to this License and to the disclaimer of warranties.
+    You may not distribute, publicly display, publicly perform, or publicly
+    digitally perform the Work with any technological measures that control
+    access or use of the Work in a manner inconsistent with the terms of this
+    License Agreement. The above applies to the Work as incorporated in a
+    Collective Work, but this does not require the Collective Work apart from
+    the Work itself to be made subject to the terms of this License. If You
+    create a Collective Work, upon notice from any Licensor You must, to the
+    extent practicable, remove from the Collective Work any reference to such
+    Licensor or the Original Author, as requested. If You create a Derivative
+    Work, upon notice from any Licensor You must, to the extent practicable,
+    remove from the Derivative Work any reference to such Licensor or the
+    Original Author, as requested.
+
+  - If you distribute, publicly display, publicly perform, or publicly
+    digitally perform the Work or any Derivative Works or Collective Works,
+    You must keep intact all copyright notices for the Work and give the
+    Original Author credit reasonable to the medium or means You are utilizing
+    by conveying the name (or pseudonym if applicable) of the Original Author
+    if supplied; the title of the Work if supplied; in the case of a
+    Derivative Work, a credit identifying the use of the Work in the
+    Derivative Work (e.g., "French translation of the Work by Original
+    Author," or "Screenplay based on original Work by Original Author"). Such
+    credit may be implemented in any reasonable manner; provided, however,
+    that in the case of a Derivative Work or Collective Work, at a minimum
+    such credit will appear where any other comparable authorship credit
+    appears and in a manner at least as prominent as such other comparable
+    authorship credit.
+
+5. Representations, Warranties and Disclaimer
+
+  - By offering the Work for public release under this License, Licensor
+    represents and warrants that, to the best of Licensor's knowledge after
+    reasonable inquiry:
+
+  - Licensor has secured all rights in the Work necessary to grant the license
+    rights hereunder and to permit the lawful exercise of the rights granted
+    hereunder without You having any obligation to pay any royalties,
+    compulsory license fees, residuals or any other payments;
+
+  - The Work does not infringe the copyright, trademark, publicity rights,
+    common law rights or any other right of any third party or constitute
+    defamation, invasion of privacy or other tortious injury to any third
+    party.
+
+  - EXCEPT AS EXPRESSLY STATED IN THIS LICENSE OR OTHERWISE AGREED IN WRITING
+    OR REQUIRED BY APPLICABLE LAW, THE WORK IS LICENSED ON AN "AS IS" BASIS,
+    WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
+    WITHOUT LIMITATION, ANY WARRANTIES REGARDING THE CONTENTS OR ACCURACY OF
+    THE WORK.
+
+6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW,
+AND EXCEPT FOR DAMAGES ARISING FROM LIABILITY TO A THIRD PARTY RESULTING FROM
+BREACH OF THE WARRANTIES IN SECTION 5, IN NO EVENT WILL LICENSOR BE LIABLE TO
+YOU ON ANY LEGAL THEORY FOR ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE
+OR EXEMPLARY DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN
+IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. Termination
+
+  - This License and the rights granted hereunder will terminate automatically
+    upon any breach by You of the terms of this License. Individuals or
+    entities who have received Derivative Works or Collective Works from You
+    under this License, however, will not have their licenses terminated
+    provided such individuals or entities remain in full compliance with those
+    licenses. Sections 1, 2, 5, 6, 7, and 8 will survive any termination of
+    this License.
+
+  - Subject to the above terms and conditions, the license granted here is
+    perpetual (for the duration of the applicable copyright in the Work).
+    Notwithstanding the above, Licensor reserves the right to release the Work
+    under different license terms or to stop distributing the Work at any
+    time; provided, however that any such election will not serve to withdraw
+    this License (or any other license that has been, or is required to be,
+    granted under the terms of this License), and this License will continue
+    in full force and effect unless terminated as stated above.
+
+8. Miscellaneous
+
+  - Each time You distribute or publicly digitally perform the Work or a
+    Collective Work, the Licensor offers to the recipient a license to the
+    Work on the same terms and conditions as the license granted to You under
+    this License.
+
+  - Each time You distribute or publicly digitally perform a Derivative Work,
+    Licensor offers to the recipient a license to the original Work on the
+    same terms and conditions as the license granted to You under this
+    License.
+
+  - If any provision of this License is invalid or unenforceable under
+    applicable law, it shall not affect the validity or enforceability of the
+    remainder of the terms of this License, and without further action by the
+    parties to this agreement, such provision shall be reformed to the minimum
+    extent necessary to make such provision valid and enforceable.
+
+  - No term or provision of this License shall be deemed waived and no breach
+    consented to unless such waiver or consent shall be in writing and signed
+    by the party to be charged with such waiver or consent.
+
+  - This License constitutes the entire agreement between the parties with
+    respect to the Work licensed here. There are no understandings, agreements
+    or representations with respect to the Work not specified here. Licensor
+    shall not be bound by any additional provisions that may appear in any
+    communication from You. This License may not be modified without the
+    mutual written agreement of the Licensor and You.

--- a/orionbelt_ontology_builder/licenses/CC-BY-3.0.txt
+++ b/orionbelt_ontology_builder/licenses/CC-BY-3.0.txt
@@ -1,0 +1,327 @@
+Creative Commons Attribution 3.0 Unported (CC BY 3.0)
+https://creativecommons.org/licenses/by/3.0/
+
+Retrieved 2026-08-29 from https://creativecommons.org/licenses/by/3.0/legalcode.txt
+See THIRD_PARTY_NOTICES.md for which bundled files this applies to.
+
+------------------------------------------------------------------------------
+
+Creative Commons Legal Code
+
+Attribution 3.0 Unported
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS LICENSE DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE INFORMATION PROVIDED, AND DISCLAIMS LIABILITY FOR
+    DAMAGES RESULTING FROM ITS USE.
+
+License
+
+THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS CREATIVE
+COMMONS PUBLIC LICENSE ("CCPL" OR "LICENSE"). THE WORK IS PROTECTED BY
+COPYRIGHT AND/OR OTHER APPLICABLE LAW. ANY USE OF THE WORK OTHER THAN AS
+AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED.
+
+BY EXERCISING ANY RIGHTS TO THE WORK PROVIDED HERE, YOU ACCEPT AND AGREE
+TO BE BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE MAY
+BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS
+CONTAINED HERE IN CONSIDERATION OF YOUR ACCEPTANCE OF SUCH TERMS AND
+CONDITIONS.
+
+1. Definitions
+
+ a. "Adaptation" means a work based upon the Work, or upon the Work and
+    other pre-existing works, such as a translation, adaptation,
+    derivative work, arrangement of music or other alterations of a
+    literary or artistic work, or phonogram or performance and includes
+    cinematographic adaptations or any other form in which the Work may be
+    recast, transformed, or adapted including in any form recognizably
+    derived from the original, except that a work that constitutes a
+    Collection will not be considered an Adaptation for the purpose of
+    this License. For the avoidance of doubt, where the Work is a musical
+    work, performance or phonogram, the synchronization of the Work in
+    timed-relation with a moving image ("synching") will be considered an
+    Adaptation for the purpose of this License.
+ b. "Collection" means a collection of literary or artistic works, such as
+    encyclopedias and anthologies, or performances, phonograms or
+    broadcasts, or other works or subject matter other than works listed
+    in Section 1(f) below, which, by reason of the selection and
+    arrangement of their contents, constitute intellectual creations, in
+    which the Work is included in its entirety in unmodified form along
+    with one or more other contributions, each constituting separate and
+    independent works in themselves, which together are assembled into a
+    collective whole. A work that constitutes a Collection will not be
+    considered an Adaptation (as defined above) for the purposes of this
+    License.
+ c. "Distribute" means to make available to the public the original and
+    copies of the Work or Adaptation, as appropriate, through sale or
+    other transfer of ownership.
+ d. "Licensor" means the individual, individuals, entity or entities that
+    offer(s) the Work under the terms of this License.
+ e. "Original Author" means, in the case of a literary or artistic work,
+    the individual, individuals, entity or entities who created the Work
+    or if no individual or entity can be identified, the publisher; and in
+    addition (i) in the case of a performance the actors, singers,
+    musicians, dancers, and other persons who act, sing, deliver, declaim,
+    play in, interpret or otherwise perform literary or artistic works or
+    expressions of folklore; (ii) in the case of a phonogram the producer
+    being the person or legal entity who first fixes the sounds of a
+    performance or other sounds; and, (iii) in the case of broadcasts, the
+    organization that transmits the broadcast.
+ f. "Work" means the literary and/or artistic work offered under the terms
+    of this License including without limitation any production in the
+    literary, scientific and artistic domain, whatever may be the mode or
+    form of its expression including digital form, such as a book,
+    pamphlet and other writing; a lecture, address, sermon or other work
+    of the same nature; a dramatic or dramatico-musical work; a
+    choreographic work or entertainment in dumb show; a musical
+    composition with or without words; a cinematographic work to which are
+    assimilated works expressed by a process analogous to cinematography;
+    a work of drawing, painting, architecture, sculpture, engraving or
+    lithography; a photographic work to which are assimilated works
+    expressed by a process analogous to photography; a work of applied
+    art; an illustration, map, plan, sketch or three-dimensional work
+    relative to geography, topography, architecture or science; a
+    performance; a broadcast; a phonogram; a compilation of data to the
+    extent it is protected as a copyrightable work; or a work performed by
+    a variety or circus performer to the extent it is not otherwise
+    considered a literary or artistic work.
+ g. "You" means an individual or entity exercising rights under this
+    License who has not previously violated the terms of this License with
+    respect to the Work, or who has received express permission from the
+    Licensor to exercise rights under this License despite a previous
+    violation.
+ h. "Publicly Perform" means to perform public recitations of the Work and
+    to communicate to the public those public recitations, by any means or
+    process, including by wire or wireless means or public digital
+    performances; to make available to the public Works in such a way that
+    members of the public may access these Works from a place and at a
+    place individually chosen by them; to perform the Work to the public
+    by any means or process and the communication to the public of the
+    performances of the Work, including by public digital performance; to
+    broadcast and rebroadcast the Work by any means including signs,
+    sounds or images.
+ i. "Reproduce" means to make copies of the Work by any means including
+    without limitation by sound or visual recordings and the right of
+    fixation and reproducing fixations of the Work, including storage of a
+    protected performance or phonogram in digital form or other electronic
+    medium.
+
+2. Fair Dealing Rights. Nothing in this License is intended to reduce,
+limit, or restrict any uses free from copyright or rights arising from
+limitations or exceptions that are provided for in connection with the
+copyright protection under copyright law or other applicable laws.
+
+3. License Grant. Subject to the terms and conditions of this License,
+Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+perpetual (for the duration of the applicable copyright) license to
+exercise the rights in the Work as stated below:
+
+ a. to Reproduce the Work, to incorporate the Work into one or more
+    Collections, and to Reproduce the Work as incorporated in the
+    Collections;
+ b. to create and Reproduce Adaptations provided that any such Adaptation,
+    including any translation in any medium, takes reasonable steps to
+    clearly label, demarcate or otherwise identify that changes were made
+    to the original Work. For example, a translation could be marked "The
+    original work was translated from English to Spanish," or a
+    modification could indicate "The original work has been modified.";
+ c. to Distribute and Publicly Perform the Work including as incorporated
+    in Collections; and,
+ d. to Distribute and Publicly Perform Adaptations.
+ e. For the avoidance of doubt:
+
+     i. Non-waivable Compulsory License Schemes. In those jurisdictions in
+        which the right to collect royalties through any statutory or
+        compulsory licensing scheme cannot be waived, the Licensor
+        reserves the exclusive right to collect such royalties for any
+        exercise by You of the rights granted under this License;
+    ii. Waivable Compulsory License Schemes. In those jurisdictions in
+        which the right to collect royalties through any statutory or
+        compulsory licensing scheme can be waived, the Licensor waives the
+        exclusive right to collect such royalties for any exercise by You
+        of the rights granted under this License; and,
+   iii. Voluntary License Schemes. The Licensor waives the right to
+        collect royalties, whether individually or, in the event that the
+        Licensor is a member of a collecting society that administers
+        voluntary licensing schemes, via that society, from any exercise
+        by You of the rights granted under this License.
+
+The above rights may be exercised in all media and formats whether now
+known or hereafter devised. The above rights include the right to make
+such modifications as are technically necessary to exercise the rights in
+other media and formats. Subject to Section 8(f), all rights not expressly
+granted by Licensor are hereby reserved.
+
+4. Restrictions. The license granted in Section 3 above is expressly made
+subject to and limited by the following restrictions:
+
+ a. You may Distribute or Publicly Perform the Work only under the terms
+    of this License. You must include a copy of, or the Uniform Resource
+    Identifier (URI) for, this License with every copy of the Work You
+    Distribute or Publicly Perform. You may not offer or impose any terms
+    on the Work that restrict the terms of this License or the ability of
+    the recipient of the Work to exercise the rights granted to that
+    recipient under the terms of the License. You may not sublicense the
+    Work. You must keep intact all notices that refer to this License and
+    to the disclaimer of warranties with every copy of the Work You
+    Distribute or Publicly Perform. When You Distribute or Publicly
+    Perform the Work, You may not impose any effective technological
+    measures on the Work that restrict the ability of a recipient of the
+    Work from You to exercise the rights granted to that recipient under
+    the terms of the License. This Section 4(a) applies to the Work as
+    incorporated in a Collection, but this does not require the Collection
+    apart from the Work itself to be made subject to the terms of this
+    License. If You create a Collection, upon notice from any Licensor You
+    must, to the extent practicable, remove from the Collection any credit
+    as required by Section 4(b), as requested. If You create an
+    Adaptation, upon notice from any Licensor You must, to the extent
+    practicable, remove from the Adaptation any credit as required by
+    Section 4(b), as requested.
+ b. If You Distribute, or Publicly Perform the Work or any Adaptations or
+    Collections, You must, unless a request has been made pursuant to
+    Section 4(a), keep intact all copyright notices for the Work and
+    provide, reasonable to the medium or means You are utilizing: (i) the
+    name of the Original Author (or pseudonym, if applicable) if supplied,
+    and/or if the Original Author and/or Licensor designate another party
+    or parties (e.g., a sponsor institute, publishing entity, journal) for
+    attribution ("Attribution Parties") in Licensor's copyright notice,
+    terms of service or by other reasonable means, the name of such party
+    or parties; (ii) the title of the Work if supplied; (iii) to the
+    extent reasonably practicable, the URI, if any, that Licensor
+    specifies to be associated with the Work, unless such URI does not
+    refer to the copyright notice or licensing information for the Work;
+    and (iv) , consistent with Section 3(b), in the case of an Adaptation,
+    a credit identifying the use of the Work in the Adaptation (e.g.,
+    "French translation of the Work by Original Author," or "Screenplay
+    based on original Work by Original Author"). The credit required by
+    this Section 4 (b) may be implemented in any reasonable manner;
+    provided, however, that in the case of a Adaptation or Collection, at
+    a minimum such credit will appear, if a credit for all contributing
+    authors of the Adaptation or Collection appears, then as part of these
+    credits and in a manner at least as prominent as the credits for the
+    other contributing authors. For the avoidance of doubt, You may only
+    use the credit required by this Section for the purpose of attribution
+    in the manner set out above and, by exercising Your rights under this
+    License, You may not implicitly or explicitly assert or imply any
+    connection with, sponsorship or endorsement by the Original Author,
+    Licensor and/or Attribution Parties, as appropriate, of You or Your
+    use of the Work, without the separate, express prior written
+    permission of the Original Author, Licensor and/or Attribution
+    Parties.
+ c. Except as otherwise agreed in writing by the Licensor or as may be
+    otherwise permitted by applicable law, if You Reproduce, Distribute or
+    Publicly Perform the Work either by itself or as part of any
+    Adaptations or Collections, You must not distort, mutilate, modify or
+    take other derogatory action in relation to the Work which would be
+    prejudicial to the Original Author's honor or reputation. Licensor
+    agrees that in those jurisdictions (e.g. Japan), in which any exercise
+    of the right granted in Section 3(b) of this License (the right to
+    make Adaptations) would be deemed to be a distortion, mutilation,
+    modification or other derogatory action prejudicial to the Original
+    Author's honor and reputation, the Licensor will waive or not assert,
+    as appropriate, this Section, to the fullest extent permitted by the
+    applicable national law, to enable You to reasonably exercise Your
+    right under Section 3(b) of this License (right to make Adaptations)
+    but not otherwise.
+
+5. Representations, Warranties and Disclaimer
+
+UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR
+OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY
+KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
+INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
+FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF
+LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF ERRORS,
+WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION
+OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO YOU.
+
+6. Limitation on Liability. EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE
+LAW, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR
+ANY SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES
+ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS
+BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. Termination
+
+ a. This License and the rights granted hereunder will terminate
+    automatically upon any breach by You of the terms of this License.
+    Individuals or entities who have received Adaptations or Collections
+    from You under this License, however, will not have their licenses
+    terminated provided such individuals or entities remain in full
+    compliance with those licenses. Sections 1, 2, 5, 6, 7, and 8 will
+    survive any termination of this License.
+ b. Subject to the above terms and conditions, the license granted here is
+    perpetual (for the duration of the applicable copyright in the Work).
+    Notwithstanding the above, Licensor reserves the right to release the
+    Work under different license terms or to stop distributing the Work at
+    any time; provided, however that any such election will not serve to
+    withdraw this License (or any other license that has been, or is
+    required to be, granted under the terms of this License), and this
+    License will continue in full force and effect unless terminated as
+    stated above.
+
+8. Miscellaneous
+
+ a. Each time You Distribute or Publicly Perform the Work or a Collection,
+    the Licensor offers to the recipient a license to the Work on the same
+    terms and conditions as the license granted to You under this License.
+ b. Each time You Distribute or Publicly Perform an Adaptation, Licensor
+    offers to the recipient a license to the original Work on the same
+    terms and conditions as the license granted to You under this License.
+ c. If any provision of this License is invalid or unenforceable under
+    applicable law, it shall not affect the validity or enforceability of
+    the remainder of the terms of this License, and without further action
+    by the parties to this agreement, such provision shall be reformed to
+    the minimum extent necessary to make such provision valid and
+    enforceable.
+ d. No term or provision of this License shall be deemed waived and no
+    breach consented to unless such waiver or consent shall be in writing
+    and signed by the party to be charged with such waiver or consent.
+ e. This License constitutes the entire agreement between the parties with
+    respect to the Work licensed here. There are no understandings,
+    agreements or representations with respect to the Work not specified
+    here. Licensor shall not be bound by any additional provisions that
+    may appear in any communication from You. This License may not be
+    modified without the mutual written agreement of the Licensor and You.
+ f. The rights granted under, and the subject matter referenced, in this
+    License were drafted utilizing the terminology of the Berne Convention
+    for the Protection of Literary and Artistic Works (as amended on
+    September 28, 1979), the Rome Convention of 1961, the WIPO Copyright
+    Treaty of 1996, the WIPO Performances and Phonograms Treaty of 1996
+    and the Universal Copyright Convention (as revised on July 24, 1971).
+    These rights and subject matter take effect in the relevant
+    jurisdiction in which the License terms are sought to be enforced
+    according to the corresponding provisions of the implementation of
+    those treaty provisions in the applicable national law. If the
+    standard suite of rights granted under applicable copyright law
+    includes additional rights not granted under this License, such
+    additional rights are deemed to be included in the License; this
+    License is not intended to restrict the license of any rights under
+    applicable law.
+
+
+Creative Commons Notice
+
+    Creative Commons is not a party to this License, and makes no warranty
+    whatsoever in connection with the Work. Creative Commons will not be
+    liable to You or any party on any legal theory for any damages
+    whatsoever, including without limitation any general, special,
+    incidental or consequential damages arising in connection to this
+    license. Notwithstanding the foregoing two (2) sentences, if Creative
+    Commons has expressly identified itself as the Licensor hereunder, it
+    shall have all rights and obligations of Licensor.
+
+    Except for the limited purpose of indicating to the public that the
+    Work is licensed under the CCPL, Creative Commons does not authorize
+    the use by either party of the trademark "Creative Commons" or any
+    related trademark or logo of Creative Commons without the prior
+    written consent of Creative Commons. Any permitted use will be in
+    compliance with Creative Commons' then-current trademark usage
+    guidelines, as may be published on its website or otherwise made
+    available upon request from time to time. For the avoidance of doubt,
+    this trademark restriction does not form part of this License.
+
+    Creative Commons may be contacted at https://creativecommons.org/.

--- a/orionbelt_ontology_builder/licenses/MIT-vis-network.txt
+++ b/orionbelt_ontology_builder/licenses/MIT-vis-network.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2017 Almende B.V.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/orionbelt_ontology_builder/licenses/W3C-Document-License.txt
+++ b/orionbelt_ontology_builder/licenses/W3C-Document-License.txt
@@ -1,0 +1,69 @@
+W3C Document License (2015)
+https://www.w3.org/copyright/document-license-2015/
+
+Retrieved 2026-08-29 from https://www.w3.org/Consortium/Legal/2015/doc-license
+Reproduced here as the licence covering the bundled W3C ontologies; see
+THIRD_PARTY_NOTICES.md for which files it applies to.
+
+------------------------------------------------------------------------------
+
+By using and/or copying this document, or the W3C document from which this
+statement is linked, you (the licensee) agree that you have read, understood,
+and will comply with the following terms and conditions:
+
+Permission to copy, and distribute the contents of this document, or the W3C
+document from which this statement is linked, in any medium for any purpose
+and without fee or royalty is hereby granted, provided that you include the
+following on ALL copies of the document, or portions thereof, that you use:
+
+  - A link or URL to the original W3C document.
+
+  - The pre-existing copyright notice of the original author, or if it doesn't
+    exist, a notice (hypertext is preferred, but a textual representation is
+    permitted) of the form: "Copyright © [$date-of-document] World Wide Web
+    Consortium, (MIT, ERCIM, Keio, Beihang).
+    https://www.w3.org/copyright/document-license-2015/"
+
+  - If it exists, the STATUS of the W3C document.
+
+When space permits, inclusion of the full text of this NOTICE should be
+provided. We request that authorship attribution be provided in any software,
+documents, or other items or products that you create pursuant to the
+implementation of the contents of this document, or any portion thereof.
+
+No right to create modifications or derivatives of W3C documents is granted
+pursuant to this license, except as follows: To facilitate implementation of
+the technical specifications set forth in this document, anyone may prepare
+and distribute derivative works and portions of this document in software, in
+supporting materials accompanying software, and in documentation of software,
+PROVIDED that all such works include the notice below. HOWEVER, the
+publication of derivative works of this document for use as a technical
+specification is expressly prohibited.
+
+In addition, "Code Components" —Web IDL in sections clearly marked as Web IDL;
+and W3C-defined markup (HTML, CSS, etc.) and computer programming language
+code clearly marked as code examples— are licensed under the W3C Software
+License.
+
+The notice is:
+
+"Copyright © 2015 W3C® (MIT, ERCIM, Keio, Beihang). This software or document
+includes material copied from or derived from [title and URI of the W3C
+document]."
+
+Disclaimers
+
+THIS DOCUMENT IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO
+REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED
+TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-
+INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY
+PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY
+THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+
+COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE
+PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.
+
+The name and trademarks of copyright holders may NOT be used in advertising or
+publicity pertaining to this document or its contents without specific,
+written prior permission.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ orionbelt_ontology_builder = [
     # the working tree, including a macOS .DS_Store, and nothing else under lib/
     # is loaded any more.
     "lib/graph_viewer/*",
+    # Third-party licence texts for what this wheel redistributes; the map from
+    # file to licence is THIRD_PARTY_NOTICES.md at the repo root.
+    "licenses/*",
     "samples/**/*.ttl",
     "samples/**/*.owl",
     "samples/**/*.rdf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,15 @@ name = "orionbelt-ontology-builder"
 version = "1.24.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
-license = {text = "BSL-1.1"}
+# SPDX. Business Source License 1.1 is BUSL-1.1; BSL-1.0 is the Boost Software
+# License and BSL-1.1 is not an SPDX identifier at all, so the old value named
+# nothing while looking like it named Boost.
+license = "BUSL-1.1"
+# PEP 639. Both reach the wheel as dist-info/licenses/, which is where a consumer
+# of the built artifact looks. MANIFEST.in governs the sdist only, so listing the
+# notices there alone left the wheel without them, and the licence texts inside
+# the package pointing at a file that was not in it.
+license-files = ["LICENSE", "THIRD_PARTY_NOTICES.md"]
 requires-python = ">=3.12"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "info@ralforion.com"}]
 keywords = ["ontology", "owl", "rdf", "rdflib", "streamlit", "semantic-web", "knowledge-graph"]
@@ -99,7 +107,8 @@ filterwarnings = [
 ]
 
 [build-system]
-requires = ["setuptools>=68.0"]
+# 77 is where PEP 639 (`license` as an SPDX expression, `license-files`) landed.
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/tests/test_third_party_notices.py
+++ b/tests/test_third_party_notices.py
@@ -11,8 +11,12 @@ ontologies shipped with no terms at all while gist and gUFO, alone, carried
 theirs.
 """
 
-import re
+import subprocess
+import sys
+import zipfile
 from pathlib import Path
+
+import pytest
 
 REPO = Path(__file__).resolve().parent.parent
 PKG = REPO / "orionbelt_ontology_builder"
@@ -71,17 +75,81 @@ def test_every_bundled_third_party_file_is_accounted_for():
         assert licence in notices, f"{licence} is not stated in THIRD_PARTY_NOTICES.md"
 
 
-def test_the_licence_texts_are_packaged():
-    """package-data decides what reaches the wheel, and a licence that does not
-    ship is not carried with the work it covers."""
-    pyproject = (REPO / "pyproject.toml").read_text(encoding="utf-8")
-    package_data = re.search(
-        r"\[tool\.setuptools\.package-data\](.*?)(?:\n\[|\Z)", pyproject, re.DOTALL
+def _build_wheel(out_dir: Path) -> Path | None:
+    """Build a wheel into ``out_dir``, or None when no builder is available.
+
+    Takes about half a second. Worth it: the thing being asserted is what the
+    *artifact* contains, and every cheaper proxy for that has already been wrong
+    once. MANIFEST.in governs the sdist only, so listing the notices there left
+    the wheel without them while a config-reading test stayed green.
+    """
+    for argv in (
+        ["uv", "build", "--wheel", "--out-dir", str(out_dir)],
+        [sys.executable, "-m", "build", "--wheel", "--outdir", str(out_dir)],
+    ):
+        try:
+            done = subprocess.run(
+                argv, cwd=REPO, capture_output=True, timeout=300, check=False
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+        if done.returncode == 0:
+            wheels = list(out_dir.glob("*.whl"))
+            if wheels:
+                return wheels[0]
+    return None
+
+
+@pytest.fixture(scope="module")
+def wheel_names(tmp_path_factory) -> list[str]:
+    wheel = _build_wheel(tmp_path_factory.mktemp("dist"))
+    if wheel is None:
+        pytest.skip("no wheel builder available (uv or build)")
+    with zipfile.ZipFile(wheel) as zf:
+        return zf.namelist()
+
+
+def test_the_project_declares_the_right_spdx_licence(wheel_names, tmp_path_factory):
+    """BUSL-1.1 is the Business Source License 1.1. BSL-1.0 is the Boost Software
+    License, and BSL-1.1 is not an SPDX identifier at all, so the value this used
+    to carry named nothing while looking like it named Boost. Asserted on the
+    built metadata rather than on pyproject.toml, because what a consumer reads
+    is the METADATA."""
+    wheel = next(iter(tmp_path_factory.getbasetemp().glob("**/*.whl")))
+    with zipfile.ZipFile(wheel) as zf:
+        meta = zf.read(
+            next(n for n in zf.namelist() if n.endswith("METADATA"))
+        ).decode()
+    assert "License-Expression: BUSL-1.1" in meta, (
+        "the wheel does not declare BUSL-1.1 as an SPDX expression"
     )
-    assert package_data, "package-data section not found"
-    assert '"licenses/*"' in package_data.group(1), (
-        "licenses/ is not in package-data, so the texts would not reach the wheel"
+    assert "Classifier: License ::" not in meta, (
+        "a License classifier alongside a PEP 639 expression is rejected by PyPI"
     )
-    assert "include THIRD_PARTY_NOTICES.md" in (REPO / "MANIFEST.in").read_text(
-        encoding="utf-8"
+
+
+def test_the_notices_reach_the_wheel(wheel_names):
+    """The licence texts inside the package point at THIRD_PARTY_NOTICES.md for
+    the map from file to licence. Shipping them without it leaves that pointer
+    dangling for anyone who installs the wheel, which is everyone."""
+    assert any(n.endswith("THIRD_PARTY_NOTICES.md") for n in wheel_names), (
+        "THIRD_PARTY_NOTICES.md is not in the wheel"
     )
+
+
+def test_every_licence_text_reaches_the_wheel(wheel_names):
+    for name in LICENCES:
+        assert any(n.endswith(f"licenses/{name}") for n in wheel_names), (
+            f"{name} is not in the wheel"
+        )
+    for vocab in ("gist", "gufo"):
+        assert any(
+            n.endswith(f"samples/{vocab}/LICENSE-CC-BY-4.0.txt") for n in wheel_names
+        ), f"{vocab}'s licence is not in the wheel"
+
+
+def test_every_covered_file_reaches_the_wheel(wheel_names):
+    """A licence carried for a file that no longer ships is stale; a file that
+    ships without one is the problem this guards."""
+    for rel in BUNDLED:
+        assert any(n.endswith(rel) for n in wheel_names), f"{rel} is not in the wheel"

--- a/tests/test_third_party_notices.py
+++ b/tests/test_third_party_notices.py
@@ -1,0 +1,87 @@
+"""Every third-party work we redistribute ships its licence text.
+
+The wheel carries a vendored copy of vis-network and seven third-party
+vocabularies. Redistributing them means carrying their terms, and the terms are
+no use to a recipient if they stay on the developer's disk: these assertions are
+about what the *package* contains, not about what is in the repository.
+
+The gap this guards was real. Tom Select shipped under Apache-2.0 with no licence
+file anywhere until the dead-vendored-libs cleanup removed it, and the sample
+ontologies shipped with no terms at all while gist and gUFO, alone, carried
+theirs.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+PKG = REPO / "orionbelt_ontology_builder"
+NOTICES = REPO / "THIRD_PARTY_NOTICES.md"
+
+#: Licence texts that must be present and non-empty, and the marker that shows
+#: the file is the licence rather than a stub.
+LICENCES = {
+    "MIT-vis-network.txt": "The MIT License",
+    "CC-BY-1.0.txt": "Creative Commons",
+    "CC-BY-3.0.txt": "Creative Commons",
+    "W3C-Document-License.txt": "W3C Document License",
+}
+
+#: Third-party files that ship, mapped to how the notices refer to them and the
+#: licence they are attributed to. The reference is given rather than derived
+#: from the filename because gist ships four files under one glob entry, and
+#: spelling all four out in the notices would be noise.
+BUNDLED = {
+    "samples/foaf.rdf": ("foaf.rdf", "CC BY 1.0"),
+    "samples/goodrelations.owl": ("goodrelations.owl", "CC BY 3.0"),
+    "samples/pizza.owl": ("pizza.owl", "CC BY 3.0"),
+    "samples/prov-o.ttl": ("prov-o.ttl", "W3C Document License"),
+    "samples/wine.owl": ("wine.owl", "W3C Document License"),
+    "samples/gist/gistCore14.1.0.ttl": ("samples/gist/", "CC BY 4.0"),
+    "samples/gufo/gufo.ttl": ("gufo.ttl", "CC BY 4.0"),
+    "lib/graph_viewer/vis-network.min.js": ("vis-network.min.js", "MIT"),
+}
+
+
+def test_every_licence_text_is_present():
+    for name, marker in LICENCES.items():
+        path = PKG / "licenses" / name
+        assert path.is_file(), f"{name} is missing"
+        assert marker in path.read_text(encoding="utf-8"), (
+            f"{name} is not the licence text"
+        )
+
+
+def test_gist_and_gufo_keep_their_own_licence_files():
+    """Those two carry their text beside the data, which is where a reader of
+    the sample looks first. Kept that way rather than moved into licenses/."""
+    for vocab in ("gist", "gufo"):
+        assert (PKG / "samples" / vocab / "LICENSE-CC-BY-4.0.txt").is_file()
+
+
+def test_every_bundled_third_party_file_is_accounted_for():
+    """A file shipped but not named in the notices is one being redistributed
+    with no stated terms, which is the thing this whole exercise was about."""
+    notices = NOTICES.read_text(encoding="utf-8")
+    for rel, (reference, licence) in BUNDLED.items():
+        assert (PKG / rel).is_file(), f"{rel} is gone; update the notices too"
+        assert reference in notices, (
+            f"{rel} ships but is not named in THIRD_PARTY_NOTICES.md"
+        )
+        assert licence in notices, f"{licence} is not stated in THIRD_PARTY_NOTICES.md"
+
+
+def test_the_licence_texts_are_packaged():
+    """package-data decides what reaches the wheel, and a licence that does not
+    ship is not carried with the work it covers."""
+    pyproject = (REPO / "pyproject.toml").read_text(encoding="utf-8")
+    package_data = re.search(
+        r"\[tool\.setuptools\.package-data\](.*?)(?:\n\[|\Z)", pyproject, re.DOTALL
+    )
+    assert package_data, "package-data section not found"
+    assert '"licenses/*"' in package_data.group(1), (
+        "licenses/ is not in package-data, so the texts would not reach the wheel"
+    )
+    assert "include THIRD_PARTY_NOTICES.md" in (REPO / "MANIFEST.in").read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
Completes the licence collection started in #338. The wheel redistributes a vendored vis-network and seven third-party vocabularies, and carried terms for two of them: gist and gUFO had `LICENSE-CC-BY-4.0.txt` beside their data, everything else shipped with nothing.

## What is added

- `orionbelt_ontology_builder/licenses/` with the four missing texts
- `THIRD_PARTY_NOTICES.md` mapping every shipped path to its upstream, licence and text

gist and gUFO keep their files beside the data, which is where a reader of the sample looks first.

| Shipped | Licence | Where the licence comes from |
| --- | --- | --- |
| `lib/graph_viewer/vis-network.min.js` | MIT | header in the bundle: Apache-2.0 **or** MIT at the recipient's choice; we take MIT |
| `samples/goodrelations.owl` | CC BY 3.0 | `dcterms:license` triple in the file |
| `samples/pizza.owl` | CC BY 3.0 | `terms:license "Creative Commons Attribution 3.0 (CC BY 3.0)"` in the file |
| `samples/foaf.rdf` | CC BY 1.0 | **not stated in-file**; from the FOAF specification |
| `samples/prov-o.ttl` | W3C Document License | **not stated in-file**; from the PROV-O Recommendation |
| `samples/wine.owl` | W3C Document License | **not stated in-file**; published with the OWL Guide |
| `samples/gist/*.ttl`, `samples/gufo/gufo.ttl` | CC BY 4.0 | already shipped their own text |

The last three assert nothing about their own terms, so those come off the publisher's specification page. The notices say that plainly in a "Where these terms came from" section rather than presenting them as something the files claim.

## Verified against built artifacts, not the working tree

A licence that does not reach the wheel is not carried with the work it covers, so `package-data` gains `licenses/*` and `MANIFEST.in` gains the notices file. From a clean build:

```
licence texts in the WHEEL:
  orionbelt_ontology_builder/licenses/CC-BY-1.0.txt
  orionbelt_ontology_builder/licenses/CC-BY-3.0.txt
  orionbelt_ontology_builder/licenses/MIT-vis-network.txt
  orionbelt_ontology_builder/licenses/W3C-Document-License.txt
  orionbelt_ontology_builder/samples/gist/LICENSE-CC-BY-4.0.txt
  orionbelt_ontology_builder/samples/gufo/LICENSE-CC-BY-4.0.txt
THIRD_PARTY_NOTICES in the SDIST: True
```

## The guard

`tests/test_third_party_notices.py` pins that every third-party file which ships is named in the notices with a licence, that each licence text exists and is the real text rather than a stub, and that `package-data` still carries `licenses/*`. The next bundled vocabulary cannot arrive silently, which is how Tom Select shipped under Apache-2.0 with no licence file for eleven releases.

## Scope note

Python runtime dependencies are installed from PyPI, not redistributed, so their licences are not reproduced. That changes if a PyInstaller bundle ever ships them inside an artifact (#54), and the notices say to revisit then.

Full suite (1657), ruff and mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
