### PR TITLE
docs: the licence badge says BUSL-1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)
 [![PyPI](https://img.shields.io/pypi/v/orionbelt-ontology-builder?logo=pypi&logoColor=white&label=PyPI&color=purple)](https://pypi.org/project/orionbelt-ontology-builder/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
+[![License: BUSL-1.1](https://img.shields.io/badge/License-BUSL--1.1-orange.svg)](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/LICENSE)
 
 [![Streamlit](https://img.shields.io/badge/Streamlit-1.28+-FF4B4B.svg?logo=streamlit&logoColor=white)](https://streamlit.io)
 [![rdflib](https://img.shields.io/badge/rdflib-7.0+-2E86C1.svg)](https://rdflib.readthedocs.io)


### PR DESCRIPTION
Follow-up to #339, which corrected the packaged metadata to `License-Expression: BUSL-1.1`. The README badge still read `BSL 1.1`, in both its alt text and its shields.io URL.

`BSL-1.0` is the Boost Software License, so the abbreviation named the wrong licence in the place every reader sees first: the top of the README, which is also the PyPI long description. That made it the most-read licence claim in the project, and the only one still disagreeing with the metadata.

```diff
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](...)
+[![License: BUSL-1.1](https://img.shields.io/badge/License-BUSL--1.1-orange.svg)](...)
```

shields.io renders a literal hyphen from a doubled one, so the URL carries `BUSL--1.1` and the badge shows `BUSL-1.1`. Checked against the rendered SVG rather than assumed.

The sentence in the License section still reads "Business Source License 1.1", which is the licence's actual name and MariaDB's trademark. Only the abbreviation was wrong. `BSL` now survives in the repository only inside comments explaining why it was wrong, and in the design plans as informal prose.

Docs only. Full suite (1660) and ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
