### PR TITLE
fix(docker): carry the licences the image redistributes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,14 @@ RUN uv sync --frozen --no-install-project
 COPY . .
 RUN uv sync --frozen --no-editable
 
+# The image redistributes CPython, the Debian base and every runtime dependency,
+# so it has to carry their terms. Almost all of that comes for free: Debian ships
+# /usr/share/doc/*/copyright for the OS packages and for CPython, and installed
+# Python distributions carry their own licence files into site-packages. The
+# streamlit wheel is the one that ships none, so its Apache-2.0 text is copied in
+# here. See THIRD_PARTY_NOTICES.md.
+COPY docker/licenses/ /app/licenses/
+
 # uv installs into a project venv; put it first on PATH so `streamlit` resolves.
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -55,7 +55,26 @@ Verified 2026-08-29.
 
 ## Python dependencies
 
-Runtime dependencies (streamlit, rdflib, owlrl, networkx, streamlit-local-storage) are
-declared in `pyproject.toml` and installed from PyPI. They are not redistributed here, so
-their licences are not reproduced. That changes if a bundle ever ships them inside an
-artifact, such as the PyInstaller build in issue #54, and this file should be revisited then.
+The wheel and sdist declare their dependencies rather than containing them, so those licences
+are not reproduced here.
+
+**The container image is a different distribution.** It is built on `python:3.14-slim` and
+pushed to Docker Hub on every version tag, so it redistributes CPython, the Debian base and
+the whole runtime dependency tree. Most of that carries its own terms:
+
+- Debian ships `/usr/share/doc/*/copyright` for the OS packages and for CPython, which is
+  under the Python Software Foundation License.
+- Installed Python distributions carry their licence files into `site-packages`. That covers
+  54 of the 55 in the current lock.
+- `streamlit` is the exception: its wheel ships no licence file at all. Its Apache-2.0 text is
+  copied into the image at `/app/licenses/`, from `docker/licenses/` in this repository.
+  Streamlit publishes no NOTICE file, so there is none to carry with it.
+
+Nothing in the tree needs a licence election. `python-dateutil` offers a choice (Apache-2.0 or
+BSD-3-Clause) and ships both texts, which satisfies it without electing either; numpy's
+`BSD-3-Clause AND 0BSD AND MIT AND Zlib` is a conjunction rather than a choice, and it ships
+all four.
+
+If the PyInstaller build in issue #54 ever bundles the interpreter and dependencies into a
+downloadable artifact, that is a third distribution channel and this section wants revisiting
+again.

--- a/docker/licenses/streamlit-Apache-2.0.txt
+++ b/docker/licenses/streamlit-Apache-2.0.txt
@@ -1,0 +1,211 @@
+Apache License 2.0, as it applies to Streamlit.
+Copied into the container image because the streamlit wheel ships no licence
+file of its own; see THIRD_PARTY_NOTICES.md.
+
+Retrieved 2026-08-29 from https://github.com/streamlit/streamlit/blob/develop/LICENSE
+Streamlit publishes no NOTICE file, so there is none to carry alongside.
+
+------------------------------------------------------------------------------
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/tests/test_third_party_notices.py
+++ b/tests/test_third_party_notices.py
@@ -148,6 +148,37 @@ def test_every_licence_text_reaches_the_wheel(wheel_names):
         ), f"{vocab}'s licence is not in the wheel"
 
 
+def test_the_image_carries_the_one_licence_pip_does_not():
+    """The container image redistributes the whole dependency tree, and almost
+    all of it carries its own terms into site-packages. The streamlit wheel does
+    not: its dist-info has METADATA, RECORD and WHEEL and no licence file, so the
+    text has to be put in by hand.
+
+    A file assertion rather than an image one. Building the image takes minutes
+    and needs a daemon, so this checks that the text exists, is the real Apache
+    licence, and that the Dockerfile copies the directory holding it. What the
+    built image contains is verified by the Docker workflow's smoke test, not
+    here.
+    """
+    text = REPO / "docker" / "licenses" / "streamlit-Apache-2.0.txt"
+    assert text.is_file(), "streamlit's licence text is missing"
+    body = text.read_text(encoding="utf-8")
+    assert "Apache License" in body and "TERMS AND CONDITIONS" in body, (
+        "that file is not the Apache licence"
+    )
+    assert "COPY docker/licenses/" in (REPO / "Dockerfile").read_text(
+        encoding="utf-8"
+    ), "the image does not copy the licence directory in"
+
+
+def test_the_notices_do_not_claim_dependencies_are_unshipped():
+    """They are, in the image, which is pushed on every version tag. Saying
+    otherwise in the file whose job is accuracy was the error this fixes."""
+    notices = NOTICES.read_text(encoding="utf-8")
+    assert "container image is a different distribution" in notices
+    assert "They are not redistributed here" not in notices
+
+
 def test_every_covered_file_reaches_the_wheel(wheel_names):
     """A licence carried for a file that no longer ships is stale; a file that
     ships without one is the problem this guards."""


### PR DESCRIPTION
Came out of the question "do we also need to elect a Python licence?". The answer is no, nothing needs electing, but the question exposed a wrong claim in the notices file and one real gap.

## The wrong claim

`THIRD_PARTY_NOTICES.md` said dependencies "are not redistributed here", and that this "changes if a bundle ever ships them inside an artifact, such as the PyInstaller build in issue #54".

It has already changed. `docker-publish.yml` builds on `python:3.14-slim` and pushes to Docker Hub on every version tag, so the image redistributes CPython, the Debian base and the entire runtime dependency tree. #339 reasoned about the wheel and never asked what else the project ships.

## What the image already carries

Most of the obligation is met without us:

- Debian ships `/usr/share/doc/*/copyright` for the OS packages and for CPython (PSF License).
- Installed Python distributions carry their licence files into `site-packages`. **54 of the 55** in the current lock do.

## The gap

`streamlit` is the exception, and it is the largest dependency. Its dist-info:

```
METADATA  RECORD  WHEEL  INSTALLER  REQUESTED  entry_points.txt  top_level.txt
```

No licence file, while declaring Apache-2.0, whose section 4 asks that recipients get a copy. Its text now lives in `docker/licenses/` and is copied to `/app/licenses/` in the image. Streamlit publishes no NOTICE file upstream, so there is none to carry alongside.

Deliberately **not** put in the package: streamlit is not redistributed in the wheel, so its licence does not belong there. Verified no `docker/` file reaches the built wheel.

## On electing

Nothing in the tree requires it.

- `python-dateutil` declares "Dual License" (Apache-2.0 or BSD-3-Clause) and ships both texts, which satisfies it without choosing.
- `numpy` is `BSD-3-Clause AND 0BSD AND MIT AND Zlib` — a conjunction, not a choice, and it ships all four.
- CPython is PSF-2.0, single-licensed.

Copyleft present and benign: `certifi` (MPL-2.0) at runtime, `pathspec` (MPL-2.0) dev-only. File-level copyleft, satisfied by unmodified redistribution.

## Tests

Two added. One asserts the streamlit text exists, is the real Apache licence, and that the Dockerfile copies the directory in. One asserts the notices no longer make the claim that was wrong. Both are file assertions rather than image ones, and say so: building the image needs a daemon and minutes, and the Docker workflow already smoke-tests the built image.

Full suite (1662), ruff and mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
