### PR TITLE
chore: release 1.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.24.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.25.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -32,7 +32,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.24.0"
+APP_VERSION = "1.25.0"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.24.0"
+version = "1.25.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 # SPDX. Business Source License 1.1 is BUSL-1.1; BSL-1.0 is the Boost Software

--- a/uv.lock
+++ b/uv.lock
@@ -701,7 +701,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.24.0"
+version = "1.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },


### PR DESCRIPTION
Nine commits since v1.24.0. **Minor, not patch**: two are `feat`, and two more change behaviour users will notice.

## Visualization

- Renaming an entity no longer zooms the graph out. The node keeps its position and the camera holds (#329).
- Edit confirmations float over the page instead of inserting a banner that pushed everything out from under the cursor (#330).
- **Auto-show new**: entities created while the node filter is narrowed can join it by themselves. Off by default, so nothing changes for anyone who does not want it (#326).
- A modifier-click on a node that is already focused undoes its own action: Ctrl/Cmd removes it from the focus, Alt leaves focus mode (#328).
- Focus mode no longer stands an arbitrary first class in when nothing is left to focus on. The picker can be cleared, and a focus whose entity is deleted or whose type is switched off now ends rather than silently moving onto a stranger (#335).

## Packaging

- `pyvis` and three vendored frontend directories are gone. None had been loaded since the custom graph component replaced them. That removes **17 packages** from the install, because pyvis pulled IPython and its whole tree.

## Licensing

- The declared licence is now the SPDX identifier `BUSL-1.1`. The old `BSL-1.1` was not an SPDX identifier at all, and `BSL-1.0` is the Boost Software License, so the metadata read as a claim about a different licence. Moved to the PEP 639 form, which needs setuptools 77.
- `THIRD_PARTY_NOTICES.md` maps every redistributed work to its licence, and the texts ship in the wheel and the sdist. The container image carries streamlit's Apache-2.0 text, which its own wheel omits.

## Verified on the built artifact

```
wheel: orionbelt_ontology_builder-1.25.0-py3-none-any.whl
  Version: 1.25.0
  License-Expression: BUSL-1.1
  License-File: LICENSE
  License-File: THIRD_PARTY_NOTICES.md
  Requires-Dist: streamlit==1.49.1, rdflib, owlrl, networkx, streamlit-local-storage
```

Grepped the repo for `1.24.0` first; the three places that declare it (`pyproject.toml`, `APP_VERSION`, the README Docker pin hint) are bumped and `uv.lock` relocked. Full suite (1662), ruff and mypy green.

## After merging

The licence corrections only reach consumers on the version tag, and the hosted app needs a manual **Manage app → Reboot** at share.streamlit.io, since the push webhook does not fire reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
