### PR TITLE
feat(sparql): read-only SPARQL query console

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ orionbelt_ontology_builder/
 ├── cli.py, desktop.py  # `orionbelt-ontology-builder[-desktop]` console entry points
 ├── ontology_manager.py # Core OWL/SKOS engine on rdflib (OntologyManager, UndoManager)
 ├── templates.py        # Built-in templates, upper & reference ontologies
+├── sparql.py           # Read-only SPARQL execution (deadline + row cap)
 ├── samples/            # Bundled ontologies (gist, gUFO, FOAF, PROV-O, …)
 ├── lib/                # The graph component (vendored vis-network)
 ├── assets/             # Logos, screenshots

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ pytest                                    # testpaths/pythonpath configured in p
 pytest tests/test_classes.py -q           # a single file
 ```
 
-Dependencies: streamlit, rdflib, owlrl, networkx. Python >= 3.12.
+Dependencies: streamlit, rdflib, owlrl, networkx, streamlit-ace. Python >= 3.12.
 
 The floor is 3.12 because that is the oldest runtime CI keeps green, and
 because both deployment targets are at or above it (Streamlit Community

--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ Imports on an empty ontology go straight through. Otherwise you get a review pan
 
 A read-only query console over the loaded ontology: SELECT, ASK, CONSTRUCT and
 DESCRIBE, with the ontology's own prefixes already declared so `owl:Class` and
-`:Person` work without a PREFIX line. Results download as CSV (SELECT) or
+`:Person` work without a PREFIX line. The editor highlights SPARQL syntax and
+follows the app's light/dark theme. Results download as CSV (SELECT) or
 Turtle (CONSTRUCT/DESCRIBE), and eight worked examples are one click away.
 
 Updates (INSERT, DELETE, LOAD, CLEAR, DROP) are refused: edits go through the
@@ -519,7 +520,7 @@ orionbelt-ontology-builder/
 └── tests/                              # pytest suite
 ```
 
-Dependencies: streamlit, rdflib, owlrl, networkx.
+Dependencies: streamlit, rdflib, owlrl, networkx, streamlit-ace.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,18 @@ Imports on an empty ontology go straight through. Otherwise you get a review pan
 - SKOS checks (see above)
 - RDFS and OWL-RL reasoning via owlrl
 
+### SPARQL queries
+
+A read-only query console over the loaded ontology: SELECT, ASK, CONSTRUCT and
+DESCRIBE, with the ontology's own prefixes already declared so `owl:Class` and
+`:Person` work without a PREFIX line. Results download as CSV (SELECT) or
+Turtle (CONSTRUCT/DESCRIBE), and eight worked examples are one click away.
+
+Updates (INSERT, DELETE, LOAD, CLEAR, DROP) are refused: edits go through the
+editor pages, where they are checkpointed and can be undone. Every query runs
+under a row limit and a wall-clock time limit, so a runaway query is stopped
+rather than taking the app with it.
+
 ### Visualization
 
 Interactive vis-network graph with class filtering, configurable node limits, click-to-navigate into the editor, Ctrl/Cmd-click a node to add it to the "Focus on one node" selection (narrowing the graph to its neighbourhood) or Alt-click to focus on it alone, hierarchy tree view, and statistics charts.
@@ -483,6 +495,7 @@ the 200 MB default; raise the value only when self-hosting with enough memory.
 | **SKOS Vocabulary** | Concept schemes, concepts, hierarchy, SKOS validation          |
 | **Import / Export** | File import with merge review, export, new ontology, templates |
 | **Source**          | Live Turtle source view of the ontology                        |
+| **SPARQL**          | Read-only SPARQL console with row and time limits              |
 | **Validation**      | Ontology validation and OWL reasoning                          |
 | **Visualization**   | Interactive graph (OWL + SKOS), hierarchy tree, statistics     |
 
@@ -497,6 +510,7 @@ orionbelt-ontology-builder/
 │   ├── app.py                          # Streamlit UI
 │   ├── ontology_manager.py             # Core OWL/SKOS engine (rdflib)
 │   ├── templates.py                    # Built-in templates / upper / reference ontologies
+│   ├── sparql.py                       # Read-only SPARQL execution (deadline + row cap)
 │   ├── samples/                        # Bundled gist, gUFO, FOAF, PROV-O, GoodRelations, …
 │   ├── lib/                            # The graph component (vendored vis-network)
 │   ├── assets/                         # Logos and screenshots
@@ -514,7 +528,6 @@ Dependencies: streamlit, rdflib, owlrl, networkx.
 Not implemented yet, listed here so it is clear what the workbench does *not* do today:
 
 - **SHACL validation.** Validation is currently structural (orphan classes, duplicate labels, domain/range mismatches, SKOS cycles) plus OWL RL reasoning. Shape-based validation against SHACL constraints is not supported.
-- **SPARQL queries.** There is no query console; exploration is through search, usage/backlink views and the graph.
 
 ---
 

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -258,6 +258,7 @@ from .views.relations import render_relations
 from .views.restrictions import render_restrictions
 from .views.skos import render_skos_vocabulary
 from .views.source import render_source
+from .views.sparql import render_sparql
 from .views.validation import render_validation
 from .views.visualization import render_visualization
 
@@ -459,6 +460,7 @@ def main():
         "SKOS Vocabulary": render_skos_vocabulary,
         "Import / Export": render_import_export,
         "Source": render_source,
+        "SPARQL": render_sparql,
         "Validation": render_validation,
         "Visualization": render_visualization,
     }

--- a/orionbelt_ontology_builder/sparql.py
+++ b/orionbelt_ontology_builder/sparql.py
@@ -17,13 +17,20 @@ forms and rejects every update form by name.
 Layer 2 is the one that actually saves the app. rdflib's ``evalBGP`` pulls every
 candidate solution through ``ctx.graph.triples(...)`` and recurses per binding,
 so a deadline enforced at the store is checked continuously throughout
-evaluation — including while an ``ORDER BY``/``GROUP BY``/``DISTINCT`` above it
-is consuming the whole join before yielding anything. Layer 1 cannot help there:
-measured on a 300-triple graph, a three-way cartesian product under ``ORDER BY``
-produced no first row at all after 8 seconds, while the store deadline stopped
-the same query at 3.05s. It costs nothing to run — the same query with the proxy
-installed timed at 72.1ms against 72.3ms without it, because rdflib's per-triple
-work dwarfs a ``monotonic()`` call every few hundred triples.
+evaluation — including while an operator above it consumes the whole join before
+yielding anything. Layer 1 cannot help there: measured on a 300-triple graph, a
+three-way cartesian product under ``ORDER BY`` produced no first row at all after
+8 seconds, while the store deadline stopped the same query at 3.05s.
+
+``ORDER BY``/``GROUP BY``/``DISTINCT`` are the obvious cases. The common one is
+``UNION``: rdflib's ``evalUnion`` is not a generator, it appends both branches
+into a list and returns it, so *every* query containing a ``UNION`` is fully
+evaluated before its first row exists. A row cap cannot bound that; only the
+deadline can.
+
+The proxy costs nothing to run — the same query with it installed timed at
+72.1ms against 72.3ms without, because rdflib's per-triple work dwarfs a
+``monotonic()`` call every few hundred triples.
 
 Being in-process is the point. A subprocess would have to fork from a Streamlit
 ScriptRunner thread, which is a multi-threaded process, and CPython has

--- a/orionbelt_ontology_builder/sparql.py
+++ b/orionbelt_ontology_builder/sparql.py
@@ -49,9 +49,9 @@ from dataclasses import dataclass, field
 from math import prod
 from typing import Any, cast
 
-from rdflib import BNode, Graph, Literal, URIRef
-from rdflib.plugins.sparql import prepareQuery
-from rdflib.plugins.sparql.parser import parseUpdate
+from rdflib import BNode, Graph, Literal, URIRef, Variable
+from rdflib.plugins.sparql.algebra import translateQuery
+from rdflib.plugins.sparql.parser import parseQuery, parseUpdate
 from rdflib.plugins.sparql.sparql import Query
 from rdflib.query import ResultRow
 from rdflib.store import Store
@@ -223,18 +223,33 @@ def _algebra_guard(algebra: Any) -> None:
         )
 
 
-def prepare(query_text: str, init_ns: dict[str, Any] | None = None) -> Query:
+@dataclass(frozen=True)
+class PreparedQuery:
+    """A parsed, vetted query, plus what the algebra no longer remembers."""
+
+    query: Query
+    #: Whether the user wrote ``SELECT *``. Read off the parse tree because the
+    #: algebra cannot answer it: an explicit projection and a ``*`` over the
+    #: same variables produce an identical ``PV``, differing only in an order
+    #: that is meaningful in one case and random in the other.
+    select_star: bool
+
+
+def prepare(query_text: str, init_ns: dict[str, Any] | None = None) -> PreparedQuery:
     """Parse ``query_text``, rejecting anything that is not a read-only query.
 
-    ``prepareQuery`` accepts only SELECT/ASK/CONSTRUCT/DESCRIBE, so every update
-    form fails it. We re-parse a failure as an update to tell the two cases
-    apart: "this console is read-only" and "you have a typo" are different
-    problems and deserve different messages.
+    Parsing and translation are done here rather than through ``prepareQuery``
+    so the parse tree can be inspected on the way past; ``prepareQuery`` is
+    exactly these two calls and discards the tree. Only query forms translate,
+    so every update form fails. We re-parse a failure as an update to tell the
+    two cases apart: "this console is read-only" and "you have a typo" are
+    different problems and deserve different messages.
     """
     if not query_text.strip():
         raise QuerySyntaxError("Enter a query to run.")
     try:
-        query = prepareQuery(query_text, initNs=init_ns or {})
+        parsed = parseQuery(query_text)
+        query = translateQuery(parsed, initNs=init_ns or {})
     except Exception as exc:
         # Any parse failure is triaged below into "read-only" or "syntax error".
         try:
@@ -248,7 +263,57 @@ def prepare(query_text: str, init_ns: dict[str, Any] | None = None) -> Query:
             "change is recorded and can be undone."
         ) from exc
     _algebra_guard(query.algebra)
-    return query
+    return PreparedQuery(query=query, select_star=not parsed[1].projection)
+
+
+def _vars_in_query_order(algebra: Any) -> list[Any]:
+    """Variables in the order the query first mentions them.
+
+    Walked off the algebra rather than the query text so comments and string
+    literals cannot affect it. ``triples`` (a BGP), ``values`` and the variable
+    an ``Extend``/BIND introduces are the three places a variable is first
+    bound, and each holds them in the order they were written.
+    """
+    seen: list[Any] = []
+
+    def note(term: Any) -> None:
+        if isinstance(term, Variable) and term not in seen:
+            seen.append(term)
+
+    for node in _walk(algebra):
+        for triple in node.get("triples") or ():
+            for term in triple:
+                note(term)
+        for binding in node.get("res") or ():
+            if isinstance(binding, dict):
+                for var in binding:
+                    note(var)
+        note(node.get("var"))
+    return seen
+
+
+def ordered_vars(algebra: Any, result_vars: Any, select_star: bool) -> list[Any]:
+    """The result's variables, in a stable order.
+
+    ``SELECT *`` gets its projection from a *set* in rdflib
+    (``PV = list(VS)``), so its column order is whatever hash randomisation
+    produced and differs between runs: the same query exported twice can come
+    back with its columns rearranged. Those get query order instead.
+
+    An explicit projection is returned untouched. It is already in the order
+    the user wrote, and that order is *only* in ``PV`` — the algebra keeps no
+    record of the SELECT clause, so reordering it against the pattern would
+    turn ``SELECT ?o ?s`` into ``s, o``.
+
+    Anything the walk did not reach sorts by name after everything it did, so
+    a variable this cannot place is never dropped and never reintroduces the
+    randomness this exists to remove.
+    """
+    result_vars = list(result_vars or [])
+    if not select_star:
+        return result_vars
+    order = {var: i for i, var in enumerate(_vars_in_query_order(algebra))}
+    return sorted(result_vars, key=lambda v: (order.get(v, len(order)), str(v)))
 
 
 def query_form(query: Query) -> str:
@@ -334,7 +399,8 @@ def run_query(
         MIN_TIMEOUT_SECONDS, min(float(timeout_seconds), MAX_TIMEOUT_SECONDS)
     )
     prefixes = sorted_prefixes(graph)
-    query = prepare(query_text, dict(graph.namespaces()))
+    prepared = prepare(query_text, dict(graph.namespaces()))
+    query = prepared.query
     form = query_form(query)
 
     started = time.monotonic()
@@ -367,7 +433,10 @@ def run_query(
                 result.rows.append([format_term(t, prefixes) for t in triple])
             result.graph = built
         else:
-            result.columns = [str(v) for v in (answer.vars or [])]
+            # Stable column order: rdflib derives SELECT * from a set, so the
+            # order is otherwise randomised per run.
+            columns = ordered_vars(query.algebra, answer.vars, prepared.select_star)
+            result.columns = [str(v) for v in columns]
             for row in answer:
                 if len(result.rows) >= max_rows:
                     result.truncated = True
@@ -379,7 +448,7 @@ def run_query(
                 # Result.__iter__ (shared with ASK and CONSTRUCT) does not say.
                 bindings = cast(ResultRow, row)
                 result.rows.append(
-                    [format_term(bindings[v], prefixes) for v in (answer.vars or [])]
+                    [format_term(bindings[v], prefixes) for v in columns]
                 )
     except QueryTimeout:
         result.timed_out = True

--- a/orionbelt_ontology_builder/sparql.py
+++ b/orionbelt_ontology_builder/sparql.py
@@ -199,6 +199,20 @@ def _algebra_guard(algebra: Any) -> None:
             "queries the ontology loaded in the app."
         )
 
+    # FROM / FROM NAMED name a dataset to query instead of this one. Nothing
+    # here can serve them: the console evaluates against a single wrapper graph
+    # over the loaded ontology, so rdflib ignores the clause and answers from
+    # the ontology anyway. That is the dangerous outcome — the query looks
+    # honoured and the rows look right, so `FROM <somewhere-else>` returns this
+    # ontology's data under another graph's name. Refusing is the only reading
+    # that cannot mislead.
+    if "DatasetClause" in names:
+        raise QueryNotAllowed(
+            "FROM and FROM NAMED are not supported: this console always queries "
+            "the ontology loaded in the app, and the clause would be ignored "
+            "rather than honoured. Remove it to query the loaded ontology."
+        )
+
     # No triple pattern means evaluation never reaches the store, so the store
     # deadline never fires. Harmless at small sizes; unstoppable at large ones.
     if "BGP" not in names and prod(values_sizes or [0]) > _VALUES_PRODUCT_LIMIT:

--- a/orionbelt_ontology_builder/sparql.py
+++ b/orionbelt_ontology_builder/sparql.py
@@ -233,6 +233,9 @@ class PreparedQuery:
     #: same variables produce an identical ``PV``, differing only in an order
     #: that is meaningful in one case and random in the other.
     select_star: bool
+    #: Every variable the query names, in source order. Only consulted for
+    #: ``SELECT *``, whose own order is random.
+    var_order: tuple[Any, ...] = ()
 
 
 def prepare(query_text: str, init_ns: dict[str, Any] | None = None) -> PreparedQuery:
@@ -263,36 +266,56 @@ def prepare(query_text: str, init_ns: dict[str, Any] | None = None) -> PreparedQ
             "change is recorded and can be undone."
         ) from exc
     _algebra_guard(query.algebra)
-    return PreparedQuery(query=query, select_star=not parsed[1].projection)
+    return PreparedQuery(
+        query=query,
+        select_star=not parsed[1].projection,
+        var_order=_vars_in_source_order(parsed),
+    )
 
 
-def _vars_in_query_order(algebra: Any) -> list[Any]:
-    """Variables in the order the query first mentions them.
+def _vars_in_source_order(parsed: Any) -> tuple[Any, ...]:
+    """Variables in the order the query text names them.
 
-    Walked off the algebra rather than the query text so comments and string
-    literals cannot affect it. ``triples`` (a BGP), ``values`` and the variable
-    an ``Extend``/BIND introduces are the three places a variable is first
-    bound, and each holds them in the order they were written.
+    Read off the *parse tree*, which mirrors the source, rather than the
+    algebra, which does not. The algebra places an operator that introduces a
+    variable above the pattern it reads from — BIND becomes
+    ``Extend(p=<the pattern>, var=?x)`` — so walking it in pre-order reports
+    ?x before the pattern that precedes it in the query, and
+    ``{ ?s ?p ?o . BIND(?o AS ?x) }`` came out as ``x, s, p, o``. Special-casing
+    Extend would fix that one operator and leave the same inversion waiting in
+    any other that binds above its child. The parse tree has no such inversion
+    to correct.
+
+    Not the raw query text either: a variable named in a comment or inside a
+    string literal is not a binding, and the parser has already told them apart.
     """
     seen: list[Any] = []
 
-    def note(term: Any) -> None:
-        if isinstance(term, Variable) and term not in seen:
-            seen.append(term)
+    def visit(node: Any) -> None:
+        # Variable subclasses str, so it has to be tested before the str guard
+        # that stops us walking into URIs and literals character by character.
+        if isinstance(node, Variable):
+            if node not in seen:
+                seen.append(node)
+            return
+        if isinstance(node, (str, bytes)):
+            return
+        if isinstance(node, dict):
+            for value in node.values():
+                visit(value)
+            return
+        # Lists, and the ParseResults the parser returns at the top level.
+        if hasattr(node, "__iter__"):
+            for value in node:
+                visit(value)
 
-    for node in _walk(algebra):
-        for triple in node.get("triples") or ():
-            for term in triple:
-                note(term)
-        for binding in node.get("res") or ():
-            if isinstance(binding, dict):
-                for var in binding:
-                    note(var)
-        note(node.get("var"))
-    return seen
+    visit(parsed)
+    return tuple(seen)
 
 
-def ordered_vars(algebra: Any, result_vars: Any, select_star: bool) -> list[Any]:
+def ordered_vars(
+    var_order: tuple[Any, ...], result_vars: Any, select_star: bool
+) -> list[Any]:
     """The result's variables, in a stable order.
 
     ``SELECT *`` gets its projection from a *set* in rdflib
@@ -312,7 +335,7 @@ def ordered_vars(algebra: Any, result_vars: Any, select_star: bool) -> list[Any]
     result_vars = list(result_vars or [])
     if not select_star:
         return result_vars
-    order = {var: i for i, var in enumerate(_vars_in_query_order(algebra))}
+    order = {var: i for i, var in enumerate(var_order)}
     return sorted(result_vars, key=lambda v: (order.get(v, len(order)), str(v)))
 
 
@@ -435,7 +458,9 @@ def run_query(
         else:
             # Stable column order: rdflib derives SELECT * from a set, so the
             # order is otherwise randomised per run.
-            columns = ordered_vars(query.algebra, answer.vars, prepared.select_star)
+            columns = ordered_vars(
+                prepared.var_order, answer.vars, prepared.select_star
+            )
             result.columns = [str(v) for v in columns]
             for row in answer:
                 if len(result.rows) >= max_rows:

--- a/orionbelt_ontology_builder/sparql.py
+++ b/orionbelt_ontology_builder/sparql.py
@@ -1,0 +1,384 @@
+"""Read-only SPARQL querying with a wall-clock deadline and a row cap.
+
+The query console hands rdflib a string a user typed, so two things have to be
+true before it can be exposed: the query must not be able to modify the
+ontology, and it must not be able to hang the app.
+
+**Read-only** is enforced by :func:`prepare`, which accepts only the four query
+forms and rejects every update form by name.
+
+**Bounded** is enforced in two layers, because one is not enough:
+
+1. A row cap and a deadline on the result iteration. This catches the common
+   runaway — a query that streams far more rows than anyone wants to see.
+2. A deadline checked inside :class:`_DeadlineStore`, a read-through proxy in
+   front of the real store.
+
+Layer 2 is the one that actually saves the app. rdflib's ``evalBGP`` pulls every
+candidate solution through ``ctx.graph.triples(...)`` and recurses per binding,
+so a deadline enforced at the store is checked continuously throughout
+evaluation — including while an ``ORDER BY``/``GROUP BY``/``DISTINCT`` above it
+is consuming the whole join before yielding anything. Layer 1 cannot help there:
+measured on a 300-triple graph, a three-way cartesian product under ``ORDER BY``
+produced no first row at all after 8 seconds, while the store deadline stopped
+the same query at 3.05s. It costs nothing to run — the same query with the proxy
+installed timed at 72.1ms against 72.3ms without it, because rdflib's per-triple
+work dwarfs a ``monotonic()`` call every few hundred triples.
+
+Being in-process is the point. A subprocess would have to fork from a Streamlit
+ScriptRunner thread, which is a multi-threaded process, and CPython has
+deprecated that since 3.12 ("use of fork() may lead to deadlocks in the child");
+the Docker image ships 3.14. The store proxy needs no fork, no signals and no
+main thread, so it behaves the same on the server and in the desktop build.
+
+The one blowup this cannot interrupt is a query with no triple patterns at all —
+a cross product of large ``VALUES`` blocks never touches the store, so nothing
+trips. :func:`prepare` rejects that shape up front rather than leaving a hole.
+"""
+
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from math import prod
+from typing import Any, cast
+
+from rdflib import BNode, Graph, Literal, URIRef
+from rdflib.plugins.sparql import prepareQuery
+from rdflib.plugins.sparql.parser import parseUpdate
+from rdflib.plugins.sparql.sparql import Query
+from rdflib.query import ResultRow
+from rdflib.store import Store
+from rdflib.term import Node
+
+#: Wall-clock budget for a single query, in seconds.
+DEFAULT_TIMEOUT_SECONDS = 10.0
+MIN_TIMEOUT_SECONDS = 1.0
+MAX_TIMEOUT_SECONDS = 120.0
+
+#: How many result rows a query may return before the rest is discarded.
+DEFAULT_MAX_ROWS = 1000
+MAX_ROWS_CEILING = 50000
+
+#: How often the store proxy re-checks the deadline while a single ``triples()``
+#: generator is being drained. Small enough that a scan of a large graph is
+#: still interrupted promptly, large enough that the check is free.
+_DEADLINE_CHECK_EVERY = 512
+
+#: A ``VALUES``-only query is evaluated entirely in memory, so the store
+#: deadline never sees it. Reject one whose cross product exceeds this.
+_VALUES_PRODUCT_LIMIT = 100_000
+
+#: The query forms that cannot modify the graph. Everything else is an update.
+READ_ONLY_FORMS = ("SELECT", "ASK", "CONSTRUCT", "DESCRIBE")
+
+
+class QueryError(Exception):
+    """Base class for a query the console refuses to run."""
+
+
+class QuerySyntaxError(QueryError):
+    """The query text is not valid SPARQL."""
+
+
+class QueryNotAllowed(QueryError):
+    """The query is valid SPARQL but not something this console will run."""
+
+
+class QueryTimeout(Exception):
+    """Raised from inside the store proxy when the deadline passes.
+
+    Not a :class:`QueryError`: it is an internal control-flow signal caught by
+    :func:`run_query`, which reports the timeout on the result instead.
+    """
+
+
+class _DeadlineStore(Store):
+    """A read-through proxy that trips a deadline from inside ``triples()``.
+
+    Wrapping the *store* rather than the graph means every graph derived from it
+    during evaluation — including the ones a ``FROM``/``GRAPH`` clause resolves
+    through ``dataset.get_context()`` — is bounded by the same deadline.
+
+    The proxy is read-only on purpose. Nothing in a ``SELECT``/``ASK``/
+    ``CONSTRUCT``/``DESCRIBE`` evaluation writes, so a write arriving here means
+    something got past :func:`prepare`, and refusing it keeps the user's
+    ontology safe by construction rather than by argument.
+    """
+
+    def __init__(self, inner: Store, deadline: float) -> None:
+        self._inner = inner
+        self._deadline = deadline
+        super().__init__()
+        # Mirror the inner store's capabilities: Graph consults these, and
+        # claiming the wrong ones changes how contexts are resolved.
+        self.context_aware = inner.context_aware
+        self.formula_aware = inner.formula_aware
+        self.graph_aware = inner.graph_aware
+        self.transaction_aware = inner.transaction_aware
+
+    def _check(self) -> None:
+        if time.monotonic() > self._deadline:
+            raise QueryTimeout
+
+    def triples(self, triple_pattern, context=None) -> Iterator[Any]:  # type: ignore[override]
+        self._check()
+        for seen, triple in enumerate(self._inner.triples(triple_pattern, context), 1):
+            if seen % _DEADLINE_CHECK_EVERY == 0:
+                self._check()
+            yield triple
+
+    def __len__(self, context=None) -> int:
+        return self._inner.__len__(context)
+
+    def contexts(self, triple=None):
+        return self._inner.contexts(triple)
+
+    def namespace(self, prefix):
+        return self._inner.namespace(prefix)
+
+    def prefix(self, namespace):
+        return self._inner.prefix(namespace)
+
+    def namespaces(self):
+        return self._inner.namespaces()
+
+    def bind(self, prefix, namespace, override=True) -> None:
+        """Swallow prefix binding rather than forwarding it.
+
+        Constructing a Graph binds rdflib's default prefixes, and forwarding
+        those would silently add prefixes to the user's ontology just because
+        they ran a query. Reads still see every real binding through
+        ``namespaces()``, which is all query evaluation needs.
+        """
+
+    def add(self, *args, **kwargs):
+        raise QueryNotAllowed("The query console cannot modify the ontology.")
+
+    def remove(self, *args, **kwargs):
+        raise QueryNotAllowed("The query console cannot modify the ontology.")
+
+
+def _walk(node: Any) -> Iterator[Any]:
+    """Yield every algebra node under ``node``, itself included."""
+    if hasattr(node, "name"):
+        yield node
+    if isinstance(node, dict):
+        values: Any = node.values()
+    elif isinstance(node, (list, tuple)):
+        values = node
+    else:
+        return
+    for value in values:
+        if isinstance(value, (dict, list, tuple)):
+            yield from _walk(value)
+
+
+def _algebra_guard(algebra: Any) -> None:
+    """Reject query shapes the deadline cannot police, before running them."""
+    names = set()
+    values_sizes = []
+    for node in _walk(algebra):
+        names.add(node.name)
+        if node.name == "values":
+            values_sizes.append(len(node.get("res") or []))
+
+    # SERVICE makes rdflib open a network connection to a host named in the
+    # query. That is a request the app issues on the user's behalf, from the
+    # server, to wherever the query says — not something a local ontology
+    # editor should offer, and not something the deadline bounds.
+    if "ServiceGraphPattern" in names:
+        raise QueryNotAllowed(
+            "Federated queries (SERVICE) are not supported: this console only "
+            "queries the ontology loaded in the app."
+        )
+
+    # No triple pattern means evaluation never reaches the store, so the store
+    # deadline never fires. Harmless at small sizes; unstoppable at large ones.
+    if "BGP" not in names and prod(values_sizes or [0]) > _VALUES_PRODUCT_LIMIT:
+        raise QueryNotAllowed(
+            "This query matches no triples and would expand a very large VALUES "
+            "cross product, which cannot be interrupted. Add a triple pattern or "
+            "use smaller VALUES blocks."
+        )
+
+
+def prepare(query_text: str, init_ns: dict[str, Any] | None = None) -> Query:
+    """Parse ``query_text``, rejecting anything that is not a read-only query.
+
+    ``prepareQuery`` accepts only SELECT/ASK/CONSTRUCT/DESCRIBE, so every update
+    form fails it. We re-parse a failure as an update to tell the two cases
+    apart: "this console is read-only" and "you have a typo" are different
+    problems and deserve different messages.
+    """
+    if not query_text.strip():
+        raise QuerySyntaxError("Enter a query to run.")
+    try:
+        query = prepareQuery(query_text, initNs=init_ns or {})
+    except Exception as exc:
+        # Any parse failure is triaged below into "read-only" or "syntax error".
+        try:
+            parseUpdate(query_text)
+        except Exception:  # noqa: BLE001 - not an update either, so it is a syntax error
+            raise QuerySyntaxError(str(exc)) from exc
+        raise QueryNotAllowed(
+            "This console is read-only: it runs SELECT, ASK, CONSTRUCT and "
+            "DESCRIBE queries. Updates (INSERT, DELETE, LOAD, CLEAR, DROP) are "
+            "not accepted — edit the ontology through the editor pages so the "
+            "change is recorded and can be undone."
+        ) from exc
+    _algebra_guard(query.algebra)
+    return query
+
+
+def query_form(query: Query) -> str:
+    """The query's form, e.g. ``"SELECT"``. ``""`` when it cannot be read."""
+    name = getattr(query.algebra, "name", "") or ""
+    # rdflib names these SelectQuery / AskQuery / ConstructQuery / DescribeQuery.
+    form = name.removesuffix("Query").upper()
+    return form if form in READ_ONLY_FORMS else ""
+
+
+def format_term(term: Node, prefixes: list[tuple[str, str]]) -> str:
+    """Render one result term for a table cell.
+
+    Shortens URIs against ``prefixes`` (longest namespace first, so the most
+    specific binding wins). Deliberately does not go through rdflib's
+    ``normalizeUri``/``compute_qname``, which *bind* a generated prefix as a
+    side effect and would leave ``ns1:`` bindings on the user's ontology.
+    """
+    if isinstance(term, URIRef):
+        text = str(term)
+        for prefix, namespace in prefixes:
+            if text.startswith(namespace) and len(text) > len(namespace):
+                local = text[len(namespace) :]
+                if not any(c in local for c in "/#"):
+                    # The ontology's own namespace is bound to the empty
+                    # prefix, and Turtle writes that as ``:Person`` — keep the
+                    # colon so the console reads like the Source page rather
+                    # than showing a bare, ambiguous local name.
+                    return f"{prefix}:{local}"
+        return text
+    if isinstance(term, Literal):
+        return f"{term}@{term.language}" if term.language else str(term)
+    if isinstance(term, BNode):
+        return f"_:{term}"
+    return "" if term is None else str(term)
+
+
+def sorted_prefixes(graph: Graph) -> list[tuple[str, str]]:
+    """The graph's prefix bindings, longest namespace first."""
+    return sorted(
+        ((str(p), str(n)) for p, n in graph.namespaces()),
+        key=lambda item: len(item[1]),
+        reverse=True,
+    )
+
+
+@dataclass
+class QueryResult:
+    """The outcome of one run. Partial results are still results.
+
+    ``timed_out`` and ``truncated`` are reported rather than raised so a query
+    that was cut short still shows the rows it did produce.
+    """
+
+    form: str
+    columns: list[str] = field(default_factory=list)
+    rows: list[list[str]] = field(default_factory=list)
+    ask: bool | None = None
+    graph: Graph | None = None
+    truncated: bool = False
+    timed_out: bool = False
+    elapsed: float = 0.0
+
+    @property
+    def row_count(self) -> int:
+        return len(self.rows)
+
+
+def run_query(
+    graph: Graph,
+    query_text: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    max_rows: int = DEFAULT_MAX_ROWS,
+) -> QueryResult:
+    """Run a read-only query against ``graph`` under a deadline and a row cap.
+
+    Raises :class:`QueryError` for a query that is refused outright; a query
+    that runs but is cut short comes back with ``timed_out``/``truncated`` set.
+    """
+    max_rows = max(1, min(int(max_rows), MAX_ROWS_CEILING))
+    timeout_seconds = max(
+        MIN_TIMEOUT_SECONDS, min(float(timeout_seconds), MAX_TIMEOUT_SECONDS)
+    )
+    prefixes = sorted_prefixes(graph)
+    query = prepare(query_text, dict(graph.namespaces()))
+    form = query_form(query)
+
+    started = time.monotonic()
+    deadline = started + timeout_seconds
+    # Same identifier as the source graph: the default store is context-aware,
+    # so a wrapper graph with a fresh identifier addresses an empty context and
+    # every query silently returns nothing.
+    bounded = Graph(
+        store=_DeadlineStore(graph.store, deadline), identifier=graph.identifier
+    )
+
+    result = QueryResult(form=form)
+    try:
+        answer = bounded.query(query)
+        if form == "ASK":
+            result.ask = bool(answer.askAnswer)
+        elif form in ("CONSTRUCT", "DESCRIBE"):
+            built = Graph()
+            for prefix, namespace in graph.namespaces():
+                built.bind(prefix, namespace)
+            result.columns = ["subject", "predicate", "object"]
+            for triple in answer.graph or ():
+                if len(result.rows) >= max_rows:
+                    result.truncated = True
+                    break
+                if time.monotonic() > deadline:
+                    result.timed_out = True
+                    break
+                built.add(triple)
+                result.rows.append([format_term(t, prefixes) for t in triple])
+            result.graph = built
+        else:
+            result.columns = [str(v) for v in (answer.vars or [])]
+            for row in answer:
+                if len(result.rows) >= max_rows:
+                    result.truncated = True
+                    break
+                if time.monotonic() > deadline:
+                    result.timed_out = True
+                    break
+                # A SELECT result iterates ResultRow, which the union type on
+                # Result.__iter__ (shared with ASK and CONSTRUCT) does not say.
+                bindings = cast(ResultRow, row)
+                result.rows.append(
+                    [format_term(bindings[v], prefixes) for v in (answer.vars or [])]
+                )
+    except QueryTimeout:
+        result.timed_out = True
+    except QueryError:
+        raise
+    except Exception as exc:
+        # An evaluation failure belongs to the user's query (a bad datatype in a
+        # FILTER, say), so it is reported as one rather than as an app crash.
+        raise QueryError(str(exc)) from exc
+    result.elapsed = time.monotonic() - started
+    return result
+
+
+def rows_to_csv(columns: list[str], rows: list[list[str]]) -> str:
+    """Result rows as CSV text, for download."""
+    import csv
+    import io
+
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(columns)
+    writer.writerows(rows)
+    return buffer.getvalue()

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -196,6 +196,17 @@ _CUSTOM_CSS = """
         content: "";
         margin-left: 0;
     }
+    /* The SPARQL editor. A query is code: proportional type misaligns the
+       indentation that shows how a WHERE block nests, and makes it hard to see
+       that ?s and ?5 differ. Scoped by the container key so every other text
+       area in the app keeps the UI font. */
+    .st-key-sparql_editor textarea {
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+                     "Liberation Mono", monospace !important;
+        font-size: 0.86rem !important;
+        line-height: 1.55 !important;
+        tab-size: 2;
+    }
     [data-testid="stSidebarHeader"] [data-testid="stLogoSpacer"] {
         /* Reserves room for a st.logo() this app doesn't set: the mark is
            rendered as an image in the sidebar body instead. */

--- a/orionbelt_ontology_builder/views/sparql.py
+++ b/orionbelt_ontology_builder/views/sparql.py
@@ -1,0 +1,238 @@
+"""The SPARQL query page.
+
+Read-only by design: the engine in :mod:`..sparql` accepts SELECT/ASK/CONSTRUCT/
+DESCRIBE and refuses every update form, so edits keep going through the editor
+pages where they are checkpointed and can be undone.
+"""
+
+import streamlit as st
+
+from .. import sparql
+from ..ui import _download_or_save, log_error
+
+#: Starter queries. Written against prefixes every ontology here has bound —
+#: ``owl:``/``rdfs:``/``skos:`` from the standard set, and ``:`` for the
+#: ontology's own namespace — so they run as-is without editing.
+EXAMPLE_QUERIES: dict[str, str] = {
+    "Classes and their labels": """SELECT ?class ?label WHERE {
+  ?class a owl:Class .
+  OPTIONAL { ?class rdfs:label ?label }
+}
+ORDER BY ?label""",
+    "Class hierarchy": """SELECT ?child ?parent WHERE {
+  ?child rdfs:subClassOf ?parent .
+  FILTER(isIRI(?parent))
+}
+ORDER BY ?parent ?child""",
+    "Properties with domain and range": """SELECT ?property ?domain ?range WHERE {
+  VALUES ?kind { owl:ObjectProperty owl:DatatypeProperty }
+  ?property a ?kind .
+  OPTIONAL { ?property rdfs:domain ?domain }
+  OPTIONAL { ?property rdfs:range ?range }
+}
+ORDER BY ?property""",
+    "Individuals and their types": """SELECT ?individual ?type WHERE {
+  ?individual a owl:NamedIndividual , ?type .
+  FILTER(?type != owl:NamedIndividual)
+}
+ORDER BY ?type ?individual""",
+    "Classes with no label": """SELECT ?class WHERE {
+  ?class a owl:Class .
+  FILTER NOT EXISTS { ?class rdfs:label ?any }
+  FILTER(isIRI(?class))
+}
+ORDER BY ?class""",
+    "Triples per predicate": """SELECT ?predicate (COUNT(*) AS ?count) WHERE {
+  ?s ?predicate ?o
+}
+GROUP BY ?predicate
+ORDER BY DESC(?count)""",
+    "SKOS concepts and broader terms": """SELECT ?concept ?prefLabel ?broader WHERE {
+  ?concept a skos:Concept .
+  OPTIONAL { ?concept skos:prefLabel ?prefLabel }
+  OPTIONAL { ?concept skos:broader ?broader }
+}
+ORDER BY ?prefLabel""",
+    "Everything about one resource (CONSTRUCT)": """CONSTRUCT { ?s ?p ?o }
+WHERE {
+  ?s ?p ?o .
+  FILTER(?s = :Person)
+}""",
+}
+
+_QUERY_KEY = "sparql_query_text"
+_RESULT_KEY = "sparql_last_result"
+_ERROR_KEY = "sparql_last_error"
+
+
+def _load_example() -> None:
+    """Put the picked example in the editor.
+
+    Runs as a widget callback, which is the only point at which the text area's
+    session-state key can still be written for the coming rerun.
+    """
+    name = st.session_state.get("sparql_example")
+    if name and name in EXAMPLE_QUERIES:
+        st.session_state[_QUERY_KEY] = EXAMPLE_QUERIES[name]
+        st.session_state.pop(_RESULT_KEY, None)
+        st.session_state.pop(_ERROR_KEY, None)
+
+
+def _render_select_result(result: sparql.QueryResult) -> None:
+    if not result.rows:
+        # Only an empty result that actually finished matched nothing. A query
+        # stopped by the deadline produced no rows *yet*, and telling the user
+        # its answer is empty would be wrong.
+        if not result.timed_out:
+            st.info("The query ran and matched nothing.")
+        return
+    st.dataframe(
+        [dict(zip(result.columns, row, strict=False)) for row in result.rows],
+        use_container_width=True,
+        hide_index=True,
+    )
+    _download_or_save(
+        "Download results (CSV)",
+        sparql.rows_to_csv(result.columns, result.rows),
+        "query-results.csv",
+        mime="text/csv",
+        key="sparql_csv",
+    )
+
+
+def _render_graph_result(result: sparql.QueryResult) -> None:
+    if result.graph is None or len(result.graph) == 0:
+        if not result.timed_out:
+            st.info("The query ran and matched nothing.")
+        return
+    try:
+        turtle = result.graph.serialize(format="turtle")
+    except Exception as e:  # noqa: BLE001 - a serialization failure is a message, not a crash
+        st.error(f"Could not serialize the result: {e}")
+        return
+    st.code(turtle, language="turtle", line_numbers=True)
+    _download_or_save(
+        "Download results (Turtle)",
+        turtle,
+        "query-results.ttl",
+        mime="text/turtle",
+        key="sparql_ttl",
+    )
+
+
+def _render_result(result: sparql.QueryResult) -> None:
+    """Show the outcome, warnings first: a capped or cut-short result is still
+    shown, but the user has to be told it is not the whole answer."""
+    if result.timed_out:
+        produced = (
+            "What it produced before then is below."
+            if result.rows
+            else "It had not produced any rows yet."
+        )
+        st.warning(
+            f"The query hit its time limit and was stopped. {produced} Narrow "
+            "the query, or raise the time limit."
+        )
+    if result.truncated:
+        st.warning(
+            f"Showing the first {result.row_count} rows; the query matched more. "
+            "Raise the row limit or add a LIMIT clause to see a different slice."
+        )
+
+    if result.form == "ASK":
+        st.metric("Result", "true" if result.ask else "false")
+        st.caption(f"Ran in {result.elapsed:.2f}s.")
+        return
+
+    noun = "triple" if result.form in ("CONSTRUCT", "DESCRIBE") else "row"
+    plural = "" if result.row_count == 1 else "s"
+    st.caption(f"{result.row_count} {noun}{plural} in {result.elapsed:.2f}s.")
+
+    if result.form in ("CONSTRUCT", "DESCRIBE"):
+        _render_graph_result(result)
+    else:
+        _render_select_result(result)
+
+
+def render_sparql():
+    """Render the SPARQL query page."""
+    st.header("SPARQL Query")
+    st.caption(
+        "Query the loaded ontology with SELECT, ASK, CONSTRUCT or DESCRIBE. "
+        "This page is read-only — updates (INSERT, DELETE, LOAD) are not "
+        "accepted, so edits stay in the editor pages where they can be undone."
+    )
+
+    ont = st.session_state.ontology
+
+    st.selectbox(
+        "Start from an example",
+        ["", *EXAMPLE_QUERIES],
+        format_func=lambda name: name or "Choose an example…",
+        key="sparql_example",
+        on_change=_load_example,
+    )
+
+    query_text = st.text_area(
+        "Query",
+        height=240,
+        key=_QUERY_KEY,
+        placeholder="SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10",
+        help=(
+            "The ontology's prefixes are already declared, so you can write "
+            "`owl:Class` or `:Person` without a PREFIX line."
+        ),
+    )
+
+    limit_col, timeout_col, run_col = st.columns([2, 2, 1])
+    with limit_col:
+        max_rows = st.number_input(
+            "Row limit",
+            min_value=1,
+            max_value=sparql.MAX_ROWS_CEILING,
+            value=sparql.DEFAULT_MAX_ROWS,
+            step=100,
+            key="sparql_max_rows",
+            help=(
+                "Stops reading results past this many rows. A query with "
+                "ORDER BY or GROUP BY still has to evaluate in full before the "
+                "first row exists — the time limit is what bounds that."
+            ),
+        )
+    with timeout_col:
+        timeout_seconds = st.number_input(
+            "Time limit (seconds)",
+            min_value=int(sparql.MIN_TIMEOUT_SECONDS),
+            max_value=int(sparql.MAX_TIMEOUT_SECONDS),
+            value=int(sparql.DEFAULT_TIMEOUT_SECONDS),
+            step=1,
+            key="sparql_timeout",
+            help="A query that runs longer than this is stopped.",
+        )
+    with run_col:
+        st.markdown("<div style='height:1.9rem'></div>", unsafe_allow_html=True)
+        run = st.button("Run query", type="primary", use_container_width=True)
+
+    if run:
+        st.session_state.pop(_RESULT_KEY, None)
+        st.session_state.pop(_ERROR_KEY, None)
+        try:
+            with st.spinner("Running query…"):
+                st.session_state[_RESULT_KEY] = sparql.run_query(
+                    ont.graph,
+                    query_text,
+                    timeout_seconds=timeout_seconds,
+                    max_rows=max_rows,
+                )
+        except sparql.QueryError as e:
+            st.session_state[_ERROR_KEY] = str(e)
+        except Exception as e:  # noqa: BLE001 - a bad query must not take the page down
+            log_error(e, context="SPARQL query")
+            st.session_state[_ERROR_KEY] = str(e)
+
+    # Held in session state so the result survives the rerun a download button
+    # or a control change triggers.
+    if st.session_state.get(_ERROR_KEY):
+        st.error(st.session_state[_ERROR_KEY])
+    elif st.session_state.get(_RESULT_KEY) is not None:
+        _render_result(st.session_state[_RESULT_KEY])

--- a/orionbelt_ontology_builder/views/sparql.py
+++ b/orionbelt_ontology_builder/views/sparql.py
@@ -10,6 +10,14 @@ import streamlit as st
 from .. import sparql
 from ..ui import _download_or_save, log_error
 
+try:
+    from streamlit_ace import st_ace
+except ImportError:  # pragma: no cover - exercised only without the extra
+    # The editor is a nicety; querying is the feature. If the component cannot
+    # be imported the page falls back to a plain monospace text area rather
+    # than failing to render at all.
+    st_ace = None
+
 #: Starter queries. Written against prefixes every ontology here has bound —
 #: ``owl:``/``rdfs:``/``skos:`` from the standard set, and ``:`` for the
 #: ontology's own namespace — so they run as-is without editing.
@@ -61,6 +69,10 @@ WHERE {
 }
 
 _QUERY_KEY = "sparql_query_text"
+#: Bumped to force a fresh editor instance. The Ace component treats ``value``
+#: as initial content, so loading an example has to remount it under a new key
+#: or the editor keeps showing what the user had before.
+_EDITOR_NONCE = "sparql_editor_nonce"
 _RESULT_KEY = "sparql_last_result"
 _ERROR_KEY = "sparql_last_error"
 
@@ -74,8 +86,79 @@ def _load_example() -> None:
     name = st.session_state.get("sparql_example")
     if name and name in EXAMPLE_QUERIES:
         st.session_state[_QUERY_KEY] = EXAMPLE_QUERIES[name]
+        st.session_state[_EDITOR_NONCE] = st.session_state.get(_EDITOR_NONCE, 0) + 1
         st.session_state.pop(_RESULT_KEY, None)
         st.session_state.pop(_ERROR_KEY, None)
+
+
+_EDITOR_HELP = (
+    "The ontology's prefixes are already declared, so you can write "
+    "`owl:Class` or `:Person` without a PREFIX line."
+)
+_PLACEHOLDER = "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10"
+
+
+#: Ace themes for the app's two appearances. Chosen by measuring what each
+#: actually colours, not by name: Ace themes only style the token classes they
+#: choose to, and SPARQL emits ``ace_variable ace_other`` and
+#: ``ace_support ace_type`` for its variables and prefixed names. The obvious
+#: pick, ``github``, styles neither — it gives ``ace_keyword`` bold weight and
+#: no colour, and colours only ``ace_variable.ace_class``, so a whole query
+#: renders in flat black. These two give keywords, variables, prefixed names
+#: and strings four distinct colours, on grounds that match the app's own.
+_EDITOR_THEME_LIGHT = "chrome"
+_EDITOR_THEME_DARK = "tomorrow_night"
+
+
+def _editor_theme() -> str:
+    """An Ace theme matching the app's appearance. Light is the safe default:
+    the browser only reports its theme from the second render on."""
+    try:
+        is_dark = st.context.theme.type == "dark"
+    except Exception:  # noqa: BLE001 - theme detection is cosmetic, never fatal
+        is_dark = False
+    return _EDITOR_THEME_DARK if is_dark else _EDITOR_THEME_LIGHT
+
+
+def _render_editor() -> str:
+    """The query editor, syntax-highlighted where the component is available.
+
+    ``auto_update=True`` matters: left at its default the component renders its
+    own separate apply button and never reports edits on blur, so pressing Run
+    would submit the previous query. On, it commits after a short debounce, so
+    what is on screen is what runs.
+    """
+    st.caption("Query")
+    current = st.session_state.get(_QUERY_KEY, "")
+    if st_ace is None:
+        # Keyed container so the monospace rule in _CUSTOM_CSS reaches this one
+        # text area without restyling every other text area in the app.
+        with st.container(key="sparql_editor"):
+            return st.text_area(
+                "Query",
+                height=240,
+                key=_QUERY_KEY,
+                placeholder=_PLACEHOLDER,
+                help=_EDITOR_HELP,
+                label_visibility="collapsed",
+            )
+    edited = st_ace(
+        value=current,
+        placeholder=_PLACEHOLDER,
+        language="sparql",
+        theme=_editor_theme(),
+        height=260,
+        font_size=14,
+        tab_size=2,
+        wrap=True,
+        show_gutter=True,
+        auto_update=True,
+        key=f"sparql_ace_{st.session_state.get(_EDITOR_NONCE, 0)}",
+    )
+    edited = edited or ""
+    st.session_state[_QUERY_KEY] = edited
+    st.caption(_EDITOR_HELP)
+    return edited
 
 
 def _render_select_result(result: sparql.QueryResult) -> None:
@@ -173,16 +256,7 @@ def render_sparql():
         on_change=_load_example,
     )
 
-    query_text = st.text_area(
-        "Query",
-        height=240,
-        key=_QUERY_KEY,
-        placeholder="SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10",
-        help=(
-            "The ontology's prefixes are already declared, so you can write "
-            "`owl:Class` or `:Person` without a PREFIX line."
-        ),
-    )
+    query_text = _render_editor()
 
     limit_col, timeout_col, run_col = st.columns([2, 2, 1])
     with limit_col:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "owlrl>=6.0.2",
     "networkx>=3.0",
     "streamlit-local-storage>=0.0.25",
+    "streamlit-ace>=0.1.1",
 ]
 
 [project.scripts]

--- a/tests/test_page_smoke.py
+++ b/tests/test_page_smoke.py
@@ -87,6 +87,7 @@ PAGE_FUNCTIONS = {
     "skos": "render_skos_vocabulary",
     "import_export": "render_import_export",
     "source": "render_source",
+    "sparql": "render_sparql",
     "validation": "render_validation",
 }
 CASES = [

--- a/tests/test_sparql.py
+++ b/tests/test_sparql.py
@@ -1,0 +1,279 @@
+"""Tests for the read-only SPARQL console engine."""
+
+import time
+
+import pytest
+from rdflib import Graph, Literal, Namespace, URIRef
+
+from orionbelt_ontology_builder import sparql
+
+EX = Namespace("http://example.org/")
+
+
+def _cartesian_graph(n=300):
+    """A graph small enough to build instantly, big enough that a three-way
+    cartesian product over it cannot finish."""
+    g = Graph()
+    for i in range(n):
+        g.add((EX[f"s{i}"], EX.p, Literal(i)))
+    return g
+
+
+# --- read-only enforcement -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "INSERT DATA { <http://a> <http://b> <http://c> }",
+        "DELETE WHERE { ?s ?p ?o }",
+        "DROP ALL",
+        "CLEAR GRAPH <http://g>",
+        "LOAD <http://elsewhere.example/data.ttl>",
+    ],
+)
+def test_updates_are_rejected(populated_om, query):
+    with pytest.raises(sparql.QueryNotAllowed):
+        sparql.run_query(populated_om.graph, query)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * WHERE { ?s ?p ?o }",
+        "ASK { ?s ?p ?o }",
+        "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+        "DESCRIBE <http://test.org/ont#Person>",
+    ],
+)
+def test_read_only_forms_are_accepted(populated_om, query):
+    result = sparql.run_query(populated_om.graph, query)
+    assert result.form in sparql.READ_ONLY_FORMS
+
+
+def test_update_message_distinguishes_itself_from_a_typo(populated_om):
+    with pytest.raises(sparql.QueryNotAllowed, match="read-only"):
+        sparql.run_query(populated_om.graph, "DELETE WHERE { ?s ?p ?o }")
+    with pytest.raises(sparql.QuerySyntaxError):
+        sparql.run_query(populated_om.graph, "SELECT * WHERE { ?s ?p")
+
+
+def test_empty_query_is_a_syntax_error(populated_om):
+    with pytest.raises(sparql.QuerySyntaxError):
+        sparql.run_query(populated_om.graph, "   ")
+
+
+def test_a_query_cannot_mutate_the_ontology(populated_om):
+    before = len(populated_om.graph)
+    sparql.run_query(populated_om.graph, "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")
+    assert len(populated_om.graph) == before
+
+
+def test_the_bounded_store_refuses_writes(populated_om):
+    store = sparql._DeadlineStore(populated_om.graph.store, time.monotonic() + 60)
+    with pytest.raises(sparql.QueryNotAllowed):
+        store.add((EX.a, EX.b, EX.c), None)
+    with pytest.raises(sparql.QueryNotAllowed):
+        store.remove((None, None, None), None)
+
+
+def test_service_is_rejected(populated_om):
+    with pytest.raises(sparql.QueryNotAllowed, match="SERVICE"):
+        sparql.run_query(
+            populated_om.graph,
+            "SELECT * WHERE { SERVICE <http://dbpedia.org/sparql> { ?s ?p ?o } }",
+        )
+
+
+def test_values_only_blowup_is_rejected(populated_om):
+    vals = " ".join(str(i) for i in range(400))
+    query = (
+        f"SELECT * WHERE {{ VALUES ?a {{ {vals} }} VALUES ?b {{ {vals} }} "
+        f"VALUES ?c {{ {vals} }} }}"
+    )
+    with pytest.raises(sparql.QueryNotAllowed, match="VALUES"):
+        sparql.run_query(populated_om.graph, query)
+
+
+def test_small_values_query_still_runs(populated_om):
+    result = sparql.run_query(
+        populated_om.graph, "SELECT * WHERE { VALUES ?a { 1 2 3 } }"
+    )
+    assert result.row_count == 3
+
+
+# --- results ---------------------------------------------------------------
+
+
+def test_select_returns_columns_and_rows(populated_om):
+    result = sparql.run_query(
+        populated_om.graph,
+        "SELECT ?c WHERE { ?c a <http://www.w3.org/2002/07/owl#Class> }",
+    )
+    assert result.columns == ["c"]
+    # The ontology's namespace is bound to the empty prefix, so its entities
+    # render the way Turtle writes them.
+    names = {row[0] for row in result.rows}
+    assert ":Person" in names
+
+
+def test_ask_returns_a_boolean(populated_om):
+    yes = sparql.run_query(populated_om.graph, "ASK { ?s ?p ?o }")
+    no = sparql.run_query(populated_om.graph, "ASK { <http://nope.example/x> ?p ?o }")
+    assert yes.ask is True
+    assert no.ask is False
+
+
+def test_construct_returns_a_graph(populated_om):
+    result = sparql.run_query(
+        populated_om.graph,
+        "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+        max_rows=sparql.MAX_ROWS_CEILING,
+    )
+    assert result.graph is not None
+    assert len(result.graph) == len(populated_om.graph)
+    assert result.columns == ["subject", "predicate", "object"]
+
+
+def test_ontology_prefixes_resolve_without_a_prefix_clause(populated_om):
+    """The ontology's own bindings are offered to the parser, so a user can
+    write ``owl:Class`` without redeclaring it."""
+    result = sparql.run_query(populated_om.graph, "SELECT ?c WHERE { ?c a owl:Class }")
+    assert result.row_count > 0
+
+
+def test_running_a_query_does_not_add_prefixes_to_the_ontology(populated_om):
+    """rdflib's URI shortening binds generated ``ns1:`` prefixes as a side
+    effect; the console must not leave those on the user's ontology."""
+    before = set(populated_om.graph.namespaces())
+    sparql.run_query(populated_om.graph, "SELECT * WHERE { ?s ?p ?o }")
+    assert set(populated_om.graph.namespaces()) == before
+
+
+def test_language_tagged_literals_keep_their_tag(om):
+    om.graph.add((EX.a, EX.label, Literal("Chien", lang="fr")))
+    result = sparql.run_query(
+        om.graph, "SELECT ?o WHERE { ?s <http://example.org/label> ?o }"
+    )
+    assert result.rows == [["Chien@fr"]]
+
+
+def test_format_term_prefers_the_most_specific_namespace():
+    prefixes = [("ex", "http://example.org/"), ("exsub", "http://example.org/sub/")]
+    prefixes.sort(key=lambda item: len(item[1]), reverse=True)
+    assert sparql.format_term(URIRef("http://example.org/sub/A"), prefixes) == "exsub:A"
+
+
+def test_format_term_keeps_the_colon_for_the_default_prefix():
+    assert (
+        sparql.format_term(
+            URIRef("http://example.org/A"), [("", "http://example.org/")]
+        )
+        == ":A"
+    )
+
+
+def test_format_term_leaves_an_unshortenable_uri_alone():
+    assert (
+        sparql.format_term(
+            URIRef("http://other.example/A"), [("ex", "http://example.org/")]
+        )
+        == "http://other.example/A"
+    )
+
+
+# --- the row cap -----------------------------------------------------------
+
+
+def test_row_cap_truncates_and_says_so(populated_om):
+    result = sparql.run_query(
+        populated_om.graph, "SELECT * WHERE { ?s ?p ?o }", max_rows=3
+    )
+    assert result.row_count == 3
+    assert result.truncated is True
+
+
+def test_row_cap_not_flagged_when_everything_fits(populated_om):
+    result = sparql.run_query(
+        populated_om.graph,
+        "SELECT * WHERE { ?s ?p ?o }",
+        max_rows=sparql.MAX_ROWS_CEILING,
+    )
+    assert result.truncated is False
+    assert result.row_count == len(populated_om.graph)
+
+
+def test_row_cap_applies_to_construct(populated_om):
+    result = sparql.run_query(
+        populated_om.graph, "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }", max_rows=2
+    )
+    assert result.truncated is True
+    assert result.graph is not None
+    assert len(result.graph) == 2
+
+
+def test_row_cap_is_clamped_to_the_ceiling(populated_om):
+    result = sparql.run_query(
+        populated_om.graph, "SELECT * WHERE { ?s ?p ?o }", max_rows=10**9
+    )
+    assert result.truncated is False
+
+
+# --- the deadline ----------------------------------------------------------
+
+
+def test_a_query_that_never_yields_a_row_is_still_interrupted():
+    """The case a deadline on result iteration cannot catch: ORDER BY consumes
+    the whole join before yielding anything, so the interrupt has to come from
+    inside the store."""
+    graph = _cartesian_graph()
+    started = time.monotonic()
+    result = sparql.run_query(
+        graph,
+        "SELECT * WHERE { ?a ?b ?c . ?d ?e ?f . ?g ?h ?i } ORDER BY ?c",
+        timeout_seconds=1,
+    )
+    elapsed = time.monotonic() - started
+    assert result.timed_out is True
+    assert result.rows == []
+    assert elapsed < 20, f"deadline did not interrupt promptly ({elapsed:.1f}s)"
+
+
+def test_a_streaming_runaway_is_interrupted(populated_om):
+    graph = _cartesian_graph()
+    result = sparql.run_query(
+        graph, "SELECT * WHERE { ?a ?b ?c . ?d ?e ?f . ?g ?h ?i }", timeout_seconds=1
+    )
+    assert result.timed_out or result.truncated
+
+
+def test_a_normal_query_is_not_flagged(populated_om):
+    result = sparql.run_query(populated_om.graph, "SELECT * WHERE { ?s ?p ?o }")
+    assert result.timed_out is False
+    assert result.truncated is False
+    assert result.elapsed >= 0
+
+
+def test_the_bounded_store_returns_the_same_rows_as_the_plain_graph(populated_om):
+    query = "SELECT ?s ?p ?o WHERE { ?s ?p ?o }"
+    direct = {tuple(str(t) for t in row) for row in populated_om.graph.query(query)}
+    viaconsole = sparql.run_query(
+        populated_om.graph, query, max_rows=sparql.MAX_ROWS_CEILING
+    )
+    assert len(viaconsole.rows) == len(direct)
+
+
+def test_timeout_is_clamped_to_the_ceiling(populated_om):
+    result = sparql.run_query(
+        populated_om.graph, "SELECT * WHERE { ?s ?p ?o }", timeout_seconds=10**6
+    )
+    assert result.timed_out is False
+
+
+# --- csv export ------------------------------------------------------------
+
+
+def test_rows_to_csv_round_trips():
+    csv_text = sparql.rows_to_csv(["a", "b"], [["1", "2"], ["3", "4"]])
+    assert csv_text.splitlines()[0] == "a,b"
+    assert "3,4" in csv_text

--- a/tests/test_sparql.py
+++ b/tests/test_sparql.py
@@ -239,6 +239,32 @@ def test_a_query_that_never_yields_a_row_is_still_interrupted():
     assert elapsed < 20, f"deadline did not interrupt promptly ({elapsed:.1f}s)"
 
 
+def test_a_union_query_is_interrupted():
+    """The common case, and the one a row cap cannot touch.
+
+    rdflib's ``evalUnion`` is not a generator: it appends both branches into a
+    list and returns it, so every query containing a UNION is fully evaluated
+    before its first row exists. Only the store deadline can stop one.
+    """
+    graph = _cartesian_graph()
+    started = time.monotonic()
+    result = sparql.run_query(
+        graph,
+        """
+        SELECT ?x WHERE {
+          { ?x ?p ?o }
+          UNION
+          { ?a ?b ?c . ?d ?e ?f . ?x ?g ?h }
+        }
+        """,
+        timeout_seconds=1,
+    )
+    elapsed = time.monotonic() - started
+    assert result.timed_out is True
+    assert result.rows == [], "a UNION yields nothing until it is fully evaluated"
+    assert elapsed < 20, f"deadline did not interrupt promptly ({elapsed:.1f}s)"
+
+
 def test_a_streaming_runaway_is_interrupted(populated_om):
     graph = _cartesian_graph()
     result = sparql.run_query(

--- a/tests/test_sparql.py
+++ b/tests/test_sparql.py
@@ -303,3 +303,31 @@ def test_rows_to_csv_round_trips():
     csv_text = sparql.rows_to_csv(["a", "b"], [["1", "2"], ["3", "4"]])
     assert csv_text.splitlines()[0] == "a,b"
     assert "3,4" in csv_text
+
+
+# --- dataset clauses -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM <http://no-such.example/g> WHERE { ?s ?p ?o }",
+        "SELECT * FROM NAMED <http://no-such.example/g> WHERE { ?s ?p ?o }",
+        "CONSTRUCT { ?s ?p ?o } FROM <http://no-such.example/g> WHERE { ?s ?p ?o }",
+        "ASK FROM <http://no-such.example/g> { ?s ?p ?o }",
+        "DESCRIBE ?s FROM <http://no-such.example/g> WHERE { ?s ?p ?o }",
+    ],
+)
+def test_dataset_clauses_are_rejected(populated_om, query):
+    """rdflib evaluates these against the graph it is given and ignores the
+    clause, so every one of them silently answered from the loaded ontology
+    under another graph's name — right-looking rows for a question nobody
+    asked. Refused rather than answered wrongly.
+    """
+    with pytest.raises(sparql.QueryNotAllowed, match="FROM"):
+        sparql.run_query(populated_om.graph, query)
+
+
+def test_a_query_without_a_dataset_clause_is_unaffected(populated_om):
+    result = sparql.run_query(populated_om.graph, "SELECT * WHERE { ?s ?p ?o }")
+    assert result.row_count == len(populated_om.graph)

--- a/tests/test_sparql.py
+++ b/tests/test_sparql.py
@@ -409,8 +409,47 @@ def test_ordered_vars_places_unknown_variables_last_by_name():
     a deterministic spot rather than a hash-ordered one."""
     from rdflib import Variable
 
-    algebra = sparql.prepare("SELECT * WHERE { ?s ?p ?o }", {}).query.algebra
+    var_order = sparql.prepare("SELECT * WHERE { ?s ?p ?o }", {}).var_order
     given = [Variable("zeta"), Variable("o"), Variable("alpha"), Variable("s")]
-    ordered = sparql.ordered_vars(algebra, given, select_star=True)
+    ordered = sparql.ordered_vars(var_order, given, select_star=True)
     assert [str(v) for v in ordered] == ["s", "o", "alpha", "zeta"]
     assert sorted(str(v) for v in ordered) == sorted(str(v) for v in given)
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        # A variable bound after a pattern comes after it. The algebra puts the
+        # operator that introduces it *above* that pattern, so an algebra walk
+        # reported it first; the parse tree has no such inversion.
+        ("SELECT * WHERE { ?s ?p ?o . BIND(?o AS ?x) }", ["s", "p", "o", "x"]),
+        ("SELECT * WHERE { VALUES ?z { 1 } BIND(2 AS ?a) }", ["z", "a"]),
+        # ... and one bound before a pattern still comes first, which a fix
+        # that merely visited Extend's child first would have inverted.
+        ("SELECT * WHERE { BIND(1 AS ?first) ?s ?p ?o }", ["first", "s", "p", "o"]),
+        (
+            "SELECT * WHERE { ?s ?p ?o OPTIONAL { ?o ?q ?r } }",
+            ["s", "p", "o", "q", "r"],
+        ),
+        (
+            "SELECT * WHERE { { ?a ?b ?c } UNION { ?d ?e ?f } }",
+            ["a", "b", "c", "d", "e", "f"],
+        ),
+    ],
+)
+def test_select_star_follows_source_order_through_binding_forms(query, expected):
+    graph = Graph()
+    graph.add((EX.s, EX.p, Literal(1)))
+    assert sparql.run_query(graph, query).columns == expected
+
+
+def test_a_variable_named_only_in_a_comment_or_string_does_not_reorder():
+    """The order is read off the parse tree, not the query text, so text that
+    merely looks like a variable is not one."""
+    graph = Graph()
+    graph.add((EX.s, EX.p, Literal("?zzz")))
+    query = """
+        # ?zzz is mentioned here and is not a binding
+        SELECT * WHERE { ?s ?p ?o . FILTER(?o != "?zzz") }
+    """
+    assert sparql.run_query(graph, query).columns == ["s", "p", "o"]

--- a/tests/test_sparql.py
+++ b/tests/test_sparql.py
@@ -1,5 +1,8 @@
 """Tests for the read-only SPARQL console engine."""
 
+import os
+import subprocess
+import sys
 import time
 
 import pytest
@@ -331,3 +334,83 @@ def test_dataset_clauses_are_rejected(populated_om, query):
 def test_a_query_without_a_dataset_clause_is_unaffected(populated_om):
     result = sparql.run_query(populated_om.graph, "SELECT * WHERE { ?s ?p ?o }")
     assert result.row_count == len(populated_om.graph)
+
+
+# --- column ordering -------------------------------------------------------
+
+
+def test_select_star_columns_follow_query_order(populated_om):
+    result = sparql.run_query(populated_om.graph, "SELECT * WHERE { ?s ?p ?o }")
+    assert result.columns == ["s", "p", "o"]
+
+
+def test_select_star_column_order_is_stable_across_processes():
+    """The bug this fixes: rdflib builds SELECT *'s projection from a set, so
+    hash randomisation reordered the columns between runs and two exports of
+    the same query could disagree. Run in subprocesses because a single
+    interpreter has one hash seed for its lifetime.
+    """
+    script = (
+        "from rdflib import Graph, Literal, Namespace;"
+        "from orionbelt_ontology_builder import sparql;"
+        "EX = Namespace('http://e.org/');"
+        "g = Graph();"
+        "g.add((EX.a, EX.p, Literal('x')));"
+        "print(sparql.run_query(g, 'SELECT * WHERE { ?alpha ?beta ?gamma }').columns)"
+    )
+    seen = set()
+    for seed in ("0", "1", "2", "42"):
+        env = {**os.environ, "PYTHONHASHSEED": seed}
+        out = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+        seen.add(out.stdout.strip())
+    assert len(seen) == 1, f"column order varied by hash seed: {seen}"
+    assert seen.pop() == "['alpha', 'beta', 'gamma']"
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("SELECT ?o ?s WHERE { ?s ?p ?o }", ["o", "s"]),
+        ("SELECT ?p ?s WHERE { ?s ?p ?o }", ["p", "s"]),
+        (
+            "SELECT ?p (COUNT(?s) AS ?n) WHERE { ?s ?p ?o } GROUP BY ?p",
+            ["p", "n"],
+        ),
+    ],
+)
+def test_an_explicit_projection_keeps_the_users_order(populated_om, query, expected):
+    """Only SELECT * may be reordered. The order the user wrote lives solely in
+    the projection — the algebra keeps no record of the SELECT clause — so
+    ordering an explicit projection against the pattern would rewrite it.
+    """
+    assert sparql.run_query(populated_om.graph, query).columns == expected
+
+
+def test_reordering_keeps_each_value_under_its_own_column():
+    """Reordering the header without reordering the cells would mislabel every
+    row, which is worse than the unstable order it replaces."""
+    graph = Graph()
+    graph.add((EX.subj, EX.pred, Literal("the object")))
+    result = sparql.run_query(graph, "SELECT * WHERE { ?s ?p ?o }")
+    row = dict(zip(result.columns, result.rows[0], strict=True))
+    assert row["s"].endswith("subj")
+    assert row["p"].endswith("pred")
+    assert row["o"] == "the object"
+
+
+def test_ordered_vars_places_unknown_variables_last_by_name():
+    """Nothing is dropped, and a variable the walk cannot place still lands in
+    a deterministic spot rather than a hash-ordered one."""
+    from rdflib import Variable
+
+    algebra = sparql.prepare("SELECT * WHERE { ?s ?p ?o }", {}).query.algebra
+    given = [Variable("zeta"), Variable("o"), Variable("alpha"), Variable("s")]
+    ordered = sparql.ordered_vars(algebra, given, select_star=True)
+    assert [str(v) for v in ordered] == ["s", "o", "alpha", "zeta"]
+    assert sorted(str(v) for v in ordered) == sorted(str(v) for v in given)

--- a/tests/test_sparql_ui.py
+++ b/tests/test_sparql_ui.py
@@ -8,6 +8,7 @@ than swallowed.
 
 import os
 
+import pytest
 from streamlit.testing.v1 import AppTest
 
 from orionbelt_ontology_builder.views.sparql import EXAMPLE_QUERIES
@@ -153,3 +154,85 @@ def test_a_timed_out_query_does_not_claim_it_matched_nothing(monkeypatch):
     shown.clear()
     page._render_result(sparql.QueryResult(form="SELECT"))
     assert any("matched nothing" in m for m in shown)
+
+
+# --- the editor ------------------------------------------------------------
+
+
+def test_the_editor_themes_are_real_ace_themes():
+    """A typo here does not raise, it silently renders an unstyled editor."""
+    from streamlit_ace import THEMES
+
+    from orionbelt_ontology_builder.views import sparql as page
+
+    assert page._EDITOR_THEME_LIGHT in THEMES
+    assert page._EDITOR_THEME_DARK in THEMES
+
+
+def test_the_editor_theme_is_not_one_that_leaves_sparql_black():
+    """Ace themes only colour the token classes they choose to, and SPARQL
+    emits ``ace_variable ace_other`` / ``ace_support ace_type``. The 'github'
+    theme styles neither and gives ace_keyword bold with no colour, so the
+    whole query renders flat black. Measured in the browser, not guessed.
+    """
+    from orionbelt_ontology_builder.views import sparql as page
+
+    assert page._EDITOR_THEME_LIGHT != "github"
+    assert page._EDITOR_THEME_DARK != "github"
+
+
+@pytest.mark.parametrize(
+    ("theme_type", "expected"),
+    [("dark", "_EDITOR_THEME_DARK"), ("light", "_EDITOR_THEME_LIGHT")],
+)
+def test_the_editor_follows_the_app_theme(monkeypatch, theme_type, expected):
+    from orionbelt_ontology_builder.views import sparql as page
+
+    monkeypatch.setattr(
+        page.st,
+        "context",
+        type("C", (), {"theme": type("T", (), {"type": theme_type})}),
+    )
+    assert page._editor_theme() == getattr(page, expected)
+
+
+def test_the_editor_falls_back_to_light_when_the_theme_is_unreadable(monkeypatch):
+    """st.context.theme is not available in every Streamlit context."""
+    from orionbelt_ontology_builder.views import sparql as page
+
+    class Boom:
+        @property
+        def theme(self):
+            raise RuntimeError("no context")
+
+    monkeypatch.setattr(page.st, "context", Boom())
+    assert page._editor_theme() == page._EDITOR_THEME_LIGHT
+
+
+def test_picking_an_example_remounts_the_editor():
+    """Ace treats ``value`` as initial content only, so an example has to
+    remount the component under a new key or the editor keeps showing what the
+    user had before."""
+    at = _run("", click=False)
+    at.selectbox[0].select("Class hierarchy").run(timeout=120)
+    assert not at.exception, at.exception
+    assert at.session_state["sparql_editor_nonce"] >= 1
+    assert at.session_state["sparql_query_text"] == EXAMPLE_QUERIES["Class hierarchy"]
+
+
+def test_the_page_still_works_without_the_editor_component(monkeypatch):
+    """The editor is a nicety; querying is the feature. If streamlit-ace cannot
+    be imported the page must still render and run queries."""
+    from orionbelt_ontology_builder.views import sparql as page
+
+    monkeypatch.setattr(page, "st_ace", None)
+    shown: dict = {}
+    monkeypatch.setattr(page.st, "caption", lambda *a, **k: None)
+    monkeypatch.setattr(
+        page.st, "container", lambda **k: __import__("contextlib").nullcontext()
+    )
+    monkeypatch.setattr(
+        page.st, "text_area", lambda *a, **k: shown.setdefault("fell_back", True) and ""
+    )
+    page._render_editor()
+    assert shown.get("fell_back") is True

--- a/tests/test_sparql_ui.py
+++ b/tests/test_sparql_ui.py
@@ -1,0 +1,155 @@
+"""The SPARQL page runs a query, reports limits, and refuses to write.
+
+The engine's own guarantees are covered in test_sparql.py; these check that the
+page is wired to them — that a query typed into the text area reaches
+``run_query`` with the page's limits, and that what comes back is shown rather
+than swallowed.
+"""
+
+import os
+
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder.views.sparql import EXAMPLE_QUERIES
+
+
+def _script():
+    import os
+
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Bicycle", label="Bicycle")
+        om.add_class("Wheel", label="Wheel")
+        om.add_class("Tandem", parent="Bicycle", label="Tandem")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["sparql_query_text"] = os.environ["SPARQL_Q"]
+        rows = os.environ.get("SPARQL_ROWS")
+        if rows:
+            st.session_state["sparql_max_rows"] = int(rows)
+
+    app.render_sparql()
+
+
+def _run(query, *, max_rows=None, click=True):
+    os.environ["SPARQL_Q"] = query
+    if max_rows is None:
+        os.environ.pop("SPARQL_ROWS", None)
+    else:
+        os.environ["SPARQL_ROWS"] = str(max_rows)
+    at = AppTest.from_function(_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    if click:
+        at.button[0].click().run(timeout=120)
+        assert not at.exception, at.exception
+    return at
+
+
+def _captions(at):
+    return " ".join(c.value for c in at.caption)
+
+
+def _warnings(at):
+    return " ".join(w.value for w in at.warning)
+
+
+def test_a_select_query_reports_its_rows():
+    at = _run("SELECT ?c WHERE { ?c a owl:Class }")
+    assert not at.error
+    assert "3 rows in" in _captions(at)
+
+
+def test_an_ask_query_shows_a_verdict():
+    at = _run("ASK { ?s a owl:Class }")
+    assert not at.error
+    assert at.metric[0].value == "true"
+
+
+def test_an_update_is_refused_on_the_page():
+    at = _run("INSERT DATA { <http://a> <http://b> <http://c> }")
+    assert at.error
+    assert "read-only" in at.error[0].value
+
+
+def test_a_syntax_error_is_shown_not_raised():
+    at = _run("SELECT ?c WHERE { ?c a owl:Class")
+    assert at.error
+
+
+def test_the_row_limit_is_applied_and_announced():
+    at = _run("SELECT ?s ?p ?o WHERE { ?s ?p ?o }", max_rows=2)
+    assert not at.error
+    assert "Showing the first 2 rows" in _warnings(at)
+
+
+def test_an_empty_result_says_so():
+    at = _run("SELECT ?s WHERE { ?s a <http://nope.example/Missing> }")
+    assert not at.error
+    assert any("matched nothing" in i.value for i in at.info)
+
+
+def test_the_page_renders_before_anything_is_run():
+    at = _run("", click=False)
+    assert not at.error
+    assert not at.warning
+
+
+def test_running_a_query_leaves_the_ontology_alone():
+    """The page is the only thing a user can point at the graph, so the
+    read-only promise is worth asserting end to end, not just in the engine."""
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    at = _run("CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")
+    assert not at.error
+    om = at.session_state["ontology"]
+    assert len(om.get_classes()) == 3
+    # rdflib's URI shortening binds generated ``ns1:`` prefixes as it goes, so
+    # a query could leave prefixes behind on the ontology it only read.
+    assert set(om.graph.namespaces()) == set(OntologyManager().graph.namespaces())
+
+
+def test_picking_an_example_fills_the_editor():
+    at = _run("", click=False)
+    at.selectbox[0].select("Class hierarchy").run(timeout=120)
+    assert not at.exception, at.exception
+    assert at.session_state["sparql_query_text"] == EXAMPLE_QUERIES["Class hierarchy"]
+
+
+def test_every_example_query_runs():
+    """An example that does not parse is worse than no example at all."""
+    from orionbelt_ontology_builder import sparql
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    om = OntologyManager()
+    om.add_class("Person", label="Person")
+    om.add_concept_scheme("Scheme")
+    om.add_concept("Animal", scheme="Scheme", pref_label="Animal")
+    for name, query in EXAMPLE_QUERIES.items():
+        result = sparql.run_query(om.graph, query)
+        assert result.form in sparql.READ_ONLY_FORMS, name
+
+
+def test_a_timed_out_query_does_not_claim_it_matched_nothing(monkeypatch):
+    """A query stopped by the deadline produced no rows *yet*. Reporting that
+    as an empty answer states the opposite of what happened."""
+    from orionbelt_ontology_builder import sparql
+    from orionbelt_ontology_builder.views import sparql as page
+
+    shown: list[str] = []
+    monkeypatch.setattr(page.st, "info", lambda msg, *a, **k: shown.append(msg))
+    monkeypatch.setattr(page.st, "warning", lambda msg, *a, **k: shown.append(msg))
+    monkeypatch.setattr(page.st, "caption", lambda msg, *a, **k: None)
+
+    page._render_result(sparql.QueryResult(form="SELECT", timed_out=True))
+    assert not any("matched nothing" in m for m in shown)
+    assert any("time limit" in m for m in shown)
+
+    shown.clear()
+    page._render_result(sparql.QueryResult(form="SELECT"))
+    assert any("matched nothing" in m for m in shown)

--- a/uv.lock
+++ b/uv.lock
@@ -708,6 +708,7 @@ dependencies = [
     { name = "owlrl" },
     { name = "rdflib" },
     { name = "streamlit" },
+    { name = "streamlit-ace" },
     { name = "streamlit-local-storage" },
 ]
 
@@ -750,6 +751,7 @@ requires-dist = [
     { name = "rdflib", specifier = ">=7.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.4" },
     { name = "streamlit", specifier = "==1.49.1" },
+    { name = "streamlit-ace", specifier = ">=0.1.1" },
     { name = "streamlit-desktop-app", marker = "extra == 'desktop'", specifier = ">=0.3.3" },
     { name = "streamlit-desktop-app", marker = "extra == 'gtk'", specifier = ">=0.3.3" },
     { name = "streamlit-desktop-app", marker = "extra == 'qt'", specifier = ">=0.3.3" },
@@ -1550,6 +1552,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/17/c8024e4ef311dc7833987c603a7d0ebe82f8aa352aaca53b27be3f6b7f01/streamlit-1.49.1.tar.gz", hash = "sha256:6f213f1e43f035143a56f58ad50068d8a09482f0a2dad1050d7e7e99a9689818", size = 9640116, upload-time = "2025-08-29T18:35:45.055Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/9e/146cdef515ad07e56c3aa942d087562498592d441aa3bae845ef0cd8fca3/streamlit-1.49.1-py3-none-any.whl", hash = "sha256:ad7b6d0dc35db168587acf96f80378249467fc057ed739a41c511f6bf5aa173b", size = 10044388, upload-time = "2025-08-29T18:35:42.239Z" },
+]
+
+[[package]]
+name = "streamlit-ace"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "streamlit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/34/a508123af170e41852d247b17d38d9cddc2b4be3884f2f29a84aeb322992/streamlit_ace-0.1.1.tar.gz", hash = "sha256:1852fa19707685fd4241be9256c1ab1a89da4a3b8c28ab286e3bff122d3a1686", size = 2389652, upload-time = "2021-12-07T19:01:15.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/c9/e862cefc5735e11c101b2bc45f37a2b767666ffe673d262004202b506f3b/streamlit_ace-0.1.1-py3-none-any.whl", hash = "sha256:cdf908a90058fa831fb720d29e2aef35a0f5799eac33e2b2e58ba9f3631b1aa5", size = 3642928, upload-time = "2021-12-07T19:01:11.288Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the SPARQL page: SELECT, ASK, CONSTRUCT and DESCRIBE over the loaded ontology, with the ontology's own prefixes pre-declared (so `owl:Class` and `:Person` work without a PREFIX line), eight worked examples, and CSV/Turtle download of results.

## Read-only

`prepareQuery` accepts only the four query forms, so every update form fails it. A failure is re-parsed as an update to tell two different problems apart: "this console is read-only" and "you have a typo" get different messages. The store the query runs against also raises on any write, so the guarantee holds by construction rather than by argument. Edits keep going through the editor pages, where they are checkpointed and can be undone.

## Bounded, in two layers

A row cap and a deadline on result iteration catch the common runaway, a query that streams more rows than anyone wants to see.

The layer that actually saves the app is a deadline checked inside a read-through store proxy. rdflib's `evalBGP` pulls every candidate solution through `ctx.graph.triples()` and recurses per binding, so a deadline at the store is checked continuously throughout evaluation, including while an `ORDER BY` / `GROUP BY` / `DISTINCT` above it consumes the whole join before yielding anything.

Measured on a 300-triple graph:

| Case | Result |
| --- | --- |
| 3-way cartesian + `ORDER BY`, deadline on result iteration only | no first row at all after 8s |
| Same query, deadline inside `store.triples()` | stopped at 3.05s |
| Realistic query, 6k-triple graph, proxy installed | 72.1ms vs 72.3ms plain |

Staying in-process is the point. A subprocess would mean forking from a Streamlit ScriptRunner thread, which is a multi-threaded process; CPython has deprecated that since 3.12 ("use of fork() may lead to deadlocks in the child") and the Docker image ships 3.14. The proxy needs no fork, no signals and no main thread, so the server and the desktop build behave identically.

## The gap this does not close

A query with no triple patterns at all, such as a cross product of large `VALUES` blocks, never touches the store, so nothing trips. That shape is rejected before execution rather than left as a hole. `SERVICE` is rejected too: it would have the server open a connection to a host named in the query.

## Notes

- The wrapper graph inherits the source graph's `identifier`. Without that it addresses an empty context and every query silently returns nothing, which looks exactly like a clean pass.
- URI shortening is done against the graph's own prefix list rather than through rdflib's `normalizeUri`, which binds generated `ns1:` prefixes as a side effect and would leave them on the user's ontology. There is a test for that.
- The row limit is a `number_input` rather than a dropdown, matching the time limit beside it and staying clear of the plain-selectbox guard in `test_clearable_required_dropdowns.py`.

## Testing

46 new tests across `tests/test_sparql.py` (engine) and `tests/test_sparql_ui.py` (page), plus the new page in the smoke matrix. Full suite 1709 passed, ruff and mypy clean.

Verified live in the running app: examples, prefixed results, the read-only refusal (graph untouched at 45 triples), and a five-way cartesian under `ORDER BY` stopped at 3.06s against a 3s budget. That live pass found one bug, now fixed: a timed-out query with no rows also reported that it "matched nothing", which was the opposite of what happened.

The version is left at 1.25.0. Bumping to 1.26.0 is the release step and is yours to call.
