### PR TITLE
fix(prefixes): keep ':' bound to the ontology's own namespace, and say so on the SPARQL page

### DIFF
--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -370,8 +370,11 @@ class OntologyManager:
                 self.graph.remove(old_triple)
                 self.graph.add(new_triple)
 
-        # Re-bind the default namespace
-        self._bind_default_prefix()
+        # Re-bind the default namespace. The namespace it moves off is not
+        # preserved: every resource in it was just rewritten into the new one,
+        # so keeping a prefix for it would leave the abandoned base URI on
+        # offer in the entity-creation namespace picker.
+        self._bind_default_prefix(preserve_displaced=False)
 
     #: The ``scheme:`` an absolute IRI opens with (RFC 3986). A local name can
     #: never match it: :attr:`_LOCAL_NAME_RE` allows no colon, so "already a
@@ -5641,7 +5644,7 @@ class OntologyManager:
         self.graph.bind("dcterms", DCTERMS)
         self._bind_default_prefix()
 
-    def _bind_default_prefix(self):
+    def _bind_default_prefix(self, preserve_displaced: bool = True):
         """Bind ``:`` to this ontology's own namespace, taking it if need be.
 
         ``Graph.bind`` defaults to ``replace=False``, which does not mean "leave
@@ -5665,9 +5668,17 @@ class OntologyManager:
         other prefix is re-bound under a generated name rather than dropped: a
         binding a loaded file declared should survive a round trip, and an
         unbound namespace comes back out of the serializer as ``ns1:``.
+
+        ``preserve_displaced=False`` for the one caller that is not displacing
+        someone else's namespace but abandoning its own: :meth:`set_base_uri`
+        rewrites every resource into the new namespace, so a prefix left
+        pointing at the old one would keep the abandoned base URI in the
+        creatable-namespace list and on the dashboard as a removable prefix.
         """
         displaced = self.graph.store.namespace("")
         self.graph.bind("", self.namespace, replace=True)
+        if not preserve_displaced:
+            return
         if displaced is None or str(displaced) == str(self.namespace):
             return
         if any(str(ns) == str(displaced) for _, ns in self.graph.namespaces()):

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -371,7 +371,7 @@ class OntologyManager:
                 self.graph.add(new_triple)
 
         # Re-bind the default namespace
-        self.graph.bind("", self.namespace)
+        self._bind_default_prefix()
 
     #: The ``scheme:`` an absolute IRI opens with (RFC 3986). A local name can
     #: never match it: :attr:`_LOCAL_NAME_RE` allows no colon, so "already a
@@ -5639,7 +5639,43 @@ class OntologyManager:
         self.graph.bind("skosxl", SKOSXL)
         self.graph.bind("dc", DC)
         self.graph.bind("dcterms", DCTERMS)
-        self.graph.bind("", self.namespace)
+        self._bind_default_prefix()
+
+    def _bind_default_prefix(self):
+        """Bind ``:`` to this ontology's own namespace, taking it if need be.
+
+        ``Graph.bind`` defaults to ``replace=False``, which does not mean "leave
+        the binding alone": when ``:`` is already bound to a *different*
+        namespace, rdflib keeps that binding and quietly parks ours under a
+        generated ``default1:`` instead. Nothing raises, so the app carries on
+        believing ``:`` is its namespace while it names someone else's.
+
+        Two paths land there. Loading a file that declares its own
+        ``@prefix : <...>`` keeps the file's, and :meth:`set_base_uri` leaves
+        ``:`` on the namespace the ontology just moved away from. Both are
+        silent until something reads ``:`` back: entities the editor mints
+        serialize as ``default1:Thing``, and a ``:Thing`` in the SPARQL console
+        resolves into the foreign namespace and matches nothing.
+
+        ``:`` therefore belongs to :attr:`namespace` by force. Every editor page
+        mints URIs there, so it is the one namespace the empty prefix can mean
+        without lying.
+
+        Taking ``:`` unbinds whatever held it, so a displaced namespace with no
+        other prefix is re-bound under a generated name rather than dropped: a
+        binding a loaded file declared should survive a round trip, and an
+        unbound namespace comes back out of the serializer as ``ns1:``.
+        """
+        displaced = self.graph.store.namespace("")
+        self.graph.bind("", self.namespace, replace=True)
+        if displaced is None or str(displaced) == str(self.namespace):
+            return
+        if any(str(ns) == str(displaced) for _, ns in self.graph.namespaces()):
+            return
+        index = 1
+        while self.graph.store.namespace(f"default{index}") is not None:
+            index += 1
+        self.graph.bind(f"default{index}", displaced, replace=True)
 
     def _update_namespace_from_graph(self):
         """Update namespace based on loaded ontology."""

--- a/orionbelt_ontology_builder/views/sparql.py
+++ b/orionbelt_ontology_builder/views/sparql.py
@@ -194,8 +194,9 @@ def _prefix_rows(ont) -> list[dict[str, str]]:
         elif named:
             label = f"{named}:"
         else:
-            # Nothing names it, so the only way to write it is in full.
-            label = f"<{namespace}…>"
+            # Nothing names it. The namespace is in the next column, so
+            # repeating it here would only be noise.
+            label = "(none)"
         rows.append({"Prefix": label, "Namespace": namespace})
     return rows
 
@@ -207,7 +208,9 @@ def _render_prefixes(ont) -> None:
         st.dataframe(_prefix_rows(ont), use_container_width=True, hide_index=True)
         st.caption(
             "`owl:`, `rdf:`, `rdfs:`, `xsd:`, `skos:`, `dc:` and `dcterms:` are "
-            "always declared too, along with the prefixes rdflib binds by default."
+            "always declared too, along with the prefixes rdflib binds by "
+            "default. A namespace with no prefix has to be written in full, as "
+            "`<http://example.org/ontology#Person>`."
         )
 
 
@@ -219,7 +222,13 @@ def _matched_nothing() -> None:
     namespace the ontology does not use.
     """
     st.info("The query ran and matched nothing.")
-    st.caption(f"{_NAMESPACE_HINT} The prefix list under the editor has them all.")
+    # Shorter than the hint above the results: with the prefix list expanded
+    # the two sit on screen together, and saying it twice reads as noise.
+    st.caption(
+        "Check the prefixes if the query names an entity: `:` is this "
+        "ontology's own namespace, and an imported vocabulary keeps its own. "
+        "The list under the editor has them all."
+    )
 
 
 def _render_select_result(result: sparql.QueryResult) -> None:

--- a/orionbelt_ontology_builder/views/sparql.py
+++ b/orionbelt_ontology_builder/views/sparql.py
@@ -93,7 +93,17 @@ def _load_example() -> None:
 
 _EDITOR_HELP = (
     "The ontology's prefixes are already declared, so you can write "
-    "`owl:Class` or `:Person` without a PREFIX line."
+    "`owl:Class` or `:Person` without a PREFIX line. `:` is this ontology's "
+    "own namespace; an imported vocabulary keeps its own prefix."
+)
+
+#: Shown with an empty result and beside the prefix list. A prefixed name that
+#: points at the wrong namespace is valid SPARQL, so it does not fail — it
+#: matches nothing, which reads like an empty ontology rather than a typo.
+_NAMESPACE_HINT = (
+    "`:` is this ontology's own namespace. An entity that came in with an "
+    "imported or upper ontology keeps that vocabulary's prefix, so it is "
+    "`foaf:Person`, not `:Person`."
 )
 _PLACEHOLDER = "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10"
 
@@ -161,13 +171,64 @@ def _render_editor() -> str:
     return edited
 
 
+def _prefix_rows(ont) -> list[dict[str, str]]:
+    """How to write a name in each namespace the ontology actually holds.
+
+    Not every binding: the graph carries ~30 prefixes rdflib binds by default,
+    almost none of which name anything here, and a list that long is one nobody
+    reads. ``get_creatable_namespaces`` is the same set the entity forms offer
+    — the base namespace, plus every namespace an existing entity or a bound
+    import prefix puts in play — which is exactly where a prefixed name in a
+    query can point and find something.
+    """
+    by_namespace: dict[str, list[str]] = {}
+    for prefix, namespace in ont.graph.namespaces():
+        by_namespace.setdefault(str(namespace), []).append(str(prefix))
+
+    rows = []
+    for namespace in ont.get_creatable_namespaces():
+        bound = by_namespace.get(namespace, [])
+        named = next((p for p in bound if p), None)
+        if namespace == ont.base_uri:
+            label = ":"
+        elif named:
+            label = f"{named}:"
+        else:
+            # Nothing names it, so the only way to write it is in full.
+            label = f"<{namespace}…>"
+        rows.append({"Prefix": label, "Namespace": namespace})
+    return rows
+
+
+def _render_prefixes(ont) -> None:
+    """The namespaces in play, under the editor where a query is being written."""
+    with st.expander("Prefixes in this ontology"):
+        st.caption(_NAMESPACE_HINT)
+        st.dataframe(_prefix_rows(ont), use_container_width=True, hide_index=True)
+        st.caption(
+            "`owl:`, `rdf:`, `rdfs:`, `xsd:`, `skos:`, `dc:` and `dcterms:` are "
+            "always declared too, along with the prefixes rdflib binds by default."
+        )
+
+
+def _matched_nothing() -> None:
+    """Say the result is empty, and name the likeliest reason it is.
+
+    An empty result has no error to read, so the one thing worth pointing at is
+    the mistake that produces one silently: a prefixed name resolved into a
+    namespace the ontology does not use.
+    """
+    st.info("The query ran and matched nothing.")
+    st.caption(f"{_NAMESPACE_HINT} The prefix list under the editor has them all.")
+
+
 def _render_select_result(result: sparql.QueryResult) -> None:
     if not result.rows:
         # Only an empty result that actually finished matched nothing. A query
         # stopped by the deadline produced no rows *yet*, and telling the user
         # its answer is empty would be wrong.
         if not result.timed_out:
-            st.info("The query ran and matched nothing.")
+            _matched_nothing()
         return
     st.dataframe(
         [dict(zip(result.columns, row, strict=False)) for row in result.rows],
@@ -186,7 +247,7 @@ def _render_select_result(result: sparql.QueryResult) -> None:
 def _render_graph_result(result: sparql.QueryResult) -> None:
     if result.graph is None or len(result.graph) == 0:
         if not result.timed_out:
-            st.info("The query ran and matched nothing.")
+            _matched_nothing()
         return
     try:
         turtle = result.graph.serialize(format="turtle")
@@ -257,6 +318,7 @@ def render_sparql():
     )
 
     query_text = _render_editor()
+    _render_prefixes(ont)
 
     limit_col, timeout_col, run_col = st.columns([2, 2, 1])
     with limit_col:

--- a/tests/test_prefixes.py
+++ b/tests/test_prefixes.py
@@ -113,3 +113,65 @@ class TestPrefixNamespaceNormalization:
             om.add_prefix("q", "http://example.org/ns?term=")
             == "http://example.org/ns?term="
         )
+
+
+class TestDefaultPrefix:
+    """``:`` must name this ontology's namespace, never a foreign one.
+
+    ``Graph.bind`` defaults to ``replace=False``, so re-binding ``:`` over an
+    existing binding silently parks the new namespace under ``default1:`` and
+    leaves ``:`` where it was. Nothing raises; the damage only shows up when
+    something reads ``:`` back, which is why each case below reads it back.
+    """
+
+    def _empty_prefix(self, om):
+        return str(om.graph.store.namespace(""))
+
+    def test_loaded_file_does_not_keep_the_empty_prefix(self):
+        om = OntologyManager()
+        om.load_from_string(
+            """
+            @prefix owl: <http://www.w3.org/2002/07/owl#> .
+            @prefix : <http://other.example/vocab#> .
+            <http://example.org/ontology> a owl:Ontology .
+            <http://example.org/ontology#Event> a owl:Class .
+            """,
+            "turtle",
+        )
+        assert self._empty_prefix(om) == om.base_uri
+
+    def test_displaced_namespace_stays_bound(self):
+        om = OntologyManager()
+        om.load_from_string(
+            """
+            @prefix owl: <http://www.w3.org/2002/07/owl#> .
+            @prefix : <http://other.example/vocab#> .
+            <http://example.org/ontology> a owl:Ontology .
+            <http://example.org/ontology#Event> a owl:Class .
+            """,
+            "turtle",
+        )
+        bound = {str(ns) for _, ns in om.graph.namespaces()}
+        assert "http://other.example/vocab#" in bound
+
+    def test_set_base_uri_moves_the_empty_prefix(self, om):
+        om.add_class("Event")
+        om.set_base_uri("http://acme.example/onto#")
+        assert self._empty_prefix(om) == "http://acme.example/onto#"
+
+    def test_renamed_namespace_serializes_under_the_empty_prefix(self, om):
+        om.add_class("Event")
+        om.set_base_uri("http://acme.example/onto#")
+        turtle = om.graph.serialize(format="turtle")
+        assert "@prefix : <http://acme.example/onto#>" in turtle
+        assert ":Event" in turtle
+
+    def test_sparql_resolves_the_empty_prefix_to_this_ontology(self, om):
+        # The user-visible symptom: `:Event` matched nothing because `:` named
+        # a namespace the ontology no longer used.
+        from orionbelt_ontology_builder import sparql
+
+        om.add_class("Event")
+        om.set_base_uri("http://acme.example/onto#")
+        result = sparql.run_query(om.graph, "SELECT ?p WHERE { :Event ?p ?o }")
+        assert result.rows

--- a/tests/test_prefixes.py
+++ b/tests/test_prefixes.py
@@ -166,6 +166,16 @@ class TestDefaultPrefix:
         assert "@prefix : <http://acme.example/onto#>" in turtle
         assert ":Event" in turtle
 
+    def test_old_base_uri_is_not_kept_as_a_prefix(self, om):
+        # set_base_uri rewrites every resource into the new namespace, so the
+        # old one is abandoned, not displaced: keeping a prefix for it would
+        # offer the old base URI as a place to create entities.
+        om.add_class("Event")
+        om.set_base_uri("http://acme.example/onto#")
+        bound = {str(ns) for _, ns in om.graph.namespaces()}
+        assert "http://test.org/ont#" not in bound
+        assert "http://test.org/ont#" not in om.get_creatable_namespaces()
+
     def test_sparql_resolves_the_empty_prefix_to_this_ontology(self, om):
         # The user-visible symptom: `:Event` matched nothing because `:` named
         # a namespace the ontology no longer used.

--- a/tests/test_sparql_ui.py
+++ b/tests/test_sparql_ui.py
@@ -11,7 +11,8 @@ import os
 import pytest
 from streamlit.testing.v1 import AppTest
 
-from orionbelt_ontology_builder.views.sparql import EXAMPLE_QUERIES
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+from orionbelt_ontology_builder.views.sparql import EXAMPLE_QUERIES, _prefix_rows
 
 
 def _script():
@@ -93,6 +94,40 @@ def test_an_empty_result_says_so():
     at = _run("SELECT ?s WHERE { ?s a <http://nope.example/Missing> }")
     assert not at.error
     assert any("matched nothing" in i.value for i in at.info)
+
+
+def test_an_empty_result_points_at_the_prefixes():
+    # The mistake behind an empty result is usually a prefixed name resolved
+    # into a namespace the ontology does not use, and that fails silently.
+    at = _run("SELECT ?s WHERE { ?s a <http://nope.example/Missing> }")
+    assert "own namespace" in _captions(at)
+
+
+def test_the_page_lists_the_prefixes_that_name_something():
+    at = _run("SELECT ?s WHERE { ?s a owl:Class }", click=False)
+    assert any("Prefixes in this ontology" in e.label for e in at.expander)
+
+
+class TestPrefixRows:
+    """What the prefix list says a name in each namespace looks like."""
+
+    def test_the_ontology_namespace_comes_first_as_the_empty_prefix(self):
+        om = OntologyManager()
+        om.add_class("Person")
+        assert _prefix_rows(om)[0] == {"Prefix": ":", "Namespace": om.base_uri}
+
+    def test_an_imported_namespace_keeps_its_own_prefix(self):
+        om = OntologyManager()
+        om.add_prefix("foaf", "http://xmlns.com/foaf/0.1/")
+        om.add_class("Person", namespace="http://xmlns.com/foaf/0.1/")
+        rows = {row["Namespace"]: row["Prefix"] for row in _prefix_rows(om)}
+        assert rows["http://xmlns.com/foaf/0.1/"] == "foaf:"
+
+    def test_a_namespace_nothing_names_is_shown_in_full(self):
+        om = OntologyManager()
+        om.add_class("Widget", namespace="http://un.bound.example/ns#")
+        rows = {row["Namespace"]: row["Prefix"] for row in _prefix_rows(om)}
+        assert rows["http://un.bound.example/ns#"].startswith("<http://un.bound")
 
 
 def test_the_page_renders_before_anything_is_run():

--- a/tests/test_sparql_ui.py
+++ b/tests/test_sparql_ui.py
@@ -127,7 +127,7 @@ class TestPrefixRows:
         om = OntologyManager()
         om.add_class("Widget", namespace="http://un.bound.example/ns#")
         rows = {row["Namespace"]: row["Prefix"] for row in _prefix_rows(om)}
-        assert rows["http://un.bound.example/ns#"].startswith("<http://un.bound")
+        assert rows["http://un.bound.example/ns#"] == "(none)"
 
 
 def test_the_page_renders_before_anything_is_run():


### PR DESCRIPTION
## What

`:` in the SPARQL console, and in every Turtle export, is whatever the graph has bound to the empty prefix. The app tried to keep that pointing at the ontology's own namespace with `graph.bind("", self.namespace)`, but rdflib's `bind` defaults to `replace=False`: when `:` is already bound to a *different* namespace it keeps the old binding and quietly parks ours under a generated `default1:`. Nothing raises.

Two paths land there:

* loading a file that declares its own `@prefix : <...>` keeps the file's binding;
* `set_base_uri` leaves `:` on the namespace the ontology just moved away from.

Both are silent until something reads `:` back. Reproduced on `main`:

```
# after set_base_uri("http://acme.org/onto#")
base:    http://acme.org/onto#
empty -> http://example.org/ontology#          <- stale
bindings: [('', 'http://example.org/ontology#'), ('default1', 'http://acme.org/onto#')]
SELECT ?p WHERE { :Event ?p ?o }  ->  []
```

So the SPARQL page header names one namespace, the hint says "you can write `:Person`", and `:` means something else. Entities the editor mints also serialize as `default1:Thing`.

## Change

* one `_bind_default_prefix()` helper, used by both call sites, binding the empty prefix with `replace=True` so the ontology's namespace always owns `:`;
* a namespace displaced from `:` is re-bound under a generated name when nothing else names it, so a prefix a loaded file declared survives the round trip instead of coming back out of the serializer as `ns1:`. Not for `set_base_uri`, which abandons its old namespace rather than displacing someone else's: keeping a prefix there would leave the old base URI on offer in the entity-creation namespace picker.

## And a hint on the SPARQL page

The same class of mistake is reachable without any bug: a prefixed name that points at a namespace the ontology does not use is valid SPARQL, so it does not fail, it matches nothing. `:Event` against a loaded gUFO is the case in point, where the class is `gufo:Event`.

The page now:

* says `:` is the ontology's own namespace and that an imported vocabulary keeps its own prefix;
* lists the namespaces that actually hold something, under the editor. That is the creatable-namespace set rather than every binding, because the graph carries around thirty prefixes rdflib binds by default:

  ```
  :        http://example.org/ontology#
  gufo:    http://purl.org/nemo/gufo#
  time:    http://www.w3.org/2006/time#
  ```
* repeats the hint under "The query ran and matched nothing", where it is the likeliest explanation.

## Tests

`TestDefaultPrefix` in `tests/test_prefixes.py` covers both binding paths, reading `:` back through the serializer and through a SPARQL query, plus the abandoned base URI. Four of the first five fail on `main`. `tests/test_sparql_ui.py` covers the prefix list and the empty-result hint.

Full suite (1747 passed), ruff 0.16.4 and mypy are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
