### PR TITLE
fix(viz): the graph canvas always fits the window

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -205,9 +205,10 @@ var fsGen = 0;             // fullscreen transition counter, to void stale callb
 var fsResizeHandler = null; // active 'resize' listener from the current transition
 var fsDetachTimer = null;   // timer that detaches fsResizeHandler
 
-// When "Fit to window" is on, fill the available window height instead of using
-// the fixed Graph Height. Reads the parent window's height and this iframe's
-// position in it (same-origin), reserving room for whatever sits below.
+// Fill the available window height. Reads the parent window's height and this
+// iframe's position in it (same-origin), reserving room for whatever sits below.
+// This is how the canvas is always sized; args.height is only the fallback for
+// when the parent window cannot be read at all.
 //
 // That reserve used to be a flat 90px, which is what the status bar takes when
 // something is selected. With nothing selected the bar is a single line, so the

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -48,9 +48,7 @@ _VIZ_PERSIST_KEYS = (
     "show_skos",
     "show_ind_edges",
     "show_triples",
-    "graph_height",
     "node_spacing",
-    "fit",
     "highlight_issues",
     "auto_show_new",
     "details_panel",
@@ -59,7 +57,6 @@ _VIZ_PERSIST_KEYS = (
     "options_open",
 )
 _VIZ_INT_RANGES = {
-    "graph_height": (300, 1200),
     "node_spacing": (50, 300),
     "focus_depth": (1, 5),
 }

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -86,6 +86,15 @@ _GRAPH_ROW = '[data-testid="stHorizontalBlock"]:has(.st-key-graph_viewer)'
 # it. test_viz_overlays.py keeps this in step with the buttons' own CSS.
 _TOOLBAR_CLEARANCE = "2.75rem"
 
+# The canvas always fits itself to the window: it measures the room left below
+# the controls and re-measures whenever the layout shifts, which is the only
+# sizing anyone wants — a fixed height was an option that could only ever leave
+# white space or overflow, and it is what made collapsing the display options
+# reclaim nothing (issue #347). This height is the viewer's fallback for the one
+# case it cannot measure: a browser that walls off the parent window from the
+# component iframe, where `autofitHeight()` returns null.
+_GRAPH_FALLBACK_HEIGHT = 670
+
 
 #: The clipboard icon the canvas uses, so both copies read as the same action.
 COPY_ICON_PATH = (
@@ -364,9 +373,7 @@ def render_visualization():
             "show_skos": True,
             "show_ind_edges": False,
             "show_triples": False,
-            "graph_height": 670,
             "node_spacing": 150,
-            "fit": True,
             "details_panel": False,
             "highlight_issues": False,
             # Off keeps the shipped behaviour: a narrowed filter is a view the
@@ -402,8 +409,7 @@ def render_visualization():
                 key="viz_options_open",
                 on_change=viz_sync,
                 args=("_viz_cfg_options_open", "viz_options_open"),
-                help="Which node types to draw, the graph height and the "
-                "layout spacing.",
+                help="Which node types to draw and how far apart to space them.",
             )
         with _render_col:
             render_graph = st.button(
@@ -483,21 +489,10 @@ def render_visualization():
                     help="Show all RDF triples for visible nodes",
                 )
 
-            # Row 2: sliders + fit-to-window + highlight issues
-            col1, col2, col3, col4 = st.columns([2, 2, 1, 1])
+            # Row 2: spacing + highlight issues. There is no graph height here:
+            # the canvas always fills the window (see _GRAPH_FALLBACK_HEIGHT).
+            col1, col2 = st.columns([2, 2])
             with col1:
-                st.slider(
-                    "Graph Height",
-                    300,
-                    1200,
-                    step=10,
-                    key="viz_graph_height",
-                    on_change=viz_sync,
-                    args=("_viz_cfg_graph_height", "viz_graph_height"),
-                    disabled=st.session_state.get("_viz_cfg_fit", True),
-                    help="Used when 'Fit to window' is off.",
-                )
-            with col2:
                 st.slider(
                     "Node Spacing",
                     50,
@@ -507,16 +502,7 @@ def render_visualization():
                     on_change=viz_sync,
                     args=("_viz_cfg_node_spacing", "viz_node_spacing"),
                 )
-            with col3:
-                st.checkbox(
-                    "Fit to window",
-                    help="Resize the graph to fill the window height. "
-                    "Turn off to use the Graph Height slider.",
-                    key="viz_fit",
-                    on_change=viz_sync,
-                    args=("_viz_cfg_fit", "viz_fit"),
-                )
-            with col4:
+            with col2:
                 st.checkbox(
                     "Highlight Issues",
                     key="viz_highlight_issues",
@@ -538,9 +524,7 @@ def render_visualization():
         show_skos = _has_skos and _cfg["_viz_cfg_show_skos"]
         show_ind_edges = _cfg["_viz_cfg_show_ind_edges"]
         show_triples = _cfg["_viz_cfg_show_triples"]
-        height = _cfg["_viz_cfg_graph_height"]
         node_spacing = _cfg["_viz_cfg_node_spacing"]
-        fit = _cfg["_viz_cfg_fit"]
         highlight_issues = _cfg["_viz_cfg_highlight_issues"]
         auto_show_new = _cfg["_viz_cfg_auto_show_new"]
 
@@ -1245,7 +1229,7 @@ def render_visualization():
         # thing — the page builds and caches a graph with no target, then picking
         # one changes nothing the key can see, so no rebuild happens and the
         # cached payload still lacks the entity that was asked for.
-        graph_key = f"v{_graph_ver}_m{ont_mutation}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{height}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}_{hash(selected_inds_key)}_{focus_mode}_{'-'.join(sorted(focus_seed_ids))}_{focus_depth}_{_find_id or ''}"
+        graph_key = f"v{_graph_ver}_m{ont_mutation}_{show_classes}_{show_properties}_{show_data_props}_{show_annotations}_{show_individuals}_{show_ind_edges}_{show_skos}_{show_triples}_{node_spacing}_{highlight_issues}_{hash(selected_classes_key)}_{hash(selected_inds_key)}_{focus_mode}_{'-'.join(sorted(focus_seed_ids))}_{focus_depth}_{_find_id or ''}"
         if "last_graph_key" not in st.session_state:
             st.session_state.last_graph_key = None
             st.session_state.last_graph_data = None
@@ -2285,8 +2269,8 @@ def render_visualization():
                     nodes=gdata["nodes"],
                     edges=gdata["edges"],
                     options=gdata["options"],
-                    height=height,
-                    autofit=fit,
+                    height=_GRAPH_FALLBACK_HEIGHT,
+                    autofit=True,
                     theme=_gv_theme,
                     selected_node=(_prev_sel.get("nodeId") if _prev_has_sel else None),
                     # What the canvas copy button offers after a rebuild. The

--- a/tests/test_viz_always_fits_window.py
+++ b/tests/test_viz_always_fits_window.py
@@ -1,0 +1,47 @@
+"""The graph canvas always fits the window; there is no fixed-height mode (#347).
+
+"Fit to window" used to be a checkbox, with a Graph Height slider behind it. A
+fixed height can only ever leave white space or overflow — and with the checkbox
+off, collapsing the display options band freed room the canvas would not take,
+while the checkbox that explained why was itself inside the collapsed band. So
+the option is gone and the canvas is always fitted. The height still handed to
+the component is a fallback for the one case the viewer cannot measure: a
+browser that walls the parent window off from the component iframe.
+"""
+
+from pathlib import Path
+
+from orionbelt_ontology_builder.ui import _VIZ_INT_RANGES, _VIZ_PERSIST_KEYS
+
+_PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+_VIEWER = _PKG / "lib" / "graph_viewer" / "index.html"
+_VIZ = _PKG / "views" / "visualization.py"
+
+
+def test_the_page_offers_no_fixed_height():
+    src = _VIZ.read_text()
+    assert "Fit to window" not in src
+    assert "Graph Height" not in src
+    assert "viz_graph_height" not in src
+    assert "viz_fit" not in src
+
+
+def test_the_component_is_always_fitted():
+    src = _VIZ.read_text()
+    assert "autofit=True," in src
+    assert "height=_GRAPH_FALLBACK_HEIGHT," in src
+
+
+def test_neither_setting_is_persisted_any_more():
+    """A browser holding the old pair must not resurrect the fixed height."""
+    assert "fit" not in _VIZ_PERSIST_KEYS
+    assert "graph_height" not in _VIZ_PERSIST_KEYS
+    assert "graph_height" not in _VIZ_INT_RANGES
+
+
+def test_the_viewer_fits_to_the_window():
+    src = _VIEWER.read_text()
+    # The fit height is the measurement, floored only at the 300px minimum.
+    assert "return Math.max(Math.round(avail), 300);" in src
+    # …and the passed height is what it falls back to when it cannot measure.
+    assert "var height = args.height || 600;" in src

--- a/tests/test_viz_render_matrix.py
+++ b/tests/test_viz_render_matrix.py
@@ -100,7 +100,9 @@ CASES = {
         {"selected_class_uris": [], "known_class_uris": "__all__"},
         "full",
     ),
-    "fixed height, no fit": ({"fit": False, "graph_height": 300}, "full"),
+    # Settings a browser saved before the canvas always fitted the window. They
+    # are no longer read, and must not break the page on the way past.
+    "stale fixed-height settings": ({"fit": False, "graph_height": 300}, "full"),
     "highlight issues": ({"highlight_issues": True}, "full"),
     "status bar instead of the panel": ({"details_panel": False}, "full"),
     "options collapsed": ({"options_open": False}, "full"),

--- a/tests/test_viz_settings.py
+++ b/tests/test_viz_settings.py
@@ -10,9 +10,8 @@ DEFAULTS = {
     "show_classes": True,
     "show_obj_props": True,
     "show_skos": True,
-    "graph_height": 670,
     "node_spacing": 150,
-    "fit": True,
+    "highlight_issues": False,
     "focus_mode": False,
     "focus_depth": 1,
     "selected_classes": [],  # not in _VIZ_PERSIST_KEYS
@@ -41,20 +40,18 @@ def test_apply_validates_types_and_clamps_ints(monkeypatch, patch_ui):
     app._apply_viz_settings(
         {
             "show_classes": False,  # bool -> applied
-            "graph_height": 99999,  # clamped to 1200
             "node_spacing": 10,  # clamped to 50
-            "focus_depth": 3,  # in range
-            "fit": "yes",  # wrong type -> ignored
+            "focus_depth": 99,  # clamped to 5
+            "highlight_issues": "yes",  # wrong type -> ignored
             "selected_classes": ["X"],  # not persisted -> ignored
             "bogus": 1,  # not a known setting -> ignored
         },
         DEFAULTS,
     )
     assert fake["_viz_cfg_show_classes"] is False
-    assert fake["_viz_cfg_graph_height"] == 1200
     assert fake["_viz_cfg_node_spacing"] == 50
-    assert fake["_viz_cfg_focus_depth"] == 3
-    assert "_viz_cfg_fit" not in fake  # wrong type left at default
+    assert fake["_viz_cfg_focus_depth"] == 5
+    assert "_viz_cfg_highlight_issues" not in fake  # wrong type left at default
     assert "_viz_cfg_selected_classes" not in fake
     assert "_viz_cfg_bogus" not in fake
 
@@ -75,13 +72,17 @@ def test_disk_persist_and_restore_roundtrip(monkeypatch, patch_ui, tmp_path):
     save_state: dict = {
         "_viz_settings_dirty": True,
         "_viz_cfg_show_classes": False,
-        "_viz_cfg_graph_height": 800,
-        "_viz_cfg_fit": False,
+        "_viz_cfg_node_spacing": 200,
+        "_viz_cfg_highlight_issues": True,
     }
     monkeypatch.setattr(app.st, "session_state", save_state)
     app._persist_viz_settings()
     stored = json.loads(cfg_file.read_text())["viz_settings"]
-    assert stored == {"show_classes": False, "graph_height": 800, "fit": False}
+    assert stored == {
+        "show_classes": False,
+        "node_spacing": 200,
+        "highlight_issues": True,
+    }
 
     # Restore into a fresh "session".
     restore_state: dict = {}
@@ -89,8 +90,8 @@ def test_disk_persist_and_restore_roundtrip(monkeypatch, patch_ui, tmp_path):
     app._restore_viz_settings(DEFAULTS)
     assert restore_state["_viz_settings_restored"] is True
     assert restore_state["_viz_cfg_show_classes"] is False
-    assert restore_state["_viz_cfg_graph_height"] == 800
-    assert restore_state["_viz_cfg_fit"] is False
+    assert restore_state["_viz_cfg_node_spacing"] == 200
+    assert restore_state["_viz_cfg_highlight_issues"] is True
 
 
 def test_persist_requires_a_user_change(monkeypatch, patch_ui, tmp_path):
@@ -108,7 +109,7 @@ def test_persist_noops_when_unchanged(monkeypatch, patch_ui, tmp_path):
     cfg_file = tmp_path / "config.json"
     monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
     monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
-    state: dict = {"_viz_settings_dirty": True, "_viz_cfg_fit": True}
+    state: dict = {"_viz_settings_dirty": True, "_viz_cfg_highlight_issues": True}
     monkeypatch.setattr(app.st, "session_state", state)
     app._persist_viz_settings()
     first = cfg_file.stat().st_mtime_ns
@@ -132,7 +133,7 @@ def test_browser_restore_retries_until_real_value(monkeypatch, patch_ui):
 
 
 def test_browser_restore_applies_real_value(monkeypatch, patch_ui):
-    val = json.dumps({"show_skos": False, "graph_height": 900})
+    val = json.dumps({"show_skos": False, "node_spacing": 250})
     monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: False)
     patch_ui("_get_local_storage", lambda: _FakeLS(val))
     state: dict = {}
@@ -140,7 +141,7 @@ def test_browser_restore_applies_real_value(monkeypatch, patch_ui):
     app._restore_viz_settings(DEFAULTS)
     assert state["_viz_settings_restored"] is True
     assert state["_viz_cfg_show_skos"] is False
-    assert state["_viz_cfg_graph_height"] == 900
+    assert state["_viz_cfg_node_spacing"] == 250
 
 
 def test_browser_dirty_change_is_saved(monkeypatch, patch_ui):
@@ -185,11 +186,11 @@ def test_disk_save_still_happens_once(monkeypatch, patch_ui, tmp_path):
     cfg_file = tmp_path / "config.json"
     monkeypatch.setattr(app.local_store, "local_persist_enabled", lambda: True)
     monkeypatch.setattr(app.local_store, "config_file", lambda: cfg_file)
-    state: dict = {"_viz_settings_dirty": True, "_viz_cfg_fit": False}
+    state: dict = {"_viz_settings_dirty": True, "_viz_cfg_highlight_issues": False}
     monkeypatch.setattr(app.st, "session_state", state)
 
     app._persist_viz_settings()
-    assert state["_viz_settings_saved_json"] == json.dumps({"fit": False})
+    assert state["_viz_settings_saved_json"] == json.dumps({"highlight_issues": False})
     first = cfg_file.stat().st_mtime_ns
     app._persist_viz_settings()
     assert cfg_file.stat().st_mtime_ns == first


### PR DESCRIPTION
Closes #347

## The problem

Collapsing the **Display options** band freed about 120 px above the canvas that the graph would not take. With **Fit to window** off, the canvas is pinned to the **Graph Height** slider (default 670 px), so the reclaimed band just became white space above the status bar.

The setting is saved per browser, so once it was off it stayed off across reloads and read as a rendering regression rather than a setting. It is also unreachable while the band is collapsed, which is exactly when the wasted space is noticed: the checkbox that explains the behaviour is inside the panel that has been collapsed.

## The change

Remove the option rather than teach it about the band. A fixed height can only ever leave white space or overflow, and fullscreen already covers wanting more room than the window has.

- drop the **Fit to window** checkbox and the **Graph Height** slider; row 2 of the band is now Node Spacing and Highlight Issues
- always pass `autofit=True` to the graph component. The height it receives is a new `_GRAPH_FALLBACK_HEIGHT` constant, used only in the one case the viewer cannot measure: a browser that walls the parent window off from the component iframe, where `autofitHeight()` returns null
- stop persisting `fit` and `graph_height`, so a browser holding the old pair neither resurrects the fixed height nor writes the keys again
- revert nothing else in the viewer: the existing fit machinery (window resize, the iframe position poll, the sticky status bar reserve, leaving fullscreen) is unchanged and is now the only sizing path

## Verification

In the running app at a 1900x1139 window, with `localStorage` seeded to the broken state (`fit: false`, `graph_height: 300`, `options_open: false`):

| | before | after |
| --- | --- | --- |
| canvas height | 670 (fixed) | 777 (fitted) |
| bottom edge | 980 of 1139 | 1087 plus the status bar, at the window bottom |

Checked with the band both collapsed and expanded.

## Tests

- `tests/test_viz_always_fits_window.py` (new): no fixed-height UI on the page, the component is always fitted, neither key is persisted, and the viewer's fit math is the measurement with the fixed height only as a fallback
- `tests/test_viz_settings.py`: reworked onto `node_spacing` and `highlight_issues`, since it was using the two removed keys as its examples
- `tests/test_viz_render_matrix.py`: the "fixed height, no fit" case becomes "stale fixed-height settings", a browser arriving with the old pair

1751 passed. ruff format, ruff check and mypy are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
