### PR TITLE
chore: release 1.26.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.26.1` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.26.2` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -32,7 +32,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.26.1"
+APP_VERSION = "1.26.2"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.26.1"
+version = "1.26.2"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 # SPDX. Business Source License 1.1 is BUSL-1.1; BSL-1.0 is the Boost Software

--- a/uv.lock
+++ b/uv.lock
@@ -701,7 +701,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.26.1"
+version = "1.26.2"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },


### PR DESCRIPTION
Patch release: the graph canvas always fits the window (#347, PR #348).

Bumps `pyproject.toml`, `uv.lock`, the README docker pin and `APP_VERSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
