### PR TITLE
docs(license): name the Licensed Work without a stale version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Ontology Builder 0.8
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Ontology Builder, all versions
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/tests/test_license_parameters.py
+++ b/tests/test_license_parameters.py
@@ -1,0 +1,33 @@
+"""The BUSL parameter block must not go stale.
+
+The Licensed Work used to name a version ("OrionBelt Ontology Builder 0.8"),
+which nothing bumped, so the licence named a release from long before the code
+it shipped with. The Change Date here is a single fixed date rather than one per
+version, so the licence covers every version and says so instead of pinning one.
+"""
+
+import re
+from pathlib import Path
+
+_LICENSE = Path(__file__).resolve().parent.parent / "LICENSE"
+
+
+def test_the_licensed_work_is_not_pinned_to_a_version():
+    """A version here is a number no release bumps. Name the work, not a build."""
+    text = _LICENSE.read_text()
+    assert "Licensed Work:        OrionBelt Ontology Builder, all versions" in text
+    assert not re.search(r"OrionBelt Ontology Builder,? v?\d", text)
+
+
+def test_the_copyright_runs_from_the_first_year():
+    """A range, so a later year is added rather than replacing 2025."""
+    assert re.search(
+        r"The Licensed Work is \(c\) 2025-20\d\d RALFORION d\.o\.o\.",
+        _LICENSE.read_text(),
+    )
+
+
+def test_the_conversion_parameters_are_still_there():
+    text = _LICENSE.read_text()
+    assert "Change Date:          2030-03-30" in text
+    assert "Change License:       Apache License, Version 2.0" in text


### PR DESCRIPTION
## The problem

The BUSL parameter block still read:

```
Licensed Work:        OrionBelt Ontology Builder 0.8
                      The Licensed Work is (c) 2025 RALFORION d.o.o.
```

Nothing bumps either line, so the licence named a release from long before the code it ships with, and the copyright year had fallen behind the app footer, the README and the CLA, which all read 2025-2026.

## The change

The Change Date here is a single fixed date (2030-03-30) rather than one per version, so the licence already covers every version. The parameter block now says that instead of pinning one:

```
Licensed Work:        OrionBelt Ontology Builder, all versions
                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
```

The terms themselves are untouched: same Additional Use Grant, same Change Date, same Apache 2.0 Change License. Naming the work without a version is well precedented under BUSL (Sentry does the same).

`tests/test_license_parameters.py` keeps the block from drifting back: no version may be pinned to the product name, the copyright stays a range from 2025, and both conversion parameters must still be present.

## Note on the published artifacts

`license-files` bakes `LICENSE` into the wheel, so 1.26.2 on PyPI carries the old block. PyPI files are immutable, so the corrected text reaches PyPI and Docker Hub with the next release rather than by re-uploading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
