### PR TITLE
docs(readme): put SPARQL and the SKOS depth in the top bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   ✔ Visual graph editor<br>
   ✔ OWL RL reasoning &amp; consistency checks<br>
   ✔ OWL + SKOS in one workbench<br>
+  ✔ Read-only SPARQL console<br>
   ✔ RDF/OWL import &amp; export<br>
   ✔ Pure Python
 </p>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   ✔ Visual graph editor<br>
   ✔ OWL RL reasoning &amp; consistency checks<br>
   ✔ OWL + SKOS in one workbench<br>
+  ✔ SKOS in depth: poly-hierarchy, mappings, 22 checks with autofix<br>
   ✔ Read-only SPARQL console<br>
   ✔ RDF/OWL import &amp; export<br>
   ✔ Pure Python

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   ✔ Visual graph editor<br>
   ✔ OWL RL reasoning &amp; consistency checks<br>
   ✔ OWL + SKOS in one workbench<br>
-  ✔ SKOS in depth: poly-hierarchy, mappings, 22 checks with autofix<br>
+  ✔ SKOS mappings, poly-hierarchy, 22 checks<br>
   ✔ Read-only SPARQL console<br>
   ✔ RDF/OWL import &amp; export<br>
   ✔ Pure Python

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   ✔ SKOS mappings, poly-hierarchy, 22 checks<br>
   ✔ Read-only SPARQL console<br>
   ✔ RDF/OWL import &amp; export<br>
-  ✔ Pure Python, browser or desktop
+  ✔ Pure Python: <a href="https://orionbelt.streamlit.app/">hosted app</a>, browser or desktop
 </p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   ✔ SKOS mappings, poly-hierarchy, 22 checks<br>
   ✔ Read-only SPARQL console<br>
   ✔ RDF/OWL import &amp; export<br>
-  ✔ Pure Python
+  ✔ Pure Python, browser or desktop
 </p>
 
 [![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-ontology-builder?style=social)](https://github.com/ralforion/orionbelt-ontology-builder)


### PR DESCRIPTION
The bullet list at the top of the README is where most readers decide whether the project does what they need, and it was two features behind what the app actually ships.

## SPARQL

The read-only query console landed in 1.26.0. It was documented in the feature table, the SKOS/SPARQL section and the module map, but not in the top bullets.

## SKOS

"OWL + SKOS in one workbench" reads like SKOS is bolted on, when the SKOS page carries poly-hierarchy, the full relation set including mapping properties to external IRIs such as Wikidata, Dublin Core scheme metadata, and 22 validation checks in three tiers with autofix. The added bullet names the parts that distinguish it.

```
✔ Visual graph editor
✔ OWL RL reasoning & consistency checks
✔ OWL + SKOS in one workbench
✔ SKOS in depth: poly-hierarchy, mappings, 22 checks with autofix
✔ Read-only SPARQL console
✔ RDF/OWL import & export
✔ Pure Python
```

The check count is `len(OntologyManager.SKOS_CHECKS)`, verified at 22 against the current code rather than copied from the prose further down.

README only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
