### PR TITLE
ci: pin every Action to a SHA, scope permissions, verify the pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,24 @@ on:
   pull_request:
     branches: [main]
 
+# Nothing in CI writes to the repository: it lints, type checks and runs the
+# suite. Scopes a job actually needs are granted on that job, never here.
+permissions:
+  contents: read
+
 jobs:
+  # Every `uses:` in every workflow must name an immutable commit SHA whose
+  # version comment really is the release that SHA was cut from. See the header
+  # of the script for what that buys and what it deliberately does not.
+  pins:
+    name: pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
+
   check:
     runs-on: ubuntu-latest
     strategy:
@@ -22,7 +39,7 @@ jobs:
         python: ["3.12", "3.14"]
     name: check (py${{ matrix.python }})
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # python-version sets UV_PYTHON, binding every uv command below to the
       # matrix interpreter: uv is otherwise free to pick any python satisfying
@@ -30,7 +47,7 @@ jobs:
       # one it names. It also feeds setup-uv's cache key, which would otherwise
       # be computed from the runner's system python and so collide across legs.
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python }}
@@ -68,7 +85,7 @@ jobs:
   desktop-extra:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Qt GUI runtime libraries
         run: |
@@ -78,7 +95,7 @@ jobs:
             libfontconfig1 libfreetype6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,6 +51,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# No job here writes to the repository: the Hub push and the description sync
+# authenticate with DOCKERHUB_TOKEN, not GITHUB_TOKEN. A scope any future job
+# needs belongs on that job, not up here.
+permissions:
+  contents: read
+
 env:
   IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/orionbelt-ontology-builder
 
@@ -65,8 +71,12 @@ jobs:
       docker: ${{ steps.filter.outputs.docker }}
       readme: ${{ steps.filter.outputs.readme }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
+
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |
@@ -97,15 +107,18 @@ jobs:
       && (github.event_name == 'workflow_dispatch'
           || (github.event_name == 'pull_request' && needs.changes.outputs.docker == 'true')) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       # linux/amd64 only: it matches the runner, so this needs no QEMU and can
       # load the result for the smoke test. The release build covers both arches.
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64
@@ -152,7 +165,10 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
 
       # linux/amd64 -> linux-amd64, for cache scopes and artifact names (neither
       # accepts a slash).
@@ -160,10 +176,10 @@ jobs:
         run: echo "PLATFORM_SLUG=${{ matrix.platform }}" | tr / - >> "$GITHUB_ENV"
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -172,7 +188,7 @@ jobs:
       # applied once, to the manifest list, by the merge job below.
       - name: Derive labels
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE }}
           labels: |
@@ -181,7 +197,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: ${{ matrix.platform }}
@@ -208,7 +224,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ env.PLATFORM_SLUG }}
           path: /tmp/digests/*
@@ -216,29 +232,31 @@ jobs:
           retention-days: 1
 
   manifest:
+    # No pin check here: this job checks nothing out, and it runs only after
+    # `image`, which verified the pins before it built anything.
     needs: image
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Derive tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -290,10 +308,13 @@ jobs:
           || startsWith(github.ref, 'refs/tags/v')
           || needs.changes.outputs.readme == 'true') }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
 
       - name: Sync Docker Hub description
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,6 +8,10 @@ on:
     tags: ["v*.*.*"]
   workflow_dispatch:
 
+# Read-only by default; the publish job below adds the one scope it needs.
+permissions:
+  contents: read
+
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
@@ -17,12 +21,21 @@ jobs:
       name: pypi
       url: https://pypi.org/project/orionbelt-ontology-builder/
     permissions:
+      contents: read # checkout; a job-level block sets every unlisted scope to none
       id-token: write # required for Trusted Publishing
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Before any other action runs: an action that has already executed could
+      # have rewritten the workspace, this script included, so a verifier placed
+      # after it would only be checking whatever that action left behind.
+      # Checkout itself runs unverified and has to, since nothing can be checked
+      # before the tree it fetches exists.
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -36,5 +49,9 @@ jobs:
           python -m pip install --upgrade twine
           python -m twine check dist/*
 
+      # Pinned to a commit rather than the `release/v1` branch this used to
+      # track: that branch was repointed at each new v1 release, which is
+      # exactly the mutability the pin is here to remove. Dependabot bumps the
+      # SHA and the comment together.
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,15 @@ and the CI matrix in `.github/workflows/ci.yml` must agree, and
   missed.
 - Code is reviewed with OpenAI Codex — keep changes clean and minimal.
 - Match the surrounding style; add tests under `tests/` for new engine behavior.
+- **GitHub Actions are pinned to commit SHAs**, each with a `# vX.Y.Z` comment
+  naming the exact patch release it came from. Never write `uses: owner/repo@v7`.
+  Resolve a SHA with `git ls-remote https://github.com/owner/repo 'refs/tags/vX.Y.Z^{}'`,
+  and run `./scripts/check-action-pins.sh` (`--offline` skips the upstream
+  lookups) before pushing. CI enforces it as the `pins` job, and both release
+  workflows run it as the first step after checkout. Adding an action from a new
+  owner also means adding that owner to `ALLOWED_OWNERS` in the script, which is
+  a deliberate decision rather than a formality. See the README's Development
+  section for the reasoning.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -519,10 +519,55 @@ orionbelt-ontology-builder/
 │   ├── assets/                         # Logos and screenshots
 │   └── favicon.png
 ├── pyproject.toml                      # Project metadata
+├── scripts/                            # Repo tooling (check-action-pins.sh)
 └── tests/                              # pytest suite
 ```
 
 Dependencies: streamlit, rdflib, owlrl, networkx, streamlit-ace.
+
+---
+
+## Development
+
+### Pinned GitHub Actions
+
+Every `uses:` in `.github/workflows/` names a 40-character commit SHA followed
+by a comment giving the exact release it came from:
+
+```yaml
+- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+```
+
+A tag such as `v7` is a movable label, so it runs whichever commit the action's
+owner has pointed it at by the time the job starts. A SHA cannot move. The
+comment is what makes the line readable again, and `scripts/check-action-pins.sh`
+is what keeps it honest: it walks every workflow and requires a SHA, an owner on
+its `ALLOWED_OWNERS` list, and a comment naming an exact patch release, then
+resolves that tag upstream with `git ls-remote` and fails if the commit it names
+is not the one pinned. Without it, a pull request could swap the hash for one
+taken from a fork, leave `# v7.0.1` in place, and read as a routine Dependabot
+bump.
+
+```bash
+./scripts/check-action-pins.sh            # every check, including the upstream lookups
+./scripts/check-action-pins.sh --offline  # SHA and comment format only, no network
+```
+
+CI runs it as the `pins` job, and both release workflows run it as the first
+step after checkout, before any other action gets to touch the workspace.
+
+The comment must be a patch release, never `# v7`: a major tag moves with every
+upstream release, so checking against one would fail a pin that is still good.
+Dependabot updates the SHA and the comment together, so routine bumps need no
+manual work. Adding an owner to `ALLOWED_OWNERS` is a deliberate decision — a
+pin verifying against its own tag says nothing about whether that action belongs
+in this repo.
+
+What the check does *not* do: it does not judge whether an action is safe, only
+that the hash matches its own label, so a pinned SHA of a genuinely malicious
+release passes. It does not stop a downgrade to a real but ancient version. And
+`actions/checkout` necessarily runs before the check, since nothing can be
+verified before the tree it fetches exists.
 
 ---
 

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Verify that every third-party Action used by the workflows is pinned to an
+# immutable commit SHA, comes from an owner we trust, and carries a version
+# comment that really does name the release that SHA was cut from.
+#
+#   ./scripts/check-action-pins.sh              # every check
+#   ./scripts/check-action-pins.sh --offline    # skip the upstream tag lookups
+#
+# A git tag is a movable label, so `uses: actions/checkout@v7` runs whichever
+# commit that label points at when the job starts, and the owner of the action
+# can repoint it at any time. Pinning to a SHA fixes the code, but it also
+# makes the reference unreadable to a human, and that is the weakness this
+# guards. A pull request can swap the hash for one taken from an attacker's
+# fork while leaving the reassuring `# v7.0.1` comment untouched, and the diff
+# then looks exactly like a routine Dependabot bump. Forks share object storage
+# with their parent, so such a commit is even reachable under the real
+# repository's URL. Only resolving the tag tells the two apart.
+#
+# Version comments must name exact patch releases, never major tags. A major
+# tag such as v7 moves with every release, so checking against it would turn CI
+# red the moment upstream ships v7.0.2, for a pin that is still perfectly good.
+# Patch tags never move, so this check stays quiet until something is wrong.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Only actions published by these owners may appear in a workflow. This is the
+# check that carries the most weight: a SHA matching its own tag says nothing
+# about whether the action belongs here at all, because `evil/action@<sha>
+# # v1` verifies perfectly well against evil's own v1 tag.
+#
+# Each owner here is a deliberate decision, so adding one belongs in a pull
+# request of its own rather than alongside the action that wanted it:
+#
+#   actions      GitHub's own checkout / setup-python / {up,down}load-artifact
+#   astral-sh    setup-uv, the installer for the tool that drives every CI step
+#   docker       buildx, login, metadata and build-push, for the published image
+#   dorny        paths-filter, which decides whether the Docker jobs run at all
+#   peter-evans  dockerhub-description, which syncs README.md to the Hub overview
+#   pypa         gh-action-pypi-publish, the Trusted Publishing uploader
+ALLOWED_OWNERS="actions astral-sh docker dorny peter-evans pypa"
+
+offline=false
+case "${1:-}" in
+    --offline) offline=true ;;
+    "") ;;
+    *) echo "usage: $0 [--offline]" >&2; exit 2 ;;
+esac
+
+# Resolve a tag to the commit it names, following annotated tags through to
+# their target. git ls-remote needs no token and is not rate limited, unlike
+# the REST API, which matters because hosted runners share outbound addresses.
+#
+# Three outcomes have to stay distinguishable. A tag that resolves prints its
+# SHA. A tag that does not exist prints nothing and returns 0, because
+# ls-remote reports a missing ref as success. A lookup that could not be made
+# at all, from a network failure or a repository that is not there, returns
+# non-zero and writes the reason to stderr. Collapsing the last two would let
+# an unreachable network read as a verified pin, and swallowing the error under
+# set -e would kill the run with no file or line to point at.
+resolve_tag() {
+    out=$(git ls-remote "https://github.com/$1" "refs/tags/$2" "refs/tags/$2^{}" 2>&1) || {
+        status=$?
+        printf 'git ls-remote exit %s: %s\n' "$status" "$(printf '%s' "$out" | tr '\n' ' ')" >&2
+        return "$status"
+    }
+    printf '%s\n' "$out" |
+        awk '{ sha[$2] = $1 }
+             END { print (("refs/tags/'"$2"'^{}") in sha) \
+                          ? sha["refs/tags/'"$2"'^{}"] \
+                          : sha["refs/tags/'"$2"'"] }'
+}
+
+failures=0
+checked=0
+
+fail() {
+    echo "::error file=$1,line=$2::$3"
+    echo "  $1:$2: $3" >&2
+    failures=$((failures + 1))
+}
+
+# Every `uses:` line in every workflow, carrying its file and line number so a
+# failure points straight at the offending reference.
+while IFS=: read -r file line body; do
+    # `uses: owner/repo@ref  # comment`, with the step's leading "- " optional.
+    spec=$(printf '%s\n' "$body" | sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//')
+    comment=$(printf '%s\n' "$body" | sed -nE 's/.*#[[:space:]]*(v[0-9][^[:space:]]*).*/\1/p')
+
+    # Actions living in this repository are covered by our own review.
+    case "$spec" in
+        ./*|.\\*) continue ;;
+    esac
+
+    checked=$((checked + 1))
+
+    # A container action is third-party executable code exactly as a repository
+    # action is, and an image tag such as :latest is every bit as movable as a
+    # git tag, so one cannot simply be waved through for having no git ref to
+    # resolve. A digest is what pins an image, and anything else is rejected.
+    # Note the residual gap: a digest fixes which image runs without saying
+    # whether it ought to run here, because there is no registry equivalent of
+    # ALLOWED_OWNERS. Adding a container action stays a deliberate act.
+    case "$spec" in
+        docker://*)
+            if ! printf '%s\n' "$spec" | grep -qE '^docker://[^@[:space:]]+@sha256:[0-9a-f]{64}$'; then
+                fail "$file" "$line" "$spec is a container action that is not pinned by digest; write it as docker://image@sha256:<64 hex digits>"
+            fi
+            continue
+            ;;
+    esac
+
+    repo=${spec%%@*}
+    ref=${spec#*@}
+    owner=${repo%%/*}
+
+    # A subdirectory action such as owner/repo/path@ref still pins the whole
+    # repository, so trim the path before resolving anything.
+    repo=$(printf '%s\n' "$repo" | cut -d/ -f1,2)
+
+    allowed=false
+    for candidate in $ALLOWED_OWNERS; do
+        [ "$owner" = "$candidate" ] && allowed=true
+    done
+    if [ "$allowed" = false ]; then
+        fail "$file" "$line" "owner '$owner' is not in ALLOWED_OWNERS ($ALLOWED_OWNERS); add it deliberately in scripts/check-action-pins.sh if this action is meant to run here"
+        continue
+    fi
+
+    if ! printf '%s\n' "$ref" | grep -qE '^[0-9a-f]{40}$'; then
+        fail "$file" "$line" "$repo is pinned to '$ref', which is a movable tag; pin it to the 40-character commit SHA that tag points at"
+        continue
+    fi
+
+    if [ -z "$comment" ]; then
+        fail "$file" "$line" "$repo@${ref:0:8} has no version comment; append '# vX.Y.Z' naming the release this SHA was cut from"
+        continue
+    fi
+
+    if ! printf '%s\n' "$comment" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+        fail "$file" "$line" "$repo carries the comment '# $comment'; name an exact patch release such as v7.0.1, because major tags move with every release and would fail this check for a good pin"
+        continue
+    fi
+
+    [ "$offline" = true ] && continue
+
+    # Folding stderr into the capture keeps the reason in $actual when the
+    # lookup fails, and the condition context exempts this from set -e so one
+    # unreachable repository cannot mask the findings on every later pin.
+    if ! actual=$(resolve_tag "$repo" "$comment" 2>&1); then
+        fail "$file" "$line" "could not resolve $repo $comment upstream: $actual"
+    elif [ -z "$actual" ]; then
+        fail "$file" "$line" "$repo has no tag $comment upstream"
+    elif [ "$actual" != "$ref" ]; then
+        fail "$file" "$line" "$repo $comment is upstream commit $actual, but the workflow pins $ref"
+    fi
+done < <(grep -rnE '^[[:space:]]*(-[[:space:]]+)?uses:' .github/workflows)
+
+if [ "$failures" -gt 0 ]; then
+    echo >&2
+    echo "$failures of $checked action pin(s) failed verification" >&2
+    exit 1
+fi
+
+echo "all $checked action pin(s) verified$([ "$offline" = true ] && echo " (offline: SHA and comment format only)")"


### PR DESCRIPTION
Ports the workflow hardening from [ralforion/qvd2parquet#55](https://github.com/ralforion/qvd2parquet/pull/55) and [#56](https://github.com/ralforion/qvd2parquet/pull/56) to this repo.

## Pin every Action

All 25 `uses:` references across the three workflows named a movable major tag, so each job ran whichever commit the action's owner had pointed that tag at when the job started. Each is now a 40-character commit SHA with a comment naming the exact patch release it came from:

```yaml
- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
```

Majors are unchanged, so this is a pin and not an upgrade. `pypa/gh-action-pypi-publish` was the one exception: it tracked the `release/v1` branch, which is repointed at every v1 release, and is now pinned to v1.14.2 like the rest. Dependabot already covers `github-actions` here and bumps SHA and comment together, so routine updates need no manual work.

## Scope the permissions

`permissions: contents: read` at the top of all three workflows. Nothing in this repo writes to itself: the Docker Hub push and the description sync authenticate with `DOCKERHUB_TOKEN`, and PyPI uses Trusted Publishing. The only granted scope is `id-token: write` on the publish job, now alongside an explicit `contents: read`, because a job-level block sets every unlisted scope to none and checkout needs it.

## Verify the pins actually match their comments

Pinning fixes *which* code runs. It also makes every reference unreadable, and nothing kept the SHA and the comment beside it in agreement. A pull request can swap the hash for one taken from a fork, leave the comment saying `# v7.0.1`, and the diff looks exactly like a routine Dependabot bump. Forks share object storage with their parent, so such a commit is reachable under the real repository's URL as well. No one checks 40 hex characters by eye.

`scripts/check-action-pins.sh` walks every `uses:` line under `.github/workflows` and requires a SHA, an owner on `ALLOWED_OWNERS`, and a comment naming an exact patch release, then resolves that tag upstream with `git ls-remote` and fails when the commit it names is not the one pinned. Container actions must be pinned by digest; local `./` actions are skipped. Tags resolve via `git ls-remote` rather than the REST API, so it needs no token and is not rate limited on shared runner addresses. It fails closed: a lookup that could not be made at all is a failure, not a pass, and one unreachable repository does not stop the loop and hide a forged pin behind it.

`ALLOWED_OWNERS` carries the most weight of the three checks, since `evil/action@<sha> # v1.0.0` verifies perfectly well against evil's own tag. It lists the six owners this repo uses, each with a line saying what it is there for, so adding a seventh is a visible decision.

### Where it runs

- CI gets a `pins` job.
- Both release workflows run it as the first step after checkout, in every job that checks out. Ordering is the point: an action that has already executed could have rewritten the workspace, this script included, so a verifier placed after it would be checking whatever that action left behind.
- `manifest` has no check step because it checks nothing out and runs only after `image`, which verified before it built anything.

## What this does not do

- It does not judge whether an action is safe, only that the hash matches its own label. A pinned SHA of a genuinely malicious release passes.
- It does not stop a downgrade to a real but ancient release.
- A digest fixes which container image runs, not whether it ought to run here.
- `actions/checkout` runs before the check and is therefore unverified. That is an irreducible bootstrap dependency, not an oversight.

## Verified locally

- `./scripts/check-action-pins.sh` and `--offline`: all 25 pins verified.
- Negative cases each fail with the right message and line number: a forged SHA under an untouched comment, a movable `@v7` ref, a `# v7` major-tag comment, and an owner outside the allowlist.
- All three workflows parse; `pytest tests/test_python_floor.py` still passes.

## Follow-up outside this PR

`pins` needs adding to the required status checks for `main`. The job does not exist on `main` until this merges, so that has to happen after the merge, or a PR opened beforehand waits forever on a context that never reports.

## Docs

New Development section in the README covering why the workflows are full of hex, why the comments are patch releases, and that `--offline` exists. AGENTS.md gets the convention plus the `git ls-remote` one-liner for resolving a SHA.