### PR TITLE
chore: 1.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.26.2` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.27.0` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -33,7 +33,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.26.2"
+APP_VERSION = "1.27.0"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.26.2"
+version = "1.27.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 # SPDX. Business Source License 1.1 is BUSL-1.1; BSL-1.0 is the Boost Software

--- a/uv.lock
+++ b/uv.lock
@@ -891,7 +891,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.26.2"
+version = "1.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },


### PR DESCRIPTION
Minor rather than patch: the batch since v1.26.2 carries a new feature.

| | |
|---|---|
| `feat(viz)` #352 | shortest path between two entities |
| `feat(viz)` #361 | a path's links ringed rather than repainted (#357) |
| `chore(deps)` #363 | streamlit 1.49.1 -> 1.62.0, pillow -> 12.3.0, closing 22 Dependabot alerts |
| `chore(deps)` #358, `ci` #355, `docs` #350 #351 | housekeeping |

The dependency work is the part worth shipping promptly: closing the alerts on `main` does nothing for anyone who installs from PyPI or pulls the Docker image until a version carries the fix.

Bumped in all three places that declare the version, plus the lockfile's own entry for this package:

- `pyproject.toml`
- `APP_VERSION` in `orionbelt_ontology_builder/ui.py`
- the README's Docker `:1.26.2` pin example
- `uv.lock`

`tests/test_version_consistency.py` guards the first two against drift (the 1.9.3 incident, issue #74), and it passes.

## Verified

`pytest` 1817 passed, `ruff check`, `mypy` clean.

No tag is pushed by this PR - the release is a separate, deliberate step.