### PR TITLE
fix(sparql): an editor that does not have to be downloaded (#356)

### DIFF
--- a/orionbelt_ontology_builder/views/sparql.py
+++ b/orionbelt_ontology_builder/views/sparql.py
@@ -69,6 +69,21 @@ WHERE {
 }
 
 _QUERY_KEY = "sparql_query_text"
+#: Swaps the Ace editor for a plain text area. Ace is a Streamlit component,
+#: which means an iframe the browser loads on its own, and picking an example
+#: remounts it (see ``_EDITOR_NONCE``) — a fresh iframe refetching about a
+#: megabyte of editor, served without a cache header that would let the browser
+#: keep it. Where that download outruns the three seconds Streamlit waits for a
+#: component to report in, the page says it is having trouble loading the
+#: editor: alarming, and about a component the query does not need at all. The
+#: plain box has nothing to load and nothing to remount (issue #356).
+_PLAIN_KEY = "sparql_plain_editor"
+#: The plain box's own widget key. It is deliberately not ``_QUERY_KEY``: a
+#: widget's state is dropped as soon as it stops being rendered, so with the two
+#: editors sharing one key, switching from the plain box to Ace threw the query
+#: away. ``_QUERY_KEY`` is the source of truth and belongs to neither widget;
+#: each editor seeds itself from it and writes back to it.
+_BOX_KEY = "sparql_query_box"
 #: Bumped to force a fresh editor instance. The Ace component treats ``value``
 #: as initial content, so loading an example has to remount it under a new key
 #: or the editor keeps showing what the user had before.
@@ -84,11 +99,28 @@ def _load_example() -> None:
     session-state key can still be written for the coming rerun.
     """
     name = st.session_state.get("sparql_example")
-    if name and name in EXAMPLE_QUERIES:
-        st.session_state[_QUERY_KEY] = EXAMPLE_QUERIES[name]
+    if not name or name not in EXAMPLE_QUERIES:
+        return
+    query = EXAMPLE_QUERIES[name]
+    if st.session_state.get(_QUERY_KEY) == query:
+        # Already on screen: nothing to load, and a result still answering this
+        # very query is worth keeping (issue #356).
+        return
+    st.session_state[_QUERY_KEY] = query
+    if _BOX_KEY in st.session_state:
+        # The plain box is on screen and holds its own state. A callback is the
+        # one place a widget's key can still be written for the coming rerun.
+        st.session_state[_BOX_KEY] = query
+    if st_ace is not None and not st.session_state.get(_PLAIN_KEY):
+        # Only Ace needs the remount: it takes ``value`` as initial content and
+        # ignores it afterwards, so a new key is the one way to change what it
+        # shows. That costs a new iframe refetching about a megabyte of editor
+        # the browser is not allowed to cache, so it is spent only when there is
+        # an Ace editor on screen to update. The plain box reads the text
+        # straight back out of session state (issue #356).
         st.session_state[_EDITOR_NONCE] = st.session_state.get(_EDITOR_NONCE, 0) + 1
-        st.session_state.pop(_RESULT_KEY, None)
-        st.session_state.pop(_ERROR_KEY, None)
+    st.session_state.pop(_RESULT_KEY, None)
+    st.session_state.pop(_ERROR_KEY, None)
 
 
 _EDITOR_HELP = (
@@ -138,20 +170,43 @@ def _render_editor() -> str:
     would submit the previous query. On, it commits after a short debounce, so
     what is on screen is what runs.
     """
-    st.caption("Query")
+    label_col, plain_col = st.columns([4, 1], vertical_alignment="bottom")
+    with label_col:
+        st.caption("Query")
+    with plain_col:
+        # Short-circuits when the component is not installed: there is no choice
+        # to offer then, and a toggle that changed nothing would be a lie.
+        plain = st_ace is None or st.toggle(
+            "Plain editor",
+            key=_PLAIN_KEY,
+            help=(
+                "Swap the highlighted editor for a plain text box. The "
+                "highlighted one is a separate component your browser loads, "
+                "and picking an example loads it again; on a slow connection "
+                "that can take long enough for a warning to appear. The plain "
+                "box loads nothing."
+            ),
+        )
     current = st.session_state.get(_QUERY_KEY, "")
-    if st_ace is None:
+    if plain:
+        # Seeded rather than passed as ``value``: on the runs after the first the
+        # box has its own state, which is what carries the user's typing, and
+        # only a fresh box (a first render, or one Ace has since replaced) should
+        # take the query from session state.
+        st.session_state.setdefault(_BOX_KEY, current)
         # Keyed container so the monospace rule in _CUSTOM_CSS reaches this one
         # text area without restyling every other text area in the app.
         with st.container(key="sparql_editor"):
-            return st.text_area(
+            edited = st.text_area(
                 "Query",
                 height=240,
-                key=_QUERY_KEY,
+                key=_BOX_KEY,
                 placeholder=_PLACEHOLDER,
                 help=_EDITOR_HELP,
                 label_visibility="collapsed",
             )
+        st.session_state[_QUERY_KEY] = edited
+        return edited
     edited = st_ace(
         value=current,
         placeholder=_PLACEHOLDER,

--- a/tests/test_sparql_ui.py
+++ b/tests/test_sparql_ui.py
@@ -258,7 +258,9 @@ def test_picking_an_example_remounts_the_editor():
 def _nonce(at) -> int:
     """The editor's remount counter, which does not exist until it first moves."""
     key = "sparql_editor_nonce"
-    return at.session_state[key] if key in at.session_state else 0
+    # SIM401 wants `.get` here, but AppTest's session_state has none: its
+    # rewrite raises instead of returning the default.
+    return at.session_state[key] if key in at.session_state else 0  # noqa: SIM401
 
 
 def test_an_example_the_editor_already_shows_is_not_reloaded():

--- a/tests/test_sparql_ui.py
+++ b/tests/test_sparql_ui.py
@@ -255,6 +255,66 @@ def test_picking_an_example_remounts_the_editor():
     assert at.session_state["sparql_query_text"] == EXAMPLE_QUERIES["Class hierarchy"]
 
 
+def _nonce(at) -> int:
+    """The editor's remount counter, which does not exist until it first moves."""
+    key = "sparql_editor_nonce"
+    return at.session_state[key] if key in at.session_state else 0
+
+
+def test_an_example_the_editor_already_shows_is_not_reloaded():
+    """Picking an example whose text is already in the editor has nothing to
+    load, and remounting for it would cost a fresh component iframe and throw
+    away a result that still answers that very query (issue #356)."""
+    at = _run(EXAMPLE_QUERIES["Class hierarchy"], click=True)
+    before = _nonce(at)
+    assert "sparql_last_result" in at.session_state
+
+    at.selectbox[0].select("Class hierarchy").run(timeout=120)
+    assert not at.exception, at.exception
+    assert _nonce(at) == before
+    assert "sparql_last_result" in at.session_state
+
+
+def test_the_plain_editor_is_a_text_area_and_needs_no_remount():
+    """The plain box takes its content straight from session state, so loading
+    an example into it does not have to remount anything (issue #356)."""
+    at = _run("", click=False)
+    assert not at.get("text_area"), "the component editor is the default"
+
+    at.toggle(key="sparql_plain_editor").set_value(True).run(timeout=120)
+    assert not at.exception, at.exception
+    assert at.text_area(key="sparql_query_box") is not None
+    before = _nonce(at)
+
+    at.selectbox[0].select("Class hierarchy").run(timeout=120)
+    assert not at.exception, at.exception
+    assert at.session_state["sparql_query_text"] == EXAMPLE_QUERIES["Class hierarchy"]
+    assert (
+        at.text_area(key="sparql_query_box").value == EXAMPLE_QUERIES["Class hierarchy"]
+    )
+    assert _nonce(at) == before
+
+
+def test_the_query_survives_switching_editors_both_ways():
+    """The two editors are different widgets, and a widget's state goes away the
+    moment it stops being rendered — so neither may own the query (issue #356)."""
+    at = _run("", click=False)
+    at.selectbox[0].select("Class hierarchy").run(timeout=120)
+    written = EXAMPLE_QUERIES["Class hierarchy"]
+
+    at.toggle(key="sparql_plain_editor").set_value(True).run(timeout=120)
+    assert at.text_area(key="sparql_query_box").value == written
+    assert at.session_state["sparql_query_text"] == written
+
+    at.toggle(key="sparql_plain_editor").set_value(False).run(timeout=120)
+    assert at.session_state["sparql_query_text"] == written
+
+    at.toggle(key="sparql_plain_editor").set_value(True).run(timeout=120)
+    assert not at.exception, at.exception
+    assert at.text_area(key="sparql_query_box").value == written
+    assert at.session_state["sparql_query_text"] == written
+
+
 def test_the_page_still_works_without_the_editor_component(monkeypatch):
     """The editor is a nicety; querying is the feature. If streamlit-ace cannot
     be imported the page must still render and run queries."""


### PR DESCRIPTION
Closes #356.

## What is happening

"Your app is having trouble loading the streamlit_ace.streamlit_ace component" is Streamlit's warning when a component fails to report ready within three seconds. Two things line up to provoke it, and both do on every example pick:

1. **A new iframe each time.** Ace takes `value` as its initial content and ignores it afterwards, so remounting under a new key is the only way to change what it displays. I checked rather than assumed: with a stable key the editor keeps showing the old query while returning the new one, which is worse than the remount. A new key is a new element, so the old iframe is destroyed and a new one built from an empty document.
2. **The browser cannot cache what it refetches.** Streamlit serves component files as `cache-control: public` with no `max-age`, no `ETag` and no `Last-Modified` - no freshness lifetime and no validator, so it goes back to the network. Confirmed in the network log: the second mount got a fresh 200 with the whole body, 286 KB gzipped from 1.06 MB raw.

So every example pick is a ~286 KB download that cannot be cached. On localhost it is invisible. Over mobile data it is not, which is where the report comes from.

Neither half is ours to fix. The files live inside `streamlit-ace`, whose last release was December 2021, and the headers come from Streamlit's own component static handler - the same one that serves our vendored graph viewer, so vendoring a copy would not buy the caching either.

## What this does instead

**Removes the need to download anything.** A "Plain editor" toggle beside the Query label swaps Ace for the plain text area the page already falls back to when the component is not installed. No iframe, no remount, examples land instantly, and there is nothing left to fail to load. The cost is syntax highlighting, on a page whose feature is the query.

**Stops spending remounts that buy nothing.** The nonce is no longer bumped when there is no Ace editor on screen to remount, nor when the picked example is already the text in the editor - the latter also keeps a result that still answers that very query.

**Gives the query an owner that is neither editor.** The two editors deliberately do not share a widget key. Streamlit drops a widget's state the moment it stops being rendered, so with one key the query was lost switching from the plain box back to Ace. I hit exactly that while testing this branch; `sparql_query_text` is now the source of truth and belongs to neither widget, and there is a regression test for the round trip.

## Verified

Live in the running app, with the reporter's own ontology imported (1,008 classes, 5,698 triples):

- the toggle both ways, with the query carried across intact;
- an example loading into the plain box with zero iframes and zero requests;
- a query running from the plain box;
- every example query running against their ontology.

`pytest` 1820 passed (three new), `ruff` and `mypy` clean.

## Not in scope

The payload itself could be cut by dropping streamlit-ace for a minimal editor we build and vendor, the way `vis-network.min.js` is. That is a JS build to own and maintain for a nicety, and it would not fix the caching. Worth its own issue if anyone wants it.