### PR TITLE
fix(ui): dark-mode contrast — the selected tab, and the accents around it (#368)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -24,6 +24,7 @@ from .ui import (  # noqa: F401
     _CUSTOM_CSS,
     _DARK_ACCENT,
     _DARK_CSS,
+    _DARK_FILL,
     _DARK_TINT,
     _EDGE_ID_SEP,
     _FAVICON,

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -225,6 +225,7 @@ from .ui import (  # noqa: F401
     set_active_language_pack,
     set_flash_message,
     show_message,
+    theme_is_dark,
     viz_apply_focus_click,
     viz_auto_show_new_toggled,
     viz_drop_focus_seeds,
@@ -324,13 +325,8 @@ def _configure_page() -> None:
     # themes would otherwise revert it to red), then lighten tab/pill accents in
     # dark mode (injected after, so it wins there).
     st.markdown(_BRAND_CSS, unsafe_allow_html=True)
-    try:
-        if st.context.theme.get("type") == "dark":
-            st.markdown(_DARK_CSS, unsafe_allow_html=True)
-    except Exception:
-        logger.debug(
-            "Dark-theme CSS skipped: st.context.theme unavailable", exc_info=True
-        )
+    if theme_is_dark():
+        st.markdown(_DARK_CSS, unsafe_allow_html=True)
     if "app_started" not in st.session_state:
         st.session_state.app_started = True
         logger.info(f"{APP_NAME} v{APP_VERSION}")

--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -25,7 +25,6 @@ from .ui import (  # noqa: F401
     _DARK_ACCENT,
     _DARK_CSS,
     _DARK_FILL,
-    _DARK_TINT,
     _EDGE_ID_SEP,
     _FAVICON,
     _FILTER_KINDS,

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -263,17 +263,18 @@ _BRAND_CSS = f"""
         background-color: {_BRAND} !important;
         border-color: {_BRAND} !important;
     }}
-    /* Active segmented-control pill and tab */
-    [data-testid="stBaseButton-segmented_controlActive"] {{
-        color: {_BRAND} !important;
+    /* Active segmented-control pill (the page tab pickers). Selected by ARIA
+       state rather than by a testid: the testid this used to name,
+       ``stBaseButton-segmented_controlActive``, is not on the button in
+       Streamlit 1.62, so the rule matched nothing and went unnoticed — worth
+       re-checking in the DOM after a Streamlit upgrade (issue #368).
+       No ``color`` here: Streamlit paints the active label with the configured
+       primaryColor, which is the brand navy and reads at 12.6:1 on a light
+       background. Dark backgrounds are where that fails, and _DARK_CSS below
+       overrides it. */
+    button[data-variant="segmented_control"][aria-checked="true"] {{
         border-color: {_BRAND} !important;
         background-color: {_BRAND_TINT} !important;
-    }}
-    .stTabs [data-baseweb="tab"][aria-selected="true"] {{
-        color: {_BRAND} !important;
-    }}
-    .stTabs [data-baseweb="tab-highlight"] {{
-        background-color: {_BRAND} !important;
     }}
     /* Slider thumb + its floating value label */
     [data-testid="stSlider"] [role="slider"] {{
@@ -302,16 +303,14 @@ _DARK_ACCENT = "#6EA8FE"
 _DARK_TINT = "rgba(110, 168, 254, 0.15)"
 _DARK_CSS = f"""
 <style>
-    [data-testid="stBaseButton-segmented_controlActive"] {{
+    /* The brand navy Streamlit puts on the active label is 1.48:1 against
+       Streamlit's own dark background and 1.61:1 against the darker custom one
+       in issue #368 — the selected tab was the single unreadable label on the
+       page. The accent below is 7:1 and 8.5:1 on those two. */
+    button[data-variant="segmented_control"][aria-checked="true"] {{
         color: {_DARK_ACCENT} !important;
         border-color: {_DARK_ACCENT} !important;
         background-color: {_DARK_TINT} !important;
-    }}
-    .stTabs [data-baseweb="tab"][aria-selected="true"] {{
-        color: {_DARK_ACCENT} !important;
-    }}
-    .stTabs [data-baseweb="tab-highlight"] {{
-        background-color: {_DARK_ACCENT} !important;
     }}
     /* Text/indicator accents from _BRAND_CSS that are too dark on a dark
        backdrop: the slider value label and the multiselect focus outline.
@@ -324,6 +323,64 @@ _DARK_CSS = f"""
     }}
 </style>
 """
+
+
+#: A background counts as dark when white text reads better on it than black
+#: does. That is where the two contrast ratios cross, at a relative luminance of
+#: 0.179 by the W3C formula.
+_DARK_BACKGROUND_LUMINANCE = 0.179
+
+
+def _relative_luminance(colour: str) -> float | None:
+    """The W3C relative luminance of a ``#rgb`` or ``#rrggbb`` colour.
+
+    ``None`` for anything this cannot read, so a caller can fall back rather
+    than treat an unparsable colour as black.
+    """
+    text = colour.strip().lstrip("#")
+    if len(text) == 3:
+        text = "".join(channel * 2 for channel in text)
+    if len(text) != 6:
+        return None
+    try:
+        channels = [int(text[i : i + 2], 16) / 255 for i in (0, 2, 4)]
+    except ValueError:
+        return None
+    linear = [
+        c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4 for c in channels
+    ]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def theme_is_dark() -> bool:
+    """Is the app being drawn on a dark background?
+
+    ``st.context.theme`` reports the theme's *base*, and a config.toml that
+    overrides only colours has no base — so an app themed to a near-black
+    background still reports ``light``, the dark styling never loads, and the
+    navy accents land on black (issue #368). Where the type says light, the
+    configured background colour is the better witness, and it is a colour, so
+    it can simply be measured.
+
+    Both lookups are guarded: ``st.context`` is unavailable outside a script
+    run, and the option is absent unless a theme sets it.
+    """
+    try:
+        if st.context.theme.get("type") == "dark":
+            return True
+    except Exception:  # theme detection is cosmetic, never fatal
+        logger.debug(
+            "Theme type unavailable; reading the configured colour", exc_info=True
+        )
+    try:
+        background = st.get_option("theme.backgroundColor")
+    except Exception:  # as above
+        logger.debug("Theme background unavailable; assuming light", exc_info=True)
+        return False
+    if not background:
+        return False
+    luminance = _relative_luminance(str(background))
+    return luminance is not None and luminance < _DARK_BACKGROUND_LUMINANCE
 
 
 def get_ontology_manager_class():

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -363,19 +363,49 @@ _DARK_BACKGROUND_LUMINANCE = 0.179
 
 
 def _relative_luminance(colour: str) -> float | None:
-    """The W3C relative luminance of a ``#rgb`` or ``#rrggbb`` colour.
+    """The W3C relative luminance of a CSS colour, or ``None`` if unreadable.
 
-    ``None`` for anything this cannot read, so a caller can fall back rather
-    than treat an unparsable colour as black.
+    Streamlit hands a configured theme colour to the browser untouched, so it
+    can be any CSS colour at all: verified against 1.62, ``rgb(3,4,5)``,
+    ``#030405ff`` and ``black`` all render. The hex forms and the ``rgb()``
+    family are read here; a colour name, ``hsl()``, ``oklch()`` and the rest are
+    not, and deliberately so — knowing them all means carrying CSS's 148 colour
+    names and its colour spaces around. ``None`` is the "cannot say" answer, and
+    :func:`theme_is_dark` falls back to the theme's reported type rather than
+    guessing from a colour it did not understand.
+
+    Alpha is accepted and ignored: what sits behind a translucent background is
+    the browser's, not ours, and the opaque colour is the better guess of the
+    two.
     """
-    text = colour.strip().lstrip("#")
-    if len(text) == 3:
-        text = "".join(channel * 2 for channel in text)
-    if len(text) != 6:
-        return None
-    try:
-        channels = [int(text[i : i + 2], 16) / 255 for i in (0, 2, 4)]
-    except ValueError:
+    text = colour.strip().lower()
+    if text.startswith("#"):
+        digits = text[1:]
+        if len(digits) in (3, 4):  # #rgb, #rgba
+            digits = "".join(digit * 2 for digit in digits[:3])
+        elif len(digits) in (6, 8):  # #rrggbb, #rrggbbaa
+            digits = digits[:6]
+        else:
+            return None
+        try:
+            channels = [int(digits[i : i + 2], 16) / 255 for i in (0, 2, 4)]
+        except ValueError:
+            return None
+    elif text.startswith(("rgb(", "rgba(")) and text.endswith(")"):
+        # Commas or spaces, and a "/ alpha" tail: rgb(3, 4, 5), rgb(3 4 5) and
+        # rgb(3 4 5 / 50%) are all the same colour. Percentages are not read.
+        parts = (
+            text[text.index("(") + 1 : -1].replace(",", " ").replace("/", " ").split()
+        )
+        if len(parts) < 3:
+            return None
+        try:
+            channels = [float(part) / 255 for part in parts[:3]]
+        except ValueError:
+            return None
+        if any(not 0.0 <= channel <= 1.0 for channel in channels):
+            return None
+    else:
         return None
     linear = [
         c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4 for c in channels

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -242,84 +242,115 @@ _BRAND = local_store.BRAND_PRIMARY_COLOR  # "#0D2B7A"
 _BRAND_TINT = "rgba(13, 43, 122, 0.12)"
 _BRAND_CSS = f"""
 <style>
+    /* Every hook below names Streamlit's own DOM, which is internal and moves
+       without notice: 1.62 rebuilt these widgets on react-aria, and every
+       ``[data-baseweb=...]`` selector this file used stopped matching in
+       silence (issue #368). Re-check them in the browser whenever the Streamlit
+       pin moves — the check is to inspect a rendered widget and confirm the
+       element carrying the accent is still the one named here. */
+
     /* Primary buttons */
     [data-testid="stBaseButton-primary"] {{
         background-color: {_BRAND} !important;
         border-color: {_BRAND} !important;
     }}
-    /* Checked checkbox box */
-    [data-testid="stCheckbox"] label[data-baseweb="checkbox"]:has(input:checked) > span {{
+    /* The box of a checked checkbox, and the track of a toggle that is on:
+       st.toggle reuses stCheckbox's testid, and in 1.62 both mark the state on
+       the label, so one rule covers the pair.
+
+       ``:not([data-testid])`` is what separates the mark from the words beside
+       it. Both are plain divs directly under the label; only the label carries a
+       testid (stWidgetLabel). Without it this paints the text's background too,
+       and every checked checkbox reads as highlighted. The radio and slider
+       rules below exclude their own labels the same way. */
+    [data-testid="stCheckbox"] label[data-selected="true"] > div:not([data-testid]) {{
         background-color: {_BRAND} !important;
         border-color: {_BRAND} !important;
     }}
-    /* Toggle track when on. st.toggle shares stCheckbox's testid; what tells
-       them apart is the mark: a checkbox renders a <span>, a toggle a <div>
-       track wrapping the knob. */
-    [data-testid="stCheckbox"] label[data-baseweb="checkbox"]:has(input:checked) > div:first-child {{
+    /* The dot inside a selected radio, not the label wrapper (which carries a
+       hover/focus tint of its own). */
+    label[data-testid="stRadioOption"][data-selected="true"] > div > div > div:not([data-testid]) {{
         background-color: {_BRAND} !important;
-    }}
-    /* Selected radio (its control circle; not the label wrapper) */
-    [data-testid="stRadio"] label[data-baseweb="radio"]:has(input:checked) > div:first-child {{
-        background-color: {_BRAND} !important;
-        border-color: {_BRAND} !important;
     }}
     /* Active segmented-control pill (the page tab pickers). Selected by ARIA
        state rather than by a testid: the testid this used to name,
-       ``stBaseButton-segmented_controlActive``, is not on the button in
-       Streamlit 1.62, so the rule matched nothing and went unnoticed — worth
-       re-checking in the DOM after a Streamlit upgrade (issue #368).
-       No ``color`` here: Streamlit paints the active label with the configured
-       primaryColor, which is the brand navy and reads at 12.6:1 on a light
-       background. Dark backgrounds are where that fails, and _DARK_CSS below
-       overrides it. */
+       ``stBaseButton-segmented_controlActive``, is not on the button in 1.62.
+       No ``color`` here — Streamlit paints the active label with the configured
+       primaryColor, which is the brand navy and reads at 12.8:1 on a light
+       background. Dark backgrounds are where that fails, and _DARK_CSS
+       overrides it there. */
     button[data-variant="segmented_control"][aria-checked="true"] {{
         border-color: {_BRAND} !important;
         background-color: {_BRAND_TINT} !important;
     }}
-    /* Slider thumb + its floating value label */
-    [data-testid="stSlider"] [role="slider"] {{
+    /* Slider thumb and its floating value label. There is no [role=slider] in
+       1.62; the thumb is an unlabelled div, told apart from the rail beside it
+       by the value label it carries. */
+    [data-testid="stSlider"] div:has(> [data-testid="stSliderThumbValue"]) {{
         background-color: {_BRAND} !important;
     }}
     [data-testid="stSliderThumbValue"] {{
         color: {_BRAND} !important;
     }}
-    /* Slider track: the filled portion's colour (red on a reset theme) is baked
-       into a per-value class we can't recolour selectively, so neutralise the
-       whole bar to Streamlit's unfilled tint — no red shows, and the navy thumb
-       marks the position. Targets the track (the thumb's direct parent). */
-    [data-testid="stSlider"] [data-baseweb="slider"] div:has(> [role="slider"]) {{
+    /* Slider rail: the filled portion's colour (red on a reset theme) is baked
+       into a per-value class we cannot recolour selectively, so the whole bar is
+       neutralised — no red shows, and the thumb marks the position. Painting the
+       rail with the accent instead would colour the unfilled half too, which
+       says the slider is at its maximum. It is the childless div; the thumb is
+       the one with the value label inside. */
+    [data-testid="stSlider"] > div > div > div:not([data-testid]):not(:has(*)) {{
         background: rgba(151, 166, 195, 0.25) !important;
     }}
-    /* Multiselect selected chips and their focus outline */
-    [data-testid="stMultiSelect"] [data-baseweb="tag"] {{
+    /* Multiselect selected chips */
+    [data-testid="stMultiSelectTagsContainer"] > span > span {{
         background-color: {_BRAND} !important;
-    }}
-    [data-testid="stMultiSelect"] [data-baseweb="select"] > div:focus-within {{
-        border-color: {_BRAND} !important;
     }}
 </style>
 """
+#: Text and line accents on a dark backdrop: the active tab's label, the slider
+#: value, borders. The brand navy is 1.48:1 against Streamlit's dark background
+#: and cannot be read there; this is 7.8:1, and 8.5:1 against the darker custom
+#: theme in issue #368.
 _DARK_ACCENT = "#6EA8FE"
 _DARK_TINT = "rgba(110, 168, 254, 0.15)"
+#: Filled controls — a button, a checkbox, a radio dot, a slider thumb. They
+#: cannot take _DARK_ACCENT, because a filled control carries white text and
+#: white on that accent is 2.4:1. This is the brightest blue that still holds a
+#: white label: 4.6:1 for the label, and 4.1:1 for the control against the page,
+#: comfortably past the 3:1 WCAG asks of a control against its surroundings.
+_DARK_FILL = "#3B6FE0"
 _DARK_CSS = f"""
 <style>
-    /* The brand navy Streamlit puts on the active label is 1.48:1 against
-       Streamlit's own dark background and 1.61:1 against the darker custom one
-       in issue #368 — the selected tab was the single unreadable label on the
-       page. The accent below is 7:1 and 8.5:1 on those two. */
+    /* The active pill's label: Streamlit paints it with primaryColor, and the
+       brand navy is 1.48:1 on Streamlit's dark background and 1.61:1 on the
+       custom one in issue #368 — the single unreadable label on the page. The
+       accent is 7.8:1 and 8.5:1 on those two. */
     button[data-variant="segmented_control"][aria-checked="true"] {{
         color: {_DARK_ACCENT} !important;
         border-color: {_DARK_ACCENT} !important;
         background-color: {_DARK_TINT} !important;
     }}
-    /* Text/indicator accents from _BRAND_CSS that are too dark on a dark
-       backdrop: the slider value label and the multiselect focus outline.
-       (The filled thumb and chips stay navy, like the checkboxes/buttons.) */
     [data-testid="stSliderThumbValue"] {{
         color: {_DARK_ACCENT} !important;
     }}
-    [data-testid="stMultiSelect"] [data-baseweb="select"] > div:focus-within {{
-        border-color: {_DARK_ACCENT} !important;
+    /* The filled controls, lightened together so they read as one family. They
+       keep their white labels, which is what stops them taking _DARK_ACCENT. */
+    [data-testid="stBaseButton-primary"] {{
+        background-color: {_DARK_FILL} !important;
+        border-color: {_DARK_FILL} !important;
+    }}
+    [data-testid="stCheckbox"] label[data-selected="true"] > div:not([data-testid]) {{
+        background-color: {_DARK_FILL} !important;
+        border-color: {_DARK_FILL} !important;
+    }}
+    label[data-testid="stRadioOption"][data-selected="true"] > div > div > div:not([data-testid]) {{
+        background-color: {_DARK_FILL} !important;
+    }}
+    [data-testid="stSlider"] div:has(> [data-testid="stSliderThumbValue"]) {{
+        background-color: {_DARK_FILL} !important;
+    }}
+    [data-testid="stMultiSelectTagsContainer"] > span > span {{
+        background-color: {_DARK_FILL} !important;
     }}
 </style>
 """

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -307,34 +307,47 @@ _BRAND_CSS = f"""
     }}
 </style>
 """
-#: Text and line accents on a dark backdrop: the active tab's label, the slider
-#: value, borders. The brand navy is 1.48:1 against Streamlit's dark background
-#: and cannot be read there; this is 7.8:1, and 8.5:1 against the darker custom
-#: theme in issue #368.
-_DARK_ACCENT = "#6EA8FE"
-_DARK_TINT = "rgba(110, 168, 254, 0.15)"
-#: Filled controls — a button, a checkbox, a radio dot, a slider thumb. They
-#: cannot take _DARK_ACCENT, because a filled control carries white text and
-#: white on that accent is 2.4:1. This is the brightest blue that still holds a
-#: white label: 4.6:1 for the label, and 4.1:1 for the control against the page,
-#: comfortably past the 3:1 WCAG asks of a control against its surroundings.
-_DARK_FILL = "#3B6FE0"
+#: Accent *text* on a dark backdrop: links, the slider value. The brand navy is
+#: 1.48:1 against Streamlit's dark background and cannot be read there at all;
+#: this is 4.35:1, which is as dark as text in this family can go and stay
+#: near the 4.5:1 AA asks of body text.
+_DARK_ACCENT = "#4275DE"
+#: Filled controls: a button, a checkbox, a radio dot, a slider thumb, and the
+#: active tab. One step darker than the text accent, which buys the white label
+#: they all carry 5.8:1 instead of 4.35:1, while the control itself still clears
+#: the 3:1 WCAG asks against its surroundings (3.26:1). The two are a step apart
+#: on purpose and read as one family; going darker still would take the link
+#: text down with it, since for a colour used both ways the two numbers move
+#: together.
+_DARK_FILL = "#3560C4"
 _DARK_CSS = f"""
 <style>
-    /* The active pill's label: Streamlit paints it with primaryColor, and the
-       brand navy is 1.48:1 on Streamlit's dark background and 1.61:1 on the
-       custom one in issue #368 — the single unreadable label on the page. The
-       accent is 7.8:1 and 8.5:1 on those two. */
+    /* The active pill is filled rather than written in the accent. Streamlit
+       paints its label with primaryColor, and the brand navy is 1.48:1 on
+       Streamlit's dark background — the single unreadable label on the page,
+       which is issue #368. Writing it in the accent fixed that but left the
+       selected tab dimmer than the two unselected ones beside it, which read at
+       18:1 in the theme's own white: the selected item looked like the weakest.
+       Filled, it is the strongest, it matches the button, and the accent is
+       never dim text — the tint below is left to the light theme. */
     button[data-variant="segmented_control"][aria-checked="true"] {{
-        color: {_DARK_ACCENT} !important;
-        border-color: {_DARK_ACCENT} !important;
-        background-color: {_DARK_TINT} !important;
+        color: #FFFFFF !important;
+        border-color: {_DARK_FILL} !important;
+        background-color: {_DARK_FILL} !important;
     }}
     [data-testid="stSliderThumbValue"] {{
         color: {_DARK_ACCENT} !important;
     }}
-    /* The filled controls, lightened together so they read as one family. They
-       keep their white labels, which is what stops them taking _DARK_ACCENT. */
+    /* Links, which Streamlit draws in a blue of its own (#3D9DF3) that belongs
+       to no other accent on the page. On the accent they read at 7.8:1 and look
+       like the rest of the theme. */
+    a,
+    a:visited {{
+        color: {_DARK_ACCENT} !important;
+    }}
+    /* The filled controls take the same accent as the text above: one blue for
+       the whole theme. They keep their white labels, which is half of what set
+       the colour — see _DARK_ACCENT. */
     [data-testid="stBaseButton-primary"] {{
         background-color: {_DARK_FILL} !important;
         border-color: {_DARK_FILL} !important;

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -64,6 +64,7 @@ from ..ui import (
     prune_reused_focus_seeds,
     reconcile_filter_selection,
     seed_filter_from_saved,
+    theme_is_dark,
     viz_apply_focus_click,
     viz_auto_show_new_toggled,
     viz_filter_changed,
@@ -2534,14 +2535,7 @@ def render_visualization():
             # Theme the graph (canvas + legend) to match the app, so it isn't a
             # white box in dark mode. Standard Streamlit dark/light colours are
             # used, derived from the active theme type (issue #62).
-            _gv_dark = False
-            try:
-                _gv_dark = st.context.theme.get("type") == "dark"
-            except Exception:
-                logger.debug(
-                    "Graph theme defaulting to light: st.context.theme unavailable",
-                    exc_info=True,
-                )
+            _gv_dark = theme_is_dark()
             _gv_theme = (
                 {"bg": "#0e1117", "panel": "#262730", "text": "#fafafa"}
                 if _gv_dark

--- a/tests/test_brand_theme.py
+++ b/tests/test_brand_theme.py
@@ -30,7 +30,12 @@ def test_brand_css_forces_the_brand_colour_on_every_accent_widget():
         'data-testid="stSliderThumbValue"',  # slider value label
         'data-testid="stMultiSelect"',  # multiselect chips + focus border
         'data-baseweb="tag"',  # the selected chips themselves
-        ".stTabs",  # selected tab
+        # The active pill of a segmented control, which is how every page picker
+        # on this app is drawn. Named by its ARIA state: the testid this rule
+        # used to use is not on the button in Streamlit 1.62, so it quietly
+        # matched nothing (issue #368). Worth re-checking in the DOM whenever
+        # the Streamlit pin moves.
+        'button[data-variant="segmented_control"][aria-checked="true"]',
     ]
     missing = [h for h in required_hooks if h not in css]
     assert not missing, f"_BRAND_CSS no longer styles: {missing}"
@@ -46,5 +51,9 @@ def test_dark_css_relightens_text_and_indicator_accents():
     for hook in [
         'data-testid="stSliderThumbValue"',
         'data-testid="stMultiSelect"',
+        # The active pill's label: Streamlit paints it with the configured
+        # primaryColor, and the brand navy is 1.48:1 on Streamlit's dark
+        # background — unreadable, and the reason for issue #368.
+        'button[data-variant="segmented_control"][aria-checked="true"]',
     ]:
         assert hook in dark, f"_DARK_CSS missing a dark override for {hook}"

--- a/tests/test_brand_theme.py
+++ b/tests/test_brand_theme.py
@@ -45,7 +45,6 @@ def test_dark_css_relightens_every_accent_the_navy_is_too_dark_for():
     """
     dark = app._DARK_CSS
     assert app._DARK_ACCENT in dark
-    assert app._DARK_FILL in dark
 
     for hook in [
         'data-testid="stSliderThumbValue"',  # a text accent
@@ -55,16 +54,35 @@ def test_dark_css_relightens_every_accent_the_navy_is_too_dark_for():
         'label[data-testid="stRadioOption"][data-selected="true"]',
         '[data-testid="stSlider"] div:has(> [data-testid="stSliderThumbValue"])',
         'data-testid="stMultiSelectTagsContainer"',
+        # Links: Streamlit's own link blue belongs to no other accent here.
+        "a:visited",
     ]:
         assert hook in dark, f"_DARK_CSS missing a dark override for {hook}"
 
 
-def test_the_fill_and_the_text_accent_are_not_the_same_colour():
-    """They cannot be. A filled control carries white text, and white on the
-    text accent is 2.4:1; a blue dark enough to hold that label is too dark to
-    read as text itself. The split is the point, so it is asserted — and the
-    button, which carries a label, takes the fill rather than the accent."""
-    assert app._DARK_ACCENT != app._DARK_FILL
+def test_text_accents_and_filled_controls_take_their_own_blue():
+    """Two blues a step apart, on purpose. A filled control carries a white
+    label, which wants the darker one; text on the page wants the lighter one,
+    and for a colour used both ways those two demands move together — so one
+    colour cannot serve both without giving up 1.5:1 somewhere. The rules are
+    asserted by job, so a future edit cannot quietly swap them."""
     dark = app._DARK_CSS
-    button = dark[dark.index('[data-testid="stBaseButton-primary"]') :]
-    assert app._DARK_FILL in button[: button.index("}")]
+
+    def rule_for(selector):
+        rule = dark[dark.index(selector) :]
+        return rule[: rule.index("}")]
+
+    for selector in [
+        "a,",  # links
+        'data-testid="stSliderThumbValue"',  # the slider's value label
+    ]:
+        assert app._DARK_ACCENT in rule_for(selector), (
+            f"{selector} is not text-accented"
+        )
+
+    for selector in [
+        '[data-testid="stBaseButton-primary"]',
+        'button[data-variant="segmented_control"][aria-checked="true"]',  # a filled pill
+        '[data-testid="stCheckbox"] label[data-selected="true"] > div:not([data-testid])',
+    ]:
+        assert app._DARK_FILL in rule_for(selector), f"{selector} is not filled"

--- a/tests/test_brand_theme.py
+++ b/tests/test_brand_theme.py
@@ -15,45 +15,56 @@ def test_brand_css_forces_the_brand_colour_on_every_accent_widget():
     css = app._BRAND_CSS
     assert app._BRAND in css  # the navy is actually referenced
 
-    # Each accent widget Streamlit would otherwise render in default red.
+    # Each accent widget Streamlit would otherwise render in default red, named
+    # by the hook it carries in the pinned Streamlit. These are internal DOM
+    # details: 1.62 moved these widgets to react-aria and every
+    # ``[data-baseweb=...]`` hook here stopped matching in silence (issue #368),
+    # so they want re-checking in the browser whenever the pin moves.
     required_hooks = [
         'data-testid="stBaseButton-primary"',  # primary buttons
-        'data-testid="stCheckbox"',  # checked checkbox
-        # The toggle track. st.toggle reuses stCheckbox's testid, so only the
-        # full selector tells its rule apart from the checkbox's.
-        (
-            '[data-testid="stCheckbox"] label[data-baseweb="checkbox"]'
-            ":has(input:checked) > div:first-child"
-        ),
-        'data-testid="stRadio"',  # selected radio
-        'data-testid="stSlider"',  # slider thumb
-        'data-testid="stSliderThumbValue"',  # slider value label
-        'data-testid="stMultiSelect"',  # multiselect chips + focus border
-        'data-baseweb="tag"',  # the selected chips themselves
-        # The active pill of a segmented control, which is how every page picker
-        # on this app is drawn. Named by its ARIA state: the testid this rule
-        # used to use is not on the button in Streamlit 1.62, so it quietly
-        # matched nothing (issue #368). Worth re-checking in the DOM whenever
-        # the Streamlit pin moves.
+        # A checked checkbox's box, and the track of a toggle that is on:
+        # st.toggle reuses stCheckbox's testid and marks state the same way.
+        '[data-testid="stCheckbox"] label[data-selected="true"] > div:not([data-testid])',
+        # The dot inside a selected radio.
+        'label[data-testid="stRadioOption"][data-selected="true"]',
+        # The active pill of a segmented control: every page picker in the app.
         'button[data-variant="segmented_control"][aria-checked="true"]',
+        '[data-testid="stSlider"] div:has(> [data-testid="stSliderThumbValue"])',  # thumb
+        'data-testid="stSliderThumbValue"',  # slider value label
+        'data-testid="stMultiSelectTagsContainer"',  # multiselect chips
     ]
     missing = [h for h in required_hooks if h not in css]
     assert not missing, f"_BRAND_CSS no longer styles: {missing}"
 
 
-def test_dark_css_relightens_text_and_indicator_accents():
-    # Navy is too dark for text/indicator accents on a dark backdrop, so the
-    # dark-mode CSS must re-colour those to the lighter accent. The slider value
-    # label and the multiselect focus outline are text/line accents and must be
-    # covered (filled shapes like the thumb and chips stay navy).
+def test_dark_css_relightens_every_accent_the_navy_is_too_dark_for():
+    """On a dark backdrop the navy is 1.48:1 against the background — text drawn
+    in it cannot be read, and a control filled with it barely separates from the
+    page. Both directions are covered here: text/line accents take the lighter
+    accent, filled shapes take the fill.
+    """
     dark = app._DARK_CSS
     assert app._DARK_ACCENT in dark
+    assert app._DARK_FILL in dark
+
     for hook in [
-        'data-testid="stSliderThumbValue"',
-        'data-testid="stMultiSelect"',
-        # The active pill's label: Streamlit paints it with the configured
-        # primaryColor, and the brand navy is 1.48:1 on Streamlit's dark
-        # background — unreadable, and the reason for issue #368.
-        'button[data-variant="segmented_control"][aria-checked="true"]',
+        'data-testid="stSliderThumbValue"',  # a text accent
+        'button[data-variant="segmented_control"][aria-checked="true"]',  # its label
+        'data-testid="stBaseButton-primary"',  # and the filled controls
+        '[data-testid="stCheckbox"] label[data-selected="true"] > div:not([data-testid])',
+        'label[data-testid="stRadioOption"][data-selected="true"]',
+        '[data-testid="stSlider"] div:has(> [data-testid="stSliderThumbValue"])',
+        'data-testid="stMultiSelectTagsContainer"',
     ]:
         assert hook in dark, f"_DARK_CSS missing a dark override for {hook}"
+
+
+def test_the_fill_and_the_text_accent_are_not_the_same_colour():
+    """They cannot be. A filled control carries white text, and white on the
+    text accent is 2.4:1; a blue dark enough to hold that label is too dark to
+    read as text itself. The split is the point, so it is asserted — and the
+    button, which carries a label, takes the fill rather than the accent."""
+    assert app._DARK_ACCENT != app._DARK_FILL
+    dark = app._DARK_CSS
+    button = dark[dark.index('[data-testid="stBaseButton-primary"]') :]
+    assert app._DARK_FILL in button[: button.index("}")]

--- a/tests/test_theme_is_dark.py
+++ b/tests/test_theme_is_dark.py
@@ -1,0 +1,95 @@
+"""Which backdrop the app thinks it is drawn on.
+
+``st.context.theme`` reports a theme's *base*, and a config.toml that overrides
+only colours has no base — so an app themed to a near-black background reported
+``light``, the dark styling never loaded, and the navy accents landed on black
+(issue #368). These cover the reading of the configured colour that fixes it.
+"""
+
+import pytest
+
+from orionbelt_ontology_builder.ui import (
+    _DARK_BACKGROUND_LUMINANCE,
+    _relative_luminance,
+    theme_is_dark,
+)
+
+
+class TestRelativeLuminance:
+    @pytest.mark.parametrize(
+        ("colour", "dark"),
+        [
+            ("#030405", True),  # the background from issue #368
+            ("#0e1117", True),  # Streamlit's own dark
+            ("#0D2B7A", True),  # the brand navy, which is why it needs a lighter accent
+            ("#ffffff", False),
+            ("#fff", False),  # three-digit form
+            ("  #FFFFFF  ", False),  # whitespace and case
+        ],
+    )
+    def test_a_colour_is_measured(self, colour, dark):
+        luminance = _relative_luminance(colour)
+        assert luminance is not None
+        assert (luminance < _DARK_BACKGROUND_LUMINANCE) is dark
+
+    @pytest.mark.parametrize(
+        "colour", ["", "#", "red", "#12345", "#gggggg", "rgb(0,0,0)"]
+    )
+    def test_a_colour_this_cannot_read_says_so(self, colour):
+        """None rather than 0.0: an unparsable colour must not read as black and
+        flip the whole app into dark styling."""
+        assert _relative_luminance(colour) is None
+
+
+class TestThemeIsDark:
+    """The two signals, in order: the reported type, then the configured colour."""
+
+    def _patch(self, monkeypatch, *, reported, background):
+        from orionbelt_ontology_builder import ui
+
+        class _Ctx:
+            def __init__(self, reported):
+                self.theme = {"type": reported}
+
+        monkeypatch.setattr(ui.st, "context", _Ctx(reported))
+        monkeypatch.setattr(ui.st, "get_option", lambda name: background)
+
+    def test_a_theme_reporting_dark_is_dark(self, monkeypatch):
+        self._patch(monkeypatch, reported="dark", background=None)
+        assert theme_is_dark() is True
+
+    def test_a_dark_background_is_dark_even_when_the_type_says_light(self, monkeypatch):
+        """The reported case: colours customised, no base, so Streamlit says
+        light while the app is drawn on near-black."""
+        self._patch(monkeypatch, reported="light", background="#030405")
+        assert theme_is_dark() is True
+
+    def test_a_light_theme_stays_light(self, monkeypatch):
+        self._patch(monkeypatch, reported="light", background="#ffffff")
+        assert theme_is_dark() is False
+
+    def test_no_configured_background_stays_light(self, monkeypatch):
+        self._patch(monkeypatch, reported="light", background=None)
+        assert theme_is_dark() is False
+
+    def test_an_unreadable_background_stays_light(self, monkeypatch):
+        self._patch(monkeypatch, reported="light", background="whatever")
+        assert theme_is_dark() is False
+
+    def test_an_unavailable_theme_does_not_raise(self, monkeypatch):
+        """Both lookups are guarded: st.context is unavailable outside a script
+        run, and a page that raised here would be a page that did not render."""
+        from orionbelt_ontology_builder import ui
+
+        class _Boom:
+            @property
+            def theme(self):
+                raise RuntimeError("no context")
+
+        monkeypatch.setattr(ui.st, "context", _Boom())
+
+        def _explode(name):
+            raise RuntimeError("no options either")
+
+        monkeypatch.setattr(ui.st, "get_option", _explode)
+        assert theme_is_dark() is False

--- a/tests/test_theme_is_dark.py
+++ b/tests/test_theme_is_dark.py
@@ -16,15 +16,29 @@ from orionbelt_ontology_builder.ui import (
 
 
 class TestRelativeLuminance:
+    """Streamlit hands a theme colour to the browser untouched, so a config can
+    hold any CSS colour — verified against 1.62, ``rgb(3,4,5)``, ``#030405ff``
+    and ``black`` all render. The hex and ``rgb()`` forms are read; the rest are
+    not, and say so rather than guessing.
+    """
+
     @pytest.mark.parametrize(
         ("colour", "dark"),
         [
             ("#030405", True),  # the background from issue #368
             ("#0e1117", True),  # Streamlit's own dark
-            ("#0D2B7A", True),  # the brand navy, which is why it needs a lighter accent
+            ("#0D2B7A", True),  # the brand navy, which is why it needs an accent
             ("#ffffff", False),
-            ("#fff", False),  # three-digit form
+            ("#fff", False),  # three-digit
+            ("#0345", True),  # four-digit, alpha ignored
+            ("#030405ff", True),  # eight-digit, alpha ignored
+            ("rgb(3,4,5)", True),
+            ("rgb(3 4 5)", True),  # space-separated, CSS Color 4
+            ("rgba(3, 4, 5, 0.5)", True),
+            ("rgb(3 4 5 / 50%)", True),  # slash alpha
+            ("rgb(255, 255, 255)", False),
             ("  #FFFFFF  ", False),  # whitespace and case
+            ("RGB(3,4,5)", True),
         ],
     )
     def test_a_colour_is_measured(self, colour, dark):
@@ -33,10 +47,26 @@ class TestRelativeLuminance:
         assert (luminance < _DARK_BACKGROUND_LUMINANCE) is dark
 
     @pytest.mark.parametrize(
-        "colour", ["", "#", "red", "#12345", "#gggggg", "rgb(0,0,0)"]
+        "colour",
+        [
+            "",
+            "#",
+            "#12345",  # not a hex length CSS has
+            "#gggggg",
+            "rgb(3,4)",  # a channel short
+            "rgb(300, 0, 0)",  # out of range
+            "rgb(50%, 0%, 0%)",  # percentages are not read
+            # Deliberately not known: naming every CSS colour means carrying all
+            # 148 of them, and hsl()/oklch() mean carrying colour spaces. The
+            # caller falls back to the theme's reported type for these.
+            "black",
+            "red",
+            "hsl(0 0% 0%)",
+            "oklch(0.2 0 0)",
+        ],
     )
     def test_a_colour_this_cannot_read_says_so(self, colour):
-        """None rather than 0.0: an unparsable colour must not read as black and
+        """None rather than 0.0: an unreadable colour must not read as black and
         flip the whole app into dark styling."""
         assert _relative_luminance(colour) is None
 
@@ -58,10 +88,25 @@ class TestThemeIsDark:
         self._patch(monkeypatch, reported="dark", background=None)
         assert theme_is_dark() is True
 
-    def test_a_dark_background_is_dark_even_when_the_type_says_light(self, monkeypatch):
+    @pytest.mark.parametrize("background", ["#030405", "rgb(3,4,5)", "#030405ff"])
+    def test_a_dark_background_is_dark_even_when_the_type_says_light(
+        self, monkeypatch, background
+    ):
         """The reported case: colours customised, no base, so Streamlit says
-        light while the app is drawn on near-black."""
-        self._patch(monkeypatch, reported="light", background="#030405")
+        light while the app is drawn on near-black. All three spellings render
+        identically in Streamlit 1.62, so all three have to be read."""
+        self._patch(monkeypatch, reported="light", background=background)
+        assert theme_is_dark() is True
+
+    def test_a_background_this_cannot_read_falls_back_to_the_reported_type(
+        self, monkeypatch
+    ):
+        """``black`` renders in Streamlit but is not a colour this measures. The
+        answer is the reported type, not a guess — being wrong towards light
+        leaves the app looking as it does today rather than inverting it."""
+        self._patch(monkeypatch, reported="light", background="black")
+        assert theme_is_dark() is False
+        self._patch(monkeypatch, reported="dark", background="black")
         assert theme_is_dark() is True
 
     def test_a_light_theme_stays_light(self, monkeypatch):


### PR DESCRIPTION
Closes #368.

## The reported bug: the selected tab

Two faults, either of which alone would have done it.

**The rule meant to prevent this matched nothing.** Both CSS blocks styled the active pill through `[data-testid="stBaseButton-segmented_controlActive"]`, a testid that is not on the button in Streamlit 1.62 - it carries `data-variant="segmented_control"` and `aria-checked="true"` instead. What was left is Streamlit painting the active label with the configured `primaryColor`, the brand navy:

| backdrop | selected label | contrast |
|---|---|---|
| Streamlit's dark | `#0D2B7A` | **1.48:1** |
| the custom dark theme in the report | `#0D2B7A` | **1.61:1** |
| its neighbours | theme text | 18:1 / 14:1 |

**And the dark override would not have run anyway.** It was gated on `st.context.theme` reporting `"dark"`. That reports a theme's *base*, and a `config.toml` overriding only colours has no base - so an app themed to a near-black background reports `"light"`. Reproduced with `--theme.backgroundColor "#030405"`. `theme_is_dark()` now asks the type first, then measures the configured background colour. The graph canvas used the same check, so a custom dark theme also got a **white graph in a black app**; the same helper fixes it.

## What checking that turned up

Of the seven widgets `_BRAND_CSS` styles, **four matched nothing**: 1.62 rebuilt checkboxes, toggles, radios, sliders and multiselect chips on react-aria, and every `[data-baseweb=...]` hook went quiet with it. Each is re-pointed at the element that actually carries the accent, found by inspecting rendered widgets.

The marks are separated from their labels with `:not([data-testid])`. Both sit directly under the label and only the words carry one (`stWidgetLabel`, `stMarkdownContainer`, `stSliderTickBar`); without it the rule paints the text's background too and every checked box reads as highlighted.

## Dark-mode accents

With the hooks live again the dark theme can reach the filled controls, and they needed it - the navy is 1.48:1 against the dark background, so a button, checkbox, radio dot or slider thumb barely separated from the page.

| | light | dark | why |
|---|---|---|---|
| text accents (tab label, slider value) | navy | `#6EA8FE` | 7.8:1 against the page |
| filled controls (button, checkbox, radio, thumb) | navy | `#3B6FE0` | 4.1:1 against the page, and a white label still at 4.6:1 |

The two cannot be one colour: white on `#6EA8FE` is 2.4:1, so a filled control cannot take it; and a blue dark enough to hold a white label is too dark to read as text.

The slider rail is neutralised rather than filled, restoring what the old rule did before it stopped matching - painting the rail with the accent colours the unfilled half too, which reads as a slider at its maximum.

## Also removed

The `.stTabs` rules. Nothing in the app calls `st.tabs`, so they styled a widget that never renders.

`tests/test_brand_theme.py` guarded `.stTabs` but never the segmented control, which is how a dead selector survived; it now names every hook in both directions, `tests/test_theme_is_dark.py` covers the detection, and both files carry the note that these are internal DOM details to re-check whenever the Streamlit pin moves.

## Measured, before -> after

```
selected tab, stock dark    1.48:1  ->  7.82:1
selected tab, custom dark   1.61:1  ->  8.50:1
filled controls, dark       1.48:1  ->  4.08:1
light mode                 12.78:1  -> 12.78:1   (unchanged)
```

## Verified

Driven live in stock light, stock dark and the reporter's custom colours: every selector matches, every colour lands where the contrast maths says, and the light theme is unchanged apart from the slider rail returning to neutral.

`pytest` 1839 passed, `ruff` and `mypy` clean.

## Note on when this appeared

v1.27.0 moved the pin from Streamlit 1.49.1 to 1.62.0 and the reporter's screenshot shows v1.27.0. I did not confirm which release dropped each hook, so I cannot say how long any individual rule had been dead.