### PR TITLE
feat(viz): the path finder keeps its pair when the panel is closed (#360)

### DIFF
--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -1307,10 +1307,20 @@ def render_visualization():
             if r["node_kind"] != "property"
         }
         path_labels = {key: label for label, key in path_choices.items()}
+        # What the pickers hold has to outlive them. They are widgets inside the
+        # panel, and Streamlit drops a widget's state as soon as it stops being
+        # rendered, so switching the panel off and on again came back empty and
+        # the pair had to be picked from scratch (issue #360). These two keys are
+        # written after each render and seed the widgets on the next one.
+        _PATH_PICK_KEYS = (
+            ("viz_path_source", "_viz_cfg_path_source"),
+            ("viz_path_target", "_viz_cfg_path_target"),
+        )
         # A pick whose entity is gone — deleted, or its type toggled off — is no
         # longer an option, and Streamlit would otherwise carry the stale label
-        # into a widget that cannot show it.
-        for _pkey in ("viz_path_source", "viz_path_target"):
+        # into a widget that cannot show it. The remembered copy goes with it,
+        # or the entity would come back the next time the panel is opened.
+        for _pkey in (key for pair in _PATH_PICK_KEYS for key in pair):
             if st.session_state.get(_pkey) not in path_choices:
                 st.session_state.pop(_pkey, None)
 
@@ -1328,6 +1338,21 @@ def render_visualization():
         # goes on its own.
         if path_panel:
             with st.expander("Shortest path between two entities", expanded=False):
+                # Put the last pair back into the pickers. Written to the
+                # widgets' own keys, and only where they have none: Streamlit
+                # prefers a widget's stored state over anything passed in, so
+                # this seeds a picker that has just been rebuilt without ever
+                # overriding one the user is holding. Seeding by session state
+                # rather than by an ``index`` keeps ``index=None`` below, which
+                # is what makes these two clearable (tests/
+                # test_clearable_required_dropdowns.py).
+                for _widget_key, _remember_key in _PATH_PICK_KEYS:
+                    if _widget_key in st.session_state:
+                        continue
+                    _remembered = st.session_state.get(_remember_key)
+                    if _remembered in path_choices:
+                        st.session_state[_widget_key] = _remembered
+
                 _psrc_col, _ptgt_col = st.columns(2)
                 with _psrc_col:
                     _path_source = st.selectbox(
@@ -1352,6 +1377,21 @@ def render_visualization():
                         help="The path is undirected — it answers 'how are these "
                         "two related', so it reads a link either way round.",
                     )
+
+                # Remembered for the next time the panel is opened. Written
+                # every render rather than on change: the widgets' own state is
+                # the live value while the panel is up, and this only has to be
+                # right at the moment the panel goes away. A picker that has been
+                # cleared drops its key rather than remembering a None, so
+                # "nothing remembered" is one state and not two.
+                for _remember_key, _picked in (
+                    ("_viz_cfg_path_source", _path_source),
+                    ("_viz_cfg_path_target", _path_target),
+                ):
+                    if _picked:
+                        st.session_state[_remember_key] = _picked
+                    else:
+                        st.session_state.pop(_remember_key, None)
 
                 _src_key = path_choices.get(_path_source)
                 _tgt_key = path_choices.get(_path_target)

--- a/tests/test_viz_shortest_path.py
+++ b/tests/test_viz_shortest_path.py
@@ -331,6 +331,62 @@ def test_nothing_is_highlighted_when_the_switch_is_off():
     assert all(n["color"]["border"] != PATH_HIGHLIGHT_COLOR for n in nodes)
 
 
+def _panel(at, shown):
+    """Show or hide the panel for the next run, and check that it moved.
+
+    The *config* key is what to set: the page copies it onto the switch's widget
+    key on every render (see the ``_viz_cfg`` loop), so setting the widget key
+    would be overwritten and the panel would never move — which is a way this
+    test can pass while proving nothing. Clicking the switch is no good either:
+    that fires the persist callback, which marks the settings dirty and mounts
+    the localStorage component, and that waits for a browser.
+    """
+    at.session_state["_viz_cfg_path_panel"] = shown
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+    drawn = bool([b for b in at.button if b.label == "Focus on this path"])
+    assert drawn is shown, f"panel {'hidden' if shown else 'still drawn'}"
+    return at
+
+
+def test_the_pair_survives_the_panel_being_switched_off_and_on():
+    """The pickers are widgets inside the panel, and Streamlit drops a widget's
+    state as soon as it stops being rendered — so the pair used to have to be
+    chosen again every time the panel was reopened (issue #360)."""
+    at = _render("Class: A", "Class: C")
+    assert at.session_state["viz_path_source"] == "Class: A"
+
+    _panel(at, False)
+    _panel(at, True)
+
+    assert at.selectbox(key="viz_path_source").value == "Class: A"
+    assert at.selectbox(key="viz_path_target").value == "Class: C"
+
+
+def test_a_remembered_pick_whose_entity_is_gone_is_forgotten():
+    """The remembered copy outlives the widget, so it has to be pruned with it:
+    an entity that has since been deleted must not come back when the panel is
+    reopened."""
+    at = _render("Class: A", "Class: C")
+    assert at.session_state["_viz_cfg_path_source"] == "Class: A"
+
+    at.session_state.ontology.delete_class(
+        next(
+            c["uri"]
+            for c in at.session_state.ontology.get_classes()
+            if c["name"] == "A"
+        )
+    )
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+
+    assert "_viz_cfg_path_source" not in at.session_state
+    # The picker itself comes back empty rather than naming a class that is gone.
+    assert at.selectbox(key="viz_path_source").value is None
+    # The other half of the pair is untouched — only the gone one is dropped.
+    assert at.session_state["_viz_cfg_path_target"] == "Class: C"
+
+
 def test_the_switch_is_offered_beside_the_display_options_switch():
     at = _render("", "")
     labels = [t.label for t in at.toggle]


### PR DESCRIPTION
Closes #360.

## What was happening

The From/To pickers are widgets inside the Path finder panel, and Streamlit drops a widget's state the moment it stops being rendered. Switching the panel off and on again therefore came back empty, and the pair had to be chosen from scratch - which is what makes the panel awkward to reach for, since reopening it costs two lookups before it can answer anything.

Reproduced before touching anything: pick a class in **From**, toggle the panel off, toggle it on, both pickers are empty.

## The fix

The pair is kept in `_viz_cfg_path_source` / `_viz_cfg_path_target`, which belong to no widget and so survive the panel going away. The pickers are seeded from them when they are rebuilt.

Two details worth a reviewer's eye:

**Seeded through session state, not through `index=`.** That was my first attempt, and `tests/test_clearable_required_dropdowns.py` failed it: `index=None` is what makes these two clearable, and passing a real index silently takes the clear cross away. Seeding the widget key instead keeps `index=None` literally, and Streamlit prefers a widget's stored state over anything passed in.

**Seeding only fills a picker that has no state of its own**, so a live selection is never overridden; and the remembered copy is pruned alongside the widget value, so an entity deleted while the panel was closed does not come back when it is reopened.

## The tests

Both fail without the fix, which I checked by reverting it.

They drive the panel by its config key rather than by clicking the switch, for two reasons written into the helper: clicking fires the persist callback, which mounts the localStorage component and waits for a browser that is not there (a 300s hang); and setting the *widget* key does nothing, because the page rewrites it from the config key on every render - a test that cannot actually close the panel would pass while proving nothing. So the helper asserts the panel moved.

## Verified

`pytest` 1857 passed, `ruff` and `mypy` clean. In the running app: pick, switch off, switch on, the pick is still there, and the clear cross with it.