### PR TITLE
chore: 1.27.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.27.0` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.27.1` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -33,7 +33,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.27.0"
+APP_VERSION = "1.27.1"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.27.0"
+version = "1.27.1"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 # SPDX. Business Source License 1.1 is BUSL-1.1; BSL-1.0 is the Boost Software

--- a/uv.lock
+++ b/uv.lock
@@ -891,7 +891,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.27.0"
+version = "1.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },


### PR DESCRIPTION
A patch rather than a minor: everything since v1.27.0 restores behaviour that was expected and missing, rather than adding anything.

| | |
|---|---|
| `feat(viz)` #373 | the path finder keeps its pair when the panel is closed (#360) |
| `fix(ui)` #370 | dark-mode contrast: the selected tab, the theme detection, the re-pointed CSS, the blue palette (#368) |
| `fix(sparql)` #369 | a plain-editor toggle, so picking an example does not refetch 286 KB of editor (#356) |
| `chore(deps)` #364 #365 #366 | Dockerfile uv, setup-uv action, ruff |

#373 carries a `feat` type in its commit, but it is a panel that forgot what you told it - the same shape of complaint as the other two, so the release is a patch.

All three user-facing items came from @SuperCowProducts, and all three only reach them through a release plus a hosted reboot.

Bumped in all three places that declare the version, plus the lockfile's own entry for this package:

- `pyproject.toml`
- `APP_VERSION` in `orionbelt_ontology_builder/ui.py`
- the README's Docker `:1.27.0` pin example
- `uv.lock`

`tests/test_version_consistency.py` guards the first two against drift (issue #74) and passes.

## Verified

`pytest` 1857 passed, `ruff check`, `mypy` clean.

No tag is pushed by this PR - the release is a separate, deliberate step.