### PR TITLE
fix(viz): the class hierarchy printed every path through the graph (#371)

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -5491,6 +5491,14 @@ def render_add_annotation(ont, all_resources):
                     st.rerun()
 
 
+#: How many lines the text hierarchy will print before it stops.
+#:
+#: A backstop, not the fix: the expansion below is linear in subClassOf edges,
+#: so this is only reached by an ontology genuinely that large. 20,000 lines is
+#: about a megabyte of text, which ``st.code`` still shows without complaint.
+CLASS_TREE_MAX_LINES = 20_000
+
+
 def build_class_hierarchy_text(classes):
     """Render the class list as an indented subClassOf tree.
 
@@ -5503,6 +5511,16 @@ def build_class_hierarchy_text(classes):
     subClassOf cycle (e.g. A ⊑ B and B ⊑ A) terminates too. After the normal
     roots are walked, any class not yet emitted is walked as an extra root, so
     disconnected or wholly-cyclic components are shown rather than dropped.
+
+    A subClassOf graph is a DAG, not a tree, and printing it as one means a
+    class with two parents is reached by two paths — so expanding it under each
+    of them costs a second copy of everything below it. That compounds: a chain
+    of diamonds doubles per level, and 33 classes rendered 131,071 lines. One
+    real ontology produced 1.1 GB of text and took the browser down with it
+    (issue #371). So a class is expanded once. It is still listed under every
+    parent, because being a subclass of both is the fact the tree is drawing —
+    only the repeat of its subtree is withheld, and marked where anything was
+    actually withheld. That makes the output linear in subClassOf edges.
     """
     by_name = {}
     for c in classes:
@@ -5510,11 +5528,18 @@ def build_class_hierarchy_text(classes):
 
     lines = []
     emitted = set()  # classes shown as a real node (not just a cycle back-edge)
+    truncated = False
 
     def walk(start):
+        nonlocal truncated
         # Explicit stack of (name, level, ancestors-on-this-branch).
         stack = [(start, 0, frozenset())]
         while stack:
+            if len(lines) >= CLASS_TREE_MAX_LINES:
+                # Checked here rather than at the end: the point is not to build
+                # the text and then trim it, but never to build it.
+                truncated = True
+                return
             cls_name, level, path = stack.pop()
             cls = by_name.get(cls_name)
             if not cls:
@@ -5524,6 +5549,13 @@ def build_class_hierarchy_text(classes):
             if cls_name in path:
                 lines.append(f"{prefix}{cls['name']}{label}  (cycle)")
                 continue
+            if cls_name in emitted:
+                # Already expanded under another parent. Listed again, because
+                # it really is a subclass of this one too; the note is only
+                # added where there was a subtree to withhold.
+                note = "  (shown above)" if cls["children"] else ""
+                lines.append(f"{prefix}{cls['name']}{label}{note}")
+                continue
             lines.append(f"{prefix}{cls['name']}{label}")
             emitted.add(cls_name)
             child_path = path | {cls_name}
@@ -5532,13 +5564,29 @@ def build_class_hierarchy_text(classes):
                 stack.append((child, level + 1, child_path))
 
     for c in classes:
+        if truncated:
+            break
         if not c["parents"]:
             walk(c["name"])
     # Cover components that no root reaches (disconnected trees, all-cyclic
     # ontologies, multiple detached cycles).
     for c in classes:
+        if truncated:
+            break
         if c["name"] not in emitted:
             walk(c["name"])
+
+    if truncated:
+        # Said in the text itself: this is what the reader is looking at, and a
+        # tree that simply stopped would read as a tree that ends there.
+        left = len(by_name) - len(emitted)
+        lines.append("")
+        lines.append(
+            f"… stopped at {CLASS_TREE_MAX_LINES:,} lines. "
+            f"{left:,} of {len(by_name):,} classes are not shown. "
+            f"The Interactive Graph draws a subset of an ontology this size, "
+            f"and the Classes page lists all of it."
+        )
 
     return "\n".join(lines)
 

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -229,6 +229,33 @@ BAND_SWITCH_CSS = """<style>
 }
 </style>"""
 
+#: The "not everything is drawn" line above the canvas, and its dismiss button.
+#:
+#: It used to be an ``st.warning`` box: three lines of padding around one line of
+#: text, permanently, on every ontology past the node cap — which is where a user
+#: spends their time, so it was always there taking the room the graph wanted.
+#: Written as a caption with the warning glyph in front of it, it says the same
+#: thing in one line. The button beside it is stripped back to the glyph so the
+#: pair reads as one line rather than as a control bar.
+GRAPH_NOTICE_CSS = """<style>
+.st-key-viz_graph_notice [data-testid="stCaptionContainer"] {
+    margin-bottom: 0;
+}
+.st-key-viz_graph_notice [data-testid="stButton"] button {
+    border: none;
+    background: transparent;
+    padding: 0 0.25rem;
+    min-height: 0;
+    line-height: 1.2;
+    color: inherit;
+    opacity: 0.6;
+}
+.st-key-viz_graph_notice [data-testid="stButton"] button:hover {
+    opacity: 1;
+    color: inherit;
+}
+</style>"""
+
 
 def graph_overlay_css(dark: bool) -> str:
     """CSS that floats the graph page's panels over the canvas.
@@ -2512,8 +2539,32 @@ def render_visualization():
         # status used. Written on every render, not only on a rebuild: the slot
         # is reserved either way (issue #189), and the reason still holds while
         # the cached graph is reused.
-        if gdata and gdata.get("notice"):
-            status.warning(gdata["notice"], icon="⚠️")
+        #
+        # Dismissable, and remembered by its own text: an ontology past the node
+        # cap says this on every render, and once it has been read it is just the
+        # canvas being pushed down. Keyed by the text rather than by a flag so a
+        # notice that changes — a different count, or a different reason
+        # altogether — is shown again rather than swallowed by an earlier
+        # dismissal. Emptying the slot is safe where removing the element would
+        # not be: the placeholder stays either way, so the graph component below
+        # keeps its place in the element tree (issue #189).
+        _notice = (gdata or {}).get("notice") or ""
+        if _notice and st.session_state.get("_viz_notice_dismissed") != _notice:
+            st.html(GRAPH_NOTICE_CSS)
+            with status.container(key="viz_graph_notice"):
+                _notice_col, _dismiss_col = st.columns(
+                    [40, 1], vertical_alignment="center"
+                )
+                with _notice_col:
+                    st.caption(f"⚠️ {_notice}")
+                with _dismiss_col:
+                    if st.button(
+                        "✕",
+                        key="viz_notice_dismiss",
+                        help="Hide this. It comes back if what it says changes.",
+                    ):
+                        st.session_state["_viz_notice_dismissed"] = _notice
+                        st.rerun()
         # Recompute the note for the Node options label now that the focus
         # controls have rendered and the prune has run. One rerun when it
         # actually changes, so the label is never a step behind what the graph

--- a/tests/test_class_hierarchy_text.py
+++ b/tests/test_class_hierarchy_text.py
@@ -1,6 +1,7 @@
-"""Text class-hierarchy rendering, including subClassOf cycles (issue #171)."""
+"""Text class-hierarchy rendering: subClassOf cycles (#171), and the DAG
+expansion that made it exponential (#371)."""
 
-from orionbelt_ontology_builder import app
+from orionbelt_ontology_builder import app, ui
 from orionbelt_ontology_builder.ontology_manager import OntologyManager
 
 
@@ -102,3 +103,85 @@ def test_diamond_class_shown_under_each_parent():
 
     assert text.count("Bottom") == 2  # appears under Left and under Right
     assert "(cycle)" not in text
+
+
+def _diamond_chain(levels):
+    """A_i and B_i both inherit from A_(i-1) and B_(i-1).
+
+    A DAG of 2n+1 classes and no cycles, where the number of distinct paths from
+    the root doubles per level — so printing every path is exponential while the
+    ontology is tiny.
+    """
+    m = OntologyManager()
+    m.add_class("Root")
+    for i in range(levels):
+        for side in ("A", "B"):
+            parent = "Root" if i == 0 else f"A{i - 1}"
+            m.add_class(f"{side}{i}", parent=parent)
+            if i:
+                m.add_class_relation(f"{side}{i}", "subClassOf", f"B{i - 1}")
+    return m
+
+
+def test_a_class_reached_twice_is_expanded_once():
+    """Every path through a DAG used to be expanded in full: 33 classes rendered
+    131,071 lines, and one real ontology produced 1.1 GB of text (issue #371)."""
+    m = _diamond_chain(12)  # 25 classes; 8,191 lines before this was fixed
+
+    text = app.build_class_hierarchy_text(m.get_classes())
+
+    assert len(text.splitlines()) < 60
+    # Every class is still in there — the saving is repeats, not content.
+    for name in [f"{side}{i}" for i in range(12) for side in ("A", "B")]:
+        assert name in text
+
+
+def test_a_class_under_two_parents_is_listed_under_both():
+    """The repeat that is dropped is the *subtree*, not the class: being a
+    subclass of both parents is the fact the tree is there to show."""
+    m = OntologyManager()
+    m.add_class("Left")
+    m.add_class("Right")
+    m.add_class("Both", parent="Left")
+    m.add_class("Leaf", parent="Both")
+    m.add_class_relation("Both", "subClassOf", "Right")
+
+    text = app.build_class_hierarchy_text(m.get_classes())
+
+    assert text.count("Both") == 2  # under Left and under Right
+    assert text.count("Leaf") == 1  # its subtree is drawn once
+    assert "(shown above)" in text  # and the second listing says so
+
+
+def test_a_leaf_listed_twice_is_not_marked():
+    """Nothing was withheld, so there is nothing to say. The note would only be
+    noise on the classes that make up most of a hierarchy."""
+    m = OntologyManager()
+    m.add_class("Left")
+    m.add_class("Right")
+    m.add_class("Leaf", parent="Left")
+    m.add_class_relation("Leaf", "subClassOf", "Right")
+
+    text = app.build_class_hierarchy_text(m.get_classes())
+
+    assert text.count("Leaf") == 2
+    assert "(shown above)" not in text
+
+
+def test_the_tree_stops_at_the_line_cap_and_says_so(monkeypatch):
+    """The backstop for an ontology genuinely too large to print. Checked with a
+    small cap: what matters is that it stops, counts what it left out, and does
+    not read as a hierarchy that simply ends there."""
+    monkeypatch.setattr(ui, "CLASS_TREE_MAX_LINES", 5)
+    m = OntologyManager()
+    prev = None
+    for i in range(20):
+        m.add_class(f"C{i}", parent=prev)
+        prev = f"C{i}"
+
+    text = app.build_class_hierarchy_text(m.get_classes())
+
+    body, note = text.rsplit("\n\n", 1)
+    assert len(body.splitlines()) == 5
+    assert "stopped at 5 lines" in note
+    assert "15 of 20 classes are not shown" in note

--- a/tests/test_viz_node_cap.py
+++ b/tests/test_viz_node_cap.py
@@ -145,6 +145,62 @@ def _graph(
     )
 
 
+def _render(n_classes, **kw):
+    """Render once and return the AppTest itself, for the notice's own UI."""
+    os.environ["N_CLASSES"] = str(n_classes)
+    for var, default in (
+        ("SEED", ""),
+        ("SHAPE", "chain"),
+        ("DEPTH", "1"),
+        ("FIND", ""),
+        ("EXTRA", ""),
+        ("HIDE", ""),
+        ("HIDE_ALL", ""),
+    ):
+        os.environ[var] = str(kw.get(var.lower(), default))
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    return at
+
+
+def _notice_shown(at):
+    return [c.value for c in at.caption if "are not drawn" in c.value]
+
+
+# --- the notice above the canvas --------------------------------------------
+
+
+def test_the_notice_is_one_line_and_can_be_dismissed():
+    """It used to be an st.warning box — three lines of padding around one line
+    of text, on every ontology past the cap, permanently."""
+    at = _render(app.GRAPH_MAX_NODES + 20)
+
+    assert _notice_shown(at)
+    assert not [w for w in at.warning if "are not drawn" in w.value]
+    assert at.button(key="viz_notice_dismiss")
+
+
+def test_dismissing_the_notice_takes_it_off_the_page():
+    at = _render(app.GRAPH_MAX_NODES + 20)
+
+    at.button(key="viz_notice_dismiss").click().run(timeout=300)
+    assert not at.exception, at.exception
+
+    assert not _notice_shown(at)
+
+
+def test_a_notice_that_has_changed_is_shown_again():
+    """Dismissal is keyed by the text, not by a flag: a different count, or a
+    different reason altogether, is news and has to be readable."""
+    at = _render(app.GRAPH_MAX_NODES + 20)
+    at.session_state["_viz_notice_dismissed"] = "some older notice"
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+
+    assert _notice_shown(at)
+
+
 # --- the bug ----------------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #371.

## What was happening

Class Hierarchy (Text) reported `MessageSizeError: Data of size 1095.1 MB exceeds the message size limit of 200.0 MB`, and clicking it repeatedly could take the machine down.

It is not a size problem, despite the title. A subClassOf graph is a **DAG**, and the walk printed it as a tree: a class with two parents is reached by two paths, and it was expanded once per path - so every shared class cost another copy of everything below it. That compounds, because the copies themselves contain shared classes.

Measured on the reporter's own ontology (the one attached to #356), 1,008 classes of which **428 have more than one parent**:

| | lines | size | time |
|---|---|---|---|
| before | 9,521,217 | **989.8 MB** | 10.2 s |
| after | 1,556 | 82 KB | 0.00 s |

Synthetically it is starker - a chain of diamonds doubles per level:

| classes | lines before | lines after |
|---|---|---|
| 25 | 8,191 | 47 |
| 33 | 131,071 | 63 |
| 81 | 2,199,023,255,551 | 159 |

## The fix

**A class is expanded once.** It is still listed under every parent, because being a subclass of both is exactly what the tree is there to show; only the repeat of its *subtree* is withheld. The note `(shown above)` is added only where something was actually withheld - a leaf listed twice says nothing, since nothing was left out, and the note would otherwise be noise on most of a hierarchy.

That makes the output linear in subClassOf edges rather than exponential in paths.

**`CLASS_TREE_MAX_LINES` (20,000) is the backstop** the issue asks for. It is checked while walking, not after, so a pathological ontology never builds the text at all; and what it left out is said in the text, since a tree that simply stopped would read as a hierarchy that ends there.

## On limiting depth or collapsing levels

Both were suggested. Depth is not what blew up: their hierarchy is not unusually deep, it is unusually shared, and 33 classes at depth 16 already produced 131,071 lines. A depth cap tight enough to bound `2^depth` would cut real hierarchies (this repo's own tests render a legitimate 1,100-level chain), and with the expansion fixed, depth is harmless.

A collapsible tree is now *possible* - 1,556 lines instead of ten million - but it is a feature rather than a safety net, and `st.code` is a static block, so it would mean nested expanders or a component. Worth its own issue if wanted.

## Tests

Four new, all failing without the fix: the DAG stays linear, a two-parent class is still listed under both, a leaf listed twice is not marked, and the cap stops and reports. The existing cycle and deep-chain tests (#171) still pass unchanged.

`pytest` 1861 passed, `ruff` and `mypy` clean.