### PR TITLE
fix(viz): the graph pickers show the label the canvas draws

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -197,6 +197,7 @@ from .ui import (  # noqa: F401
     path_nodes,
     persist_autosave,
     persist_language_packs,
+    picker_option_caption,
     prioritise_find_target,
     prune_reused_focus_seeds,
     reconcile_filter_selection,

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -2329,6 +2329,27 @@ def confirm_delete(resource_name: str, resource_type: str, key_suffix: str) -> b
 LABEL_NAME_SEPARATOR = " · "
 
 
+def picker_option_caption(option: str, name: str, text: str) -> str:
+    """What a graph picker shows for one of its options.
+
+    The canvas draws a node under its rdfs:label (a concept's prefLabel), so
+    that is what someone reads off the graph and then goes looking for in Find,
+    in the focus seeds, or in the path finder — where the options were the local
+    name alone. In an ontology whose names are identifiers (``0-I`` labelled
+    "zero current") the two share nothing, and the entity could not be found by
+    the only name the user had seen.
+
+    The label is shown, never stored: ``option`` stays the identifier the rest of
+    the page is built on — focus seeds are persisted as it, the paste box
+    round-trips it, and rename notes re-point it (issues #142, #179, #275).
+    Only what is drawn in the dropdown changes, which is also what Streamlit
+    matches typed text against, so the label is searchable too.
+    """
+    if text and text != name:
+        return f"{option}{LABEL_NAME_SEPARATOR}{text}"
+    return option
+
+
 def format_label_name(name: str, label: str) -> str:
     """Format display string as 'name · Label' if label exists and differs from name."""
     if label and label != name:

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -60,6 +60,7 @@ from ..ui import (
     path_entity_kinds,
     path_highlight,
     path_nodes,
+    picker_option_caption,
     prioritise_find_target,
     prune_reused_focus_seeds,
     reconcile_filter_selection,
@@ -740,11 +741,23 @@ def render_visualization():
         # The same targets in list form, carrying what the paste / copy box
         # needs to write one down and read it back (issue #283).
         focus_records: list[dict] = []
+        #: Option -> what the picker shows for it. Only entities whose label
+        #: differs from their name are in here; :func:`_picker_caption` falls
+        #: back to the option itself for the rest.
+        focus_captions: dict[str, str] = {}
 
-        def _focus_target(kind_word, name, node_kind, ref, uri=None):
-            """Register one focusable entity under the label the picker shows."""
+        def _focus_target(kind_word, name, node_kind, ref, uri=None, text=""):
+            """Register one focusable entity under the label the picker shows.
+
+            ``text`` is the entity's rdfs:label (a SKOS concept's prefLabel);
+            see :func:`picker_option_caption` for what it is used for and why it
+            is not what the option is keyed by.
+            """
             label = f"{kind_word}: {name}"
             focus_targets[label] = viz_node_id(node_kind, ref)
+            caption = picker_option_caption(label, name, text)
+            if caption != label:
+                focus_captions[label] = caption
             focus_records.append(
                 {
                     "kind": kind_word,
@@ -759,18 +772,39 @@ def render_visualization():
                 }
             )
 
+        # The labels the canvas draws, by URI, so a picker can show what the
+        # graph shows (see _focus_target).
+        _class_label_by_uri = {c["uri"]: c.get("label") or "" for c in classes}
+        _ind_label_by_uri = {i["uri"]: i.get("label") or "" for i in individuals}
         if show_classes:
             for e in class_entries:
-                _focus_target("Class", e["display"], "class", e["uri"], e["uri"])
+                _focus_target(
+                    "Class",
+                    e["display"],
+                    "class",
+                    e["uri"],
+                    e["uri"],
+                    _class_label_by_uri.get(e["uri"], ""),
+                )
         if show_individuals:
             for e in ind_entries:
                 _focus_target(
-                    "Individual", e["display"], "individual", e["uri"], e["uri"]
+                    "Individual",
+                    e["display"],
+                    "individual",
+                    e["uri"],
+                    e["uri"],
+                    _ind_label_by_uri.get(e["uri"], ""),
                 )
         if show_data_props:
             for prop in data_props:
                 _focus_target(
-                    "Data Property", prop["name"], "property", prop["uri"], prop["uri"]
+                    "Data Property",
+                    prop["name"],
+                    "property",
+                    prop["uri"],
+                    prop["uri"],
+                    prop.get("label") or "",
                 )
         if show_skos and _has_skos:
             for concept in ont.get_concepts():
@@ -782,7 +816,12 @@ def render_visualization():
                     "concept",
                     concept["name"],
                     concept.get("uri"),
+                    concept.get("prefLabel") or "",
                 )
+
+        def _picker_caption(option):
+            """What a picker shows for one of its options."""
+            return focus_captions.get(option, option)
 
         # A seed whose entity was renamed is held under a label that no longer
         # exists; re-point it at the new one first, or the prune below reads the
@@ -880,6 +919,7 @@ def render_visualization():
                 _find_choice = st.selectbox(
                     "Find entity in graph",
                     options=sorted(focus_targets),
+                    format_func=_picker_caption,
                     index=None,
                     placeholder="🔍 Find and centre on an entity…",
                     label_visibility="collapsed",
@@ -997,6 +1037,7 @@ def render_visualization():
                     focus_seeds = st.multiselect(
                         "Focus node(s)",
                         options=focus_labels,
+                        format_func=_picker_caption,
                         key="viz_focus_seeds",
                         on_change=viz_focus_seeds_changed,
                         help="Classes, individuals or SKOS concepts to centre on. "
@@ -1358,6 +1399,7 @@ def render_visualization():
                     _path_source = st.selectbox(
                         "From",
                         options=sorted(path_choices),
+                        format_func=_picker_caption,
                         index=None,
                         placeholder="Start entity…",
                         key="viz_path_source",
@@ -1371,6 +1413,7 @@ def render_visualization():
                     _path_target = st.selectbox(
                         "To",
                         options=sorted(path_choices),
+                        format_func=_picker_caption,
                         index=None,
                         placeholder="End entity…",
                         key="viz_path_target",

--- a/tests/test_viz_node_cap.py
+++ b/tests/test_viz_node_cap.py
@@ -392,3 +392,56 @@ def test_find_does_not_rewrite_the_users_node_filter():
                     f"line {node.lineno}: Find must not write the node filter; "
                     "the graph exempts the target at build time instead"
                 )
+
+
+# --- what the pickers show ---------------------------------------------------
+
+
+class TestPickerCaptions:
+    """The canvas draws a node under its rdfs:label, so that is the name someone
+    reads off the graph — and the pickers listed the local name alone, which in
+    an ontology of identifiers shares nothing with it.
+    """
+
+    def test_a_label_is_shown_beside_the_name(self):
+        assert (
+            app.picker_option_caption("Class: 0-I", "0-I", "zero current")
+            == "Class: 0-I · zero current"
+        )
+
+    def test_no_label_leaves_the_option_alone(self):
+        assert (
+            app.picker_option_caption("Class: Person", "Person", "") == "Class: Person"
+        )
+
+    def test_a_label_equal_to_the_name_is_not_repeated(self):
+        assert (
+            app.picker_option_caption("Class: Person", "Person", "Person")
+            == "Class: Person"
+        )
+
+    def test_the_option_itself_is_untouched(self):
+        """It is the identifier the rest of the page runs on: focus seeds are
+        persisted as it, the paste box round-trips it, rename notes re-point it.
+        Only the caption carries the label."""
+        for var, value in (
+            ("N_CLASSES", "3"),
+            ("SEED", ""),
+            ("SHAPE", "chain"),
+            ("DEPTH", "1"),
+            ("FIND", ""),
+            ("EXTRA", ""),
+            ("HIDE", ""),
+            ("HIDE_ALL", ""),
+        ):
+            os.environ[var] = value
+        at = AppTest.from_function(_script)
+        at.run(timeout=300)
+        assert not at.exception, at.exception
+
+        options = at.selectbox(key="viz_find_entity").options
+        assert options
+        assert all(" · " not in o for o in options)
+        assert all(
+            o.startswith(("Class: ", "Individual: ", "Concept: ")) for o in options
+        )


### PR DESCRIPTION
Reported in passing while testing #371: *"in the graph the class label is shown, but in the path dropdown, you cannot find the label"*.

## The mismatch

A node is drawn under its **rdfs:label** (`visualization.py`: `label = cls["label"] if cls["label"] else disp_cls_name`), while Find, the focus seeds and the path finder list the **local name** alone. In an ontology whose names are identifiers the two share nothing:

| | shows |
|---|---|
| the canvas | `zero current` |
| the pickers | `Class: 0-I` |

So the only name a user has actually seen could not be typed into any of the three pickers. On the ontology attached to #356 that makes the path finder close to unusable - the list is `Class: $ARGS`, `Class: 0-l`, `Class: RH-rule`, and nothing you can read off the graph is in it.

## What changed

The three pickers show `Class: 0-I · zero current`, using the separator the rest of the app already uses for name-and-label. Streamlit matches typed text against what it draws, so the label is searchable: typing `zero current` now finds the class.

**Shown, never stored.** The option itself stays `Class: 0-I`, because that string is the identifier the page is built on - focus seeds are persisted as it (#142), the paste box round-trips it (#179), and rename notes re-point it (#275). Putting the label into the option would break all three quietly, so there is a test pinning the options to their bare form.

SKOS concepts take their `prefLabel`, which is what their node is drawn under.

## Verified

Live on the reporter's ontology:

- Find lists `Class: 0-I · zero current`, `Class: 0-div · divison by zero`, and leaves unlabelled classes as they were.
- Typing `zero current` - the label, not the name - matches exactly one option, where before it matched none.
- The path finder's From shows `Class: RH-rule · right-hand rule`.

`pytest` 1861 passed (4 new), `ruff` and `mypy` clean.