### PR TITLE
fix(viz): say when a path is only half drawn, even on a capped graph

### DIFF
--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -1622,8 +1622,11 @@ def render_visualization():
         # focus mode stopped charging an annotation a hop (issue #272), so a
         # cached focus payload is one built under the old pruning. 21: nodes and
         # edges along a shortest path are repainted (issue #176), which a cached
-        # pre-#176 payload has none of.
-        _graph_ver = 21
+        # pre-#176 payload has none of. 22: the notice cached with the payload
+        # now reports a path that is only half drawn, where before the generic
+        # cap line suppressed it — a cached v21 payload carries the suppressed
+        # one and would keep showing it until something unrelated evicted it.
+        _graph_ver = 22
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.
@@ -2358,12 +2361,19 @@ def render_visualization():
             # block below replaces this with something more specific when it has
             # it, since a focus that finds nothing is the sharper symptom.
             _cut_classes = len(visible_class_uris) - len(displayed_class_uris)
+            # Whether the line above is the only thing the graph has to say. The
+            # path block at the end replaces this one and nothing else: the focus
+            # messages below are sharper (one of them explains an empty canvas),
+            # and their advice is about the focus the user is already in, which
+            # "use Focus on this path" would talk straight over.
+            _notice_is_the_cap_line = False
             if show_classes and _cut_classes > 0:
                 graph_notice = (
                     f"{_cut_classes} of {len(visible_class_uris)} classes are not "
                     f"drawn: the graph stops at {max_nodes} nodes. Hide some in "
                     f"{VIZ_NODE_PANEL}, or focus on one node, to see the rest."
                 )
+                _notice_is_the_cap_line = True
 
             # Focus mode: keep only the seed nodes' neighbourhood within
             # focus_depth hops over the assembled edges (BFS over all node
@@ -2399,6 +2409,7 @@ def render_visualization():
                                 f"only part of it is shown. Pick fewer focus "
                                 f"nodes, or a lower depth, to see it in full."
                             )
+                            _notice_is_the_cap_line = False
                             break
                         keep |= ring
                         nxt: set = set()
@@ -2465,6 +2476,7 @@ def render_visualization():
                         f"or individuals in {VIZ_NODE_PANEL} to bring it into "
                         f"range."
                     )
+                    _notice_is_the_cap_line = False
 
             # Repaint the shortest path onto whatever of it the canvas is
             # drawing (issue #176). After the focus prune, so a node lit up here
@@ -2502,7 +2514,7 @@ def render_visualization():
                         }
                         node["borderWidth"] = PATH_HIGHLIGHT_BORDER
                 _path_missing = len(_path_ids - {n["id"] for n in net.nodes})
-                if _path_missing:
+                if _path_missing and (not graph_notice or _notice_is_the_cap_line):
                     # Said instead of whatever the graph had to say about its own
                     # size, not only when it had nothing to say. The two have the
                     # same cause — the view holds less than the ontology — but on

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -2432,11 +2432,20 @@ def render_visualization():
                         }
                         node["borderWidth"] = PATH_HIGHLIGHT_BORDER
                 _path_missing = len(_path_ids - {n["id"] for n in net.nodes})
-                if _path_missing and not graph_notice:
+                if _path_missing:
+                    # Said instead of whatever the graph had to say about its own
+                    # size, not only when it had nothing to say. The two have the
+                    # same cause — the view holds less than the ontology — but on
+                    # a graph at the node cap the generic line was always set
+                    # first, so this one never appeared: the path came out in
+                    # disconnected pieces with nothing on screen accounting for
+                    # it, which reads as a broken highlight rather than as a view
+                    # that does not hold all of it. This one also names the way
+                    # out, and it is the more specific of the two.
                     graph_notice = (
-                        f"{_path_missing} of the {len(_path_ids)} entities on the "
-                        f"path are not drawn, so the highlight is partial. Use "
-                        f"“Focus on this path” to bring all of it into view."
+                        f"{_path_missing} of the {len(_path_ids)} entities on this "
+                        f"path are not drawn, so the highlight is broken into "
+                        f"pieces. Use “Focus on this path” to see all of it."
                     )
 
             # Spread parallel edges so they don't overlap

--- a/tests/test_viz_shortest_path.py
+++ b/tests/test_viz_shortest_path.py
@@ -201,6 +201,24 @@ def test_a_path_that_is_only_half_drawn_says_so_over_the_cap_notice(patch_ui):
     assert "Focus on this path" in notice
 
 
+def test_a_focus_keeps_its_own_advice_when_the_path_is_half_drawn(patch_ui):
+    """The path line replaces the generic cap line and nothing else. The focus
+    messages are sharper — one of them explains an empty canvas — and their
+    advice is about the focus the user is already in, which "use Focus on this
+    path" would talk straight over (Codex review of PR #377)."""
+    patch_ui("GRAPH_MAX_NODES", 2)
+    at = _render("Class: A", "Class: C")
+
+    at.session_state["_viz_cfg_focus_mode"] = True
+    at.session_state["_viz_cfg_focus_seeds"] = ["Class: A", "Class: B", "Class: C"]
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+
+    notice = at.session_state["last_graph_data"]["notice"]
+    assert "focus" in notice.lower()
+    assert "Focus on this path" not in notice
+
+
 def test_a_path_drawn_in_full_leaves_the_graph_notice_alone():
     """Nothing is missing from the path, so there is nothing for it to say."""
     notice = _render("Class: A", "Class: C").session_state["last_graph_data"]["notice"]

--- a/tests/test_viz_shortest_path.py
+++ b/tests/test_viz_shortest_path.py
@@ -188,6 +188,26 @@ def test_the_cached_graph_is_rebuilt_when_the_path_changes():
     assert first != second
 
 
+def test_a_path_that_is_only_half_drawn_says_so_over_the_cap_notice(patch_ui):
+    """A capped graph always had something to say about its own size, and that
+    silenced this: the path came out in disconnected pieces with nothing on
+    screen accounting for it (reported against v1.27.1). This message is the
+    more specific of the two, and the only one that names the way out."""
+    patch_ui("GRAPH_MAX_NODES", 2)  # the A -> B -> C path cannot fit
+
+    notice = _render("Class: A", "Class: C").session_state["last_graph_data"]["notice"]
+
+    assert "entities on this path are not drawn" in notice
+    assert "Focus on this path" in notice
+
+
+def test_a_path_drawn_in_full_leaves_the_graph_notice_alone():
+    """Nothing is missing from the path, so there is nothing for it to say."""
+    notice = _render("Class: A", "Class: C").session_state["last_graph_data"]["notice"]
+
+    assert "entities on this path" not in notice
+
+
 # --- what the panel says ----------------------------------------------------
 
 


### PR DESCRIPTION
Reported against v1.27.1: a highlighted path on a large ontology comes out in disconnected pieces.

## What is actually happening

Nothing is wrong with the highlight. Reproduced on the ontology from #356, asking for a path from `right-hand rule` to `json`:

- the path is **16 hops, 17 entities**, all `subClassOf`;
- the view holds **500 of 1008** classes, because of the node cap;
- **9 of the 17** entities on the path are among the ones it does not hold;
- so only the **4** links with both ends drawn can be ringed, and the path looks broken.

## Why nothing said so

The page has a line for exactly this case, and it could never appear:

```python
if _path_missing and not graph_notice:
```

A graph at the node cap has always already set the generic *"N of M classes are not drawn"*, so the guard was never satisfied. The one message that explains the pieces - and the only one that names the way out, `Focus on this path` - was suppressed by the vaguer message that shares its cause.

It is now said *instead of* that line rather than only in its absence, on the grounds that it is the more specific of the two and it is about what the user is looking at right now.

## Tests

Two, and the first fails without the change: a path that cannot fit under the cap reports itself, and a path drawn in full leaves the graph's own message alone.

`pytest` 1859 passed, `ruff` and `mypy` clean.

## Not in this PR

The better answer, suggested while reviewing this: keep the path's entities *in* the graph by giving them priority within the cap, dropping unrelated nodes to make room, the way the Find target already survives the cap (#234). That is a change to the builder's gates rather than to a message, and it wants its own PR - this one stops the current release lying by omission.