### PR TITLE
feat(viz): a highlighted path is drawn whatever the node cap (#378)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -197,7 +197,7 @@ from .ui import (  # noqa: F401
     path_nodes,
     persist_autosave,
     persist_language_packs,
-    prioritise_find_target,
+    prioritise_pinned,
     prune_reused_focus_seeds,
     reconcile_filter_selection,
     render_add_annotation,

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -4304,31 +4304,45 @@ VIZ_NODE_PANEL = "Node options"
 FOCUS_BUILD_MAX_NODES = 5000
 
 
-def prioritise_find_target(items, node_id_of, find_id):
-    """Build the entity picked in Find first, so the cap cannot drop it (#234).
+def prioritise_pinned(items, node_id_of, pinned):
+    """Build the entities in ``pinned`` first, so the cap cannot drop them.
 
     Each loop stops at a fixed node budget, in list order, so an entity far
-    enough down was never drawn. The Find dropdown lists every entity regardless
-    of what was drawn, so picking one of those left the viewer nothing to centre
-    on. It then dropped the camera pin, and dropping the pin re-enables the
-    post-layout auto-fit, so the graph visibly reframed while the entity the user
-    asked for was missing: movement, and no result, which is exactly what the
-    issue describes.
+    enough down was never drawn. The pickers list every entity regardless of
+    what was drawn, so an entity picked from one of them could be missing from
+    the graph that is supposed to answer for it.
+
+    Two things are pinned. The entity picked in **Find** (issue #234): picking
+    one the cap had cut left the viewer nothing to centre on, it dropped the
+    camera pin, and dropping the pin re-enabled the post-layout auto-fit — so
+    the graph visibly reframed while the entity the user asked for was missing.
+    And every entity on a **highlighted path** (issue #378): a path whose middle
+    is not drawn is ringed in disconnected pieces, which reads as a broken
+    highlight rather than as a view that does not hold all of it.
 
     Ordering alone is enough for classes, which are built first and so still fit
     inside the budget. It is not enough for the kinds after them: by the time
-    those loops run the budget is spent, so each also lets the target itself past
-    its own cap check. That costs at most one node over the cap, since only the
-    single entity the user named is let through. One extra node is immaterial to
-    the browser the cap protects; a graph silently missing what you asked for is
-    not.
+    those loops run the budget is spent, so each also lets a pinned entity past
+    its own cap check. That costs at most one node over the cap per pinned
+    entity — one for Find, at most the length of the path for a path — which is
+    immaterial to the browser the cap protects. A graph silently missing what
+    you asked for is not.
+
+    ``pinned`` may be a single id or any collection of them; ``None`` and empty
+    both mean "nothing pinned", and the items are returned untouched.
     """
-    if not find_id:
+    if not pinned:
         return items
-    for i, item in enumerate(items):
-        if node_id_of(item) == find_id:
-            return [item, *items[:i], *items[i + 1 :]]
-    return items
+    if isinstance(pinned, str):
+        pinned = {pinned}
+    else:
+        pinned = set(pinned)
+    first, rest = [], []
+    for item in items:
+        (first if node_id_of(item) in pinned else rest).append(item)
+    if not first:
+        return items
+    return [*first, *rest]
 
 
 def graph_node_cap(focus_pruning: bool) -> int:

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -919,11 +919,6 @@ def render_visualization():
         # sits beside the Filter Classes expander so it doesn't cost the graph a
         # whole row; the empty state is a placeholder (clearable), not a "—" row.
         _find_id: str | None = None
-        # Whether that target is a class. Class node ids carry no prefix, so the
-        # kind cannot be read back off the id the way the others can, and the
-        # class loop's own guard needs it: an emptied filter would otherwise skip
-        # the loop before the per-node bypass could run (issue #234 review).
-        _find_is_class = False
         focus_seed_ids: list = []
         # Declared with the rest, not left to the branch that draws the picker:
         # with focus mode on and every focusable type switched off, that branch
@@ -957,9 +952,6 @@ def render_visualization():
                 )
                 if _find_choice:
                     _find_id = focus_targets.get(_find_choice)
-                    _find_is_class = bool(_find_id) and _find_choice.startswith(
-                        "Class: "
-                    )
                     # The target may currently be hidden — by one of the display
                     # filters, or pruned away in focus mode — in which case its
                     # node isn't in the graph and the JS focus() would silently
@@ -1626,7 +1618,9 @@ def render_visualization():
         # now reports a path that is only half drawn, where before the generic
         # cap line suppressed it — a cached v21 payload carries the suppressed
         # one and would keep showing it until something unrelated evicted it.
-        _graph_ver = 22
+        # 23: the entities on a path are pinned past the node cap (issue #378),
+        # so a cached v22 payload is a graph built without them.
+        _graph_ver = 23
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.
@@ -1796,8 +1790,17 @@ def render_visualization():
             # way back from a node it kept to the resource to read (issue #272).
             annotatable: dict = {}
 
-            # Add classes as nodes (only selected classes)
-            if show_classes and (selected_classes or _find_is_class):
+            # Class node ids are bare uids with no kind prefix, so a pinned
+            # class cannot be spotted the way _pinned_kind_is spots the others —
+            # it takes the class list to tell. Worth the set: without it this
+            # loop does not run at all when the filter is empty, and a path
+            # pinned into a graph whose class loop never ran is a path with
+            # nowhere to be drawn (Codex review of PR #379). Subsumes the old
+            # `_find_is_class`, since the Find target is pinned too.
+            _pinned_class_ids = _pinned_ids & {_uid(c["uri"]) for c in classes}
+
+            # Add classes as nodes (only selected ones, plus anything pinned)
+            if show_classes and (selected_classes or _pinned_class_ids):
                 for cls in prioritise_pinned(
                     classes, lambda c: _uid(c["uri"]), _pinned_ids
                 ):

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -60,7 +60,7 @@ from ..ui import (
     path_entity_kinds,
     path_highlight,
     path_nodes,
-    prioritise_find_target,
+    prioritise_pinned,
     prune_reused_focus_seeds,
     reconcile_filter_selection,
     seed_filter_from_saved,
@@ -1676,15 +1676,24 @@ def render_visualization():
             max_nodes = graph_node_cap(focus_pruning)
             node_count = 0
 
-            def _find_kind_is(prefix: str, _fid=_find_id) -> bool:
-                """Is the Find target one of *this* kind of node? (issue #234)
+            # The entities the cap may not drop: the one picked in Find (issue
+            # #234) and every one on a highlighted path (issue #378). Both are
+            # things the user has just asked to see, and both are listed from
+            # pickers that offer the whole ontology rather than only what is
+            # drawn — so the graph has to hold them whatever else it holds. They
+            # are pinned as node ids, which is what the builder deals in and what
+            # carries the entity's kind as a prefix.
+            _pinned_ids = {i for i in (_find_id, *path_node_ids) if i}
 
-                Ordering the target first only helps if its loop runs at all, and
+            def _pinned_kind_is(prefix: str, _pins=_pinned_ids) -> bool:
+                """Is anything pinned one of *this* kind of node?
+
+                Ordering the pinned first only helps if the loop runs at all, and
                 the kinds after classes are skipped outright once the budget is
                 spent. Node ids carry their kind as a prefix, so the guard can
-                let a block through for the one entity the user asked for.
+                let a block through for the entities that must be in it.
                 """
-                return bool(_fid) and _fid.startswith(prefix)
+                return any(pin.startswith(prefix) for pin in _pins)
 
             # Why the graph is smaller than the ontology, shown above it. Empty
             # when nothing was left out.
@@ -1716,10 +1725,10 @@ def render_visualization():
 
             # Add classes as nodes (only selected classes)
             if show_classes and (selected_classes or _find_is_class):
-                for cls in prioritise_find_target(
-                    classes, lambda c: _uid(c["uri"]), _find_id
+                for cls in prioritise_pinned(
+                    classes, lambda c: _uid(c["uri"]), _pinned_ids
                 ):
-                    if node_count >= max_nodes:
+                    if node_count >= max_nodes and _uid(cls["uri"]) not in _pinned_ids:
                         break
                     # The entity picked in Find is drawn even when the node
                     # filter hides it: you asked to see it, and a graph that
@@ -1734,7 +1743,7 @@ def render_visualization():
                     # a node it had not sent (issue #234).
                     if (
                         cls["uri"] not in visible_class_uris
-                        and _uid(cls["uri"]) != _find_id
+                        and _uid(cls["uri"]) not in _pinned_ids
                     ):
                         continue
                     cls_node_id = _uid(cls["uri"])
@@ -1863,13 +1872,13 @@ def render_visualization():
             if (
                 show_data_props
                 and data_props
-                and (node_count < max_nodes or _find_kind_is("dprop_"))
+                and (node_count < max_nodes or _pinned_kind_is("dprop_"))
             ):
-                for prop in prioritise_find_target(
-                    data_props, lambda p: f"dprop_{_uid(p['uri'])}", _find_id
+                for prop in prioritise_pinned(
+                    data_props, lambda p: f"dprop_{_uid(p['uri'])}", _pinned_ids
                 ):
                     if node_count >= max_nodes and (
-                        f"dprop_{_uid(prop['uri'])}" != _find_id
+                        f"dprop_{_uid(prop['uri'])}" not in _pinned_ids
                     ):
                         break
                     # Skip if domain is set but the class node isn't displayed.
@@ -1884,7 +1893,7 @@ def render_visualization():
                         dom_uri
                         and show_classes
                         and dom_uri not in displayed_class_uris
-                        and prop_node_id != _find_id
+                        and prop_node_id not in _pinned_ids
                     ):
                         continue
 
@@ -1925,15 +1934,15 @@ def render_visualization():
             if (
                 show_individuals
                 and individuals
-                and (node_count < max_nodes or _find_kind_is("ind_"))
+                and (node_count < max_nodes or _pinned_kind_is("ind_"))
             ):
                 ind_collisions = _build_name_collision_set(individuals)
-                for ind in prioritise_find_target(
-                    individuals, lambda i: f"ind_{_uid(i['uri'])}", _find_id
+                for ind in prioritise_pinned(
+                    individuals, lambda i: f"ind_{_uid(i['uri'])}", _pinned_ids
                 ):
                     if (
                         node_count >= max_nodes
-                        and f"ind_{_uid(ind['uri'])}" != _find_id
+                        and f"ind_{_uid(ind['uri'])}" not in _pinned_ids
                     ):
                         break
                     # Individuals filter (issue #196). Focus mode builds the full
@@ -1942,7 +1951,7 @@ def render_visualization():
                     if (
                         not focus_mode
                         and ind["uri"] not in selected_ind_uris
-                        and f"ind_{_uid(ind['uri'])}" != _find_id
+                        and f"ind_{_uid(ind['uri'])}" not in _pinned_ids
                     ):
                         continue
                     ind_node_id = f"ind_{_uid(ind['uri'])}"
@@ -2116,14 +2125,14 @@ def render_visualization():
                             )
 
             # Add SKOS concepts and relations
-            if show_skos and (node_count < max_nodes or _find_kind_is("skos_")):
+            if show_skos and (node_count < max_nodes or _pinned_kind_is("skos_")):
                 concepts = ont.get_concepts()
-                for concept in prioritise_find_target(
-                    concepts, lambda c: f"skos_{c['name']}", _find_id
+                for concept in prioritise_pinned(
+                    concepts, lambda c: f"skos_{c['name']}", _pinned_ids
                 ):
                     if (
                         node_count >= max_nodes
-                        and f"skos_{concept['name']}" != _find_id
+                        and f"skos_{concept['name']}" not in _pinned_ids
                     ):
                         break
                     c_id = f"skos_{concept['name']}"

--- a/tests/test_viz_shortest_path.py
+++ b/tests/test_viz_shortest_path.py
@@ -188,6 +188,34 @@ def test_the_cached_graph_is_rebuilt_when_the_path_changes():
     assert first != second
 
 
+# --- the path survives the node cap (issue #378) -----------------------------
+
+
+def test_the_whole_path_is_drawn_even_when_the_cap_cannot_hold_it(patch_ui):
+    """The reported case, in miniature: on an ontology past the cap the middle
+    of a path was simply not built, so it was ringed in disconnected pieces —
+    the answer to the question, drawn with the answer missing."""
+    patch_ui("GRAPH_MAX_NODES", 2)  # the A -> B -> C path is three
+
+    nodes, edges = _graph(_render("Class: A", "Class: C"))
+
+    assert {"A", "B", "C"} <= {n["label"] for n in nodes}
+    # And ringed end to end, not in pieces: both links, not one.
+    assert len(_highlighted_edges(edges)) == 2
+
+
+def test_a_pinned_path_does_not_lift_the_cap_for_everything_else(patch_ui):
+    """The cap is what protects the browser. Pinning buys the path its own
+    nodes, not a bigger graph: D is unrelated and stays out."""
+    patch_ui("GRAPH_MAX_NODES", 2)
+
+    nodes, _ = _graph(_render("Class: A", "Class: B"))
+
+    labels = {n["label"] for n in nodes}
+    assert {"A", "B"} <= labels
+    assert "D" not in labels
+
+
 # --- what the panel says ----------------------------------------------------
 
 

--- a/tests/test_viz_shortest_path.py
+++ b/tests/test_viz_shortest_path.py
@@ -204,6 +204,32 @@ def test_the_whole_path_is_drawn_even_when_the_cap_cannot_hold_it(patch_ui):
     assert len(_highlighted_edges(edges)) == 2
 
 
+def test_a_path_is_drawn_when_the_class_filter_is_empty():
+    """Pinning a class is no use if the loop that builds classes never runs.
+
+    Its gate opened for a non-empty filter or for a Find target that was a
+    class, and a pinned class satisfied neither — class node ids carry no kind
+    prefix, so nothing recognised them. With the filter emptied the graph came
+    out with no nodes at all and the path had nowhere to be drawn (Codex review
+    of PR #379).
+    """
+    at = _render("Class: A", "Class: C")
+    # The filter emptied, with the reveal already marked done so nothing
+    # re-adds the classes behind the test's back.
+    uris = {c["uri"] for c in at.session_state.ontology.get_classes()}
+    at.session_state["_viz_cfg_selected_class_uris"] = []
+    at.session_state["_viz_cfg_known_class_uris"] = uris
+    at.session_state["_viz_find_seq"] = 1
+    at.session_state["_viz_find_revealed_seq"] = 1
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+
+    nodes, edges = _graph(at)
+    # Only the path: the filter still hides everything it was hiding.
+    assert {n["label"] for n in nodes} == {"A", "B", "C"}
+    assert len(_highlighted_edges(edges)) == 2
+
+
 def test_a_pinned_path_does_not_lift_the_cap_for_everything_else(patch_ui):
     """The cap is what protects the browser. Pinning buys the path its own
     nodes, not a bigger graph: D is unrelated and stays out."""


### PR DESCRIPTION
Closes #378.

## The problem

Asking for a path on an ontology past the node cap answered the question and then drew the answer with its middle missing. On the ontology from #356, `right-hand rule` to `json`:

| | before | after |
|---|---|---|
| path entities drawn | 8 of 17 | **17 of 17** |
| links ringed | 4 of 16 | **16 of 16** |
| nodes drawn in total | 500 | **500** |

The cap is unchanged: the path's classes are built first, so they displace unrelated ones rather than inflating the graph.

## How

The builder already knew how to protect one entity from the cap - the entity picked in **Find** is ordered first and let past each per-kind budget check (#234). That exception was threaded through the gates one at a time, and every gate added since has had to remember it.

So this does not add a second exception beside the first. Both become **one pinned set of node ids** that the gates consult once:

- `prioritise_find_target(items, node_id_of, find_id)` -> `prioritise_pinned(items, node_id_of, pinned)`, taking a set (a bare id still works);
- `_find_kind_is(prefix)` -> `_pinned_kind_is(prefix)`;
- the eight `!= _find_id` escapes -> `not in _pinned_ids`.

`_pinned_ids` is `{the Find target} | {every entity on the highlighted path}`. The path is known before the build - the panel renders above it - and the graph cache key already includes it, so a path change rebuilding the graph is existing behaviour.

Where a path is longer than the cap, the graph can exceed the cap by what it pins. That is the trade #234 already made for one node, and the issue's option (1).

The node-filter escape comes along with the cap escape: a class the filter hides is drawn when it is on the path, for the same reason it is drawn when it is the Find target - you asked to see it.

## Tests

Two new. The first fails on unmodified source: a path that cannot fit under the cap is drawn whole and ringed end to end. The second guards the other direction - pinning buys the path its own nodes, not a bigger graph, so an unrelated class stays out.

`pytest` 1859 passed, `ruff` and `mypy` clean.

## Relationship to #377

#377 makes the page *say* when a path is only half drawn. With this merged that message becomes the fallback rather than the common case - it still fires where pinning cannot help, such as a path through an entity type that is switched off entirely.