### PR TITLE
fix(viz): the graph no longer flashes white when a panel is toggled (#372)

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -2,8 +2,41 @@
 <html>
 <head>
 <meta charset="utf-8">
+<script>
+// Paint the background before anything else is parsed.
+//
+// This document is replaced whenever Streamlit re-mounts the component — which
+// a click on the Display options or Path finder switch is enough to do — and a
+// fresh one used to paint the stylesheet's white until the theme arrived over
+// the round trip from Python. Two or three frames of white, in the middle of a
+// dark app, on a control people toggle constantly (issue #372).
+//
+// The colour is the one this component last drew, kept per session and per
+// origin. The stylesheet below carries the fallbacks for a first-ever load,
+// where nothing is remembered yet.
+(function () {
+    try {
+        var bg = sessionStorage.getItem('viz_theme_bg');
+        // Straight into a stylesheet, so it applies to a <body> that does not
+        // exist yet. Only a colour is let through: this value is written by
+        // applyTheme from what Python sends, and a stylesheet is not the place
+        // to find out that something else got in.
+        if (bg && /^(#[0-9a-fA-F]{3,8}|rgba?\([\d\s.,%/]+\))$/.test(bg)) {
+            var early = document.createElement('style');
+            early.textContent = 'html, body { background: ' + bg + '; }';
+            document.head.appendChild(early);
+        }
+    } catch (e) {}   // private mode, or storage blocked: fall through to the CSS
+})();
+</script>
 <style>
 html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
+/* Nothing remembered yet — a first load in a fresh session. The OS preference
+   is the best guess available before Python has said anything, and it is right
+   for the common case of a dark app on a dark desktop. */
+@media (prefers-color-scheme: dark) {
+    html, body { background: #0e1117; }
+}
 #graph { width: 100%; }
 #legend {
     position: absolute; top: 8px; left: 8px; background: rgba(255,255,255,0.92);
@@ -483,6 +516,9 @@ function drawPathRings(ctx, rings) {
 function applyTheme(theme) {
     theme = theme || {bg: '#ffffff', panel: 'rgba(255,255,255,0.92)', text: '#333333'};
     currentTheme = theme;
+    // Remembered for the next document this component gets: see the script in
+    // the head, which paints it before the first frame (issue #372).
+    try { sessionStorage.setItem('viz_theme_bg', theme.bg); } catch (e) {}
     document.documentElement.style.background = theme.bg;
     document.body.style.background = theme.bg;
     document.getElementById('container').style.background = theme.bg;

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -2,33 +2,6 @@
 <html>
 <head>
 <meta charset="utf-8">
-<script>
-// Paint the background before anything else is parsed.
-//
-// This document is replaced whenever Streamlit re-mounts the component — which
-// a click on the Display options or Path finder switch is enough to do — and a
-// fresh one used to paint the stylesheet's white until the theme arrived over
-// the round trip from Python. Two or three frames of white, in the middle of a
-// dark app, on a control people toggle constantly (issue #372).
-//
-// The colour is the one this component last drew, kept per session and per
-// origin. The stylesheet below carries the fallbacks for a first-ever load,
-// where nothing is remembered yet.
-(function () {
-    try {
-        var bg = sessionStorage.getItem('viz_theme_bg');
-        // Straight into a stylesheet, so it applies to a <body> that does not
-        // exist yet. Only a colour is let through: this value is written by
-        // applyTheme from what Python sends, and a stylesheet is not the place
-        // to find out that something else got in.
-        if (bg && /^(#[0-9a-fA-F]{3,8}|rgba?\([\d\s.,%/]+\))$/.test(bg)) {
-            var early = document.createElement('style');
-            early.textContent = 'html, body { background: ' + bg + '; }';
-            document.head.appendChild(early);
-        }
-    } catch (e) {}   // private mode, or storage blocked: fall through to the CSS
-})();
-</script>
 <style>
 html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 /* Nothing remembered yet — a first load in a fresh session. The OS preference
@@ -70,6 +43,36 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
    the fullscreen box the UA gives us, which is the screen. */
 #container:fullscreen { width: 100%; height: 100%; }
 </style>
+<script>
+// Paint the remembered background before the first frame.
+//
+// This document is replaced whenever Streamlit re-mounts the component — which
+// a click on the Display options or Path finder switch is enough to do — and a
+// fresh one used to paint the stylesheet's white until the theme arrived over
+// the round trip from Python. Two or three frames of white, in the middle of a
+// dark app, on a control people toggle constantly (issue #372).
+//
+// The colour is the one this component last drew, kept per session and per
+// origin. This runs *after* the stylesheet above so the rule it inserts is the
+// last one standing: same specificity, so document order decides, and the
+// remembered colour has to beat both the white default and the dark media
+// query. The stylesheet is the fallback for a first-ever load, where nothing
+// is remembered yet.
+(function () {
+    try {
+        var bg = sessionStorage.getItem('viz_theme_bg');
+        // Straight into a stylesheet, so it applies to a <body> that does not
+        // exist yet. Only a colour is let through: this value is written by
+        // rememberThemeBg from what Python sends, and a stylesheet is not the
+        // place to find out that something else got in.
+        if (bg && /^(#[0-9a-fA-F]{3,8}|rgba?\([\d\s.,%/]+\))$/.test(bg)) {
+            var early = document.createElement('style');
+            early.textContent = 'html, body { background: ' + bg + '; }';
+            document.head.appendChild(early);
+        }
+    } catch (e) {}   // private mode, or storage blocked: fall through to the CSS
+})();
+</script>
 </head>
 <body>
 <div id="container" style="position: relative;">
@@ -513,12 +516,18 @@ function drawPathRings(ctx, rings) {
 // Apply theme colours without rebuilding the graph, so a theme change (or the
 // first-render theme settling) doesn't reset the user's zoom/pan. Node colours
 // encode type, not theme, so only the background, overlays and edge labels change.
+// Remembered for the next document this component gets: see the script in the
+// head, which paints it before the first frame (issue #372). Both theme paths
+// call this — a fresh mount rebuilds rather than calling applyTheme, and a
+// session that only ever rebuilt would have nothing to paint.
+function rememberThemeBg(bg) {
+    try { sessionStorage.setItem('viz_theme_bg', bg); } catch (e) {}
+}
+
 function applyTheme(theme) {
     theme = theme || {bg: '#ffffff', panel: 'rgba(255,255,255,0.92)', text: '#333333'};
     currentTheme = theme;
-    // Remembered for the next document this component gets: see the script in
-    // the head, which paints it before the first frame (issue #372).
-    try { sessionStorage.setItem('viz_theme_bg', theme.bg); } catch (e) {}
+    rememberThemeBg(theme.bg);
     document.documentElement.style.background = theme.bg;
     document.body.style.background = theme.bg;
     document.getElementById('container').style.background = theme.bg;
@@ -961,6 +970,7 @@ function renderGraph(args) {
     // box in dark mode (issue #62). Defaults keep the original light look.
     var theme = args.theme || {bg: '#ffffff', panel: 'rgba(255,255,255,0.92)', text: '#333333'};
     currentTheme = theme;
+    rememberThemeBg(theme.bg);
     document.documentElement.style.background = theme.bg;
     document.body.style.background = theme.bg;
     document.getElementById('container').style.background = theme.bg;

--- a/tests/test_viz_theme_flash.py
+++ b/tests/test_viz_theme_flash.py
@@ -1,0 +1,44 @@
+"""Guards for the graph viewer's first-frame background (issue #372).
+
+Streamlit replaces the component's document whenever a panel is toggled, and a
+fresh document paints the stylesheet's white until Python's theme arrives. The
+viewer paints the colour it last drew instead, from sessionStorage, before the
+first frame. Two things make that work, and neither shows up in a unit test of
+the Python side, so they are pinned here.
+"""
+
+from pathlib import Path
+
+_VIEWER = (
+    Path(__file__).resolve().parent.parent
+    / "orionbelt_ontology_builder"
+    / "lib"
+    / "graph_viewer"
+    / "index.html"
+)
+
+
+def test_the_remembered_colour_outranks_the_fallback_css():
+    """The early script inserts `html, body { background: ... }`, which has the
+    same specificity as the stylesheet's white and its dark media query. Same
+    specificity means document order decides, so the script has to come after
+    the stylesheet or the remembered colour is simply ignored — and the flash
+    comes back for anyone whose app theme differs from their OS preference."""
+    html = _VIEWER.read_text(encoding="utf-8")
+    early = html.index("viz_theme_bg")
+    fallback = html.index("@media (prefers-color-scheme: dark)")
+    assert fallback < early, (
+        "the early-paint script must run after the fallback stylesheet, "
+        "otherwise the remembered background loses the cascade"
+    )
+    assert html.index("</style>", fallback) < early
+
+
+def test_both_theme_paths_remember_the_colour():
+    """A same-data re-render goes through applyTheme; a fresh mount rebuilds the
+    network instead. Only the rebuild path runs on the very first render, so if
+    it doesn't store the colour there is nothing to paint on the next mount."""
+    html = _VIEWER.read_text(encoding="utf-8")
+    assert html.count("rememberThemeBg(") == 3  # the definition and both callers
+    # Nobody writes the key behind the helper's back.
+    assert html.count("sessionStorage.setItem('viz_theme_bg'") == 1


### PR DESCRIPTION
Closes #372.

## What was flashing

Not what I first assumed. Sampling the component's background colour **every frame** across a toggle of Display options, on unmodified `main`:

```
rgb(14,17,23) → transparent → unreadable → rgb(255,255,255) → rgb(14,17,23)
                                            ^^^ three frames of white
```

Streamlit replaces the component's *document* on those toggles, and the viewer's stylesheet opens with:

```css
html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
```

So a fresh document paints white and holds it until the theme arrives over the round trip from Python. In a dark app that is the flash, and it lands on two switches people toggle constantly.

## The fix

The viewer paints the colour it last drew, before anything else is parsed. `applyTheme` keeps it in `sessionStorage` (per session, per origin) and a script in the head turns it into a stylesheet - a stylesheet rather than a style property, because `<body>` does not exist yet at that point. Only a colour is let through: the value is written by our own code from what Python sends, and a stylesheet is not the place to find out otherwise.

For a first load in a fresh session there is nothing remembered, so the CSS carries a `prefers-color-scheme` fallback. A guess, but the right one for the common case of a dark app on a dark desktop, and better than white either way.

## Measured

Sampling every frame, both toggles, dark theme:

| | white frames |
|---|---|
| before | 3 per toggle |
| after | **0** across 1141 frames |

Path finder behaves the same, and light mode stays white throughout (1082 frames, one distinct colour).

## A wrong turn worth recording

My first attempt wrapped the display-options band and the path panel in always-present containers, on the theory that the toggle moved the component in Streamlit's element tree and Streamlit rebuilt the iframe (issue #189). A control run on unmodified `main` showed the iframe surviving the toggle there too - so the theory was wrong and the change bought nothing measurable. It is not in this PR; the 300-line re-indent it needed would have been pure cost.

`pytest` 1874 passed, `ruff` clean. No Python changed - this is the vendored viewer only, which is hash-versioned, so the new document serves under a fresh URL rather than from a stale cache.