### PR TITLE
feat(viz): fullscreen keeps the graph's controls, and the page gives it more room (#381)

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -773,6 +773,24 @@ function setNativeFsExitHook(fn) {
     try { if (window.top) window.top[TOP_FS_EXIT_HOOK] = fn; } catch (e) {}
 }
 
+// The hook is a function belonging to *this* document, and fullscreen now
+// outlives it: Streamlit re-mounts the component and the closure the old
+// document installed goes with it, so the desktop window leaving fullscreen
+// would have nobody left to tell and the chrome would stay hidden. Every mount
+// that finds the page still fullscreen claims it again (review P2).
+function installNativeFsExitHook() {
+    setNativeFsExitHook(function () { if (stageOn()) leaveFullscreen(true); });
+}
+
+// What a fresh document has to work out for itself: the page may already be
+// fullscreen, and nothing in here knows it (issue #372).
+function syncFullscreenState() {
+    var on = stageOn();
+    setFullscreenIcon(on);
+    if (on) installNativeFsExitHook();
+    else setNativeFsExitHook(null);
+}
+
 function rememberViewport() {
     if (!network) { fsRestoreView = null; return; }
     try {
@@ -802,7 +820,7 @@ function enterFullscreen() {
         }
     }
     if (!asked) toggleNativeWindow();
-    setNativeFsExitHook(function () { if (stageOn()) leaveFullscreen(true); });
+    installNativeFsExitHook();
     settleFullscreen(true);
 }
 
@@ -1146,8 +1164,9 @@ function renderGraph(args) {
     if (fullscreenSupported()) {
         document.getElementById('fullscreen-btn').style.display = 'flex';
         // A re-mount lands in a document that knows nothing, while the page may
-        // still be fullscreen: take the state from the page (issue #372).
-        setFullscreenIcon(stageOn());
+        // still be fullscreen: take the state from the page, and take over the
+        // hooks the last document owned.
+        syncFullscreenState();
     }
     // Restore selection + viewport after a genuine re-mount (e.g. the panel
     // toggled), so the node stays highlighted and the zoom/pan don't reset —

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -34,6 +34,35 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 #fullscreen-btn:hover, #download-btn:hover, #copy-btn:hover { opacity: 1; }
 #fullscreen-btn svg, #download-btn svg, #copy-btn svg {
     width: 18px; height: 18px; fill: #555;
+    /* The button is the hover target, not the icon: a tooltip is not looked up
+       from inside an <svg>, which is why the native `title` on these three
+       never appeared. */
+    pointer-events: none;
+}
+/* ...and the tooltips themselves, drawn by the page rather than left to the
+   browser: they show at once instead of after a second, and they can be read
+   over a busy graph. The colours are the theme's own, swapped — the text
+   colour as the chip and the background as the type — which is maximum
+   contrast in both themes by construction (see themeToolbarButtons). */
+#fullscreen-btn::after, #download-btn::after, #copy-btn::after {
+    content: attr(data-tip);
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    padding: 4px 8px;
+    border-radius: 6px;
+    font: 500 12px/1.35 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          Helvetica, Arial, sans-serif;
+    white-space: nowrap;
+    background: var(--tip-bg, #333333);
+    color: var(--tip-fg, #ffffff);
+    box-shadow: 0 4px 14px rgba(0,0,0,0.25);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.12s ease;
+}
+#fullscreen-btn:hover::after, #download-btn:hover::after, #copy-btn:hover::after {
+    opacity: 1;
 }
 /* In fullscreen the container fills the screen, so the graph doesn't fall back
    to the browser's default black backdrop. Percentages, not vw/vh: this document
@@ -78,13 +107,13 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 <div id="container" style="position: relative;">
     <div id="graph"></div>
     <div id="legend"></div>
-    <button id="fullscreen-btn" title="Fullscreen" style="display:none;" onclick="toggleFullscreen()">
+    <button id="fullscreen-btn" data-tip="Fullscreen" aria-label="Fullscreen" style="display:none;" onclick="toggleFullscreen()">
         <svg viewBox="0 0 24 24"><path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/></svg>
     </button>
-    <button id="download-btn" title="Download as PNG" style="display:none;" onclick="downloadGraph()">
+    <button id="download-btn" data-tip="Download as PNG" aria-label="Download as PNG" style="display:none;" onclick="downloadGraph()">
         <svg viewBox="0 0 24 24"><path d="M5 20h14v-2H5v2zm7-18L5.33 9h3.84v6h3.66V9h3.84L12 2z" transform="rotate(180 12 12)"/></svg>
     </button>
-    <button id="copy-btn" title="Copy what is selected" style="display:none;" onclick="copySelection()">
+    <button id="copy-btn" data-tip="Copy what is selected" aria-label="Copy what is selected" style="display:none;" onclick="copySelection()">
         <svg viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
     </button>
 </div>
@@ -104,6 +133,19 @@ function themeToolbarButtons(theme) {
         var svg = btn.querySelector('svg');
         if (svg) svg.style.fill = theme.text;
     });
+    // The tooltip chip: the theme's colours the other way round, so it reads
+    // over the canvas whichever theme is on.
+    var root = document.documentElement;
+    root.style.setProperty('--tip-bg', theme.text);
+    root.style.setProperty('--tip-fg', theme.bg);
+}
+
+// What a toolbar button says on hover. The tooltip is drawn from data-tip (see
+// the CSS); aria-label carries the same words for anyone not hovering at all.
+function setButtonTip(btn, text) {
+    if (!btn) return;
+    btn.setAttribute('data-tip', text);
+    btn.setAttribute('aria-label', text);
 }
 
 // --- Copy what is selected (issue #312) ------------------------------------
@@ -157,11 +199,11 @@ function flashCopied(ok) {
     if (!btn) return;
     var svg = btn.querySelector('svg');
     if (svg) svg.innerHTML = ok ? DONE_ICON : COPY_ICON;
-    btn.title = ok ? 'Copied' : 'Could not copy — select the text instead';
+    setButtonTip(btn, ok ? 'Copied' : 'Could not copy — select the text instead');
     setTimeout(function () {
         var s2 = btn.querySelector('svg');
         if (s2) s2.innerHTML = COPY_ICON;
-        btn.title = COPY_TITLE;
+        setButtonTip(btn, COPY_TITLE);
     }, 1400);
 }
 
@@ -337,12 +379,24 @@ function measureReserve() {
     return Math.min(lowest - bottom, AUTOFIT_MAX_RESERVE);
 }
 
+// The page's own viewport, which while the page is fullscreen is the screen.
+// Read from the parent's root element as well as from innerHeight: this document
+// is a component iframe, and a fullscreen page does not resize it, so its own
+// window.innerHeight says nothing about the box the canvas has to fill (issue
+// #177 follow-up). The larger of the two is the page's current viewport in both
+// states — out of fullscreen they agree, bar a scrollbar.
+function viewportHeight() {
+    var d = parentDoc();
+    var client = (d && d.documentElement && d.documentElement.clientHeight) || 0;
+    return Math.max(client, window.parent.innerHeight || 0);
+}
+
 function autofitHeight() {
     try {
         var fe = window.frameElement;
         if (!fe) return null;
         var rect = fe.getBoundingClientRect();
-        var avail = window.parent.innerHeight - rect.top - autofitReserve() - 8;
+        var avail = viewportHeight() - rect.top - autofitReserve() - 8;
         return Math.max(Math.round(avail), 300);
     } catch (e) {
         return null;  // cross-origin or unavailable: fall back to fixed height
@@ -544,10 +598,6 @@ function applyTheme(theme) {
 
 function autofitApply() {
     if (!network) return;
-    // In fullscreen the graph fills the screen instead of the toolbar height, and
-    // that target can change after the transition (a moved window, another
-    // monitor), so re-fit rather than bailing out.
-    if (isFullscreen() || desktopFsOn) { fitFullscreenGraph(); return; }
     if (!autofitOn) return;
     var h = autofitHeight();
     if (h) { applyHeight(h); network.redraw(); }
@@ -596,20 +646,71 @@ function downloadGraph() {
     }
 }
 
-// True when the document is fullscreen, checking the prefixed property too so a
-// WebKit implementation isn't misread as "not fullscreen" (review P3).
-function isFullscreen() {
-    return !!(document.fullscreenElement || document.webkitFullscreenElement);
+// --- Fullscreen (issues #177, #189, #381) -----------------------------------
+//
+// Fullscreen is taken on the *parent page's* root element, not on this iframe's
+// #container, and the app's chrome is hidden by a class the page's own CSS
+// selects (visualization.graph_fullscreen_css). Fullscreening the container gave
+// the graph the screen and left every control outside it: Display options, Find
+// & focus, Path finder, Node options and the details panel are all Streamlit's
+// DOM, out here in the parent, so reaching any of them meant leaving fullscreen
+// and going back in (issue #381).
+//
+// Taking the page also retires the workaround from issue #189. The fullscreen
+// element used to live in this document, which Streamlit replaces whenever it
+// re-mounts the component, so a selection that reached Python destroyed it and
+// dropped fullscreen; selections had to be held back until exit. The parent's
+// root element survives every rerun, so they round-trip again and the details
+// panel behind the graph is the live one.
+var FS_CLASS = 'orionbelt-graph-fullscreen';
+
+// The parent document, or null where it can't be reached — a cross-origin host,
+// where there is no page to fullscreen and the button stays hidden.
+function parentDoc() {
+    try {
+        var fe = window.frameElement;
+        return fe ? fe.ownerDocument : null;
+    } catch (e) {
+        return null;
+    }
 }
 
-// Whether the HTML Fullscreen API is actually available here. The desktop
-// pywebview doesn't support it — requestFullscreen throws "Fullscreen is not
-// supported" (#177) — in which case we fall back to toggling the native window.
+// True while the *page* is the fullscreen element. Only the page: Streamlit
+// fullscreens elements of its own (the chart and image expanders), and adopting
+// one of those would hide the app's chrome behind it. The prefixed property is
+// read too, so a WebKit implementation isn't misread as "not fullscreen".
+function pageFullscreenOn() {
+    var d = parentDoc();
+    if (!d) return false;
+    var el = d.fullscreenElement || d.webkitFullscreenElement;
+    return !!el && el === d.documentElement;
+}
+
+// The chrome-hidden state. It lives on the parent's <body> rather than in a
+// variable here, because Streamlit replaces this document on every re-mount
+// (issue #372) and a flag in it would be lost while the app was still
+// fullscreen — leaving the button offering to enter what it is already in.
+function stageOn() {
+    var d = parentDoc();
+    return !!(d && d.body && d.body.classList.contains(FS_CLASS));
+}
+
+function setStage(on) {
+    var d = parentDoc();
+    if (!d || !d.body) return;
+    if (on) d.body.classList.add(FS_CLASS);
+    else d.body.classList.remove(FS_CLASS);
+}
+
+// Whether the HTML Fullscreen API is actually available for the page. The
+// desktop pywebview doesn't support it — requestFullscreen throws "Fullscreen is
+// not supported" (#177) — in which case we fall back to the native window.
 function htmlFullscreenSupported() {
     try {
-        var c = document.getElementById('container');
-        return !!(document.fullscreenEnabled || document.webkitFullscreenEnabled) &&
-            !!(c && (c.requestFullscreen || c.webkitRequestFullscreen));
+        var d = parentDoc();
+        var root = d && d.documentElement;
+        return !!(d && (d.fullscreenEnabled || d.webkitFullscreenEnabled) &&
+            root && (root.requestFullscreen || root.webkitRequestFullscreen));
     } catch (e) {
         return false;
     }
@@ -626,47 +727,32 @@ function desktopFullscreenToggle() {
     return null;
 }
 
-// Offer the button when either the HTML API works (web) or we can build the
-// desktop overlay (a same-origin frame plus the native pywebview toggle); hide
-// it only where neither path exists.
+// Offer the button wherever the page can be reached and either path works: the
+// HTML API on the web, the native window in the desktop app. Hide it only where
+// neither exists.
 function fullscreenSupported() {
-    return htmlFullscreenSupported() ||
-        (!!desktopFullscreenToggle() && !!window.frameElement);
+    return !!parentDoc() && (htmlFullscreenSupported() || !!desktopFullscreenToggle());
 }
 
-var desktopFsOn = false;   // tracked pseudo-fullscreen state (no fullscreenchange)
-var pseudoFsPrevStyle = null;  // saved inline style of this iframe in the parent
+function toggleNativeWindow() {
+    var toggle = desktopFullscreenToggle();
+    if (!toggle) return;
+    try {
+        var r = toggle();
+        if (r && r.catch) r.catch(function () {});
+    } catch (e) {}
+}
 
-// While the graph is fullscreen, selections stay client-side. Sending one to
-// Streamlit reruns the app, which repaints the details panel / status bar that
-// nobody can see behind the fullscreen graph — and it was that rerun's rebuild
-// of this component that dropped fullscreen altogether (issue #189). vis still
-// highlights the clicked node locally, so the feedback is immediate; the last
-// selection is flushed on exit, so the panel comes back showing the node the
-// user left selected.
-var pendingSelection = null;
-
+// Selections round-trip even while fullscreen: the details panel and status bar
+// they repaint are on screen now, and the fullscreen element is the page, which
+// no rerun replaces (issues #189, #381).
 function sendSelection(value) {
-    if (isFullscreen() || desktopFsOn) { pendingSelection = value; return; }
     sendToStreamlit("streamlit:setComponentValue", {value: value});
 }
 
-function flushPendingSelection() {
-    if (!pendingSelection) return;
-    var value = pendingSelection;
-    pendingSelection = null;
-    sendToStreamlit("streamlit:setComponentValue", {value: value});
-}
-
-// Desktop graph-only fullscreen. The webview has no HTML Fullscreen API and the
-// native-window toggle alone fullscreens the whole app (sidebar + toolbar), not
-// the graph (issue #177 follow-up). So promote this same-origin iframe to a
-// fixed, full-viewport overlay — it covers the sidebar and toolbar, leaving just
-// the graph — and also toggle the native window so it fills the monitor.
-// Run fn after the browser has reflowed (two frames), falling back to a timer,
-// so window.innerHeight reflects the iframe's new full-viewport size. Reading it
-// synchronously after the style change returns the stale pre-overlay height,
-// which left the graph filling only part of the screen.
+// Run fn after the browser has reflowed (two frames), falling back to a timer.
+// The fullscreen box is not at its final size when the request resolves, and
+// reading it synchronously returns the pre-fullscreen height.
 function afterReflow(fn) {
     if (window.requestAnimationFrame) {
         requestAnimationFrame(function () { requestAnimationFrame(fn); });
@@ -678,176 +764,96 @@ function afterReflow(fn) {
 // Name of the hook the native host (desktop.py) calls when its window leaves
 // fullscreen without going through our button — Esc, the macOS green button, the
 // Window menu. The webview surfaces no fullscreenchange for the native window,
-// so without this the overlay stays pinned at 100vw/100vh while the window
-// shrinks back, leaving the graph covering the whole app (issue #177 follow-up).
-// It lives
-// on the top window because that is the frame Python's evaluate_js runs in.
+// so without this the chrome would stay hidden while the window shrank back
+// (issue #177 follow-up). It lives on the top window because that is the frame
+// Python's evaluate_js runs in.
 var TOP_FS_EXIT_HOOK = '__orionbeltNativeFullscreenExit';
 
 function setNativeFsExitHook(fn) {
     try { if (window.top) window.top[TOP_FS_EXIT_HOOK] = fn; } catch (e) {}
 }
 
-function enterPseudoFullscreen() {
-    var fe = window.frameElement;
-    if (!fe) return false;
-    if (network) {
-        try { fsRestoreView = {scale: network.getScale(), position: network.getViewPosition()}; }
-        catch (e) { fsRestoreView = null; }
+function rememberViewport() {
+    if (!network) { fsRestoreView = null; return; }
+    try {
+        fsRestoreView = {scale: network.getScale(), position: network.getViewPosition()};
+    } catch (e) {
+        fsRestoreView = null;
     }
-    pseudoFsPrevStyle = fe.getAttribute('style') || '';
-    fe.style.position = 'fixed';
-    fe.style.top = '0';
-    fe.style.left = '0';
-    fe.style.width = '100vw';
-    fe.style.height = '100vh';
-    fe.style.zIndex = '2147483647';
-    fe.style.background = currentTheme.bg;
-    desktopFsOn = true;
-    // The native window can leave fullscreen on its own; drop the overlay then
-    // (without toggling the window back, it has already left).
-    setNativeFsExitHook(function () { if (desktopFsOn) exitPseudoFullscreen(); });
+}
+
+function enterFullscreen() {
+    rememberViewport();
+    setStage(true);
     setFullscreenIcon(true);
-    afterReflow(function () { if (desktopFsOn) scheduleFullscreenView(true); });
-    watchFullscreenBox();
-    return true;
-}
-
-function exitPseudoFullscreen() {
-    var fe = window.frameElement;
-    if (fe) fe.setAttribute('style', pseudoFsPrevStyle || '');
-    desktopFsOn = false;
-    setNativeFsExitHook(null);
-    unwatchFullscreenBox();
-    setFullscreenIcon(false);
-    scheduleFullscreenView(false);
-    flushPendingSelection();
-}
-
-// Toggle desktop fullscreen: the overlay (graph-only) plus, when available, the
-// native window (fills the monitor). Returns true if it handled the toggle.
-function tryDesktopFullscreen() {
-    if (!window.frameElement) return false;  // can't build the overlay
-    var nativeToggle = desktopFullscreenToggle();
-    var callNative = function () {
-        if (!nativeToggle) return;
-        try { var r = nativeToggle(); if (r && r.catch) r.catch(function () {}); } catch (e) {}
-    };
-    if (!desktopFsOn) {
-        callNative();
-        enterPseudoFullscreen();
-    } else {
-        exitPseudoFullscreen();
-        callNative();
-    }
-    return true;
-}
-
-// Enter/exit fullscreen for just the graph. The whole vis-network canvas lives
-// in this iframe, so fullscreening the container makes the graph fill the
-// physical screen — no sidebar, no toolbar, no black borders (issue #177). On
-// the web the HTML Fullscreen API does this; in the desktop app it's
-// unavailable, so tryDesktopFullscreen() builds an equivalent graph-only overlay
-// (used both when the API is reported unsupported and if a requestFullscreen
-// attempt throws/rejects anyway). Before entering, remember the viewport so
-// exiting restores it.
-function toggleFullscreen() {
-    var c = document.getElementById('container');
-    if (htmlFullscreenSupported()) {
+    var d = parentDoc();
+    var root = d && d.documentElement;
+    var req = root && (root.requestFullscreen || root.webkitRequestFullscreen);
+    var asked = false;
+    if (htmlFullscreenSupported() && req) {
         try {
-            if (!isFullscreen()) {
-                if (network) {
-                    try {
-                        fsRestoreView = {scale: network.getScale(), position: network.getViewPosition()};
-                    } catch (e) { fsRestoreView = null; }
-                }
-                var req = c.requestFullscreen || c.webkitRequestFullscreen;
-                var p = req && req.call(c);
-                // If the request rejects (e.g. a webview that claims support but
-                // refuses), fall back to the native toggle instead of no-op.
-                if (p && p.catch) p.catch(function () { tryDesktopFullscreen(); });
-            } else {
-                var exit = document.exitFullscreen || document.webkitExitFullscreen;
-                var pe = exit && exit.call(document);
-                if (pe && pe.catch) pe.catch(function () {});
-            }
-            return;
+            var p = req.call(root);
+            asked = true;
+            // A webview can claim support and still refuse: fall back to the
+            // native window rather than leaving the page half changed.
+            if (p && p.catch) p.catch(function () { toggleNativeWindow(); });
         } catch (e) {
-            // Synchronous failure: fall through to the native toggle.
+            asked = false;
         }
     }
-    tryDesktopFullscreen();
+    if (!asked) toggleNativeWindow();
+    setNativeFsExitHook(function () { if (stageOn()) leaveFullscreen(true); });
+    settleFullscreen(true);
+}
+
+// fromNative: the desktop window has already left fullscreen on its own, so the
+// only thing left to do is put the chrome back.
+function leaveFullscreen(fromNative) {
+    setStage(false);
+    setFullscreenIcon(false);
+    setNativeFsExitHook(null);
+    if (pageFullscreenOn()) {
+        var d = parentDoc();
+        var exit = d && (d.exitFullscreen || d.webkitExitFullscreen);
+        try {
+            var p = exit && exit.call(d);
+            if (p && p.catch) p.catch(function () {});
+        } catch (e) {}
+    } else if (!fromNative) {
+        toggleNativeWindow();
+    }
+    settleFullscreen(false);
+}
+
+// Enter/exit fullscreen for the graph page: the canvas plus the controls that
+// drive it, with the app's chrome hidden (issue #381).
+function toggleFullscreen() {
+    if (stageOn()) leaveFullscreen(false);
+    else enterFullscreen();
 }
 
 // Swap the button glyph/hint between the "enter" and "exit" states.
 function setFullscreenIcon(on) {
     var fsBtn = document.getElementById('fullscreen-btn');
     if (!fsBtn) return;
-    fsBtn.title = on ? 'Exit fullscreen' : 'Fullscreen';
+    setButtonTip(fsBtn, on ? 'Exit fullscreen' : 'Fullscreen');
     fsBtn.querySelector('svg').innerHTML = on
         ? '<path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/>'
         : '<path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>';
 }
 
-// Height the graph canvas needs to fill the screen while fullscreen. This
-// document is a Streamlit component iframe, so window.innerHeight stays the
-// *iframe's* height even while the container is fullscreen: reading it here left
-// the canvas at the pre-fullscreen height, cutting the graph off whenever the
-// browser window was smaller than the screen (issue #177 follow-up). Measure the
-// fullscreen box itself instead. The desktop overlay has no fullscreen element
-// and falls back to the iframe height — which is the full window by then, hence
-// the afterReflow() before its call.
-function fullscreenHeight() {
-    var c = document.getElementById('container');
-    var fsEl = document.fullscreenElement || document.webkitFullscreenElement;
-    if (c && fsEl === c && c.clientHeight) return c.clientHeight;
-    return window.innerHeight;
-}
-
-// Keep the canvas matched to the fullscreen box. Redraws only on a real change,
-// so the observer below cannot feed itself.
-function fitFullscreenGraph() {
-    var el = document.getElementById('graph');
-    if (!el) return;
-    var h = fullscreenHeight();
-    if (!h || parseInt(el.style.height, 10) === h) return;
-    el.style.height = h + 'px';
-    if (network) network.redraw();
-}
-
-// The fullscreen box isn't always at its final size when fullscreenchange fires
-// (the transition animates, and inside an iframe no window 'resize' need follow),
-// so watch it while fullscreen lasts and re-fit as it settles.
-var fsBoxObserver = null;
-
-function watchFullscreenBox() {
-    if (fsBoxObserver || !window.ResizeObserver) return;
-    var c = document.getElementById('container');
-    if (!c) return;
-    fsBoxObserver = new ResizeObserver(function () {
-        if (isFullscreen() || desktopFsOn) fitFullscreenGraph();
-    });
-    try { fsBoxObserver.observe(c); } catch (e) { fsBoxObserver = null; }
-}
-
-function unwatchFullscreenBox() {
-    if (!fsBoxObserver) return;
-    try { fsBoxObserver.disconnect(); } catch (e) {}
-    fsBoxObserver = null;
-}
-
-// Size the graph to the fullscreen viewport (on enter) or back to the
-// toolbar-driven height (on exit), then hold the viewport steady. vis rescales
-// the view on each of the several 'resize' events it fires while the canvas
-// changes size, and a moveTo() *inside* that emit is overwritten by vis — so we
-// re-apply after each resize via a deferred call (which sticks) and detach after
-// a window so we never fight the user later. On enter the graph zooms out ~30%
-// around the same centre; on exit the pre-fullscreen viewport is restored, so a
-// round-trip leaves the user's zoom/pan untouched (review P2). Used by both the
-// web HTML path and the desktop overlay. Measures the fullscreen box when called,
-// so callers must call it *after* the box has reflowed to its full size.
+// Size the canvas to the new box and hold the viewport steady. There is no
+// separate fullscreen measurement any more: fullscreen or not, the canvas takes
+// the room left below the controls, which is what autofitHeight() measures — it
+// reads the page's viewport, and in fullscreen the page's viewport is the screen.
+//
+// vis rescales the view on each of the several 'resize' events it fires while
+// the canvas changes size, and a moveTo() *inside* that emit is overwritten by
+// vis — so we re-apply after each resize via a deferred call (which sticks) and
+// detach after a window so we never fight the user later. On enter the graph
+// zooms out ~30% around the same centre; on exit the pre-fullscreen viewport is
+// restored, so a round trip leaves the user's zoom/pan untouched (review P2).
 function scheduleFullscreenView(entering) {
-    var el = document.getElementById('graph');
     // Each transition gets a generation id; a deferred callback only acts if it
     // still matches, so a superseded transition (e.g. a quick enter/exit) can't
     // apply its zoom after a newer one has run (review P3).
@@ -857,13 +863,10 @@ function scheduleFullscreenView(entering) {
         var scale = entering ? fsRestoreView.scale * FS_ZOOM_OUT : fsRestoreView.scale;
         try { network.moveTo({scale: scale, position: fsRestoreView.position}); } catch (e) {}
     }
-    if (entering) {
-        el.style.height = fullscreenHeight() + 'px';
-    } else {
-        var h = autofitOn ? (autofitHeight() || currentHeight) : currentHeight;
-        el.style.height = h + 'px';
-        sendToStreamlit("streamlit:setFrameHeight", {height: h});
-    }
+    // Fullscreen always fills; out of it, a user who turned autofit off keeps
+    // the height they asked for.
+    var h = (entering || autofitOn) ? (autofitHeight() || currentHeight) : currentHeight;
+    if (h) applyHeight(h);
     if (network) {
         // Tear down the previous transition's listener/timer before redraw(),
         // which synchronously emits 'resize' — otherwise a stale "entering"
@@ -884,23 +887,39 @@ function scheduleFullscreenView(entering) {
     }
 }
 
-function onFullscreenChange() {
-    var entering = isFullscreen();
-    setFullscreenIcon(entering);
+// The box arrives at its final size in its own time — the browser animates the
+// transition, the desktop window resizes after its own toggle, and hiding the
+// sidebar reflows the page underneath. Re-measure as it settles rather than
+// trusting the first read.
+function settleFullscreen(entering) {
     scheduleFullscreenView(entering);
-    if (entering) {
-        // The fullscreen box is often still the old size at this point, so
-        // re-measure once the browser has reflowed and keep watching it settle.
-        afterReflow(function () { if (isFullscreen()) scheduleFullscreenView(true); });
-        watchFullscreenBox();
-    } else {
-        unwatchFullscreenBox();
-        // Hand the panel/status bar the node the user left selected (issue #189).
-        flushPendingSelection();
-    }
+    afterReflow(function () { scheduleFullscreenView(entering); });
+    setTimeout(function () { scheduleFullscreenView(entering); }, 250);
 }
-document.addEventListener('fullscreenchange', onFullscreenChange);
-document.addEventListener('webkitfullscreenchange', onFullscreenChange);
+
+// Esc, or the browser dropping fullscreen on its own. Only our own page
+// fullscreen is followed; anything else on the page fullscreening something of
+// its own is none of our business.
+function onPageFullscreenChange() {
+    if (!stageOn() || pageFullscreenOn()) return;
+    setStage(false);
+    setFullscreenIcon(false);
+    setNativeFsExitHook(null);
+    settleFullscreen(false);
+}
+
+(function () {
+    var d = parentDoc();
+    if (!d) return;
+    d.addEventListener('fullscreenchange', onPageFullscreenChange);
+    d.addEventListener('webkitfullscreenchange', onPageFullscreenChange);
+    // This document is replaced on every re-mount, so leave the parent as we
+    // found it: otherwise each mount piles another dead listener onto it.
+    window.addEventListener('pagehide', function () {
+        d.removeEventListener('fullscreenchange', onPageFullscreenChange);
+        d.removeEventListener('webkitfullscreenchange', onPageFullscreenChange);
+    });
+})();
 // Fullscreen from inside an iframe needs the frame to permit it. Streamlit's
 // component iframe is same-origin, so grant it defensively (belt and braces on
 // top of Streamlit's own allowFullScreen).
@@ -924,7 +943,7 @@ function renderGraph(args) {
     if (network && args.seq === lastSeq && args.nodes === lastNodes && args.edges === lastEdges) {
         applyTheme(args.theme);
         var hh = autofitOn ? autofitHeight() : (args.height || 600);
-        if (hh) { currentHeight = hh; if (!isFullscreen() && !desktopFsOn) applyHeight(hh); }
+        if (hh) { currentHeight = hh; applyHeight(hh); }
         // A fresh "Find entity" pick is a same-data re-render (only focus_seq
         // changed), so centre on the new node here without rebuilding the whole
         // network (issue #144). Anything that isn't a new pick leaves the
@@ -957,14 +976,9 @@ function renderGraph(args) {
         if (af) height = af;
     }
     var el = document.getElementById('graph');
-    // In fullscreen the graph fills the screen; don't clobber that with the
-    // toolbar height. Remember the requested height so exiting fullscreen can
-    // restore it.
+    // Remember the requested height so a fullscreen round trip can restore it.
     currentHeight = height;
-    if (!isFullscreen() && !desktopFsOn) {
-        el.style.height = height + 'px';
-        sendToStreamlit("streamlit:setFrameHeight", {height: height});
-    }
+    applyHeight(height);
 
     // Theme the canvas + overlays to match the app, so the graph isn't a white
     // box in dark mode (issue #62). Defaults keep the original light look.
@@ -1128,22 +1142,20 @@ function renderGraph(args) {
         network.on('beforeDrawing', function(ctx) { drawPathRings(ctx, pathRings); });
     }
     document.getElementById('download-btn').style.display = 'flex';
-    // Only offer fullscreen where the API works — hidden in the desktop webview.
+    // Only offer fullscreen where there is a page to fullscreen.
     if (fullscreenSupported()) {
         document.getElementById('fullscreen-btn').style.display = 'flex';
+        // A re-mount lands in a document that knows nothing, while the page may
+        // still be fullscreen: take the state from the page (issue #372).
+        setFullscreenIcon(stageOn());
     }
     // Restore selection + viewport after a genuine re-mount (e.g. the panel
     // toggled), so the node stays highlighted and the zoom/pan don't reset —
     // making the rebuild invisible. selectNodes() does not fire selectNode, so
-    // this doesn't loop back to Streamlit.
-    // A selection made while fullscreen hasn't reached Streamlit yet (it is
-    // flushed on exit), so args.selected_node is stale for the rebuilds that do
-    // still happen in fullscreen — a Ctrl/Cmd-click focus expand. Restore what
-    // the user actually has selected instead (issue #189).
+    // this doesn't loop back to Streamlit. Python's value is authoritative in
+    // both states now: a selection made while fullscreen reaches it like any
+    // other (issue #381).
     var restoreNode = args.selected_node;
-    if (pendingSelection) {
-        restoreNode = pendingSelection.selected ? (pendingSelection.nodeId || null) : null;
-    }
     // A node comes back by id and the rest is read off it; an edge has no id to
     // come back by, so Python hands its copy text over instead.
     setCopyTarget(restoreNode !== null && restoreNode !== undefined

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -31,7 +31,13 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 #fullscreen-btn { right: 8px; }
 #download-btn { right: 48px; }
 #copy-btn { right: 88px; }
-#fullscreen-btn:hover, #download-btn:hover, #copy-btn:hover { opacity: 1; }
+#fullscreen-btn:hover, #download-btn:hover, #copy-btn:hover {
+    opacity: 1;
+    /* Over its neighbours while its tooltip is out: the three buttons share a
+       z-index and the tip reaches back across the ones to its left, so the
+       later button in the markup painted over the words. */
+    z-index: 11;
+}
 #fullscreen-btn svg, #download-btn svg, #copy-btn svg {
     width: 18px; height: 18px; fill: #555;
     /* The button is the hover target, not the icon: a tooltip is not looked up
@@ -47,8 +53,12 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 #fullscreen-btn::after, #download-btn::after, #copy-btn::after {
     content: attr(data-tip);
     position: absolute;
+    /* Under the button, shifted left of the right-hand strip: the panel's
+       reopen toggle is a Streamlit element floating over the canvas from just
+       below this toolbar, outside this iframe, so it paints over anything the
+       viewer draws in its 30px. 32px of offset clears it. */
     top: calc(100% + 6px);
-    right: 0;
+    right: 32px;
     padding: 4px 8px;
     border-radius: 6px;
     font: 500 12px/1.35 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
@@ -63,6 +73,17 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 }
 #fullscreen-btn:hover::after, #download-btn:hover::after, #copy-btn:hover::after {
     opacity: 1;
+}
+/* ...and beside the button when the space under it is taken. The details panel
+   is a Streamlit card floating over the canvas from just below this toolbar and
+   it is outside this iframe, so a tooltip dropped underneath is not dimmed or
+   clipped — it is simply not there. See placeTip(). */
+#fullscreen-btn.tip-left::after,
+#download-btn.tip-left::after,
+#copy-btn.tip-left::after {
+    top: 50%;
+    right: calc(100% + 8px);
+    transform: translateY(-50%);
 }
 /* In fullscreen the container fills the screen, so the graph doesn't fall back
    to the browser's default black backdrop. Percentages, not vw/vh: this document
@@ -147,6 +168,31 @@ function setButtonTip(btn, text) {
     btn.setAttribute('data-tip', text);
     btn.setAttribute('aria-label', text);
 }
+
+// Where the tooltip goes: under the button, or beside it when the app has
+// something parked under it. Everything the graph page floats over the canvas —
+// the details panel, its reopen toggle, the Node options card — is Streamlit's
+// DOM in the parent, which always paints over this iframe, so a tip underneath
+// one of them is invisible rather than merely dimmed. The page is same-origin,
+// so ask it what is at the spot and step aside when the answer isn't us.
+function placeTip(btn) {
+    var flip = false;
+    try {
+        var fe = window.frameElement;
+        var d = parentDoc();
+        if (fe && d && d.elementFromPoint) {
+            var fr = fe.getBoundingClientRect();
+            var r = btn.getBoundingClientRect();
+            flip = d.elementFromPoint(fr.left + r.right - 40, fr.top + r.bottom + 12) !== fe;
+        }
+    } catch (e) {}   // cross-origin: leave it under the button
+    btn.classList.toggle('tip-left', flip);
+}
+
+['fullscreen-btn', 'download-btn', 'copy-btn'].forEach(function (id) {
+    var btn = document.getElementById(id);
+    if (btn) btn.addEventListener('mouseenter', function () { placeTip(btn); });
+});
 
 // --- Copy what is selected (issue #312) ------------------------------------
 // The bar under the graph cuts its line to fit and a node's own label is cut to

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -121,11 +121,16 @@ _CUSTOM_CSS = """
     /* CSS injected through st.markdown leaves an empty element behind, which
        is invisible but still takes a slot in the page column's 16px gap grid.
        Four of them ride above the graph, so the canvas started ~64px lower than
-       it had to. Nothing to show, so take them out of the flow. */
+       it had to. Nothing to show, so take them out of the flow.
+
+       Descendant combinators, not the child chain this used to be written as:
+       Streamlit put another wrapper div between the markdown element and its
+       container, the chain stopped matching, and all four blocks quietly came
+       back into the layout (measured: 0 elements matched, 4 in the page). The
+       `style:only-child` test is what makes this safe — a markdown block with
+       anything to show never matches. */
     [data-testid="stElementContainer"]:has(
-        > [data-testid="stMarkdown"]
-        > [data-testid="stMarkdownContainer"]
-        > style:only-child
+        [data-testid="stMarkdownContainer"] > style:only-child
     ) {
         display: none !important;
     }

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -57,6 +57,7 @@ _VIZ_PERSIST_KEYS = (
     "focus_depth",
     "options_open",
     "path_panel",
+    "find_row_open",
 )
 _VIZ_INT_RANGES = {
     "node_spacing": (50, 300),

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -98,6 +98,11 @@ _GRAPH_ROW = '[data-testid="stHorizontalBlock"]:has(.st-key-graph_viewer)'
 # it. test_viz_overlays.py keeps this in step with the buttons' own CSS.
 _TOOLBAR_CLEARANCE = "2.75rem"
 
+#: Class the graph viewer puts on the app's ``<body>`` while the graph is
+#: fullscreen (see ``lib/graph_viewer/index.html``). The rules it selects live
+#: here, in the page whose chrome they hide.
+GRAPH_FS_CLASS = "orionbelt-graph-fullscreen"
+
 # The canvas always fits itself to the window: it measures the room left below
 # the controls and re-measures whenever the layout shifts, which is the only
 # sizing anyone wants — a fixed height was an option that could only ever leave
@@ -349,6 +354,104 @@ def graph_overlay_css(dark: bool) -> str:
     </style>"""
 
 
+def graph_space_css(find_row_open: bool) -> str:
+    """CSS that hands room above the canvas back to the graph (issue #381).
+
+    The canvas already fits itself to whatever is left below the controls, so
+    the only way to make it taller is to spend less above it. Two things here
+    do: the Render button, cut back to its label, and the Find row when its
+    switch is off. The page's own spacing — the title, the section tabs and the
+    gaps between the rows — is left exactly as it is.
+
+    The Find row is hidden rather than skipped. What it holds — the find target,
+    the node filter, the focus seeds and their depth — is read further down by
+    the run that builds the graph, so a run that never rendered it would have to
+    rebuild all of that from the saved config; taking it out of the flow costs
+    the same height and none of that.
+    """
+    # The row's own wrapper as well as the row: hidden on its own, the container
+    # collapses to nothing but Streamlit's block still holds its slot in the
+    # column's 16px gap grid, which is a band of empty page where the row was.
+    hide_find_row = (
+        ""
+        if find_row_open
+        else """
+    .st-key-viz_find_row,
+    [data-testid="stLayoutWrapper"]:has(> .st-key-viz_find_row) {
+        display: none !important;
+    }"""
+    )
+    return f"""<style>
+    /* Render, cut back to its label. Streamlit's default button is 38px tall
+       and stretched across its whole column, which made it the largest thing
+       above the canvas — for a button that is only reached after changing
+       something else. */
+    .st-key-viz_render_btn button {{
+        min-height: 28px;
+        height: 28px;
+        padding: 0 0.9rem;
+        line-height: 1.2;
+    }}{hide_find_row}
+    </style>"""
+
+
+def graph_fullscreen_css(dark: bool) -> str:
+    """CSS for fullscreen: the graph keeps its controls, the app loses its chrome.
+
+    Fullscreen used to be taken on the canvas' own container, which lives inside
+    the component iframe. That gave the graph the screen and left every control
+    outside it: Display options, Find & focus, Path finder, Node options and the
+    details panel are all Streamlit's DOM, so reaching any of them meant leaving
+    fullscreen and going back in (issue #381). The viewer now fullscreens the
+    page itself and puts this class on the body, which hides what is not the
+    graph page — the sidebar, Streamlit's own header, the title and the section
+    tabs — so the controls come along and the room still goes to the canvas.
+
+    The rules are injected with the rest of the graph page, so they exist only
+    while that page is on screen: if a rerun ever navigates away with the class
+    still set, the chrome comes back by itself.
+    """
+    bg = "#0e1117" if dark else "#ffffff"
+    return f"""<style>
+    body.{GRAPH_FS_CLASS} [data-testid="stSidebar"],
+    body.{GRAPH_FS_CLASS} [data-testid="stSidebarCollapsedControl"],
+    body.{GRAPH_FS_CLASS} [data-testid="stHeader"],
+    body.{GRAPH_FS_CLASS} [data-testid="stToolbar"],
+    body.{GRAPH_FS_CLASS} [data-testid="stDecoration"] {{
+        display: none !important;
+    }}
+    /* Everything above the switch row: the breadcrumb, the page title, the
+       section tabs. Named by where it sits rather than one by one — it is
+       whatever precedes the row the switches are in — so a fourth thing landing
+       above the canvas is covered without touching this.
+
+       `~ * .st-key-…` and not `~ *:has(.st-key-…)`: a :has() inside a :has() is
+       invalid, and an invalid selector takes the whole rule down with it in
+       silence — which is exactly what it did, leaving the title and the tabs on
+       screen in fullscreen. The form here says the same thing: a following
+       sibling with the switches somewhere inside it. */
+    body.{GRAPH_FS_CLASS} .stMainBlockContainer > [data-testid="stVerticalBlock"]
+        > *:has(~ * .st-key-viz_band_switches),
+    body.{GRAPH_FS_CLASS} .stMainBlockContainer > [data-testid="stVerticalBlock"]
+        > *:has(~ .st-key-viz_band_switches) {{
+        display: none !important;
+    }}
+    body.{GRAPH_FS_CLASS} .stMainBlockContainer {{
+        padding: 0.5rem 1rem 0 !important;
+        max-width: none !important;
+    }}
+    /* The page is the fullscreen box now: nothing should be scrolled out of it,
+       and the ground behind it is the graph's own, not the browser's black. */
+    body.{GRAPH_FS_CLASS} {{
+        overflow: hidden;
+        background: {bg};
+    }}
+    body.{GRAPH_FS_CLASS} [data-testid="stAppViewContainer"] {{
+        background: {bg};
+    }}
+    </style>"""
+
+
 def _add_annotation_nodes(net, ont, subject_uri, subject_node_id, room):
     """Hang ``subject_uri``'s annotations off its node, at most ``room`` of them.
 
@@ -470,6 +573,10 @@ def render_visualization():
             # Off by default: the panel is a tool you reach for, not something
             # every graph needs, and off it costs no vertical space at all.
             "path_panel": False,
+            # The Find / Node options / Focus row. On by default, because Find
+            # is how you get around a large graph; off, the row costs the canvas
+            # nothing (issue #381).
+            "find_row_open": True,
         }
         # Bring back settings saved in a previous session before applying
         # defaults, so a returning user opens with their own preferences (#142).
@@ -489,13 +596,15 @@ def render_visualization():
         # persisted viz settings, so a band you collapsed stays collapsed.
         # Render sits outside it, since redrawing is the one thing still worth
         # doing while the rest is out of the way.
-        # Both bands above the canvas are switched from the same row, and Render
-        # sits outside them: redrawing is the one thing still worth doing while
-        # the rest is out of the way. The two switches share one column and are
-        # laid out inline (see BAND_SWITCH_CSS), so they read as a pair and
-        # neither label can be squeezed into breaking.
+        # All three bands above the canvas are switched from the same row, and
+        # Render sits outside them: redrawing is the one thing still worth doing
+        # while the rest is out of the way. The switches share one column and are
+        # laid out inline (see BAND_SWITCH_CSS), so they read as a set and no
+        # label can be squeezed into breaking.
         st.html(BAND_SWITCH_CSS)
-        _switch_col, _, _render_col = st.columns([2.4, 2.6, 1])
+        _switch_col, _, _render_col = st.columns(
+            [3.6, 1.9, 0.5], vertical_alignment="center"
+        )
         with _switch_col.container(key="viz_band_switches"):
             options_open = st.toggle(
                 "Display options",
@@ -503,6 +612,15 @@ def render_visualization():
                 on_change=viz_sync,
                 args=("_viz_cfg_options_open", "viz_options_open"),
                 help="Which node types to draw and how far apart to space them.",
+            )
+            find_row_open = st.toggle(
+                "Find & focus",
+                key="viz_find_row_open",
+                on_change=viz_sync,
+                args=("_viz_cfg_find_row_open", "viz_find_row_open"),
+                help="The row that finds an entity, narrows which ones are "
+                "drawn, and focuses on one node. Off, it gives its height to "
+                "the canvas and keeps whatever it was set to.",
             )
             path_panel = st.toggle(
                 "Path finder",
@@ -514,10 +632,13 @@ def render_visualization():
                 "Off, the panel takes no room and nothing is highlighted.",
             )
         with _render_col:
+            # Sized to its label, not to its column: stretched across a third of
+            # the row it was the largest thing above the canvas, for a button
+            # that is only reached after changing something else (issue #381).
             render_graph = st.button(
                 "Render",
+                key="viz_render_btn",
                 type="primary",
-                use_container_width=True,
                 help="Redraw the graph and re-run the layout. Also re-centres on "
                 "the current Find selection.",
             )
@@ -935,7 +1056,13 @@ def render_visualization():
         # The mode column is sized to the checkbox, not to an even third: the
         # spare width goes to the panel, whose collapsed label carries the note
         # about what the view is holding back.
-        _find_col, _mode_col, _filter_col = st.columns([1, 0.5, 2.5])
+        # Hidden by CSS rather than skipped, so the switch above costs nothing
+        # but height: the focus seeds, the node filter and the find target are
+        # all read out of this block further down, and a run that never rendered
+        # it would have to reconstruct every one of them from the saved config
+        # (see graph_overlay_css). The container is what the rule has to aim at.
+        _find_row = st.container(key="viz_find_row")
+        _find_col, _mode_col, _filter_col = _find_row.columns([1, 0.5, 2.5])
         with _find_col:
             if focus_targets:
                 _find_choice = st.selectbox(
@@ -2738,6 +2865,10 @@ def render_visualization():
             # reopen toggle took a sliver of it, and the Node options picker
             # pushed the graph down far enough to squeeze it to its floor.
             st.markdown(graph_overlay_css(_gv_dark), unsafe_allow_html=True)
+            # ...and the room above it, which is the rest of what the canvas
+            # has to work with (issue #381).
+            st.markdown(graph_space_css(find_row_open), unsafe_allow_html=True)
+            st.markdown(graph_fullscreen_css(_gv_dark), unsafe_allow_html=True)
 
             _panel_on = bool(st.session_state.get("_viz_cfg_details_panel", True))
             if _panel_on:

--- a/tests/test_viz_fullscreen.py
+++ b/tests/test_viz_fullscreen.py
@@ -97,7 +97,8 @@ def test_the_fullscreen_state_lives_on_the_page():
     assert f"var FS_CLASS = '{GRAPH_FS_CLASS}'" in src
     assert GRAPH_FS_CLASS in graph_fullscreen_css(dark=False)
     # And the button reads it back on mount rather than assuming "not fullscreen".
-    assert "setFullscreenIcon(stageOn())" in src
+    assert "setFullscreenIcon(on)" in src
+    assert "syncFullscreenState()" in src
 
 
 def test_only_our_own_page_fullscreen_is_followed():
@@ -131,6 +132,22 @@ def test_selections_reach_python_while_fullscreen():
         assert "setComponentValue" not in handler, (
             f"{event} must not send to Streamlit directly"
         )
+
+
+def test_the_native_exit_hook_is_reclaimed_by_every_mount():
+    """The desktop host calls a hook on the top window when its own window
+    leaves fullscreen (Esc, the green button, the Window menu). The hook is a
+    function of the document that installed it, and fullscreen now outlives
+    that document — so a mount that finds the page still fullscreen has to
+    claim the hook back, or the chrome stays hidden with nobody to put it back.
+    """
+    src = _VIEWER.read_text(encoding="utf-8")
+    sync = src[src.index("function syncFullscreenState(") :].split("\n}", 1)[0]
+    assert "installNativeFsExitHook()" in sync
+    assert "setNativeFsExitHook(null)" in sync
+    # ...and that is what a fresh render runs.
+    assert "syncFullscreenState();" in src
+    assert "setFullscreenIcon(stageOn())" not in src
 
 
 def test_the_page_listener_is_removed_with_the_document():

--- a/tests/test_viz_fullscreen.py
+++ b/tests/test_viz_fullscreen.py
@@ -10,6 +10,11 @@ from pathlib import Path
 
 import sources
 
+from orionbelt_ontology_builder.views.visualization import (
+    GRAPH_FS_CLASS,
+    graph_fullscreen_css,
+)
+
 _PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
 _VIEWER = _PKG / "lib" / "graph_viewer" / "index.html"
 
@@ -63,26 +68,131 @@ def test_graph_status_placeholder_is_unconditional():
     )
 
 
-def test_viewer_defers_selection_while_fullscreen():
-    """Selections must not round-trip to Streamlit while the graph is fullscreen.
+def test_fullscreen_is_taken_on_the_page_not_on_the_canvas():
+    """The fullscreen element must be the *parent page's* root element.
 
-    A round-trip reruns the app and repaints the details panel / status bar
-    behind the fullscreen graph; the last selection is flushed on exit instead,
-    so the panel returns showing the node the user left selected.
+    Fullscreening the canvas' own container put the whole of Streamlit's DOM —
+    Display options, Find & focus, Path finder, Node options, the details panel
+    — behind the fullscreen graph, so every one of them meant leaving fullscreen
+    and going back in (issue #381).
     """
     src = _VIEWER.read_text(encoding="utf-8")
 
-    assert "function sendSelection(" in src
-    assert "function flushPendingSelection(" in src
+    enter = src[src.index("function enterFullscreen(") :].split("\n}", 1)[0]
+    assert "parentDoc()" in enter and "documentElement" in enter, (
+        "fullscreen must be requested on the parent page's root element"
+    )
+    assert "getElementById('container')" not in enter, (
+        "fullscreening the component's own container leaves every control "
+        "outside it behind (issue #381)"
+    )
 
-    # Every selection event goes through the deferring helper, never straight to
-    # setComponentValue.
+
+def test_the_fullscreen_state_lives_on_the_page():
+    """Streamlit replaces this document whenever it re-mounts the component, so
+    a flag in it would be lost while the app was still fullscreen — the button
+    would offer to enter what it is already in. The state is a class on the
+    parent's body, and both sides have to agree on its name."""
+    src = _VIEWER.read_text(encoding="utf-8")
+    assert f"var FS_CLASS = '{GRAPH_FS_CLASS}'" in src
+    assert GRAPH_FS_CLASS in graph_fullscreen_css(dark=False)
+    # And the button reads it back on mount rather than assuming "not fullscreen".
+    assert "setFullscreenIcon(stageOn())" in src
+
+
+def test_only_our_own_page_fullscreen_is_followed():
+    """Streamlit fullscreens elements of its own (the chart and image
+    expanders). Following one of those would hide the app's chrome behind
+    somebody else's fullscreen element."""
+    src = _VIEWER.read_text(encoding="utf-8")
+    fn = src[src.index("function pageFullscreenOn(") :].split("\n}", 1)[0]
+    assert "=== d.documentElement" in fn
+
+
+def test_selections_reach_python_while_fullscreen():
+    """The workaround from issue #189 is retired.
+
+    Selections used to be held back until exit: the fullscreen element lived in
+    this document, so a rerun that re-mounted the component destroyed it. The
+    page survives every rerun, and the details panel the selection repaints is
+    now on screen — holding it back would leave a visible panel showing a stale
+    node.
+    """
+    src = _VIEWER.read_text(encoding="utf-8")
+
+    assert "flushPendingSelection" not in src
+    assert "pendingSelection" not in src
+
+    # Every selection event still goes through the one helper, so there is a
+    # single place where what reaches Python is decided.
     for event in ("selectNode", "selectEdge", "deselectNode", "deselectEdge"):
         handler = src.split(f"network.on('{event}'", 1)[1].split("});", 1)[0]
         assert "sendSelection(" in handler, f"{event} must use sendSelection()"
         assert "setComponentValue" not in handler, (
-            f"{event} must not send to Streamlit directly (issue #189)"
+            f"{event} must not send to Streamlit directly"
         )
 
-    # Both exit paths — the web Fullscreen API and the desktop overlay — flush.
-    assert src.count("flushPendingSelection();") == 2
+
+def test_the_page_listener_is_removed_with_the_document():
+    """The listener is registered on the parent, which outlives this document by
+    many re-mounts. Without the teardown each mount piles another dead one on."""
+    src = _VIEWER.read_text(encoding="utf-8")
+    assert "d.addEventListener('fullscreenchange', onPageFullscreenChange)" in src
+    assert "d.removeEventListener('fullscreenchange', onPageFullscreenChange)" in src
+    assert "window.addEventListener('pagehide'" in src
+
+
+def test_fullscreen_hides_the_app_chrome_but_not_the_controls():
+    """What fullscreen hides is the app around the page: the sidebar, Streamlit's
+    header, and everything above the switch row. The controls themselves come
+    along — that is the point of taking the page (issue #381)."""
+    css = graph_fullscreen_css(dark=False)
+    for hook in (
+        '[data-testid="stSidebar"]',
+        '[data-testid="stHeader"]',
+    ):
+        assert hook in css, f"{hook} must be hidden in fullscreen"
+    # Everything above the switch row, named by position rather than one by one.
+    assert "*:has(~ * .st-key-viz_band_switches)" in css
+    # A :has() inside a :has() is invalid and takes its whole rule down without
+    # a word, which is how the title and the tabs stayed on screen the first
+    # time this was written.
+    assert ":has(~ *:has(" not in css
+    # ...and nothing that hides a control.
+    for hook in (
+        ".st-key-viz_band_switches",
+        ".st-key-viz_find_row",
+        ".st-key-graph_viewer",
+    ):
+        assert f"{hook} {{" not in css
+
+
+def test_the_canvas_measures_the_page_not_its_own_iframe():
+    """A fullscreen page does not resize the component iframe, so the iframe's
+    own window.innerHeight says nothing about the box to fill. The height comes
+    from the page's viewport in both states — there is no separate fullscreen
+    measurement left to drift (issue #177 follow-up)."""
+    src = _VIEWER.read_text(encoding="utf-8")
+    fn = src[src.index("function viewportHeight(") :].split("\n}", 1)[0]
+    assert "documentElement.clientHeight" in fn
+    assert "window.parent.innerHeight" in fn
+    assert "viewportHeight()" in src.split("function autofitHeight(", 1)[1]
+    assert "function fullscreenHeight(" not in src
+
+
+def test_the_toolbar_says_what_its_buttons_do():
+    """The three canvas buttons carried a native `title`, which never appeared:
+    the hover target is the <svg> inside the button, and a tooltip is not looked
+    up from there. The page draws them instead."""
+    src = _VIEWER.read_text(encoding="utf-8")
+
+    for tip in ("Fullscreen", "Download as PNG", "Copy what is selected"):
+        assert f'data-tip="{tip}"' in src
+        assert f'aria-label="{tip}"' in src
+    assert "title=" not in src.split("<body>", 1)[1].split("</button>", 1)[0]
+    # The icon must not eat the hover, or there is nothing to show a tip for.
+    svg_rule = src[src.index("#fullscreen-btn svg, #download-btn svg") :]
+    assert "pointer-events: none" in svg_rule[: svg_rule.index("}")]
+    # Every later change of what a button says goes through the one helper.
+    assert "btn.title =" not in src
+    assert src.count("setButtonTip(") >= 4

--- a/tests/test_viz_fullscreen.py
+++ b/tests/test_viz_fullscreen.py
@@ -213,3 +213,18 @@ def test_the_toolbar_says_what_its_buttons_do():
     # Every later change of what a button says goes through the one helper.
     assert "btn.title =" not in src
     assert src.count("setButtonTip(") >= 4
+
+
+def test_a_tooltip_steps_aside_for_whatever_is_under_the_button():
+    """The tip drops under its button, where the details panel's card also
+    floats — and that card is Streamlit's DOM in the parent, which always paints
+    over this iframe, so a tip behind it is not dimmed but absent. The viewer
+    asks the page what is at the spot and moves the tip beside the button when
+    the answer is not itself."""
+    src = _VIEWER.read_text(encoding="utf-8")
+    fn = src[src.index("function placeTip(") :].split("\n}", 1)[0]
+    assert "elementFromPoint" in fn
+    assert "!== fe" in fn, "the test must be 'is the page showing us, or itself'"
+    assert "classList.toggle('tip-left'" in fn
+    assert ".tip-left::after" in src
+    assert "addEventListener('mouseenter'" in src

--- a/tests/test_viz_room_for_the_graph.py
+++ b/tests/test_viz_room_for_the_graph.py
@@ -1,0 +1,76 @@
+"""Guards for the room above the canvas (issue #381).
+
+The canvas fits itself to whatever is left below the controls, so every pixel
+these give back is a pixel of graph. None of it is observable outside a browser,
+so the hooks are pinned here.
+"""
+
+from pathlib import Path
+
+import sources
+
+from orionbelt_ontology_builder import ui
+from orionbelt_ontology_builder.views.visualization import graph_space_css
+
+_PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+
+
+def test_empty_style_blocks_stay_out_of_the_layout():
+    """CSS injected through st.markdown leaves an empty element behind that
+    still takes a slot in the page column's 16px gap grid — four of them ride
+    above the graph.
+
+    The rule that hides them was written as a chain of child combinators and
+    stopped matching when Streamlit put another wrapper between the markdown
+    element and its container: measured in the browser, 0 elements matched
+    while 4 sat in the page. Descendant combinators survive that.
+    """
+    css = ui._CUSTOM_CSS
+    rule = css[css.index('[data-testid="stElementContainer"]:has(') :]
+    rule = rule[: rule.index("}") + 1]
+    assert "style:only-child" in rule, (
+        "only a markdown block with nothing to show may be hidden"
+    )
+    assert '> [data-testid="stMarkdown"]' not in rule, (
+        "the child chain breaks whenever Streamlit adds a wrapper; match on "
+        "descendants instead"
+    )
+
+
+def test_the_find_row_gives_its_height_back_when_switched_off():
+    """Off, the row must cost the page nothing — not even the slot its own
+    wrapper holds in the gap grid, which is a band of empty page where the row
+    used to be."""
+    on, off = graph_space_css(True), graph_space_css(False)
+    assert ".st-key-viz_find_row" not in on
+    assert ".st-key-viz_find_row" in off
+    assert '[data-testid="stLayoutWrapper"]:has(> .st-key-viz_find_row)' in off
+
+
+def test_the_find_row_is_hidden_rather_than_skipped():
+    """What the row holds — the find target, the node filter, the focus seeds —
+    is read by the run that builds the graph further down. A run that never
+    rendered it would have to rebuild all of that from the saved config, so the
+    row is always rendered and only ever taken out of the flow."""
+    src = sources.viz_text()
+    assert 'st.container(key="viz_find_row")' in src
+    # ...and nothing gates it behind the switch.
+    assert "if find_row_open:" not in src
+
+
+def test_render_is_sized_to_its_label():
+    """Stretched across its column, Render was the largest thing above the
+    canvas — for a button only reached after changing something else."""
+    src = sources.viz_text()
+    button = src[src.index("render_graph = st.button(") :].split(")", 1)[0]
+    assert "use_container_width" not in button
+    assert 'key="viz_render_btn"' in button
+    assert ".st-key-viz_render_btn button" in graph_space_css(True)
+
+
+def test_the_page_keeps_its_own_spacing():
+    """The title, the section tabs and the gaps between the rows are left
+    alone: the room comes from the controls, not from crowding the page."""
+    css = graph_space_css(True)
+    assert "stHeading" not in css
+    assert "gap:" not in css

--- a/tests/test_viz_shortest_path.py
+++ b/tests/test_viz_shortest_path.py
@@ -501,6 +501,9 @@ def test_the_switch_is_remembered_across_sessions():
     from orionbelt_ontology_builder.ui import _VIZ_PERSIST_KEYS
 
     assert "path_panel" in _VIZ_PERSIST_KEYS
+    # The Find & focus switch is presented as one of the same set, so it is
+    # remembered like one (issue #381).
+    assert "find_row_open" in _VIZ_PERSIST_KEYS
 
 
 def test_turning_the_switch_off_rebuilds_the_graph_without_the_highlight():

--- a/tests/test_viz_shortest_path.py
+++ b/tests/test_viz_shortest_path.py
@@ -487,11 +487,12 @@ def test_a_remembered_pick_whose_entity_is_gone_is_forgotten():
     assert at.session_state["_viz_cfg_path_target"] == "Class: C"
 
 
-def test_the_switch_is_offered_beside_the_display_options_switch():
+def test_the_switch_is_offered_in_the_band_switch_row():
+    """One row of switches above the canvas, one per band, in the order the
+    bands sit in: Display options, Find & focus, Path finder (issue #381)."""
     at = _render("", "")
     labels = [t.label for t in at.toggle]
-    assert "Path finder" in labels
-    assert labels.index("Path finder") == labels.index("Display options") + 1
+    assert labels[:3] == ["Display options", "Find & focus", "Path finder"]
 
 
 def test_the_switch_is_remembered_across_sessions():


### PR DESCRIPTION
Addresses two of the three ideas in #381: the menus in fullscreen, and more room for the canvas. Manual height (idea 1) is deliberately not brought back, since the canvas already takes everything below the controls and a slider could only give it less.

## Fullscreen keeps the controls

Fullscreen was taken on the canvas' own container, inside the component iframe, so every control stayed outside it. It is now taken on the page, with a class on the body that hides the sidebar, Streamlit's header, the breadcrumb, the title and the section tabs. Display options, Find & focus, Path finder, Node options, the details panel and the status bar all come along.

This also retires the workaround from #189: the fullscreen element used to be destroyed by any rerun that re-mounted the component, so selections had to be held back until exit. The page survives every rerun, so a node click in fullscreen updates the panel that is now on screen.

## Room above the canvas

- A third band switch, **Find & focus**, for the Find / Node options / Focus row. Off, it hands its 66px to the graph.
- **Render** sized to its label rather than stretched across its column: the switch row drops from 40px to 28px.
- The rule that takes empty CSS-only blocks out of the layout had stopped matching after a Streamlit DOM change. Measured in the browser: 0 elements matched while 4 sat above the graph, each holding a 16px slot.

The page's own spacing (title, tabs, row gaps) is untouched.

## Also

The canvas toolbar's tooltips never appeared: they were native `title` attributes and the hover target is the `<svg>` inside the button. The page draws them itself now.

## Verified in the running app (1440x900)

- Canvas 540px, 606px with the Find row off, 752px in fullscreen with the controls still on screen.
- Fullscreen survives a panel toggle and a node click; the Esc path puts the chrome back and resizes the canvas.
- Sidebar, header, breadcrumb, title and tabs all hidden in fullscreen; every control visible.

1888 tests pass; ruff and mypy clean.

Note for review: the fullscreen box was measured in a headless browser, where the window is already the screen. Worth one look in a real window smaller than the screen.