### PR TITLE
fix(viz): fullscreen fills the window, it no longer takes the screen (#390)

### DIFF
--- a/orionbelt_ontology_builder/desktop.py
+++ b/orionbelt_ontology_builder/desktop.py
@@ -213,75 +213,14 @@ def _install_window_bridges(app_name: str):
             except Exception:  # noqa: BLE001 - clipboard bridge is best-effort across backends
                 return False
 
-        def orionbelt_toggle_fullscreen():
-            # The embedded webview doesn't support the HTML Fullscreen API, so the
-            # graph's Fullscreen button routes here to toggle the native window
-            # instead (issue #177). Returns True once the toggle is away, or None
-            # if it couldn't be requested — deliberately not the resulting
-            # fullscreen state: pywebview keeps that on its platform window, and
-            # some backends (Qt) only flip it once the GUI thread catches up, so
-            # anything read here could be a lie. The page tracks its own overlay
-            # state and is told about native exits by _on_window_restored below.
-            try:
-                window.toggle_fullscreen()
-                return True
-            except Exception:  # noqa: BLE001 - pywebview backends differ on toggle_fullscreen
-                return None
-
         try:
             window.expose(
                 orionbelt_set_window_title,
                 orionbelt_copy_to_clipboard,
-                orionbelt_toggle_fullscreen,
             )
         except Exception:
             logger.debug(
                 "JS bridge not exposed; backend has no window.expose()", exc_info=True
-            )
-
-        def _clear_native_fullscreen_flag():
-            # pywebview decides which way toggle_fullscreen() goes purely from a
-            # flag it keeps on the platform window, so a fullscreen exit it didn't
-            # initiate (Esc) leaves that flag stale and the next toggle fails to
-            # re-enter. There is no public setter, hence reaching for the platform
-            # window; every step is optional so an unknown backend simply keeps
-            # today's behaviour.
-            try:
-                view = window.gui.BrowserView.instances.get(window.uid)
-            except Exception:  # noqa: BLE001 - platform window internals vary by backend
-                return
-            if view is not None and getattr(view, "is_fullscreen", False):
-                try:
-                    view.is_fullscreen = False
-                except Exception:
-                    logger.debug(
-                        "Could not clear the native fullscreen flag", exc_info=True
-                    )
-
-        def _on_window_restored():
-            # macOS fires the window's "restored" event when it leaves fullscreen
-            # (Esc, the green button, the Window menu). The webview reports no
-            # fullscreenchange to the page, so the graph's desktop fullscreen
-            # overlay would stay stretched over the shrunken window and keep
-            # covering the whole app (issue #177 follow-up). Tell the page to drop
-            # it. The event runs on its own thread, so evaluate_js can't deadlock.
-            _clear_native_fullscreen_flag()
-            try:
-                window.evaluate_js(
-                    "window.__orionbeltNativeFullscreenExit &&"
-                    " window.__orionbeltNativeFullscreenExit()"
-                )
-            except Exception:
-                logger.debug(
-                    "Fullscreen-exit notice not delivered to the page", exc_info=True
-                )
-
-        try:
-            window.events.restored += _on_window_restored
-        except Exception:
-            logger.debug(
-                "Backend has no 'restored' event; fullscreen-exit sync disabled",
-                exc_info=True,
             )
 
         def _inject():

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -121,7 +121,7 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
 <div id="container" style="position: relative;">
     <div id="graph"></div>
     <div id="legend"></div>
-    <button id="fullscreen-btn" data-tip="Fullscreen" aria-label="Fullscreen" style="display:none;" onclick="toggleFullscreen()">
+    <button id="fullscreen-btn" data-tip="Maximize" aria-label="Maximize" style="display:none;" onclick="toggleFullscreen()">
         <svg viewBox="0 0 24 24"><path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/></svg>
     </button>
     <button id="download-btn" data-tip="Download as PNG" aria-label="Download as PNG" style="display:none;" onclick="downloadGraph()">
@@ -797,10 +797,15 @@ function toggleFullscreen() {
 }
 
 // Swap the button glyph/hint between the "enter" and "exit" states.
+//
+// The button says Maximize/Restore rather than Fullscreen: what it does is
+// fill the browser window, and the screen and the OS window are left alone
+// (issue #390). Only the words a user reads changed — everything else here
+// keeps the fullscreen names the issues behind it use.
 function setFullscreenIcon(on) {
     var fsBtn = document.getElementById('fullscreen-btn');
     if (!fsBtn) return;
-    setButtonTip(fsBtn, on ? 'Exit fullscreen' : 'Fullscreen');
+    setButtonTip(fsBtn, on ? 'Restore' : 'Maximize');
     fsBtn.querySelector('svg').innerHTML = on
         ? '<path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z"/>'
         : '<path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z"/>';

--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -85,13 +85,6 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
     right: calc(100% + 8px);
     transform: translateY(-50%);
 }
-/* In fullscreen the container fills the screen, so the graph doesn't fall back
-   to the browser's default black backdrop. Percentages, not vw/vh: this document
-   is a Streamlit component iframe, where vw/vh resolve against the *iframe's*
-   viewport, so a browser window smaller than the screen left the container that
-   size with black bands around it (issue #177 follow-up). 100% resolves against
-   the fullscreen box the UA gives us, which is the screen. */
-#container:fullscreen { width: 100%; height: 100%; }
 </style>
 <script>
 // Paint the remembered background before the first frame.
@@ -425,12 +418,12 @@ function measureReserve() {
     return Math.min(lowest - bottom, AUTOFIT_MAX_RESERVE);
 }
 
-// The page's own viewport, which while the page is fullscreen is the screen.
-// Read from the parent's root element as well as from innerHeight: this document
-// is a component iframe, and a fullscreen page does not resize it, so its own
-// window.innerHeight says nothing about the box the canvas has to fill (issue
-// #177 follow-up). The larger of the two is the page's current viewport in both
-// states — out of fullscreen they agree, bar a scrollbar.
+// The page's own viewport, which is the box the graph has to fit into. Read
+// from the parent's root element as well as from innerHeight: this document is a
+// component iframe, so its own window.innerHeight is the height of the slot it
+// has been given, not of the page (issue #177 follow-up). The larger of the two
+// is the page's current viewport, in fullscreen and out of it — they agree bar a
+// scrollbar, and in fullscreen the page has no scrollbar.
 function viewportHeight() {
     var d = parentDoc();
     var client = (d && d.documentElement && d.documentElement.clientHeight) || 0;
@@ -692,26 +685,32 @@ function downloadGraph() {
     }
 }
 
-// --- Fullscreen (issues #177, #189, #381) -----------------------------------
+// --- Fullscreen (issues #177, #189, #381, #390) ------------------------------
 //
-// Fullscreen is taken on the *parent page's* root element, not on this iframe's
-// #container, and the app's chrome is hidden by a class the page's own CSS
-// selects (visualization.graph_fullscreen_css). Fullscreening the container gave
-// the graph the screen and left every control outside it: Display options, Find
-// & focus, Path finder, Node options and the details panel are all Streamlit's
-// DOM, out here in the parent, so reaching any of them meant leaving fullscreen
-// and going back in (issue #381).
+// Fullscreen here means the graph page filling the browser window, not the
+// window filling the screen. The app's chrome is hidden by a class the page's
+// own CSS selects (visualization.graph_fullscreen_css) and that is the whole of
+// it: no requestFullscreen on the page, and no native window toggle on the
+// desktop. Taking the screen fought the way people actually work — an ontology
+// is built alongside other windows, and the OS already has a shortcut for
+// anyone who does want the screen (issue #390).
 //
-// Taking the page also retires the workaround from issue #189. The fullscreen
-// element used to live in this document, which Streamlit replaces whenever it
-// re-mounts the component, so a selection that reached Python destroyed it and
-// dropped fullscreen; selections had to be held back until exit. The parent's
-// root element survives every rerun, so they round-trip again and the details
-// panel behind the graph is the live one.
+// The class goes on the *parent page's* body, not on this iframe's #container.
+// Fullscreening the container gave the graph the room and left every control
+// outside it: Display options, Find & focus, Path finder, Node options and the
+// details panel are all Streamlit's DOM, out here in the parent, so reaching any
+// of them meant leaving fullscreen and going back in (issue #381).
+//
+// Working on the page also retires the workaround from issue #189. The
+// fullscreen element used to live in this document, which Streamlit replaces
+// whenever it re-mounts the component, so a selection that reached Python
+// destroyed it and dropped fullscreen; selections had to be held back until
+// exit. A class on the parent's body survives every rerun, so they round-trip
+// again and the details panel behind the graph is the live one.
 var FS_CLASS = 'orionbelt-graph-fullscreen';
 
 // The parent document, or null where it can't be reached — a cross-origin host,
-// where there is no page to fullscreen and the button stays hidden.
+// where there is no page to expand into and the button stays hidden.
 function parentDoc() {
     try {
         var fe = window.frameElement;
@@ -719,17 +718,6 @@ function parentDoc() {
     } catch (e) {
         return null;
     }
-}
-
-// True while the *page* is the fullscreen element. Only the page: Streamlit
-// fullscreens elements of its own (the chart and image expanders), and adopting
-// one of those would hide the app's chrome behind it. The prefixed property is
-// read too, so a WebKit implementation isn't misread as "not fullscreen".
-function pageFullscreenOn() {
-    var d = parentDoc();
-    if (!d) return false;
-    var el = d.fullscreenElement || d.webkitFullscreenElement;
-    return !!el && el === d.documentElement;
 }
 
 // The chrome-hidden state. It lives on the parent's <body> rather than in a
@@ -748,57 +736,23 @@ function setStage(on) {
     else d.body.classList.remove(FS_CLASS);
 }
 
-// Whether the HTML Fullscreen API is actually available for the page. The
-// desktop pywebview doesn't support it — requestFullscreen throws "Fullscreen is
-// not supported" (#177) — in which case we fall back to the native window.
-function htmlFullscreenSupported() {
-    try {
-        var d = parentDoc();
-        var root = d && d.documentElement;
-        return !!(d && (d.fullscreenEnabled || d.webkitFullscreenEnabled) &&
-            root && (root.requestFullscreen || root.webkitRequestFullscreen));
-    } catch (e) {
-        return false;
-    }
-}
-
-// The native desktop window's fullscreen toggle, exposed by the pywebview host
-// (desktop.py). Reached via window.top since the graph is in a same-origin
-// iframe; returns null on the web (cross-origin access throws, or no pywebview).
-function desktopFullscreenToggle() {
-    try {
-        var api = window.top && window.top.pywebview && window.top.pywebview.api;
-        if (api && api.orionbelt_toggle_fullscreen) return api.orionbelt_toggle_fullscreen;
-    } catch (e) {}
-    return null;
-}
-
-// Offer the button wherever the page can be reached and either path works: the
-// HTML API on the web, the native window in the desktop app. Hide it only where
-// neither exists.
+// Offer the button wherever there is a page whose chrome we can hide. That is
+// every host the component is embedded in same-origin — Streamlit on the web and
+// the desktop webview alike — and nowhere else.
 function fullscreenSupported() {
-    return !!parentDoc() && (htmlFullscreenSupported() || !!desktopFullscreenToggle());
-}
-
-function toggleNativeWindow() {
-    var toggle = desktopFullscreenToggle();
-    if (!toggle) return;
-    try {
-        var r = toggle();
-        if (r && r.catch) r.catch(function () {});
-    } catch (e) {}
+    return !!parentDoc();
 }
 
 // Selections round-trip even while fullscreen: the details panel and status bar
-// they repaint are on screen now, and the fullscreen element is the page, which
+// they repaint are on screen now, and the state is a class on the page, which
 // no rerun replaces (issues #189, #381).
 function sendSelection(value) {
     sendToStreamlit("streamlit:setComponentValue", {value: value});
 }
 
 // Run fn after the browser has reflowed (two frames), falling back to a timer.
-// The fullscreen box is not at its final size when the request resolves, and
-// reading it synchronously returns the pre-fullscreen height.
+// Hiding the chrome reflows the page around this iframe, and reading the height
+// synchronously returns the box as it was before.
 function afterReflow(fn) {
     if (window.requestAnimationFrame) {
         requestAnimationFrame(function () { requestAnimationFrame(fn); });
@@ -807,34 +761,10 @@ function afterReflow(fn) {
     }
 }
 
-// Name of the hook the native host (desktop.py) calls when its window leaves
-// fullscreen without going through our button — Esc, the macOS green button, the
-// Window menu. The webview surfaces no fullscreenchange for the native window,
-// so without this the chrome would stay hidden while the window shrank back
-// (issue #177 follow-up). It lives on the top window because that is the frame
-// Python's evaluate_js runs in.
-var TOP_FS_EXIT_HOOK = '__orionbeltNativeFullscreenExit';
-
-function setNativeFsExitHook(fn) {
-    try { if (window.top) window.top[TOP_FS_EXIT_HOOK] = fn; } catch (e) {}
-}
-
-// The hook is a function belonging to *this* document, and fullscreen now
-// outlives it: Streamlit re-mounts the component and the closure the old
-// document installed goes with it, so the desktop window leaving fullscreen
-// would have nobody left to tell and the chrome would stay hidden. Every mount
-// that finds the page still fullscreen claims it again (review P2).
-function installNativeFsExitHook() {
-    setNativeFsExitHook(function () { if (stageOn()) leaveFullscreen(true); });
-}
-
 // What a fresh document has to work out for itself: the page may already be
 // fullscreen, and nothing in here knows it (issue #372).
 function syncFullscreenState() {
-    var on = stageOn();
-    setFullscreenIcon(on);
-    if (on) installNativeFsExitHook();
-    else setNativeFsExitHook(null);
+    setFullscreenIcon(stageOn());
 }
 
 function rememberViewport() {
@@ -850,49 +780,19 @@ function enterFullscreen() {
     rememberViewport();
     setStage(true);
     setFullscreenIcon(true);
-    var d = parentDoc();
-    var root = d && d.documentElement;
-    var req = root && (root.requestFullscreen || root.webkitRequestFullscreen);
-    var asked = false;
-    if (htmlFullscreenSupported() && req) {
-        try {
-            var p = req.call(root);
-            asked = true;
-            // A webview can claim support and still refuse: fall back to the
-            // native window rather than leaving the page half changed.
-            if (p && p.catch) p.catch(function () { toggleNativeWindow(); });
-        } catch (e) {
-            asked = false;
-        }
-    }
-    if (!asked) toggleNativeWindow();
-    installNativeFsExitHook();
     settleFullscreen(true);
 }
 
-// fromNative: the desktop window has already left fullscreen on its own, so the
-// only thing left to do is put the chrome back.
-function leaveFullscreen(fromNative) {
+function leaveFullscreen() {
     setStage(false);
     setFullscreenIcon(false);
-    setNativeFsExitHook(null);
-    if (pageFullscreenOn()) {
-        var d = parentDoc();
-        var exit = d && (d.exitFullscreen || d.webkitExitFullscreen);
-        try {
-            var p = exit && exit.call(d);
-            if (p && p.catch) p.catch(function () {});
-        } catch (e) {}
-    } else if (!fromNative) {
-        toggleNativeWindow();
-    }
     settleFullscreen(false);
 }
 
 // Enter/exit fullscreen for the graph page: the canvas plus the controls that
 // drive it, with the app's chrome hidden (issue #381).
 function toggleFullscreen() {
-    if (stageOn()) leaveFullscreen(false);
+    if (stageOn()) leaveFullscreen();
     else enterFullscreen();
 }
 
@@ -908,8 +808,9 @@ function setFullscreenIcon(on) {
 
 // Size the canvas to the new box and hold the viewport steady. There is no
 // separate fullscreen measurement any more: fullscreen or not, the canvas takes
-// the room left below the controls, which is what autofitHeight() measures — it
-// reads the page's viewport, and in fullscreen the page's viewport is the screen.
+// the room left below the controls, which is what autofitHeight() measures — and
+// what fullscreen changes is how much of the page is left over once the chrome
+// around it is hidden.
 //
 // vis rescales the view on each of the several 'resize' events it fires while
 // the canvas changes size, and a moveTo() *inside* that emit is overwritten by
@@ -951,46 +852,36 @@ function scheduleFullscreenView(entering) {
     }
 }
 
-// The box arrives at its final size in its own time — the browser animates the
-// transition, the desktop window resizes after its own toggle, and hiding the
-// sidebar reflows the page underneath. Re-measure as it settles rather than
-// trusting the first read.
+// The box arrives at its final size in its own time: hiding the sidebar, the
+// header and the tabs reflows the page around this iframe, and Streamlit's own
+// layout settles after that. Re-measure as it goes rather than trusting the
+// first read.
 function settleFullscreen(entering) {
     scheduleFullscreenView(entering);
     afterReflow(function () { scheduleFullscreenView(entering); });
     setTimeout(function () { scheduleFullscreenView(entering); }, 250);
 }
 
-// Esc, or the browser dropping fullscreen on its own. Only our own page
-// fullscreen is followed; anything else on the page fullscreening something of
-// its own is none of our business.
-function onPageFullscreenChange() {
-    if (!stageOn() || pageFullscreenOn()) return;
-    setStage(false);
-    setFullscreenIcon(false);
-    setNativeFsExitHook(null);
-    settleFullscreen(false);
+// Esc leaves fullscreen. The browser used to do this for us, back when the page
+// was the fullscreen element; expanding inside the window means wiring it up
+// (issue #390). Both documents are listened to: the key lands in this one while
+// the canvas has focus and in the parent while any of the controls do.
+function onEscape(e) {
+    if ((e.key !== 'Escape' && e.keyCode !== 27) || !stageOn()) return;
+    leaveFullscreen();
 }
 
+document.addEventListener('keydown', onEscape);
 (function () {
     var d = parentDoc();
     if (!d) return;
-    d.addEventListener('fullscreenchange', onPageFullscreenChange);
-    d.addEventListener('webkitfullscreenchange', onPageFullscreenChange);
+    d.addEventListener('keydown', onEscape);
     // This document is replaced on every re-mount, so leave the parent as we
     // found it: otherwise each mount piles another dead listener onto it.
     window.addEventListener('pagehide', function () {
-        d.removeEventListener('fullscreenchange', onPageFullscreenChange);
-        d.removeEventListener('webkitfullscreenchange', onPageFullscreenChange);
+        d.removeEventListener('keydown', onEscape);
     });
 })();
-// Fullscreen from inside an iframe needs the frame to permit it. Streamlit's
-// component iframe is same-origin, so grant it defensively (belt and braces on
-// top of Streamlit's own allowFullScreen).
-try {
-    var _fe = window.frameElement;
-    if (_fe) { _fe.allowFullscreen = true; _fe.setAttribute('allow', 'fullscreen'); }
-} catch (e) {}
 
 function renderGraph(args) {
     if (!visLoaded) { pendingArgs = args; return; }
@@ -1206,12 +1097,11 @@ function renderGraph(args) {
         network.on('beforeDrawing', function(ctx) { drawPathRings(ctx, pathRings); });
     }
     document.getElementById('download-btn').style.display = 'flex';
-    // Only offer fullscreen where there is a page to fullscreen.
+    // Only offer fullscreen where there is a page whose chrome we can hide.
     if (fullscreenSupported()) {
         document.getElementById('fullscreen-btn').style.display = 'flex';
         // A re-mount lands in a document that knows nothing, while the page may
-        // still be fullscreen: take the state from the page, and take over the
-        // hooks the last document owned.
+        // still be fullscreen: take the state from the page.
         syncFullscreenState();
     }
     // Restore selection + viewport after a genuine re-mount (e.g. the panel

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -385,12 +385,28 @@ def graph_space_css(find_row_open: bool) -> str:
     /* Render, cut back to its label. Streamlit's default button is 38px tall
        and stretched across its whole column, which made it the largest thing
        above the canvas — for a button that is only reached after changing
-       something else. */
+       something else.
+
+       Sized to its label means never below it: the column is a share of the
+       row, so on a narrow window it squeezed the button until "Render" broke
+       into "Rend / er". The label is held on one line and the button keeps its
+       own width, and it sits at the end of its column so the spare width stays
+       in the gap before it rather than between it and the page edge. */
+    .st-key-viz_render_btn {{
+        display: flex;
+        justify-content: flex-end;
+        width: 100%;
+    }}
     .st-key-viz_render_btn button {{
         min-height: 28px;
         height: 28px;
         padding: 0 0.9rem;
         line-height: 1.2;
+        width: max-content;
+        white-space: nowrap;
+    }}
+    .st-key-viz_render_btn button p {{
+        white-space: nowrap;
     }}{hide_find_row}
     </style>"""
 
@@ -606,8 +622,10 @@ def render_visualization():
         # laid out inline (see BAND_SWITCH_CSS), so they read as a set and no
         # label can be squeezed into breaking.
         st.html(BAND_SWITCH_CSS)
+        # The last column is wide enough for the button at the widths the app
+        # is actually used at; the spare width sits in the gap between the two.
         _switch_col, _, _render_col = st.columns(
-            [3.6, 1.9, 0.5], vertical_alignment="center"
+            [3.6, 1.4, 1.0], vertical_alignment="center"
         )
         with _switch_col.container(key="viz_band_switches"):
             options_open = st.toggle(

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -402,10 +402,14 @@ def graph_fullscreen_css(dark: bool) -> str:
     the component iframe. That gave the graph the screen and left every control
     outside it: Display options, Find & focus, Path finder, Node options and the
     details panel are all Streamlit's DOM, so reaching any of them meant leaving
-    fullscreen and going back in (issue #381). The viewer now fullscreens the
-    page itself and puts this class on the body, which hides what is not the
-    graph page — the sidebar, Streamlit's own header, the title and the section
-    tabs — so the controls come along and the room still goes to the canvas.
+    fullscreen and going back in (issue #381). The viewer puts this class on the
+    body instead, and it hides what is not the graph page — the sidebar,
+    Streamlit's own header, the title and the section tabs — so the controls come
+    along and the room still goes to the canvas.
+
+    This class is now the whole of fullscreen: the browser window is left alone,
+    because people build an ontology alongside other windows and the OS already
+    has a shortcut for anyone who does want the screen (issue #390).
 
     The rules are injected with the rest of the graph page, so they exist only
     while that page is on screen: if a rerun ever navigates away with the class
@@ -440,8 +444,8 @@ def graph_fullscreen_css(dark: bool) -> str:
         padding: 0.5rem 1rem 0 !important;
         max-width: none !important;
     }}
-    /* The page is the fullscreen box now: nothing should be scrolled out of it,
-       and the ground behind it is the graph's own, not the browser's black. */
+    /* The window is the fullscreen box: nothing should be scrolled out of it,
+       and the ground behind it is the graph's own. */
     body.{GRAPH_FS_CLASS} {{
         overflow: hidden;
         background: {bg};

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -229,12 +229,8 @@ class _FakeWindow:
         self.exposed = []
         self.title = None
         self.evaluated = []
-        self.uid = "master"
-        self.gui = None
-        # Real pywebview keeps the fullscreen state on the platform window, not
-        # here, so the fake tracks toggles rather than exposing a state field the
-        # bridge could read (a stub that did would overstate the API).
-        self.toggle_fullscreen_calls = 0
+        # `restored` is real pywebview's; it is kept here so a bridge that
+        # started watching it again would be caught rather than skipped.
         self.events = types.SimpleNamespace(loaded=_Event(), restored=_Event())
 
     def expose(self, *fns):
@@ -242,9 +238,6 @@ class _FakeWindow:
 
     def set_title(self, title):
         self.title = title
-
-    def toggle_fullscreen(self):
-        self.toggle_fullscreen_calls += 1
 
     def evaluate_js(self, js):
         self.evaluated.append(js)
@@ -328,9 +321,14 @@ def test_window_bridges_wire_clipboard(monkeypatch):
     assert any("__orionbeltClipboardBridge" in js for js in window.evaluated)
 
 
-def test_window_bridges_wire_fullscreen_toggle(monkeypatch):
-    """The bridge exposes a native fullscreen toggle for the graph button to call
-    when the webview lacks the HTML Fullscreen API (issue #177)."""
+def test_the_window_is_never_put_into_fullscreen(monkeypatch):
+    """The graph's Fullscreen button hides the app's chrome and stops there.
+
+    It used to route through a bridge to pywebview's toggle_fullscreen() where
+    the webview had no HTML Fullscreen API (issue #177), which took the whole
+    desktop window into fullscreen along with the graph. Nothing asks for the
+    screen any more (issue #390), so nothing is exposed to ask with.
+    """
     window = _FakeWindow()
     fake_webview = types.ModuleType("webview")
     fake_webview.create_window = lambda *a, **k: window
@@ -342,67 +340,12 @@ def test_window_bridges_wire_fullscreen_toggle(monkeypatch):
 
     webview.create_window("AppName", "http://localhost")
 
-    toggler = next(
-        fn for fn in window.exposed if fn.__name__ == "orionbelt_toggle_fullscreen"
-    )
-    # Each call reaches the native window and reports only that it got there:
-    # pywebview holds the resulting state on its platform window, and Qt flips it
-    # asynchronously, so the bridge deliberately doesn't claim to know it.
-    assert toggler() is True
-    assert window.toggle_fullscreen_calls == 1
-    assert toggler() is True
-    assert window.toggle_fullscreen_calls == 2
-
-    # A backend that can't toggle reports failure rather than raising into JS.
-    def _boom():
-        raise RuntimeError("no fullscreen here")
-
-    window.toggle_fullscreen = _boom
-    assert toggler() is None
-
-
-def test_native_fullscreen_exit_notifies_page(monkeypatch):
-    """Leaving fullscreen outside our button (Esc) must reach the page and reset
-    pywebview's tracked flag, or the graph overlay keeps covering the shrunken
-    window (issue #177 follow-up)."""
-    window = _FakeWindow()
-    view = types.SimpleNamespace(is_fullscreen=True)
-    window.gui = types.SimpleNamespace(
-        BrowserView=types.SimpleNamespace(instances={window.uid: view})
-    )
-    fake_webview = types.ModuleType("webview")
-    fake_webview.create_window = lambda *a, **k: window
-    monkeypatch.setitem(sys.modules, "webview", fake_webview)
-
-    desktop._install_window_bridges("AppName")
-
-    import webview
-
-    webview.create_window("AppName", "http://localhost")
-
-    assert window.events.restored, "no restored handler registered"
-    window.events.restored[0]()
-
-    assert any("__orionbeltNativeFullscreenExit" in js for js in window.evaluated)
-    # The stale flag is cleared so the next Fullscreen click enters again.
-    assert view.is_fullscreen is False
-
-
-def test_native_fullscreen_exit_survives_unknown_backend(monkeypatch):
-    """A backend without the internals we poke at must still notify the page."""
-    window = _FakeWindow()  # gui is None: no BrowserView to reach
-    fake_webview = types.ModuleType("webview")
-    fake_webview.create_window = lambda *a, **k: window
-    monkeypatch.setitem(sys.modules, "webview", fake_webview)
-
-    desktop._install_window_bridges("AppName")
-
-    import webview
-
-    webview.create_window("AppName", "http://localhost")
-    window.events.restored[0]()
-
-    assert any("__orionbeltNativeFullscreenExit" in js for js in window.evaluated)
+    assert [fn.__name__ for fn in window.exposed] == [
+        "orionbelt_set_window_title",
+        "orionbelt_copy_to_clipboard",
+    ]
+    # ...and no window event is watched for a fullscreen exit that can't happen.
+    assert not window.events.restored, "nothing should watch for a native exit"
 
 
 def test_copy_to_clipboard_uses_platform_command(monkeypatch):

--- a/tests/test_viz_fullscreen.py
+++ b/tests/test_viz_fullscreen.py
@@ -6,6 +6,7 @@ details panel behind it, and no other test would notice.
 """
 
 import ast
+import re
 from pathlib import Path
 
 import sources
@@ -228,7 +229,7 @@ def test_the_toolbar_says_what_its_buttons_do():
     up from there. The page draws them instead."""
     src = _VIEWER.read_text(encoding="utf-8")
 
-    for tip in ("Fullscreen", "Download as PNG", "Copy what is selected"):
+    for tip in ("Maximize", "Download as PNG", "Copy what is selected"):
         assert f'data-tip="{tip}"' in src
         assert f'aria-label="{tip}"' in src
     assert "title=" not in src.split("<body>", 1)[1].split("</button>", 1)[0]
@@ -238,6 +239,23 @@ def test_the_toolbar_says_what_its_buttons_do():
     # Every later change of what a button says goes through the one helper.
     assert "btn.title =" not in src
     assert src.count("setButtonTip(") >= 4
+
+
+def test_the_button_says_maximize_not_fullscreen():
+    """What the button does is fill the browser window; the screen and the OS
+    window are left alone (issue #390). So it is labelled the way a window
+    control is — Maximize, and Restore once it is one — and the word fullscreen
+    never reaches a user. Everything else here keeps the fullscreen names the
+    issues behind it use."""
+    src = _VIEWER.read_text(encoding="utf-8")
+    fn = src[src.index("function setFullscreenIcon(") :].split("\n}", 1)[0]
+    assert "'Restore' : 'Maximize'" in fn
+
+    said = re.findall(r'(?:data-tip|aria-label)="([^"]*)"', src)
+    said += re.findall(r"setButtonTip\([^,]+,\s*'([^']*)'", src)
+    assert said, "the button labels are read from the page, so they must be found"
+    for words in said:
+        assert "fullscreen" not in words.lower(), f"{words!r} says fullscreen"
 
 
 def test_a_tooltip_steps_aside_for_whatever_is_under_the_button():

--- a/tests/test_viz_fullscreen.py
+++ b/tests/test_viz_fullscreen.py
@@ -68,8 +68,8 @@ def test_graph_status_placeholder_is_unconditional():
     )
 
 
-def test_fullscreen_is_taken_on_the_page_not_on_the_canvas():
-    """The fullscreen element must be the *parent page's* root element.
+def test_fullscreen_hides_the_chrome_and_nothing_else():
+    """Entering fullscreen is one thing: the class on the *parent page's* body.
 
     Fullscreening the canvas' own container put the whole of Streamlit's DOM —
     Display options, Find & focus, Path finder, Node options, the details panel
@@ -79,13 +79,42 @@ def test_fullscreen_is_taken_on_the_page_not_on_the_canvas():
     src = _VIEWER.read_text(encoding="utf-8")
 
     enter = src[src.index("function enterFullscreen(") :].split("\n}", 1)[0]
-    assert "parentDoc()" in enter and "documentElement" in enter, (
-        "fullscreen must be requested on the parent page's root element"
+    assert "setStage(true)" in enter, (
+        "fullscreen is the chrome-hiding class on the page's body"
     )
     assert "getElementById('container')" not in enter, (
         "fullscreening the component's own container leaves every control "
         "outside it behind (issue #381)"
     )
+
+
+def test_the_window_is_left_alone():
+    """Fullscreen must not take the screen as well as the page.
+
+    The button used to call requestFullscreen() on the page (and pywebview's
+    toggle_fullscreen() on the desktop), which put the whole OS window into
+    fullscreen. An ontology is built alongside other windows, and the OS has its
+    own shortcut for anyone who does want the screen (issue #390).
+    """
+    # Comment lines are dropped: they are where the old behaviour is explained,
+    # and the point is that no code does it any more.
+    code = "\n".join(
+        line
+        for line in _VIEWER.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("//")
+    )
+
+    for banned in (
+        "requestFullscreen",
+        "exitFullscreen",
+        "fullscreenEnabled",
+        "fullscreenElement",
+        "orionbelt_toggle_fullscreen",
+        "allowFullscreen",
+    ):
+        assert banned not in code, (
+            f"{banned} takes the OS window into fullscreen with the graph (issue #390)"
+        )
 
 
 def test_the_fullscreen_state_lives_on_the_page():
@@ -97,17 +126,8 @@ def test_the_fullscreen_state_lives_on_the_page():
     assert f"var FS_CLASS = '{GRAPH_FS_CLASS}'" in src
     assert GRAPH_FS_CLASS in graph_fullscreen_css(dark=False)
     # And the button reads it back on mount rather than assuming "not fullscreen".
-    assert "setFullscreenIcon(on)" in src
+    assert "setFullscreenIcon(stageOn())" in src
     assert "syncFullscreenState()" in src
-
-
-def test_only_our_own_page_fullscreen_is_followed():
-    """Streamlit fullscreens elements of its own (the chart and image
-    expanders). Following one of those would hide the app's chrome behind
-    somebody else's fullscreen element."""
-    src = _VIEWER.read_text(encoding="utf-8")
-    fn = src[src.index("function pageFullscreenOn(") :].split("\n}", 1)[0]
-    assert "=== d.documentElement" in fn
 
 
 def test_selections_reach_python_while_fullscreen():
@@ -134,28 +154,33 @@ def test_selections_reach_python_while_fullscreen():
         )
 
 
-def test_the_native_exit_hook_is_reclaimed_by_every_mount():
-    """The desktop host calls a hook on the top window when its own window
-    leaves fullscreen (Esc, the green button, the Window menu). The hook is a
-    function of the document that installed it, and fullscreen now outlives
-    that document — so a mount that finds the page still fullscreen has to
-    claim the hook back, or the chrome stays hidden with nobody to put it back.
-    """
+def test_the_state_is_read_back_by_every_mount():
+    """A re-mount lands in a document that knows nothing while the page may still
+    be fullscreen, so the button would offer to enter what it is already in."""
     src = _VIEWER.read_text(encoding="utf-8")
     sync = src[src.index("function syncFullscreenState(") :].split("\n}", 1)[0]
-    assert "installNativeFsExitHook()" in sync
-    assert "setNativeFsExitHook(null)" in sync
+    assert "stageOn()" in sync
     # ...and that is what a fresh render runs.
     assert "syncFullscreenState();" in src
-    assert "setFullscreenIcon(stageOn())" not in src
+
+
+def test_escape_leaves_fullscreen():
+    """The browser used to do this for us, back when the page was the fullscreen
+    element. Expanding inside the window means wiring Esc up by hand, in both
+    documents: the key lands in the viewer's while the canvas has focus and in
+    the page's while any of the controls do (issue #390)."""
+    src = _VIEWER.read_text(encoding="utf-8")
+    fn = src[src.index("function onEscape(") :].split("\n}", 1)[0]
+    assert "'Escape'" in fn and "leaveFullscreen()" in fn
+    assert "document.addEventListener('keydown', onEscape)" in src
+    assert "d.addEventListener('keydown', onEscape)" in src
 
 
 def test_the_page_listener_is_removed_with_the_document():
     """The listener is registered on the parent, which outlives this document by
     many re-mounts. Without the teardown each mount piles another dead one on."""
     src = _VIEWER.read_text(encoding="utf-8")
-    assert "d.addEventListener('fullscreenchange', onPageFullscreenChange)" in src
-    assert "d.removeEventListener('fullscreenchange', onPageFullscreenChange)" in src
+    assert "d.removeEventListener('keydown', onEscape)" in src
     assert "window.addEventListener('pagehide'" in src
 
 
@@ -185,10 +210,10 @@ def test_fullscreen_hides_the_app_chrome_but_not_the_controls():
 
 
 def test_the_canvas_measures_the_page_not_its_own_iframe():
-    """A fullscreen page does not resize the component iframe, so the iframe's
-    own window.innerHeight says nothing about the box to fill. The height comes
-    from the page's viewport in both states — there is no separate fullscreen
-    measurement left to drift (issue #177 follow-up)."""
+    """The iframe's own window.innerHeight is the height of the slot Streamlit
+    gave it, not of the page, so it says nothing about the box to fill. The
+    height comes from the page's viewport in both states — there is no separate
+    fullscreen measurement left to drift (issue #177 follow-up)."""
     src = _VIEWER.read_text(encoding="utf-8")
     fn = src[src.index("function viewportHeight(") :].split("\n}", 1)[0]
     assert "documentElement.clientHeight" in fn

--- a/tests/test_viz_room_for_the_graph.py
+++ b/tests/test_viz_room_for_the_graph.py
@@ -68,6 +68,19 @@ def test_render_is_sized_to_its_label():
     assert ".st-key-viz_render_btn button" in graph_space_css(True)
 
 
+def test_the_render_label_never_breaks():
+    """The button's column is a share of the row, so a narrow window squeezed
+    it until "Render" broke into "Rend / er". The label is held on one line and
+    the button keeps its own width whatever the column does."""
+    css = graph_space_css(True)
+    button = css[css.index(".st-key-viz_render_btn button {") :]
+    button = button[: button.index("}")]
+    assert "white-space: nowrap" in button
+    assert "width: max-content" in button
+    # The label is its own element inside the button, and it wraps on its own.
+    assert ".st-key-viz_render_btn button p" in css
+
+
 def test_the_page_keeps_its_own_spacing():
     """The title, the section tabs and the gaps between the rows are left
     alone: the room comes from the controls, not from crowding the page."""


### PR DESCRIPTION
Closes #390.

## What was wrong

The graph's `Fullscreen` button did two separate things: it hid the app's chrome (sidebar, header, title, tabs) so the canvas and its controls got the whole page, and it also put the browser window into OS fullscreen. Only the first is what the button is for. As #390 puts it, an ontology gets built alongside other windows, and anyone who does want the screen already has their system's own shortcut for it.

## What changed

Fullscreen is now the chrome-hiding class on the page's body and nothing else.

- No `requestFullscreen()` on the page, and no `exitFullscreen()`.
- No pywebview `orionbelt_toggle_fullscreen` bridge, which was the desktop equivalent (issue #177), and no `__orionbeltNativeFullscreenExit` hook or `restored` event watcher to put the chrome back after a native exit. All of that existed only to serve this button.
- Esc used to come free with the Fullscreen API, so it is wired up by hand: on the viewer's document, where the key lands while the canvas has focus, and on the page's, where it lands while any of the controls do.
- The `#container:fullscreen` rule and the iframe's `allowFullscreen` grant go with them.

Everything the button is actually for is unchanged: the graph fills the window, keeps Display options / Find & focus / Path finder / Node options / the details panel alongside it (#381), zooms out ~30% on entry and restores the viewport on exit, and survives a Streamlit rerun with the button reading its state back off the page (#372).

## Verified

Live in the running app, in Visualization:

- Entering hides the sidebar and header, the canvas takes the window, and `document.fullscreenElement` stays `null`.
- Esc leaves fullscreen, both from the page and from inside the graph iframe.
- Toggling a display switch while fullscreen reruns the app: the state holds and the button still reads "Restore".
- No console errors.

`pytest` (1891 passed), `ruff format --check`, `ruff check` and `mypy` are all clean. `tests/test_viz_fullscreen.py` gains `test_the_window_is_left_alone`, which fails if `requestFullscreen`, `exitFullscreen` or the pywebview toggle comes back, and `test_escape_leaves_fullscreen`; `tests/test_desktop.py` pins the exposed bridge to the two functions that remain.

## Also in here

**The button is called Maximize.** With the screen and the OS window left alone, `Fullscreen` promised something the button no longer does, so it says `Maximize`, and `Restore` once it is. Only the words a user reads changed: the class, the functions and the tests around them keep the fullscreen names the issues behind them use. `test_the_button_says_maximize_not_fullscreen` pins the pair and fails if the word reaches a tooltip or an aria-label again.

**Render no longer breaks in half.** The button is a share of its row, so a narrow window squeezed it until the label wrapped into `Rend / er`. The label is held on one line, the button keeps its own width whatever its column does, and the column is wide enough for it at the widths the app is used at, with the spare width left in the gap before it. Measured live at 1100, 1000, 760 and 620 CSS px: one line at every one of them, flush with the right edge of the row, and no page overflow once Streamlit stacks the columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
