### PR TITLE
fix(viz): a focus click is applied without a toast about it (#389)

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1636,10 +1636,10 @@ def focus_seeds_after_request(seeds, label, replace=False, focus_on=False):
 def viz_apply_focus_click(label, replace=False):
     """Apply a modifier-click on ``label`` to the focus state in session.
 
-    Returns the ``(seeds, focus_on)`` it wrote, so the caller can word the
-    toast. Split out from the page so the state it touches can be tested: the
-    click arrives through the graph component, which does not render under
-    AppTest, so nothing else can reach this path.
+    Returns the ``(seeds, focus_on)`` it wrote. Split out from the page so the
+    state it touches can be tested: the click arrives through the graph
+    component, which does not render under AppTest, so nothing else can reach
+    this path.
 
     Mode and seeds are written together, never across renders: focus mode with
     no seeds backfills an arbitrary first label, so a pass through that state

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -2980,20 +2980,16 @@ def render_visualization():
                     _id_to_label = {v: k for k, v in focus_targets.items()}
                     _focus_label = _id_to_label.get(selection.get("nodeId"))
                     if _focus_label:
-                        _replace = bool(selection.get("replace"))
-                        _seeds, _focus_on = viz_apply_focus_click(
-                            _focus_label, replace=_replace
+                        # Applied without a word about it. A toast confirming a
+                        # click the user just made is a second telling: the
+                        # canvas redraws to the focus, and the standing note on
+                        # the Node options label names the seeds, the depth and
+                        # what is held back — and stays there instead of fading
+                        # (issues #389, #222 follow-up). What is still said here
+                        # is the case below, where the click did nothing.
+                        viz_apply_focus_click(
+                            _focus_label, replace=bool(selection.get("replace"))
                         )
-                        if not _focus_on:
-                            _note = "Focus off"
-                        elif _focus_label not in _seeds:
-                            # Ctrl/Cmd-click took it out and left others behind.
-                            _note = f"Dropped {_focus_label} from the focus"
-                        else:
-                            _note = f"Focusing on {_focus_label}" + (
-                                " only" if _replace else ""
-                            )
-                        st.toast(_note, icon="🎯")
                         st.rerun()
                     else:
                         st.toast(

--- a/tests/test_viz_focus_click.py
+++ b/tests/test_viz_focus_click.py
@@ -12,6 +12,7 @@ that changed was a no-op before.
 """
 
 import pytest
+import sources
 
 from orionbelt_ontology_builder import app, ui
 
@@ -195,3 +196,31 @@ def test_a_click_that_leaves_the_mode_alone_does_not_mark_it_dirty(session):
 
     assert session["_viz_cfg_focus_seeds"] == [PERSON, ORG]
     assert "_viz_settings_dirty" not in session
+
+
+def test_a_focus_click_is_not_announced():
+    """A toast confirming a click the user just made was a second telling, and
+    a distracting one while working (issue #389): the canvas redraws to the
+    focus, and the standing note on the Node options label names the seeds, the
+    depth and what is held back, without fading.
+
+    Pinned at the source because the click arrives through the graph component,
+    which does not render under AppTest.
+    """
+    src = sources.viz_text()
+    branch = src[src.index('selection.get("focusRequest")') :]
+    branch = branch[: branch.index("# Status bar outside iframe")]
+
+    assert "viz_apply_focus_click(" in branch, "the click must still be applied"
+    assert 'icon="🎯"' not in branch
+    # What is still said here is the click that did nothing at all, which
+    # nothing else on the page explains.
+    assert "Focus is available for classes" in branch
+
+
+def test_the_focus_that_ended_itself_still_says_so():
+    """The other 🎯 toast stays: focus mode ending on its own is not something
+    the user did, and un-ticking the box in silence is what issue #335 was."""
+    src = sources.viz_text()
+    assert "_viz_focus_left_note" in src
+    assert "Focus off: nothing left to focus on" in src


### PR DESCRIPTION
Addresses #389.

## What was wrong

Ctrl/Cmd-clicking a node in the graph raised a toast in the top right corner saying what had just been clicked: `Focusing on Class: Person`, `Dropped Class: Person from the focus`, `Focus off`. It is a second telling of something the user did on purpose, it sits there for four seconds at a time (measured: added 157ms after the click, removed at 4160ms), and it repeats all through a working session, which is what #389 is about.

### It was also wrong as soon as you worked at speed

A toast is reused for the same point in the script, and one already on screen is not re-shown. So a second focus click inside those four seconds changed nothing in the corner. Measured on `main`, cmd-clicking real nodes on the canvas:

| t | event | toast in the corner |
| --- | --- | --- |
| 0.03s | cmd-click `Person` | `🎯 Focusing on Class: Person` |
| 1.05s | cmd-click `Department`, toast still up | still `...Person` |
| 1.3s to 3.8s | | still `...Person`: one distinct toast text across the whole window |
| 4.09s | | gone, and no toast for the second click ever appeared |

The second click had applied all along: the focus ended at `Focused on Person · 1 hop`, meaning `Department` had been taken back out of it while the corner still read "Focusing on Class: Person". So for the second click the toast said nothing, and what it did say named the wrong node. The note has no such window; it was correct at every sample.

## What changed

The click is applied and the page reruns, with nothing said about it. What was already there says more, and stays:

- The canvas redraws to the focused neighbourhood.
- The note on the Node options label reads `Focused on Person, Department · 1 hop · 12 hidden by focus`. It names the seeds (up to five, then a count), the depth and what is held back, it is visible whether the panel is open or closed, it does not fade, and it keeps up with clicks that come faster than a toast can.

The other toasts on the page are left alone, and each for its own reason:

- **Focus ended by itself** (`🎯 Focus off: nothing left to focus on`) is not something the user did. Un-ticking the box in silence is precisely what issue #335 was filed about.
- **What a filter kept out of the view** (`🙈`) is the same kind of thing: state the user did not set, and it is announced as it happens (issue #194).
- **A modifier-click that did nothing** (`ℹ️ Focus is available for classes, individuals, and SKOS concepts`) explains why nothing happened, which nothing else on the page does.

## Verified

Live in the running app, on the org template:

- Modifier-click on `Person`: no toast, the note reads `Focused on Person · 1 hop`, and the graph redraws to the focus.
- Modifier-click on `Person` again, which takes it back out: no toast, and the note goes empty, focus off.
- The same measurement run against `main` for a control, since an absent toast proves nothing unless the toast was there to begin with: a DOM observer catches it being added 157ms after the click and removed at 4160ms, at full opacity throughout. On this branch the observer sees nothing.

`pytest` (1913 passed), `ruff format --check`, `ruff check` and `mypy` are all clean. `tests/test_viz_focus_click.py` gains two source-level pins: one that this branch applies the click and says nothing, one that the focus-that-ended-itself toast is still there. They are pinned at the source because the click arrives through the graph component, which does not render under AppTest.

## Note on scope

The patch in #389 also comments out the other two toasts. Those are the ones that report state the user did not cause, so they are kept here. If they are unwanted as well, the better answer than deleting them is a persisted "Graph notifications" setting alongside the other display settings, and that can be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
