### PR TITLE
fix(viz): say when a focus has nothing left to focus on (#389 follow-up)

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -5808,7 +5808,12 @@ _FILTER_KINDS = (
 
 
 def viz_hidden_caption(
-    focus_mode, focus_seeds, focus_depth, focus_hidden, hidden_by_filter
+    focus_mode,
+    focus_seeds,
+    focus_depth,
+    focus_hidden,
+    hidden_by_filter,
+    focusable_drawn=True,
 ) -> str:
     """One line saying what is not on screen, or "" when everything is.
 
@@ -5818,7 +5823,19 @@ def viz_hidden_caption(
 
     Seeds are listed by name up to five, then counted, so a focus on half the
     ontology stays one short line.
+
+    ``focusable_drawn`` is False when Classes, Individuals and SKOS are all
+    switched off: focus mode is still on and still holding its seeds, but there
+    is nothing it can act on. The page says so inside the Node options panel,
+    which is closed by default, so on its own that left the switch on, the graph
+    unfocused and no visible reason why (issue #389 follow-up). This line is
+    read whether the panel is open or shut, so it is where the state belongs.
     """
+    if focus_mode and not focusable_drawn:
+        stalled = "Focus is on, but Classes, Individuals and SKOS are all off"
+        if hidden_by_filter:
+            stalled += f" · {hidden_by_filter} hidden by the node filter"
+        return stalled
     parts = []
     if focus_mode and focus_seeds:
         shown = [s.split(": ", 1)[-1] for s in focus_seeds[:5]]

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -2802,10 +2802,29 @@ def render_visualization():
             (gdata or {}).get("focus_hidden", 0),
             (len(filters["class"]["uris"]) - len(filters["class"]["selected_uris"]))
             + (len(filters["ind"]["uris"]) - len(filters["ind"]["selected_uris"])),
+            focusable_drawn=bool(focus_targets),
         )
         if _note_now != st.session_state.get("_viz_hidden_note", ""):
             st.session_state["_viz_hidden_note"] = _note_now
             st.rerun()
+        # What is worth a toast, and what is not (issue #389).
+        #
+        # A toast is for what the user did *not* do: something the app decided
+        # on its own (focus leaving itself, entities a filter held back), or an
+        # action of theirs that could not be carried out. What they did on
+        # purpose is shown in the page instead — the note on the Node options
+        # label, the status bar under the canvas — where it stays put and can be
+        # read at leisure.
+        #
+        # This is not a style preference. Streamlit shows a toast when its
+        # element mounts and will not re-show one already on screen, so a second
+        # message inside the four seconds a toast lives is dropped: the corner
+        # keeps the older text and the newer event goes unreported. Anything
+        # that can fire twice in quick succession — a click, above all — is
+        # therefore the worst possible fit for this channel. The per-click focus
+        # confirmation that used to live below did exactly that, and lied about
+        # which node was focused while it did.
+        #
         # Past that rerun, so it survives to reach the user: what the filter
         # kept out of the view when it was created (issue #194).
         for _announcement in (

--- a/tests/test_viz_delete.py
+++ b/tests/test_viz_delete.py
@@ -14,6 +14,7 @@ cannot run the Visualization page twice, and the panel is what is under test.
 
 import os
 
+import sources
 from streamlit.testing.v1 import AppTest
 
 from orionbelt_ontology_builder import app
@@ -280,6 +281,39 @@ def test_many_seeds_stay_one_short_line():
     assert app.viz_hidden_caption(True, seeds, 2, 3, 0) == (
         "Focused on C0, C1, C2, C3, C4, … (+4) · 2 hops · 3 hidden by focus"
     )
+
+
+def test_a_focus_with_nothing_focusable_says_so():
+    """Switch Classes, Individuals and SKOS all off and focus mode is still on,
+    still holding its seeds, with nothing it can act on. The page says so inside
+    the Node options panel, which is shut by default, so on its own that left
+    the switch on and no visible reason why (issue #389 follow-up)."""
+    assert app.viz_hidden_caption(
+        True, ["Class: Person"], 1, 0, 0, focusable_drawn=False
+    ) == ("Focus is on, but Classes, Individuals and SKOS are all off")
+
+
+def test_a_stalled_focus_still_reports_the_node_filter():
+    assert app.viz_hidden_caption(
+        True, ["Class: Person"], 1, 0, 4, focusable_drawn=False
+    ) == (
+        "Focus is on, but Classes, Individuals and SKOS are all off · 4 hidden "
+        "by the node filter"
+    )
+
+
+def test_the_caption_assumes_something_focusable_is_drawn():
+    """The flag is the exception, so the ordinary call sites read as they did."""
+    assert app.viz_hidden_caption(True, ["Class: Person"], 1, 6, 0) == (
+        "Focused on Person · 1 hop · 6 hidden by focus"
+    )
+
+
+def test_the_page_tells_the_caption_whether_anything_is_focusable():
+    """The caption cannot see the display switches; the page passes what it
+    found. Pinned at the source: the graph component does not render under
+    AppTest, and this line is what makes the case above reachable."""
+    assert "focusable_drawn=bool(focus_targets)" in sources.viz_text()
 
 
 def test_the_node_filter_is_reported_on_its_own():


### PR DESCRIPTION
Follow-up to #393 (issue #389).

## Say when a focus has nothing left to focus on

Switch Classes, Individuals and SKOS all off while a focus is running, and focus mode stays on holding seeds it cannot act on. The page does say so, in an `st.info` inside the Node options panel, which is shut by default. On its own that leaves the switch on, the graph unfocused, and no visible reason why.

The note on the panel's label is read whether the panel is open or shut, and it is already where a focus reports itself, so it now reports this too. Measured with the switch flipped the way a user flips it:

| state | focus mode | seeds | note on the label |
| --- | --- | --- | --- |
| focus running, Classes on | on | `Class: Person` | `Focused on Person · 1 hop` |
| Classes just switched off | still on | emptied | **`Focus is on, but Classes, Individuals and SKOS are all off`** |

The `st.info` inside the panel stays as it is: open the panel and it says the same thing at more length, which is the same split the note already has with the filter controls.

## And the rule, written down

The toast work in #393 arrived at a rule, and nothing recorded it. It now sits beside the toasts it governs in `render_visualization`:

> A toast is for what the user did **not** do: something the app decided on its own, or an action of theirs that could not be carried out. What they did on purpose is shown in the page instead.

The reason is mechanical, not a style preference, which is why it is worth writing down: Streamlit shows a toast when its element mounts and will not re-show one already on screen, so a second message inside the four seconds a toast lives is dropped. The corner keeps the older text and the newer event goes unreported. Anything that can fire twice in quick succession, a click above all, is the worst possible fit for that channel. That is what made the per-click focus toast in #393 not merely redundant but wrong.

## Verified

`pytest` (1917 passed), `ruff format --check`, `ruff check` and `mypy` are clean. Four tests added in `tests/test_viz_delete.py` next to the other caption tests: the stalled focus line, the same line alongside a node filter count, that an ordinary call is unchanged, and a source-level pin that the page passes `focusable_drawn=bool(focus_targets)` (the graph component does not render under AppTest, so that call site cannot be reached from a rendered page).

Behaviour confirmed by driving the Classes switch through AppTest, which fires the widget callback exactly as the browser does, and reading the state before and after (the table above).

## Not in here

Switching Classes off also empties the focus seeds, so switching it back on does not restore the focus you had. That is existing behaviour, it is not what this change is about, and it deserves its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
