### PR TITLE
fix(viz): hiding an entity type sets its focus seeds aside (#396)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -61,7 +61,9 @@ from .ui import (  # noqa: F401
     SPARQL_STATE_KEY,
     VIZ_FILE_STATE_KEY,
     VIZ_FILE_STATE_MAX_FILES,
+    VIZ_FOCUS_SEED_KINDS,
     VIZ_NODE_PANEL,
+    VIZ_PARKED_SEEDS_KEY,
     VIZ_SETTINGS_KEY,
     _apply_annotation_edit,
     _apply_class_edit,
@@ -254,9 +256,12 @@ from .ui import (  # noqa: F401
     viz_node_id,
     viz_note_rename,
     viz_ontology_was_replaced,
+    viz_park_focus_seeds,
     viz_rename_map,
     viz_set_focus_seeds,
+    viz_show_kind_toggled,
     viz_sync,
+    viz_unpark_focus_seeds,
 )
 
 # The pages, re-exported so ``app.render_classes`` and friends still resolve.

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -63,6 +63,20 @@ _VIZ_INT_RANGES = {
     "node_spacing": (50, 300),
     "focus_depth": (1, 5),
 }
+#: Which display switch each focus-seed kind rides on. A seed label carries its
+#: kind (``Class: Person``, see ``_focus_target``), which is what lets a seed
+#: whose entity is gone be told from one whose type is merely switched off
+#: (issue #396).
+VIZ_FOCUS_SEED_KINDS = {
+    "Class": "_viz_cfg_show_classes",
+    "Individual": "_viz_cfg_show_individuals",
+    "Data Property": "_viz_cfg_show_data_props",
+    "Concept": "_viz_cfg_show_skos",
+}
+#: Seeds set aside while their entity type is switched off, as
+#: ``{kind: {"seeds": [...], "focus_mode": bool}}``. Session-only: a focus does
+#: not outlive a reload either.
+VIZ_PARKED_SEEDS_KEY = "_viz_parked_focus_seeds"
 VIZ_FILE_STATE_KEY = "viz_file_state"
 VIZ_FILE_STATE_MAX_FILES = 20
 #: Where the chosen language pack and any custom ones are stored (issue #252) —
@@ -1661,6 +1675,73 @@ def viz_apply_focus_click(label, replace=False):
     return seeds, focus_on
 
 
+def _viz_seeds_of_kind(kind_word):
+    """The current focus seeds belonging to ``kind_word``."""
+    prefix = f"{kind_word}: "
+    seeds = st.session_state.get("_viz_cfg_focus_seeds") or []
+    return [s for s in seeds if isinstance(s, str) and s.startswith(prefix)]
+
+
+def viz_park_focus_seeds(kind_word) -> None:
+    """Set this kind's focus seeds aside while its entity type is switched off.
+
+    The render prune still drops them from the live seeds, as it must: they
+    resolve to nothing while the type is off, and a seed that resolves to
+    nothing cannot be left in play (the Codex review of PR #336). What is kept
+    here is the copy to put back, along with whether focus mode was running,
+    since restoring the seeds and leaving the mode off is only half the job.
+    """
+    going = _viz_seeds_of_kind(kind_word)
+    if not going:
+        return
+    parked = dict(st.session_state.get(VIZ_PARKED_SEEDS_KEY) or {})
+    parked[kind_word] = {
+        "seeds": going,
+        "focus_mode": bool(st.session_state.get("_viz_cfg_focus_mode")),
+    }
+    st.session_state[VIZ_PARKED_SEEDS_KEY] = parked
+
+
+def viz_unpark_focus_seeds(kind_word) -> None:
+    """Put this kind's seeds back now its entity type is drawn again (#396).
+
+    Merged rather than assigned: seeds picked while the type was off are the
+    user's current focus and stay. Nothing is validated here — the seeds come
+    back with no entry in the label -> id map, which is the state of a seed the
+    user has just picked, so the next render's prune keeps the ones that resolve
+    and drops the ones whose entity has gone in the meantime.
+    """
+    parked = dict(st.session_state.get(VIZ_PARKED_SEEDS_KEY) or {})
+    entry = parked.pop(kind_word, None)
+    if not entry:
+        return
+    st.session_state[VIZ_PARKED_SEEDS_KEY] = parked
+    seeds = list(st.session_state.get("_viz_cfg_focus_seeds") or [])
+    seen = set(seeds)
+    viz_set_focus_seeds(seeds + [s for s in entry["seeds"] if s not in seen])
+    if entry.get("focus_mode") and not st.session_state.get("_viz_cfg_focus_mode"):
+        # The config key only: the next render copies it into the checkbox's
+        # widget key, and writing that here raises once the checkbox exists.
+        st.session_state["_viz_cfg_focus_mode"] = True
+        st.session_state["_viz_settings_dirty"] = True
+
+
+def viz_show_kind_toggled(cfg_key, wid_key, kind_word) -> None:
+    """An entity-type switch that focus seeds depend on (issue #396).
+
+    Persists the setting like any other display switch, and then parks or
+    restores the seeds of that kind. Done here rather than in the render prune
+    because this is the one place that knows the switch is what changed: to the
+    prune, a seed whose type was just switched off and one whose entity was just
+    deleted look exactly alike.
+    """
+    viz_sync(cfg_key, wid_key)
+    if st.session_state.get(cfg_key):
+        viz_unpark_focus_seeds(kind_word)
+    else:
+        viz_park_focus_seeds(kind_word)
+
+
 def viz_focus_toggle():
     """Persist the focus toggle, seeding the focus nodes on first use.
 
@@ -1680,6 +1761,11 @@ def viz_focus_toggle():
     on = st.session_state["viz_focus_mode"]
     st.session_state["_viz_cfg_focus_mode"] = on
     st.session_state["_viz_settings_dirty"] = True
+    if not on:
+        # Switching the mode off by hand is a decision about the focus, so a
+        # parked type coming back must not switch it on again behind the user
+        # (issue #396).
+        st.session_state.pop(VIZ_PARKED_SEEDS_KEY, None)
     if on and not st.session_state.get("_viz_cfg_focus_seeds"):
         # Forgotten wholesale rather than trimmed: these labels are derived
         # from the class selection, not picked by the user as seeds, so an id on

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1498,6 +1498,15 @@ def viz_drop_focus_seeds() -> None:
     # Notes about entities the seeds were meant to follow; with no seeds left
     # there is nothing to re-point (see viz_note_rename).
     st.session_state.pop("_viz_pending_renames", None)
+    # And the seeds set aside while their type is hidden (issue #396). This
+    # helper is also the focus half of the reset that runs when the linked file
+    # changes (see _clear_viz_file_session_state), and a parked seed names the
+    # entities of the file it was parked in. Left behind, switching the type
+    # back on in the *next* file would restore that label into it — and a
+    # restored seed deliberately carries no id, so a file that happens to have a
+    # class of the same name would be focused, and saved, as though the user had
+    # asked for it.
+    st.session_state.pop(VIZ_PARKED_SEEDS_KEY, None)
 
 
 def _viz_widget_missing(wid_key: str) -> bool:

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -82,6 +82,7 @@ from ..ui import (
     viz_ontology_was_replaced,
     viz_rename_map,
     viz_set_focus_seeds,
+    viz_show_kind_toggled,
     viz_sync,
 )
 
@@ -675,8 +676,8 @@ def render_visualization():
                 st.checkbox(
                     "Classes",
                     key="viz_show_classes",
-                    on_change=viz_sync,
-                    args=("_viz_cfg_show_classes", "viz_show_classes"),
+                    on_change=viz_show_kind_toggled,
+                    args=("_viz_cfg_show_classes", "viz_show_classes", "Class"),
                 )
             with _cols[1]:
                 st.checkbox(
@@ -689,8 +690,12 @@ def render_visualization():
                 st.checkbox(
                     "Data Props",
                     key="viz_show_data_props",
-                    on_change=viz_sync,
-                    args=("_viz_cfg_show_data_props", "viz_show_data_props"),
+                    on_change=viz_show_kind_toggled,
+                    args=(
+                        "_viz_cfg_show_data_props",
+                        "viz_show_data_props",
+                        "Data Property",
+                    ),
                 )
             with _cols[3]:
                 st.checkbox(
@@ -703,8 +708,12 @@ def render_visualization():
                 st.checkbox(
                     "Individuals",
                     key="viz_show_individuals",
-                    on_change=viz_sync,
-                    args=("_viz_cfg_show_individuals", "viz_show_individuals"),
+                    on_change=viz_show_kind_toggled,
+                    args=(
+                        "_viz_cfg_show_individuals",
+                        "viz_show_individuals",
+                        "Individual",
+                    ),
                 )
             _ind_edge_col, _triple_col = (
                 (_cols[6], _cols[7]) if _has_skos else (_cols[5], _cols[6])
@@ -714,8 +723,8 @@ def render_visualization():
                     st.checkbox(
                         "SKOS",
                         key="viz_show_skos",
-                        on_change=viz_sync,
-                        args=("_viz_cfg_show_skos", "viz_show_skos"),
+                        on_change=viz_show_kind_toggled,
+                        args=("_viz_cfg_show_skos", "viz_show_skos", "Concept"),
                     )
             with _ind_edge_col:
                 st.checkbox(

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -16,6 +16,7 @@ from ..ui import (
     PATH_HIGHLIGHT_COLOR,
     PKG_DIR,
     VIZ_NODE_PANEL,
+    VIZ_PARKED_SEEDS_KEY,
     _build_name_collision_set,
     _disambiguated_name,
     _edge_id,
@@ -1015,6 +1016,15 @@ def render_visualization():
             # whatever happens to hold that URI now, which is the very thing the
             # reuse prune below exists to stop (issue #180).
             _renames = None
+            # So do seeds parked while their type is hidden (issue #396), and
+            # they slip past that prune rather than being caught by it: a
+            # restored seed deliberately carries no id, which is the state of a
+            # seed just picked, so the prune keeps it — against whatever now
+            # answers to that label. An id would not save it either, since a
+            # same-named entity in the new ontology can be given the same node
+            # id, which is why the prune exists at all. Dropped, like the notes
+            # (Codex review of PR #397).
+            st.session_state.pop(VIZ_PARKED_SEEDS_KEY, None)
         # The graph component carries a renamed node's cached position over to
         # the id it now has, so the render it lands on stays where it was
         # instead of re-framing the whole graph (issue #329). Flattened here

--- a/tests/test_viz_file_state.py
+++ b/tests/test_viz_file_state.py
@@ -422,6 +422,29 @@ def test_relinking_does_not_write_the_old_files_seeds_under_the_new_file(
     assert stored[FILE_B]["focus_seed_ids"] == [app._uid(NS + "Person")]
 
 
+def test_relinking_forgets_seeds_parked_in_the_previous_file(monkeypatch, tmp_path):
+    """A seed set aside while its type is hidden (issue #396) names entities of
+    the file it was parked in, so the switch that clears the rest of a file's
+    session state has to take it too — or switching the type back on in the new
+    file restores the old file's label into it."""
+    _desktop(monkeypatch, tmp_path, linked=FILE_B)
+    session = _Session()
+    monkeypatch.setattr(app.st, "session_state", session)
+
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = ["Class: Person"]
+    session["viz_show_classes"] = False
+    app.viz_show_kind_toggled("_viz_cfg_show_classes", "viz_show_classes", "Class")
+    assert session[app.VIZ_PARKED_SEEDS_KEY]["Class"]["seeds"] == ["Class: Person"]
+
+    app._clear_viz_file_session_state()
+
+    assert app.VIZ_PARKED_SEEDS_KEY not in session
+    session["viz_show_classes"] = True
+    app.viz_show_kind_toggled("_viz_cfg_show_classes", "viz_show_classes", "Class")
+    assert not session.get("_viz_cfg_focus_seeds")
+
+
 def test_relinking_mid_session_restores_the_new_file(monkeypatch, tmp_path):
     _desktop(monkeypatch, tmp_path, linked=FILE_B)
     monkeypatch.setattr(app.st, "session_state", {})

--- a/tests/test_viz_focus_parking.py
+++ b/tests/test_viz_focus_parking.py
@@ -176,6 +176,54 @@ def test_the_focus_reset_forgets_what_was_parked(session):
     assert not session.get("_viz_cfg_focus_seeds")
 
 
+def _replacement_script():
+    """The page, rendered with a seed parked and an ontology swap pending."""
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager(base_uri="http://test.org/ont#")
+        om.add_class("Person", label="Person")
+        om.add_class("Org", label="Org")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["_viz_settings_restored"] = True
+        st.session_state["_local_storage"] = None
+        # A focus parked while Classes is hidden, in the ontology being left.
+        st.session_state["_viz_cfg_show_classes"] = False
+        st.session_state[app.VIZ_PARKED_SEEDS_KEY] = {
+            "Class": {"seeds": ["Class: Person"], "focus_mode": True}
+        }
+        # Counters that say "swapped, not edited": a load, import, new or undo.
+        st.session_state["_viz_cfg_seen_mutation"] = 1
+        st.session_state["_viz_cfg_seen_edits"] = 0
+        st.session_state["_ont_mutation_count"] = 2
+        st.session_state["_ont_edit_count"] = 0
+
+    app.render_visualization()
+
+
+def test_a_replaced_ontology_forgets_what_was_parked():
+    """Park a seed, then import a different ontology over the same file. The
+    label names an entity that is gone, and a restored seed carries no id by
+    design, so the reuse prune would read it as freshly picked and keep it
+    against whatever now answers to that label, which is the very thing that
+    prune exists to stop (#180, Codex review of PR #397). An id would not help
+    either: a same-named entity in the new ontology can be given the same node
+    id."""
+    from streamlit.testing.v1 import AppTest
+
+    at = AppTest.from_function(_replacement_script)
+    at.run(timeout=120)
+    assert not at.exception, at.exception
+
+    assert app.VIZ_PARKED_SEEDS_KEY not in at.session_state, (
+        "seeds parked in the ontology that was swapped out must not survive it"
+    )
+
+
 def test_a_type_with_no_seeds_parks_nothing(session):
     session["_viz_cfg_focus_mode"] = True
     session["_viz_cfg_focus_seeds"] = [ALICE]

--- a/tests/test_viz_focus_parking.py
+++ b/tests/test_viz_focus_parking.py
@@ -1,0 +1,204 @@
+"""Switching an entity type off sets its focus seeds aside (issue #396).
+
+They used to be deleted. The focus block prunes its seeds to what ``focus_targets``
+can resolve and writes the pruned list back, and ``focus_targets`` only carries
+the types whose switch is on, so unticking Classes destroyed a focus built on
+classes. Ticking it back on left the user to rebuild it by hand.
+
+The prune stays as it is: a seed that resolves to nothing cannot be left in play
+(the Codex review of PR #336). What changed is that the switch itself, which is
+the one place that knows a *switch* is what happened rather than a deletion,
+keeps a copy to put back.
+"""
+
+import pytest
+import sources
+
+from orionbelt_ontology_builder import app, ui
+
+PERSON = "Class: Person"
+ORG = "Class: Org"
+ALICE = "Individual: alice"
+
+
+class _State(dict):
+    """A session_state stand-in: dict access plus the attribute access ui uses."""
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:  # pragma: no cover - mirrors Streamlit's error
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+
+@pytest.fixture
+def session(monkeypatch):
+    state = _State()
+    monkeypatch.setattr(ui.st, "session_state", state)
+    return state
+
+
+def _switch_off(
+    session, kind="Class", cfg="_viz_cfg_show_classes", wid="viz_show_classes"
+):
+    session[wid] = False
+    ui.viz_show_kind_toggled(cfg, wid, kind)
+
+
+def _switch_on(
+    session, kind="Class", cfg="_viz_cfg_show_classes", wid="viz_show_classes"
+):
+    session[wid] = True
+    ui.viz_show_kind_toggled(cfg, wid, kind)
+
+
+def test_switching_a_type_off_keeps_its_seeds_to_one_side(session):
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON, ORG]
+
+    _switch_off(session)
+
+    assert session["_viz_cfg_show_classes"] is False
+    parked = session[ui.VIZ_PARKED_SEEDS_KEY]["Class"]
+    assert parked["seeds"] == [PERSON, ORG]
+    assert parked["focus_mode"] is True
+
+
+def test_switching_it_back_on_restores_the_focus(session):
+    """The whole point: the same focus, mode included, without rebuilding it."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON, ORG]
+
+    _switch_off(session)
+    # The render prune empties the live seeds while the type is off, and takes
+    # the mode with them, which is what the user sees before ticking it back.
+    ui.viz_set_focus_seeds([])
+    session["_viz_cfg_focus_mode"] = False
+
+    _switch_on(session)
+
+    assert session["_viz_cfg_focus_seeds"] == [PERSON, ORG]
+    assert session["_viz_cfg_focus_mode"] is True
+    assert session["_viz_settings_dirty"] is True
+    assert session[ui.VIZ_PARKED_SEEDS_KEY] == {}
+
+
+def test_only_the_switched_type_is_parked(session):
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON, ALICE]
+
+    _switch_off(session)
+
+    assert session[ui.VIZ_PARKED_SEEDS_KEY]["Class"]["seeds"] == [PERSON]
+    assert "Individual" not in session[ui.VIZ_PARKED_SEEDS_KEY]
+
+
+def test_seeds_picked_while_a_type_was_off_are_kept(session):
+    """What the user chose in the meantime is their current focus, so the
+    restored seeds join it rather than replacing it."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+
+    _switch_off(session)
+    ui.viz_set_focus_seeds([ALICE])
+
+    _switch_on(session)
+
+    assert session["_viz_cfg_focus_seeds"] == [ALICE, PERSON]
+
+
+def test_a_seed_is_not_restored_twice(session):
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+
+    _switch_off(session)
+    ui.viz_set_focus_seeds([PERSON])  # the prune left it alone this time
+
+    _switch_on(session)
+
+    assert session["_viz_cfg_focus_seeds"] == [PERSON]
+
+
+def test_a_restored_seed_carries_no_identity_so_the_prune_can_judge_it(session):
+    """A seed comes back with no entry in the label -> id map, which is the state
+    of one the user has just picked: the next prune keeps it if it resolves and
+    drops it if its entity has gone in the meantime (see viz_set_focus_seeds)."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    session["_viz_cfg_focus_seed_ids_by_label"] = {PERSON: "class-person"}
+
+    _switch_off(session)
+    ui.viz_set_focus_seeds([])  # the prune drops the seed, and its id with it
+    assert session["_viz_cfg_focus_seed_ids_by_label"] == {}
+
+    _switch_on(session)
+
+    assert session["_viz_cfg_focus_seeds"] == [PERSON]
+    assert PERSON not in session["_viz_cfg_focus_seed_ids_by_label"]
+
+
+def test_switching_focus_off_by_hand_forgets_what_was_parked(session):
+    """Turning the mode off is a decision about the focus. A type coming back
+    afterwards must not switch it on again behind the user."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    _switch_off(session)
+    ui.viz_set_focus_seeds([])  # the render prune, as in the test above
+
+    session["viz_focus_mode"] = False
+    ui.viz_focus_toggle()
+    assert ui.VIZ_PARKED_SEEDS_KEY not in session
+
+    _switch_on(session)
+    assert session["_viz_cfg_focus_mode"] is False
+    assert not session["_viz_cfg_focus_seeds"]
+
+
+def test_a_type_with_no_seeds_parks_nothing(session):
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [ALICE]
+
+    _switch_off(session)
+
+    assert not session.get(ui.VIZ_PARKED_SEEDS_KEY)
+
+
+def test_switching_a_type_off_still_persists_the_setting(session):
+    """It is a display switch first; parking rides along with it."""
+    session["viz_show_skos"] = False
+    ui.viz_show_kind_toggled("_viz_cfg_show_skos", "viz_show_skos", "Concept")
+    assert session["_viz_cfg_show_skos"] is False
+    assert session["_viz_settings_dirty"] is True
+
+
+def test_every_focusable_type_switch_goes_through_the_parking_callback():
+    """A type whose entities can be focused but whose switch still calls plain
+    viz_sync would go on deleting its seeds. Pinned at the source: the page
+    cannot be driven this far under AppTest."""
+    src = sources.viz_text()
+    for cfg_key, kind in (
+        ("_viz_cfg_show_classes", "Class"),
+        ("_viz_cfg_show_individuals", "Individual"),
+        ("_viz_cfg_show_data_props", "Data Property"),
+        ("_viz_cfg_show_skos", "Concept"),
+    ):
+        assert f'"{cfg_key}"' in src
+        assert f'"{kind}"' in src
+        block = src[src.index(f'"{cfg_key}",') :].split(")", 1)[0]
+        assert kind in block, f"{cfg_key} does not name its focus kind"
+    assert src.count("on_change=viz_show_kind_toggled") == 4
+
+
+def test_the_kinds_map_matches_what_the_page_registers():
+    """The map keys are the kind words _focus_target labels seeds with. A word
+    that drifts here would park nothing and quietly restore nothing."""
+    src = sources.viz_text()
+    for kind, cfg_key in app.VIZ_FOCUS_SEED_KINDS.items():
+        assert (
+            f'_focus_target(\n                    "{kind}"' in src
+            or f'"{kind}",' in src
+        )
+        assert cfg_key in src

--- a/tests/test_viz_focus_parking.py
+++ b/tests/test_viz_focus_parking.py
@@ -157,6 +157,25 @@ def test_switching_focus_off_by_hand_forgets_what_was_parked(session):
     assert not session["_viz_cfg_focus_seeds"]
 
 
+def test_the_focus_reset_forgets_what_was_parked(session):
+    """viz_drop_focus_seeds is also the focus half of the reset that runs when
+    the linked file changes, and a parked seed names the entities of the file it
+    was parked in. Left behind, switching the type back on in the next file
+    would restore that label into it, and a restored seed carries no id, so a
+    file that happens to have a class of the same name would be focused, and
+    saved, as though the user had asked for it (Codex review of PR #397)."""
+    session["_viz_cfg_focus_mode"] = True
+    session["_viz_cfg_focus_seeds"] = [PERSON]
+    _switch_off(session)
+    assert session[ui.VIZ_PARKED_SEEDS_KEY]["Class"]["seeds"] == [PERSON]
+
+    ui.viz_drop_focus_seeds()
+
+    assert ui.VIZ_PARKED_SEEDS_KEY not in session
+    _switch_on(session)
+    assert not session.get("_viz_cfg_focus_seeds")
+
+
 def test_a_type_with_no_seeds_parks_nothing(session):
     session["_viz_cfg_focus_mode"] = True
     session["_viz_cfg_focus_seeds"] = [ALICE]


### PR DESCRIPTION
Closes #396.

## What was wrong

With a focus running on `Class: Person`, unticking **Classes** did not set the seeds aside, it deleted them. Ticking Classes back on left an empty picker and a focus to rebuild by hand. Hiding a type to declutter the canvas is an ordinary move while exploring, so that is a poor trade.

The focus block prunes its seeds to what `focus_targets` can resolve and writes the pruned list back, and `focus_targets` carries only the types whose switch is on.

## What changed

The prune stays exactly as it is, because it has to: a seed that resolves to nothing cannot be left in play, or switching focus back on finds it invalid and turns straight off again, which is a focus that can never be switched on (the Codex review of PR #336, recorded in the comment above that line).

What changed is that the switch keeps a copy. It is the one place that knows a *switch* is what happened, since to the prune a type just hidden and an entity just deleted look identical. The four entity-type checkboxes whose entities can be focused (Classes, Individuals, Data Props, SKOS) now park their seeds on the way off and restore them on the way back:

- restoring puts focus mode back on if it was on when the seeds were parked, since restoring seeds and leaving the mode off is half a job
- seeds picked while a type was hidden are the user's current focus, so restored seeds join them rather than replacing them
- restored seeds come back with no entry in the label to id map, which is the state of a seed just picked, so the next prune judges them: an entity deleted while its type was hidden is dropped on its return
- switching focus off by hand forgets what was parked, so a type coming back cannot switch the mode on behind the user

Parked seeds are session state, not persisted: a focus does not outlive a reload today either.

## Verified

Both acceptance cases from the issue, driven through the real checkbox callback under AppTest so the widget path is the browser's:

| | Classes off | Classes back on |
| --- | --- | --- |
| a focus on `Class: Person` | seeds emptied, `Class` parked | focus on, seeds `['Class: Person']`, nothing parked |
| the same, but `Person` deleted while hidden | seeds emptied, `Class` parked | seed restored, prune finds it gone, drops it and leaves focus mode |

`pytest` (1928 passed), `ruff format --check`, `ruff check` and `mypy` are clean. New `tests/test_viz_focus_parking.py` covers park, restore, per-kind parking, merging with seeds picked meanwhile, no duplicate restore, the identity a restored seed carries, the hand-switched-off case, and two source-level pins that all four switches go through the parking callback and that the kind words match what the page labels seeds with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
