### PR TITLE
chore: bump to 1.27.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.27.1` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.27.2` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -33,7 +33,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.27.1"
+APP_VERSION = "1.27.2"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.27.1"
+version = "1.27.2"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 # SPDX. Business Source License 1.1 is BUSL-1.1; BSL-1.0 is the Boost Software

--- a/uv.lock
+++ b/uv.lock
@@ -891,7 +891,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.27.1"
+version = "1.27.2"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },


### PR DESCRIPTION
Patch bump for the eleven commits since `v1.27.1`. Near enough all of them are fixes to things that already existed rather than new capability, so a patch rather than a minor.

## What is in it

**The graph**

- fullscreen fills the window instead of taking the screen (#391), and keeps the graph's controls with more room for them (#382)
- no white flash when a panel is toggled (#380)
- a highlighted path is drawn whatever the node cap (#379), and says when it is only half drawn (#377)
- the pickers show the label the canvas draws (#376)
- the class hierarchy no longer prints every path through the graph (#375)
- a focus click is applied without a toast about it (#393), and a focus with nothing left to focus on says so on the Node options label (#394)
- hiding an entity type parks its focus seeds instead of deleting them, so switching it back on brings the focus back (#397)

**SPARQL**

- the page keeps the query, the `Plain editor` choice and the row and time limits across a page switch and a reload (#392)

## The bump

Three places declare the version and `tests/test_version_consistency.py` fails CI on any drift: `pyproject.toml`, `APP_VERSION` in `orionbelt_ontology_builder/ui.py`, and the pin example in `README.md`. All three are moved here, and `uv.lock` follows. A repo-wide grep for the old string comes back empty.

`pytest` (1931 passed) and `ruff check` are clean.

## After merging

The tag is deliberately not part of this PR. Pushing `v1.27.2` triggers the PyPI and Docker publish workflows, and the hosted app needs a manual **Manage app → Reboot** at share.streamlit.io, since the push webhook does not fire reliably (it is still serving 1.27.1 today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
