### PR TITLE
fix(viz): undo and redo keep the graph's node filters (#401)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -195,6 +195,7 @@ from .ui import (  # noqa: F401
     maybe_restore_autosave,
     missing_required,
     newly_hidden_uris,
+    note_undo_redo,
     panel_heading_html,
     panel_subject_uri,
     parent_option_index,
@@ -540,9 +541,7 @@ def main():
                 key="btn_undo",
             ):
                 label = um.undo()
-                st.session_state["_ont_mutation_count"] = (
-                    st.session_state.get("_ont_mutation_count", 0) + 1
-                )
+                note_undo_redo()
                 set_flash_message(f"Undid: {label}", "info")
                 st.rerun()
         with redo_col:
@@ -553,9 +552,7 @@ def main():
                 key="btn_redo",
             ):
                 label = um.redo()
-                st.session_state["_ont_mutation_count"] = (
-                    st.session_state.get("_ont_mutation_count", 0) + 1
-                )
+                note_undo_redo()
                 set_flash_message(f"Redid: {label}", "info")
                 st.rerun()
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -2206,7 +2206,7 @@ def viz_ontology_was_replaced() -> bool:
     """Whether the whole ontology was swapped since the last graph render.
 
     A mutation-counter jump not matched by the edit counter means a
-    load/import/new/undo rather than an incremental edit, so the node filters
+    load/import/new rather than an incremental edit, so the node filters
     reset to "everything shown" instead of diffing against an ontology that may
     reuse URIs for unrelated entities.
 
@@ -2434,6 +2434,23 @@ def _render_disk_autosave_sidebar():
                 st.rerun()
         if linked is not None:
             st.caption(f"Linked: `{linked}`")
+
+
+def note_undo_redo() -> None:
+    """Move the revision for an undo or a redo.
+
+    Both counters move, the way an edit's do. An undo restores an earlier
+    snapshot of the *same* ontology, and the Visualization reads a mutation
+    bump with no matching edit bump as "the whole graph was swapped" and resets
+    its node filters to show everything, so undoing one edit used to put every
+    hidden class back on the canvas (issue #401). The undo history is rebuilt
+    from scratch wherever the ontology is genuinely replaced, so no undo can
+    reach back into an unrelated one.
+    """
+    st.session_state["_ont_mutation_count"] = (
+        st.session_state.get("_ont_mutation_count", 0) + 1
+    )
+    st.session_state["_ont_edit_count"] = st.session_state.get("_ont_edit_count", 0) + 1
 
 
 def save_checkpoint(label: str = "Edit"):
@@ -6052,7 +6069,7 @@ def reconcile_filter_selection(
     ``auto_show_new`` is that choice, off by default so the shipped behaviour
     is unchanged (issue #326).
 
-    ``replaced`` marks that the whole ontology was swapped (load/import/new/undo)
+    ``replaced`` marks that the whole ontology was swapped (load/import/new)
     rather than incrementally edited. Diffing must not run then: an unrelated
     ontology that happens to reuse a URI could otherwise inherit its
     hidden/narrowed state and load with entities missing. On a replacement — or

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -792,7 +792,7 @@ def render_visualization():
         # instead of resetting it on every ontology mutation, which used to wipe
         # a narrowed filter whenever a class or restriction was added (#180).
         # A mutation-counter jump not matched by the edit counter means the whole
-        # ontology was replaced (load/import/new/undo), so reset to "all" rather
+        # ontology was replaced (load/import/new), so reset to "all" rather
         # than diffing against a now-unrelated ontology that may reuse URIs.
         #
         # The widget lists the namespace-tagged display names, so two classes

--- a/tests/test_viz_auto_show_new.py
+++ b/tests/test_viz_auto_show_new.py
@@ -107,7 +107,7 @@ def test_taking_the_queue_in_makes_the_filter_non_empty_again():
 
 
 def test_on_does_not_change_a_replacement():
-    """A load/import/undo shows everything either way."""
+    """A load/import/new shows everything either way."""
     for auto in (False, True):
         selected, _known = app.reconcile_filter_selection(
             _uris("A", "B"),

--- a/tests/test_viz_undo_filter.py
+++ b/tests/test_viz_undo_filter.py
@@ -1,0 +1,129 @@
+"""Undo and redo keep the graph's node filters (issue #401).
+
+The Visualization tells an edit apart from a whole-ontology swap by comparing
+two counters: a mutation bump with no matching edit bump means load / import /
+new, and the node filters reset to "everything shown" rather than being diffed
+against an ontology that may reuse URIs for unrelated entities (issue #180).
+
+The Undo and Redo buttons moved only the mutation counter, so they read as a
+swap: undoing a single edit put every hidden class back on the canvas. An undo
+restores an earlier snapshot of the *same* ontology, and the undo history is
+rebuilt from scratch wherever the ontology is genuinely replaced, so it is an
+edit for this purpose and the filter is diffed like any other.
+"""
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import ui
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager, UndoManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Shown")
+        om.add_class("Hidden")
+        st.session_state.ontology = om
+        st.session_state.undo_manager = UndoManager(om)
+        st.session_state["_autosave_restored"] = True
+        # The cross-session restore mounts the localStorage component, which
+        # blocks forever without a browser to answer it.
+        st.session_state["_viz_settings_restored"] = True
+        st.session_state["_local_storage"] = None
+        st.session_state["nav_radio"] = "Visualization"
+        # A filter narrowed on purpose: `known` carries both classes, so the
+        # deselected one reads as hidden rather than as never seen.
+        uris = [c["uri"] for c in om.get_classes()]
+        st.session_state["_viz_cfg_selected_class_uris"] = [
+            u for u in uris if u.endswith("Shown")
+        ]
+        st.session_state["_viz_cfg_known_class_uris"] = set(uris)
+    if st.session_state.pop("_test_add_class", False):
+        st.session_state.ontology.add_class("Bicycle")
+        app.save_checkpoint("Added Bicycle")
+    app.main()
+
+
+def _rerun(at):
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    return at
+
+
+def _edited():
+    """The page with one undoable edit behind it, filter still narrowed."""
+    at = _rerun(AppTest.from_function(_script))
+    at.session_state["_test_add_class"] = True
+    return _rerun(at)
+
+
+def _click(at, key):
+    at.button(key=key).click()
+    return _rerun(at)
+
+
+def _selected(at):
+    return sorted(
+        u.rsplit("#", 1)[-1] for u in at.session_state["_viz_cfg_selected_class_uris"]
+    )
+
+
+def _classes(at):
+    return sorted(c["name"] for c in at.session_state["ontology"].get_classes())
+
+
+def test_the_narrowed_filter_survives_an_undo():
+    at = _click(_edited(), "btn_undo")
+    assert _selected(at) == ["Shown"]
+
+
+def test_the_undo_still_undoes():
+    """The filter is kept by reading the undo as an edit, not by skipping it."""
+    at = _click(_edited(), "btn_undo")
+    assert _classes(at) == ["Hidden", "Shown"]
+
+
+def test_the_narrowed_filter_survives_a_redo():
+    at = _click(_click(_edited(), "btn_undo"), "btn_redo")
+    assert _classes(at) == ["Bicycle", "Hidden", "Shown"]
+    # Bicycle was created while the filter was narrowed, so it stays out of it
+    # (issue #194) — being redone doesn't let it in either.
+    assert _selected(at) == ["Shown"]
+
+
+@pytest.fixture
+def session(monkeypatch):
+    """A session_state stand-in: dict access plus the attribute access ui uses."""
+
+    class _State(dict):
+        def __getattr__(self, name):
+            try:
+                return self[name]
+            except KeyError as exc:  # pragma: no cover - mirrors Streamlit
+                raise AttributeError(name) from exc
+
+        def __setattr__(self, name, value):
+            self[name] = value
+
+    state = _State()
+    monkeypatch.setattr(ui.st, "session_state", state)
+    return state
+
+
+def test_the_bump_reads_as_an_edit_rather_than_a_swap(session):
+    ui.viz_mark_ontology_seen()
+    ui.note_undo_redo()
+    assert session["_ont_mutation_count"] == 1
+    assert not ui.viz_ontology_was_replaced()
+
+
+def test_a_bare_mutation_bump_still_reads_as_a_swap(session):
+    """The other half of the pair: a load / import / new must still reset."""
+    ui.viz_mark_ontology_seen()
+    session["_ont_mutation_count"] = 1
+    assert ui.viz_ontology_was_replaced()


### PR DESCRIPTION
Closes #401.

## The bug

Narrow the Visualization's class filter (or hide a few classes), then press **Undo** or **Redo** in the sidebar: every class comes back on the canvas.

## Why

The graph tells an edit apart from a whole-ontology swap by comparing two counters. `save_checkpoint()` moves both `_ont_mutation_count` and `_ont_edit_count`; a load / import / new moves only the mutation counter. `viz_ontology_was_replaced()` reads that gap, and on a replacement `reconcile_filter_selection()` skips the diff and selects everything, because an unrelated ontology may reuse URIs and must not inherit a hidden or narrowed state (issue #180).

The Undo and Redo handlers moved only the mutation counter, so they read as a swap. The filters reset, and `views/visualization.py` also dropped the pending renames and the focus seeds parked by issue #396.

An undo is not a swap: it restores an earlier snapshot of the *same* `OntologyManager`, in place. And the undo history can never reach back into a different ontology, because every path that genuinely replaces one rebuilds `UndoManager` from scratch (`ui.py` autosave restore and linked-file load, `views/import_export.py` new and clear). An import-replace keeps its history, but it checkpoints, so it is already treated as an edit both when applied and when undone; the "not one entity in common" guard in `reconcile_filter_selection()` covers that case exactly as it does today.

## The change

Both buttons now move both counters, through one `note_undo_redo()` helper next to `save_checkpoint()`, so the filter is diffed after an undo like it is after any other edit. The comments that listed undo among the replacements (`ui.py`, `views/visualization.py`, `tests/test_viz_auto_show_new.py`) are updated to match.

## Tests

`tests/test_viz_undo_filter.py` drives `app.main()` with a narrowed filter and one undoable edit, clicks the real sidebar buttons, and asserts the filter survives both an undo and a redo while the undo still undoes. Two unit tests pin the counter pair from both sides: an undo bump reads as an edit, a bare mutation bump still reads as a swap.

Without the fix, three of the five fail. Full suite green (1936 passed), plus ruff 0.16.5 format/check and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)