### PR TITLE
fix(viz): a selected node keeps a colour its label can be read on (#400)

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1956,6 +1956,101 @@ PATH_HIGHLIGHT_COLOR = "#FFEB3B"
 #: link it is, and it is what the graph is scanned by (issue #357).
 PATH_HIGHLIGHT_BORDER = 3
 
+#: How far a selected node's fill moves away from its own label, 0-1.
+#: Enough to read as a state change at a glance without leaving the colour the
+#: node's type is recognised by.
+SELECTED_FILL_SHIFT = 0.32
+#: The node label colour the graph options set, and so what a node's label is
+#: drawn in unless it names its own.
+DEFAULT_NODE_FONT = "#f0f0f0"
+
+
+def _hex_rgb(colour: str) -> tuple[int, int, int] | None:
+    """``#rgb`` / ``#rrggbb`` as channels, or ``None`` for anything else."""
+    if not isinstance(colour, str):
+        return None
+    value = colour.strip().lstrip("#")
+    if len(value) == 3:
+        value = "".join(c * 2 for c in value)
+    if len(value) != 6:
+        return None
+    try:
+        return (int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16))
+    except ValueError:
+        return None
+
+
+def _luminance(rgb: tuple[int, int, int]) -> float:
+    """WCAG relative luminance, so two colours can be compared for contrast."""
+    channels = []
+    for raw in rgb:
+        c = raw / 255
+        channels.append(c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4)
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+
+
+def selected_fill(fill: str, label: str, shift: float = SELECTED_FILL_SHIFT) -> str:
+    """The fill a node is drawn in while it is selected.
+
+    Its own colour, moved *away from its label*: darker under the near-white
+    labels most of the palette carries, lighter under the dark one the literal
+    nodes use. So the selected node still reads as the type its colour says it
+    is, and its label reads at least as well as it did unselected — which is the
+    whole complaint in issue #400, where the label vanished into the fill.
+    """
+    base = _hex_rgb(fill)
+    text = _hex_rgb(label)
+    if base is None:
+        return fill
+    # An unreadable label colour is no reason to leave the fill alone; assume
+    # the near-white the options set, which is what all but one node carries.
+    if text is None:
+        text = _hex_rgb(DEFAULT_NODE_FONT) or (240, 240, 240)
+    toward = 0 if _luminance(text) >= _luminance(base) else 255
+    moved = (round(c + (toward - c) * shift) for c in base)
+    return "#" + "".join(f"{c:02X}" for c in moved)
+
+
+def add_selection_colours(
+    nodes: list[dict], default_font: str = DEFAULT_NODE_FONT
+) -> None:
+    """Give every node an explicit colour for its selected state (issue #400).
+
+    vis-network paints a selected node in *its own* default highlight — a pale
+    ``#D2E5FF`` fill with a blue border — for any node that does not name one,
+    and a colour given as an object inherits nothing from the object's own
+    background. Every node here names its background and border and nothing
+    else, so clicking one replaced the colour that says what it is with a wash
+    of near-white, under a near-white label: the label disappeared, most
+    obviously in dark mode where the pale fill also glares.
+
+    So each node is given the selected state it should have had: its own
+    background moved by :func:`selected_fill`, keeping its own border. Whatever
+    a node already named for its selected state wins — the red ring a node with
+    validation issues keeps while selected is set that way.
+
+    Nodes are edited in place, and a colour given as a plain string is left
+    alone: vis derives a highlight from a string itself, and none of the
+    builder's nodes use one.
+    """
+    for node in nodes:
+        colour = node.get("color")
+        if not isinstance(colour, dict):
+            continue
+        background = colour.get("background")
+        if not isinstance(background, str):
+            continue
+        font = node.get("font")
+        label = font.get("color") if isinstance(font, dict) else None
+        highlight = colour.get("highlight")
+        highlight = dict(highlight) if isinstance(highlight, dict) else {}
+        highlight.setdefault(
+            "background", selected_fill(background, label or default_font)
+        )
+        if colour.get("border"):
+            highlight.setdefault("border", colour["border"])
+        colour["highlight"] = highlight
+
 
 def path_entity_kinds(
     show_classes: bool, show_individuals: bool, show_skos: bool

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -1956,10 +1956,19 @@ PATH_HIGHLIGHT_COLOR = "#FFEB3B"
 #: link it is, and it is what the graph is scanned by (issue #357).
 PATH_HIGHLIGHT_BORDER = 3
 
-#: How far a selected node's fill moves away from its own label, 0-1.
-#: Enough to read as a state change at a glance without leaving the colour the
-#: node's type is recognised by.
+#: How far a selected node's fill moves away from its own label at the least,
+#: 0-1. Enough to read as a state change at a glance, and applied even where the
+#: label already has all the contrast it needs: selection has to *show*.
 SELECTED_FILL_SHIFT = 0.32
+#: And at the most, so a fill that would need more than this to hit the target
+#: below lands on the best colour it can rather than collapsing into flat black
+#: or white and losing the type it is recognised by.
+SELECTED_FILL_SHIFT_MAX = 0.6
+#: What the label is aimed at against the fill it ends up on: WCAG AA for body
+#: text. Aimed at rather than asserted, hence the ceiling above — but every
+#: colour the graph currently draws clears it, the individuals' orange only just
+#: (Codex review of PR #403).
+SELECTED_LABEL_CONTRAST = 4.5
 #: The node label colour the graph options set, and so what a node's label is
 #: drawn in unless it names its own.
 DEFAULT_NODE_FONT = "#f0f0f0"
@@ -1989,6 +1998,12 @@ def _luminance(rgb: tuple[int, int, int]) -> float:
     return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
 
 
+def _contrast(one: tuple[int, int, int], other: tuple[int, int, int]) -> float:
+    """The WCAG contrast ratio between two colours, 1 (none) to 21."""
+    a, b = _luminance(one), _luminance(other)
+    return (max(a, b) + 0.05) / (min(a, b) + 0.05)
+
+
 def selected_fill(fill: str, label: str, shift: float = SELECTED_FILL_SHIFT) -> str:
     """The fill a node is drawn in while it is selected.
 
@@ -1997,6 +2012,13 @@ def selected_fill(fill: str, label: str, shift: float = SELECTED_FILL_SHIFT) -> 
     nodes use. So the selected node still reads as the type its colour says it
     is, and its label reads at least as well as it did unselected — which is the
     whole complaint in issue #400, where the label vanished into the fill.
+
+    ``shift`` is where the move starts, not where it stops: it keeps going in
+    small steps until the label clears :data:`SELECTED_LABEL_CONTRAST`, up to
+    :data:`SELECTED_FILL_SHIFT_MAX`. A single fixed shift is a number that
+    happens to work for today's palette — the orange the individuals are drawn
+    in needs half again what the class green does to read as well, and a colour
+    added later could need more than either (Codex review of PR #403).
     """
     base = _hex_rgb(fill)
     text = _hex_rgb(label)
@@ -2007,8 +2029,20 @@ def selected_fill(fill: str, label: str, shift: float = SELECTED_FILL_SHIFT) -> 
     if text is None:
         text = _hex_rgb(DEFAULT_NODE_FONT) or (240, 240, 240)
     toward = 0 if _luminance(text) >= _luminance(base) else 255
-    moved = (round(c + (toward - c) * shift) for c in base)
-    return "#" + "".join(f"{c:02X}" for c in moved)
+
+    def moved(by: float) -> tuple[int, int, int]:
+        r, g, b = (round(c + (toward - c) * by) for c in base)
+        return (r, g, b)
+
+    step = 0.02
+    out = moved(shift)
+    by = shift
+    while _contrast(out, text) < SELECTED_LABEL_CONTRAST and by < (
+        SELECTED_FILL_SHIFT_MAX - 1e-9
+    ):
+        by = min(by + step, SELECTED_FILL_SHIFT_MAX)
+        out = moved(by)
+    return "#" + "".join(f"{c:02X}" for c in out)
 
 
 def add_selection_colours(

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -11,6 +11,7 @@ from ..ui import (
     _FILTER_KINDS,
     _PAGE_BY_TYPE,
     _PRECISE_NAV_TYPES,
+    DEFAULT_NODE_FONT,
     GRAPH_MAX_NODES,
     PATH_HIGHLIGHT_BORDER,
     PATH_HIGHLIGHT_COLOR,
@@ -39,6 +40,7 @@ from ..ui import (
     _str_list,
     _uid,
     _viz_live_selection,
+    add_selection_colours,
     annotation_ename,
     build_class_hierarchy_text,
     build_class_options,
@@ -2747,6 +2749,16 @@ def render_visualization():
             try:
                 import json as _json
 
+                # Selected nodes keep their own colour instead of vis's pale
+                # default, which used to swallow the near-white labels (issue
+                # #400). Done here rather than at each add_node so every kind of
+                # node gets it, and because the rule reads off the label colour
+                # the node ended up with.
+                add_selection_colours(
+                    net.nodes,
+                    net.options.get("nodes", {}).get("font", {}).get("color")
+                    or DEFAULT_NODE_FONT,
+                )
                 nodes_json = _json.dumps(net.nodes)
                 edges_json = _json.dumps(net.edges)
                 options_json = _json.dumps(net.options)

--- a/tests/test_viz_selection_colour.py
+++ b/tests/test_viz_selection_colour.py
@@ -1,0 +1,180 @@
+"""A selected node keeps a readable colour (issue #400).
+
+vis-network paints a selected node in its own default highlight — a pale
+``#D2E5FF`` fill — for any node that does not name one, and a colour given as an
+object inherits nothing from that object's own background. The builder gives
+every node a background and a border and nothing else, so clicking one washed
+the type colour out from under a near-white label and the label disappeared,
+most obviously in dark mode.
+
+Each node now carries the selected state it should have had: its own colour,
+moved away from its label.
+"""
+
+import json
+
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder.ui import (
+    _hex_rgb,
+    _luminance,
+    add_selection_colours,
+    selected_fill,
+)
+
+VIS_DEFAULT_HIGHLIGHT = "#D2E5FF"
+CLASS_GREEN = "#4CAF50"
+NEAR_WHITE = "#f0f0f0"
+
+
+def _contrast(a, b):
+    la, lb = _luminance(_hex_rgb(a)), _luminance(_hex_rgb(b))
+    return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+
+
+# --- the colour rule --------------------------------------------------------
+
+
+def test_a_light_label_darkens_the_fill():
+    assert _luminance(_hex_rgb(selected_fill(CLASS_GREEN, NEAR_WHITE))) < _luminance(
+        _hex_rgb(CLASS_GREEN)
+    )
+
+
+def test_a_dark_label_lightens_it_instead():
+    """The literal nodes are the one place the palette writes in dark ink."""
+    lit = "#B0BEC5"
+    assert _luminance(_hex_rgb(selected_fill(lit, "#333333"))) > _luminance(
+        _hex_rgb(lit)
+    )
+
+
+def test_the_label_reads_at_least_as_well_as_it_did():
+    """Every fill the graph uses, against the label it is written in."""
+    palette = [
+        ("#4CAF50", NEAR_WHITE),  # class
+        ("#2196F3", NEAR_WHITE),  # object property
+        ("#9C27B0", NEAR_WHITE),  # data property
+        ("#FF9800", NEAR_WHITE),  # individual
+        ("#795548", NEAR_WHITE),  # annotation
+        ("#00897B", NEAR_WHITE),  # SKOS concept
+        ("#90A4AE", NEAR_WHITE),  # triple subject
+        ("#B0BEC5", "#333333"),  # literal
+    ]
+    for fill, label in palette:
+        selected = selected_fill(fill, label)
+        assert _contrast(label, selected) > _contrast(label, fill), fill
+        if label == NEAR_WHITE:
+            # The reported case: a near-white label on the pale default is 1.12,
+            # which is no contrast at all. (A dark label reads fine on it, which
+            # is why the one node written in dark ink was never the complaint.)
+            assert _contrast(label, VIS_DEFAULT_HIGHLIGHT) < 1.2
+            assert _contrast(label, selected) > 3, fill
+
+
+def test_the_selected_fill_is_visibly_a_different_colour():
+    """Readable is not enough — the click has to show."""
+    assert _contrast(CLASS_GREEN, selected_fill(CLASS_GREEN, NEAR_WHITE)) > 1.5
+
+
+def test_a_colour_it_cannot_read_is_left_alone():
+    assert selected_fill("rgba(1, 2, 3, 0.4)", NEAR_WHITE) == "rgba(1, 2, 3, 0.4)"
+
+
+# --- what the pass writes onto the nodes ------------------------------------
+
+
+def test_every_node_is_given_its_own_selected_colour():
+    nodes = [{"id": "a", "color": {"background": CLASS_GREEN, "border": "#388E3C"}}]
+    add_selection_colours(nodes)
+    highlight = nodes[0]["color"]["highlight"]
+    assert highlight["background"] == selected_fill(CLASS_GREEN, NEAR_WHITE)
+    # The border is named too: vis falls back to its own blue for that as well.
+    assert highlight["border"] == "#388E3C"
+
+
+def test_the_node_s_own_label_colour_decides_the_direction():
+    nodes = [
+        {
+            "id": "lit",
+            "color": {"background": "#B0BEC5", "border": "#78909C"},
+            "font": {"size": 9, "color": "#333333"},
+        }
+    ]
+    add_selection_colours(nodes)
+    assert nodes[0]["color"]["highlight"]["background"] == selected_fill(
+        "#B0BEC5", "#333333"
+    )
+
+
+def test_a_node_that_names_its_selected_state_keeps_it():
+    """A node with validation issues stays ringed in red while selected."""
+    nodes = [
+        {
+            "id": "a",
+            "color": {
+                "background": CLASS_GREEN,
+                "border": "#F44336",
+                "highlight": {"border": "#F44336"},
+            },
+        }
+    ]
+    add_selection_colours(nodes)
+    highlight = nodes[0]["color"]["highlight"]
+    assert highlight["border"] == "#F44336"
+    assert highlight["background"] == selected_fill(CLASS_GREEN, NEAR_WHITE)
+
+
+def test_a_node_without_a_colour_object_is_left_alone():
+    nodes = [{"id": "a"}, {"id": "b", "color": "#4CAF50"}]
+    add_selection_colours(nodes)
+    assert nodes == [{"id": "a"}, {"id": "b", "color": "#4CAF50"}]
+
+
+# --- and on a real graph ----------------------------------------------------
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Bicycle")
+        om.add_class("Wheel")
+        om.add_object_property("hasPart", domain="Bicycle", range_="Wheel")
+        om.add_data_property("serial", domain="Bicycle")
+        om.add_individual("bike1", "Bicycle")
+        om.add_annotation("Bicycle", "wikidataId", "Q-bike")
+        om.add_concept_scheme("Parts")
+        om.add_concept("Frame", scheme="Parts")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["_viz_settings_restored"] = True
+        for kind in ("annotations", "individuals", "data_props", "skos"):
+            st.session_state[f"_viz_cfg_show_{kind}"] = True
+    app.render_visualization()
+
+
+def _nodes():
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    return json.loads(at.session_state["last_graph_data"]["nodes"])
+
+
+def test_no_node_of_a_real_graph_falls_back_to_the_pale_default():
+    nodes = _nodes()
+    # A class, a data property, an individual, an annotation and a concept:
+    # every kind that carries a colour of its own.
+    assert len({n["color"]["background"] for n in nodes}) >= 5, nodes
+    for node in nodes:
+        highlight = node["color"]["highlight"]
+        assert highlight["background"] != VIS_DEFAULT_HIGHLIGHT, node["id"]
+        assert highlight["background"] == selected_fill(
+            node["color"]["background"],
+            (node.get("font") or {}).get("color") or NEAR_WHITE,
+        ), node["id"]
+        assert highlight["border"] == node["color"]["border"], node["id"]

--- a/tests/test_viz_selection_colour.py
+++ b/tests/test_viz_selection_colour.py
@@ -16,6 +16,9 @@ import json
 from streamlit.testing.v1 import AppTest
 
 from orionbelt_ontology_builder.ui import (
+    SELECTED_FILL_SHIFT,
+    SELECTED_FILL_SHIFT_MAX,
+    SELECTED_LABEL_CONTRAST,
     _hex_rgb,
     _luminance,
     add_selection_colours,
@@ -49,27 +52,64 @@ def test_a_dark_label_lightens_it_instead():
     )
 
 
-def test_the_label_reads_at_least_as_well_as_it_did():
+PALETTE = [
+    ("#4CAF50", NEAR_WHITE),  # class
+    ("#2196F3", NEAR_WHITE),  # object property
+    ("#9C27B0", NEAR_WHITE),  # data property
+    ("#FF9800", NEAR_WHITE),  # individual
+    ("#795548", NEAR_WHITE),  # annotation
+    ("#00897B", NEAR_WHITE),  # SKOS concept
+    ("#90A4AE", NEAR_WHITE),  # triple subject
+    ("#B0BEC5", "#333333"),  # literal
+]
+
+
+def test_every_label_the_graph_draws_clears_the_target():
     """Every fill the graph uses, against the label it is written in."""
-    palette = [
-        ("#4CAF50", NEAR_WHITE),  # class
-        ("#2196F3", NEAR_WHITE),  # object property
-        ("#9C27B0", NEAR_WHITE),  # data property
-        ("#FF9800", NEAR_WHITE),  # individual
-        ("#795548", NEAR_WHITE),  # annotation
-        ("#00897B", NEAR_WHITE),  # SKOS concept
-        ("#90A4AE", NEAR_WHITE),  # triple subject
-        ("#B0BEC5", "#333333"),  # literal
-    ]
-    for fill, label in palette:
+    for fill, label in PALETTE:
         selected = selected_fill(fill, label)
         assert _contrast(label, selected) > _contrast(label, fill), fill
+        assert _contrast(label, selected) >= SELECTED_LABEL_CONTRAST, fill
         if label == NEAR_WHITE:
             # The reported case: a near-white label on the pale default is 1.12,
             # which is no contrast at all. (A dark label reads fine on it, which
             # is why the one node written in dark ink was never the complaint.)
             assert _contrast(label, VIS_DEFAULT_HIGHLIGHT) < 1.2
-            assert _contrast(label, selected) > 3, fill
+
+
+def test_a_fill_that_needs_more_of_a_move_gets_it():
+    """The individuals' orange starts far worse off than the class green.
+
+    One shift for both left it at 3.91 while the green cleared 4.5 comfortably,
+    which is what the review of PR #403 found. The move now runs until the
+    label reads, so the orange simply travels further.
+    """
+    orange, green = "#FF9800", CLASS_GREEN
+    assert _contrast(NEAR_WHITE, orange) < _contrast(NEAR_WHITE, green)
+
+    def moved(fill):
+        return _contrast(fill, selected_fill(fill, NEAR_WHITE))
+
+    assert moved(orange) > moved(green)
+
+
+def test_a_fill_already_dark_enough_only_moves_the_minimum():
+    """The target is a floor, not a look: nothing moves further than it must."""
+    annotation = "#795548"  # 5.75 unselected, so the floor alone clears it
+    assert selected_fill(annotation, NEAR_WHITE) == selected_fill(
+        annotation, NEAR_WHITE, shift=SELECTED_FILL_SHIFT
+    )
+
+
+def test_an_unreachable_target_stops_at_the_ceiling():
+    """A mid grey under a mid grey label can't get there by darkening alone.
+
+    It takes the best colour within the ceiling rather than running on to black
+    and losing the colour the node is recognised by.
+    """
+    grey = "#7F7F7F"
+    capped = tuple(round(c * (1 - SELECTED_FILL_SHIFT_MAX)) for c in _hex_rgb(grey))
+    assert _hex_rgb(selected_fill(grey, "#808080")) == capped
 
 
 def test_the_selected_fill_is_visibly_a_different_colour():


### PR DESCRIPTION
Closes #400.

## The bug

Click a node in the graph and its fill is replaced by a pale near-white wash, under a near-white label. The label all but disappears, most obviously in dark mode where the pale fill also glares (the reporter's screenshot).

## Why

vis-network's default node highlight is `#D2E5FF` with a `#2B7CE9` border, and a colour given as an *object* inherits nothing from that object's own background: `background: t.highlight && t.highlight.background || e.highlight.background`, where `e` is the global default. Every node the builder makes names a background and a border and nothing else, so every one of them fell back to the pale default when selected.

Measured against the near-white `#f0f0f0` node label, that fill gives a contrast ratio of **1.12** - no contrast at all.

## The change

Each node is given the selected state it should have had: its own colour, moved away from its label. Darker under the near-white labels most of the palette carries, lighter under the dark one the literal nodes use. The node keeps the hue its type is recognised by, and the selection is plainly visible (a class fill moves `#4CAF50` -> `#347736`, ~2:1 against its unselected self).

The move starts at a floor of 0.32, enough that selection always shows even where the label already reads, and continues in small steps until the label clears 4.5:1, up to a ceiling of 0.6 so a fill that cannot get there is not run all the way to black. A single fixed shift is a number that happens to work for one palette: at 0.32 the individuals' orange came out at 3.91:1 while the class green cleared 4.8:1.

| node | fill | selected | label vs fill | label vs selected |
|---|---|---|---|---|
| Class | `#4CAF50` | `#347736` | 2.44 | 4.80 |
| Object property | `#2196F3` | `#1666A5` | 2.74 | 5.30 |
| Data property | `#9C27B0` | `#6A1B78` | 5.53 | 9.03 |
| Individual | `#FF9800` | `#9E5E00` | 1.89 | 4.54 |
| Annotation | `#795548` | `#523A31` | 5.75 | 9.18 |
| SKOS concept | `#00897B` | `#005D54` | 3.79 | 6.84 |
| Triple subject | `#90A4AE` | `#5F6C73` | 2.27 | 4.75 |
| Literal (dark label) | `#B0BEC5` | `#C9D3D8` | 6.63 | 8.30 |

It is applied once over the built node list rather than at each `add_node`, so every kind of node gets it, including any added later, and the rule can read the label colour the node actually ended up with. A node that already names its selected state keeps it: the red ring on a node with validation issues still shows while it is selected.

The rule does not depend on the theme (the labels do not change with it), so it can live in Python next to the palette and be unit tested, rather than in the viewer where the theme-dependent colours are.

## Verified live

Ran the app in dark mode against the Organization template and read the pixels back off the canvas: the selected node paints `#347736` with `#F0F0F0` label pixels, its neighbours stay `#4CAF50`. Repainting the same node with vis's default highlight reproduces the reported picture exactly.

## Tests

`tests/test_viz_selection_colour.py`: the colour rule (darkens under a light label, lightens under a dark one, every palette entry clears the target, a fill that needs a bigger move gets it, one that does not only moves the floor, an unreachable target stops at the ceiling, the selected fill is visibly different, an unparseable colour is left alone), what the pass writes onto nodes (own border named too, a node's own label colour decides the direction, an explicit selected state wins, nodes without a colour object untouched), and a real render where no node falls back to the default.

Full suite green (1949 passed), plus ruff 0.16.5 format/check and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)