### PR TITLE
feat(sparql): the engine's error goes somewhere it can be copied (#399)

### DIFF
--- a/orionbelt_ontology_builder/sparql.py
+++ b/orionbelt_ontology_builder/sparql.py
@@ -80,7 +80,17 @@ READ_ONLY_FORMS = ("SELECT", "ASK", "CONSTRUCT", "DESCRIBE")
 
 
 class QueryError(Exception):
-    """Base class for a query the console refuses to run."""
+    """Base class for a query the console refuses to run.
+
+    ``engine_text`` marks a message that is rdflib's wording rather than ours:
+    a parse or evaluation failure passed straight through. The page shows the
+    two differently — ours is prose written to be read, the engine's is a
+    diagnostic to be copied somewhere else (issue #399).
+    """
+
+    def __init__(self, message: str, *, engine_text: bool = False):
+        super().__init__(message)
+        self.engine_text = engine_text
 
 
 class QuerySyntaxError(QueryError):
@@ -258,7 +268,7 @@ def prepare(query_text: str, init_ns: dict[str, Any] | None = None) -> PreparedQ
         try:
             parseUpdate(query_text)
         except Exception:  # noqa: BLE001 - not an update either, so it is a syntax error
-            raise QuerySyntaxError(str(exc)) from exc
+            raise QuerySyntaxError(str(exc), engine_text=True) from exc
         raise QueryNotAllowed(
             "This console is read-only: it runs SELECT, ASK, CONSTRUCT and "
             "DESCRIBE queries. Updates (INSERT, DELETE, LOAD, CLEAR, DROP) are "
@@ -482,7 +492,7 @@ def run_query(
     except Exception as exc:
         # An evaluation failure belongs to the user's query (a bad datatype in a
         # FILTER, say), so it is reported as one rather than as an app crash.
-        raise QueryError(str(exc)) from exc
+        raise QueryError(str(exc), engine_text=True) from exc
     result.elapsed = time.monotonic() - started
     return result
 

--- a/orionbelt_ontology_builder/views/sparql.py
+++ b/orionbelt_ontology_builder/views/sparql.py
@@ -121,6 +121,10 @@ _BOX_KEY = "sparql_query_box"
 _EDITOR_NONCE = "sparql_editor_nonce"
 _RESULT_KEY = "sparql_last_result"
 _ERROR_KEY = "sparql_last_error"
+#: Whether what ``_ERROR_KEY`` holds is the engine's wording rather than ours.
+#: Kept beside the message rather than folded into it so a session that was
+#: showing an error when the app reloaded still renders (it reads as "ours").
+_ERROR_ENGINE_KEY = "sparql_last_error_engine"
 
 
 def _load_example() -> None:
@@ -153,6 +157,7 @@ def _load_example() -> None:
         st.session_state[_EDITOR_NONCE] = st.session_state.get(_EDITOR_NONCE, 0) + 1
     st.session_state.pop(_RESULT_KEY, None)
     st.session_state.pop(_ERROR_KEY, None)
+    st.session_state.pop(_ERROR_ENGINE_KEY, None)
 
 
 _EDITOR_HELP = (
@@ -373,6 +378,28 @@ def _render_prefixes(ont) -> None:
         )
 
 
+def _render_error(message: str, engine_text: bool) -> None:
+    """Show a run that failed.
+
+    Our own messages are prose, written to be read where they are: the console
+    is read-only, the query is empty, this shape cannot be bounded. They stay in
+    the error box.
+
+    The engine's are not. They are diagnostics — copied into a search box, or
+    handed to someone (or something) that can explain them, which is what
+    issue #399 asked for. A code block is where Streamlit puts a copy button,
+    and it fixes two more things on the way past: the box renders markdown, so
+    ``Unknown namespace prefix : my_odd_prefix`` lost its underscores and copied
+    back as a prefix that does not exist, and the positions rdflib reports
+    ("at char 25", "line:1, col:26") only line up under a monospace font.
+    """
+    if not engine_text:
+        st.error(message)
+        return
+    st.error("The query could not be run.")
+    st.code(message, language=None, wrap_lines=True)
+
+
 def _matched_nothing() -> None:
     """Say the result is empty, and name the likeliest reason it is.
 
@@ -525,6 +552,7 @@ def render_sparql():
     if run:
         st.session_state.pop(_RESULT_KEY, None)
         st.session_state.pop(_ERROR_KEY, None)
+        st.session_state.pop(_ERROR_ENGINE_KEY, None)
         try:
             with st.spinner("Running query…"):
                 st.session_state[_RESULT_KEY] = sparql.run_query(
@@ -535,14 +563,20 @@ def render_sparql():
                 )
         except sparql.QueryError as e:
             st.session_state[_ERROR_KEY] = str(e)
+            st.session_state[_ERROR_ENGINE_KEY] = e.engine_text
         except Exception as e:  # noqa: BLE001 - a bad query must not take the page down
             log_error(e, context="SPARQL query")
             st.session_state[_ERROR_KEY] = str(e)
+            # Nothing wrote this one for a reader either.
+            st.session_state[_ERROR_ENGINE_KEY] = True
 
     # Held in session state so the result survives the rerun a download button
     # or a control change triggers.
     if st.session_state.get(_ERROR_KEY):
-        st.error(st.session_state[_ERROR_KEY])
+        _render_error(
+            st.session_state[_ERROR_KEY],
+            bool(st.session_state.get(_ERROR_ENGINE_KEY)),
+        )
     elif st.session_state.get(_RESULT_KEY) is not None:
         _render_result(st.session_state[_RESULT_KEY])
 

--- a/tests/test_sparql.py
+++ b/tests/test_sparql.py
@@ -66,6 +66,28 @@ def test_empty_query_is_a_syntax_error(populated_om):
         sparql.run_query(populated_om.graph, "   ")
 
 
+def test_the_engine_s_own_wording_is_marked_as_such(populated_om):
+    """What the page shows in a copyable block hangs off this flag (#399)."""
+    with pytest.raises(sparql.QuerySyntaxError) as caught:
+        sparql.run_query(populated_om.graph, "SELECT * WHERE { ?s ?p")
+    assert caught.value.engine_text
+    assert "Expected" in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "   ",  # ours: "Enter a query to run."
+        "DELETE WHERE { ?s ?p ?o }",  # ours: the console is read-only
+        "SELECT * WHERE { SERVICE <http://x/> { ?s ?p ?o } }",  # ours: no SERVICE
+    ],
+)
+def test_our_own_wording_is_not(populated_om, query):
+    with pytest.raises(sparql.QueryError) as caught:
+        sparql.run_query(populated_om.graph, query)
+    assert not caught.value.engine_text
+
+
 def test_a_query_cannot_mutate_the_ontology(populated_om):
     before = len(populated_om.graph)
     sparql.run_query(populated_om.graph, "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")

--- a/tests/test_sparql_ui.py
+++ b/tests/test_sparql_ui.py
@@ -89,6 +89,42 @@ def test_a_syntax_error_is_shown_not_raised():
     assert at.error
 
 
+def _code_blocks(at):
+    """Every code block on the page. A failed run is the only thing that puts
+    one there for a SELECT; a CONSTRUCT result is the other source."""
+    return [c.value for c in at.code]
+
+
+def test_the_engine_s_message_is_put_somewhere_it_can_be_copied():
+    """A code block is where Streamlit puts a copy button (issue #399)."""
+    at = _run("SELECT ?c WHERE { ?c a owl:Class")
+    assert at.error, "the failure is still announced"
+    assert any("Expected" in block for block in _code_blocks(at)), _code_blocks(at)
+
+
+def test_the_message_is_copied_out_verbatim():
+    """It reaches the block as rdflib wrote it, markdown characters and all.
+
+    ``st.error`` renders markdown: the prefix below came out as *odd* in
+    italics, and copying it back gave a prefix that does not exist.
+    """
+    at = _run("SELECT ?s WHERE { ?s a my_odd_prefix:Bar }")
+    assert "Unknown namespace prefix : my_odd_prefix" in _code_blocks(at)
+
+
+def test_our_own_words_stay_in_the_error_box():
+    """A refusal is prose written to be read, not a diagnostic to copy."""
+    at = _run("INSERT DATA { <http://a> <http://b> <http://c> }")
+    assert "read-only" in at.error[0].value
+    assert not _code_blocks(at)
+
+
+def test_a_query_that_runs_leaves_no_error_block_behind():
+    at = _run("SELECT ?c WHERE { ?c a owl:Class }")
+    assert not at.error
+    assert not _code_blocks(at)
+
+
 def test_the_row_limit_is_applied_and_announced():
     at = _run("SELECT ?s ?p ?o WHERE { ?s ?p ?o }", max_rows=2)
     assert not at.error


### PR DESCRIPTION
Closes #399.

## The ask

A failed query showed rdflib's message in `st.error`. That is a red box you can only select by hand, and the message is exactly what gets pasted into a search box or handed to someone (or something) that can explain it - "great for both human and AI help", as the issue puts it.

## The change

The engine's messages now go in a code block, which is where Streamlit puts a copy button. Two more things come with it:

- **The box renders markdown.** `Unknown namespace prefix : my_odd_prefix` was displayed with the middle word in italics and copied back as `my_oddprefix`, a prefix that does not exist. A code block shows it verbatim.
- **The positions only line up in monospace.** rdflib reports `(at char 25), (line:1, col:26)`, and multi-line messages keep their alignment.

Our own messages stay in the error box, unchanged: "This console is read-only...", "Enter a query to run.", and the refusals for shapes that cannot be bounded (`SERVICE`, an unbounded `VALUES` cross product, `FROM`). Those are prose written to be read where they are, not diagnostics to copy elsewhere.

Which is which is marked at the raise site - `QueryError.engine_text`, set `True` at the two places that wrap `str(exc)` - rather than guessed from the message text in the view. The page keeps that flag in a session key beside the message, so a session that was showing an error when the app reloaded still renders (it reads as "ours" and stays in the box).

## Verified live

Ran the app and typed both cases in. A bad prefix gives `The query could not be run.` in the red box with `Unknown namespace prefix : my_odd_prefix` in a monospace block below it, carrying a "Copy to clipboard" button on hover. An `INSERT DATA` gives the read-only prose in the box and no code block at all.

## Tests

- `tests/test_sparql.py`: a parse failure carries `engine_text`; the empty query, the read-only refusal and the `SERVICE` refusal do not.
- `tests/test_sparql_ui.py`: the engine's message reaches a code block, verbatim including the underscores that markdown ate; a refusal leaves no code block; a query that runs leaves none either.

Full suite green (1957 passed), plus ruff 0.16.5 format/check and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)