### PR TITLE
fix(viz): say when a focus leaves no room for its annotations (#405)

### DIFF
--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -706,6 +706,16 @@ def render_visualization():
                     key="viz_show_annotations",
                     on_change=viz_sync,
                     args=("_viz_cfg_show_annotations", "viz_show_annotations"),
+                    # Labels and comments are the annotations most entities
+                    # carry, and they are the two this does not draw — they are
+                    # in the tooltip instead. Without saying so, a graph of
+                    # entities annotated with nothing else looks like the
+                    # toggle does nothing (issue #405).
+                    help=(
+                        "Draw each annotation as a node hanging off what it "
+                        "annotates. Labels and comments are not drawn: they are "
+                        "already in the node's tooltip."
+                    ),
                 )
             with _cols[4]:
                 st.checkbox(
@@ -2636,7 +2646,21 @@ def render_visualization():
                                 continue
                             room -= added
                             ann_left_out += left_out
-                        if ann_left_out and not graph_notice:
+                        if ann_left_out and graph_notice:
+                            # The focus was already too big to draw in full, and
+                            # the annotations are the first thing the cap takes:
+                            # a focus that overflows on its nodes alone leaves
+                            # them no room at all. Added to what the graph
+                            # already had to say rather than dropped, which is
+                            # what used to happen — Annotations ticked and not
+                            # one annotation drawn, with the notice talking only
+                            # about node counts, reads as the toggle being
+                            # broken (issue #405).
+                            graph_notice += (
+                                f" {ann_left_out} annotation(s) are not shown "
+                                f"for the same reason."
+                            )
+                        elif ann_left_out:
                             graph_notice = (
                                 f"This focus and its annotations cover more than "
                                 f"the {GRAPH_MAX_NODES} nodes the graph can draw, "

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -1799,8 +1799,12 @@ def render_visualization():
         # cap line suppressed it — a cached v21 payload carries the suppressed
         # one and would keep showing it until something unrelated evicted it.
         # 23: the entities on a path are pinned past the node cap (issue #378),
-        # so a cached v22 payload is a graph built without them.
-        _graph_ver = 23
+        # so a cached v22 payload is a graph built without them. 24: the notice
+        # now also reports the annotations a focus at the node cap left no room
+        # for (issue #405) — the same reasoning as 22, since the notice travels
+        # with the payload: a cached v23 focus graph would go on showing the one
+        # that says nothing about them.
+        _graph_ver = 24
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.

--- a/tests/test_viz_focus_annotations.py
+++ b/tests/test_viz_focus_annotations.py
@@ -36,7 +36,11 @@ def _script():
         om.add_class("B", parent="A")
         om.add_class("C", parent="B")
         for name in ("A", "B", "C"):
-            om.add_annotation(name, "wikidataId", f"Q-{name}")
+            if os.environ.get("ANNOTATION_KIND") == "label_comment":
+                # The two the graph deliberately does not draw.
+                om.add_annotation(name, "rdfs:comment", f"about {name}")
+            else:
+                om.add_annotation(name, "wikidataId", f"Q-{name}")
         st.session_state.ontology = om
         st.session_state["_autosave_restored"] = True
         # The cross-session settings restore mounts the localStorage component,
@@ -51,11 +55,12 @@ def _script():
     app.render_visualization()
 
 
-def _graph(seed="Class: A", depth=1, annotations=True):
+def _graph(seed="Class: A", depth=1, annotations=True, annotation_kind="custom"):
     """Render once and return ``(nodes, edges)``. An empty seed means focus off."""
     os.environ["SEED"] = seed
     os.environ["DEPTH"] = str(depth)
     os.environ["ANNOTATIONS"] = "1" if annotations else "0"
+    os.environ["ANNOTATION_KIND"] = annotation_kind
     at = AppTest.from_function(_script)
     at.run(timeout=300)
     assert not at.exception, at.exception
@@ -152,6 +157,40 @@ def test_the_app_says_when_annotations_were_cut(patch_ui):
     assert not at.exception, at.exception
     notice = at.session_state["last_graph_data"].get("notice") or ""
     assert "annotations" in notice.lower(), notice
+
+
+def test_the_app_says_so_when_the_focus_itself_left_no_room(patch_ui):
+    """The gap the guard left (issue #405).
+
+    A focus too big to draw in full already sets a notice, and the annotation
+    shortfall was only reported when nothing else had spoken — so a focus that
+    overflowed on its nodes alone drew not one annotation with Annotations
+    ticked, and said only that it was full. Both facts are now in the notice.
+    """
+    patch_ui("GRAPH_MAX_NODES", 2)
+    nodes, _ = _graph(seed="Class: A", depth=2)
+    assert _annotation_labels(nodes) == set(), "no room was left for any of them"
+
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    notice = at.session_state["last_graph_data"].get("notice") or ""
+    assert "annotation" in notice.lower(), notice
+    assert "covers more than" in notice, notice
+
+
+def test_a_label_or_comment_is_not_drawn_as_a_node():
+    """What issue #405 turned out to be.
+
+    An entity whose only annotations are its label and comment draws none of
+    them: those two are in the node's tooltip instead. Nothing is wrong with
+    that, but it is the whole of "sometimes annotations are not shown", so it is
+    pinned here as a rule rather than left as an accident of the loop.
+    """
+    nodes, _ = _graph(seed="Class: A", depth=1, annotation_kind="label_comment")
+
+    assert _class_labels(nodes) == {"A", "B"}
+    assert _annotation_labels(nodes) == set()
 
 
 def test_annotations_survive_an_assembly_that_ran_out_of_room(patch_ui):

--- a/tests/test_viz_focus_annotations.py
+++ b/tests/test_viz_focus_annotations.py
@@ -55,8 +55,14 @@ def _script():
     app.render_visualization()
 
 
-def _graph(seed="Class: A", depth=1, annotations=True, annotation_kind="custom"):
-    """Render once and return ``(nodes, edges)``. An empty seed means focus off."""
+def _render(seed="Class: A", depth=1, annotations=True, annotation_kind="custom"):
+    """Render once and return the app.
+
+    Every knob is written on every call, none defaulted from what is already in
+    the environment: these are process-wide, so a test that set one and a test
+    that did not would pass or fail by the order pytest happened to run them in
+    (Codex review of PR #407).
+    """
     os.environ["SEED"] = seed
     os.environ["DEPTH"] = str(depth)
     os.environ["ANNOTATIONS"] = "1" if annotations else "0"
@@ -64,9 +70,19 @@ def _graph(seed="Class: A", depth=1, annotations=True, annotation_kind="custom")
     at = AppTest.from_function(_script)
     at.run(timeout=300)
     assert not at.exception, at.exception
+    return at
+
+
+def _graph(seed="Class: A", depth=1, annotations=True, annotation_kind="custom"):
+    """Render once and return ``(nodes, edges)``. An empty seed means focus off."""
+    at = _render(seed, depth, annotations, annotation_kind)
     data = at.session_state["last_graph_data"]
     assert data, "the visualization built no graph"
     return json.loads(data["nodes"]), json.loads(data["edges"])
+
+
+def _notice(at):
+    return at.session_state["last_graph_data"].get("notice") or ""
 
 
 def _annotation_labels(nodes):
@@ -149,13 +165,7 @@ def test_annotations_are_dropped_before_the_focus_itself(patch_ui):
 
 def test_the_app_says_when_annotations_were_cut(patch_ui):
     patch_ui("GRAPH_MAX_NODES", 3)
-    os.environ["SEED"] = "Class: A"
-    os.environ["DEPTH"] = "2"
-    os.environ["ANNOTATIONS"] = "1"
-    at = AppTest.from_function(_script)
-    at.run(timeout=300)
-    assert not at.exception, at.exception
-    notice = at.session_state["last_graph_data"].get("notice") or ""
+    notice = _notice(_render(seed="Class: A", depth=2))
     assert "annotations" in notice.lower(), notice
 
 
@@ -168,13 +178,11 @@ def test_the_app_says_so_when_the_focus_itself_left_no_room(patch_ui):
     ticked, and said only that it was full. Both facts are now in the notice.
     """
     patch_ui("GRAPH_MAX_NODES", 2)
-    nodes, _ = _graph(seed="Class: A", depth=2)
-    assert _annotation_labels(nodes) == set(), "no room was left for any of them"
+    at = _render(seed="Class: A", depth=2)
+    nodes = json.loads(at.session_state["last_graph_data"]["nodes"])
 
-    at = AppTest.from_function(_script)
-    at.run(timeout=300)
-    assert not at.exception, at.exception
-    notice = at.session_state["last_graph_data"].get("notice") or ""
+    assert _annotation_labels(nodes) == set(), "no room was left for any of them"
+    notice = _notice(at)
     assert "annotation" in notice.lower(), notice
     assert "covers more than" in notice, notice
 


### PR DESCRIPTION
Addresses #405. Not a full close: what the reporter saw turned out to be by-design behaviour (below), so this makes that visible and fixes a nearby case that produces the same symptom silently.

## What the report was

`rdfs:label` and `rdfs:comment` are deliberately never drawn as annotation nodes - they are in the node's tooltip instead (`_add_annotation_nodes`). A focus whose entities carry only those draws no annotation node at all, with Annotations ticked and nothing on screen accounting for it. Reproduced exactly against the reporter's shape (an imported, Wikidata-style ontology, four classes, depth 1):

```
seed='Class: Q1'   nodes=4  {'Class': 4}                    notice=(none)   <- their screenshot
seed='Class: Q9'   nodes=2  {'Class': 1, 'Annotation': 1}   notice=(none)   <- "now they are being shown"
```

That is the whole of "sometimes": which entities carry an annotation beyond label and comment. The rule is fine; being unable to find it out is not. The Annotations checkbox now says what it draws and what it does not, and a test pins the rule so it stays deliberate.

## The bug found next to it

Sweeping 96 focus / toggle / filter / size combinations, every failure had one shape: **when the focus itself overflows the node cap, every annotation is dropped and the notice never mentions it.**

```
kids=499  nodes=500  {'Class': 500}   "...500 annotation(s) are not shown. Pick fewer focus nodes..."   <- says so
kids=505  nodes=500  {'Class': 500}   "This focus covers more than the 500 nodes..."                    <- said nothing
```

The cause is the `and not graph_notice` guard on the annotation line: the truncation had already set a notice, so the shortfall was suppressed. `test_the_app_says_when_annotations_were_cut` covers only the case where the classes fit, which is why it escaped. The shortfall is now appended to whatever the graph already had to say, rather than dropped.

## Tests

- `test_the_app_says_so_when_the_focus_itself_left_no_room` - a focus truncated by the cap draws no annotations and says both facts. Fails on `main`.
- `test_a_label_or_comment_is_not_drawn_as_a_node` - pins the rule the report ran into.

Full suite green (1959 passed), plus ruff 0.16.5 format/check and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)