### PR TITLE
fix(viz): Restore keeps where you are, not where you were (#406)

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -783,7 +783,12 @@ function enterFullscreen() {
     settleFullscreen(true);
 }
 
+// Where the user is *now*, not where they were before they maximised: exit used
+// to re-apply the viewport captured on the way in, so everything done in the
+// maximised view — the whole reason for maximising — was undone by Restore
+// (issue #406). Captured before setStage(), which is what resizes the canvas.
 function leaveFullscreen() {
+    rememberViewport();
     setStage(false);
     setFullscreenIcon(false);
     settleFullscreen(false);
@@ -830,7 +835,15 @@ function scheduleFullscreenView(entering) {
     var gen = ++fsGen;
     function applyView() {
         if (!network || !fsRestoreView || gen !== fsGen) return;
-        var scale = entering ? fsRestoreView.scale * FS_ZOOM_OUT : fsRestoreView.scale;
+        // The zoom-out is a property of the box, not of the graph: entering
+        // trades magnification for the context the bigger canvas can hold, and
+        // leaving buys it back, so the same share of the graph is on screen
+        // either side of a transition. Undoing the factor rather than restoring
+        // a remembered number is what lets the viewport carried out of the
+        // maximised view be the one the user left it in (issue #406).
+        var scale = entering
+            ? fsRestoreView.scale * FS_ZOOM_OUT
+            : fsRestoreView.scale / FS_ZOOM_OUT;
         try { network.moveTo({scale: scale, position: fsRestoreView.position}); } catch (e) {}
     }
     // Fullscreen always fills; out of it, a user who turned autofit off keeps

--- a/tests/test_viz_fullscreen.py
+++ b/tests/test_viz_fullscreen.py
@@ -177,6 +177,30 @@ def test_escape_leaves_fullscreen():
     assert "d.addEventListener('keydown', onEscape)" in src
 
 
+def test_leaving_captures_the_view_it_is_leaving():
+    """Restore has to keep where the user is, not rewind to where they were.
+
+    Exit re-applied the viewport captured on the way *in*, so a pan or a zoom
+    made while maximised — the whole reason for maximising — was thrown away by
+    Restore (issue #406). Captured before ``setStage()``, which is what resizes
+    the canvas and would otherwise have moved the view first.
+    """
+    src = _VIEWER.read_text(encoding="utf-8")
+    fn = src[src.index("function leaveFullscreen(") :].split("\n}", 1)[0]
+    assert "rememberViewport()" in fn, fn
+    assert fn.index("rememberViewport()") < fn.index("setStage("), fn
+
+
+def test_the_zoom_out_is_bought_back_on_the_way_out():
+    """Entering trades magnification for context, and leaving undoes exactly
+    that trade — so a round trip that touched nothing lands on the scale it
+    started from, and one that did keeps the share of the graph it ended on."""
+    src = _VIEWER.read_text(encoding="utf-8")
+    apply_view = src[src.index("function applyView(") :].split("\n    }", 1)[0]
+    assert "* FS_ZOOM_OUT" in apply_view, apply_view
+    assert "/ FS_ZOOM_OUT" in apply_view, apply_view
+
+
 def test_the_page_listener_is_removed_with_the_document():
     """The listener is registered on the parent, which outlives this document by
     many re-mounts. Without the teardown each mount piles another dead one on."""


### PR DESCRIPTION
Addresses #406. The issue has no body, so I measured the graph's viewport across the transition in the running app rather than guessing. Two things move; this fixes the one that is a defect, and the other is a deliberate choice worth a second look (below).

## What Restore actually did

Maximise captured the viewport on the way in, and Restore re-applied it on the way out. An untouched round trip therefore landed exactly where it started - but everything done in the maximised view was undone. Measured live:

| step | scale | position | canvas |
|---|---|---|---|
| start | 1.10 | (-220, 140) | 1076x474 |
| Maximise | 0.77 | (-220, 140) | 1408x676 |
| pan and zoom onto something | 1.40 | (300, 180) | 1408x676 |
| **Restore** | **1.10** | **(-220, 140)** | 1076x474 |

Pan across a large graph, zoom in on a node, press Restore, and you are back at the node you left. That is the whole reason for maximising, thrown away.

## The change

Exit now captures what is on screen when Restore is pressed (before `setStage()`, which resizes the canvas), and undoes the entry zoom-out rather than restoring a remembered number. The zoom-out is a property of the box, not of the graph: entering trades magnification for the context the bigger canvas can hold, leaving buys it back - so the same share of the graph is on screen either side of a transition.

Verified live on the same instance:

| | scale | position |
|---|---|---|
| untouched round trip | 1.1 -> 0.77 -> **1.1** | unchanged throughout |
| worked in it, then Restore | 1.4 -> **2.0** | (300, 180) **kept** |

Both ways out - the button and Escape - go through `leaveFullscreen`, so both capture.

## Not changed: the zoom-out on the way in

Maximise multiplies the scale by 0.70 while the canvas grows ~1.3x wide and ~1.4x tall, so you end up seeing roughly twice as much graph and everything on it is 30% smaller than before you pressed the button. That is deliberate (PR #382, review P2) and might be the other half of "view shifts" in the report. It is a taste call, not a defect, so it is left alone here - happy to drop or shrink the factor as a follow-up.

## Tests

The transition is canvas behaviour, so it is pinned at the source level the way the other fullscreen invariants are: `leaveFullscreen` captures the viewport before it resizes the canvas, and the entry factor is undone rather than re-applied. Both fail on `main`.

Full suite green (1961 passed), plus ruff 0.16.5 format/check and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)