### PR TITLE
feat(viz): the selected class's links are drawn in front (#385)

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -467,6 +467,62 @@ var hlSource = null;          // node whose neighbourhood is currently ringed
 var hlSaved = null;           // id -> styling we overwrote, for an exact restore
 var hlJustSelected = false;   // this tap changed the selection (see the click handler)
 
+// --- The selected node's links, in front (issue #385) ------------------------
+// vis draws the edges in one pass and their arrowheads in a second, both in the
+// order of `body.edgeIndices` — so which arrowhead lands on top of which comes
+// down to the order the builder happened to emit them in, and a restriction's
+// was always over a relation's because restrictions are assembled last. Nothing
+// about the ontology says one is above the other, so the answer is not to
+// reorder the builder but to put what you are *looking at* on top: selecting a
+// class raises its links over everything they cross.
+//
+// The order is a view concern, so it is changed here and not in the DataSet:
+// the edges themselves are untouched, and dropping the selection puts the order
+// back exactly. `edgeIndices` is mutated in place rather than reassigned — vis
+// hands the same array around its renderer, and a fresh one would leave those
+// holders pointing at the old order.
+var edgeOrder = null;   // the order to put back, captured before the first raise
+
+function setEdgeIndices(order) {
+    var idx = network && network.body && network.body.edgeIndices;
+    if (!idx) return;
+    idx.length = 0;
+    Array.prototype.push.apply(idx, order);
+}
+
+function raiseEdgesOf(id) {
+    var idx = network && network.body && network.body.edgeIndices;
+    if (!idx || id === null || id === undefined) return;
+    if (!edgeOrder) edgeOrder = idx.slice();
+    var connected = {};
+    try {
+        (network.getConnectedEdges(id) || []).forEach(function(eid) { connected[eid] = true; });
+    } catch (e) { return; }
+    // A stable partition: within the two groups the builder's order is kept, so
+    // the only thing that changes is that the selection is above the rest.
+    var back = [], front = [];
+    idx.forEach(function(eid) { (connected[eid] ? front : back).push(eid); });
+    setEdgeIndices(back.concat(front));
+    try { network.redraw(); } catch (e) {}
+}
+
+function restoreEdgeOrder() {
+    var idx = network && network.body && network.body.edgeIndices;
+    if (!edgeOrder || !idx) { edgeOrder = null; return; }
+    // Against what is in the graph now, not what was there when the order was
+    // taken: a rebuild between the two leaves ids that have gone and ids that
+    // were never in the saved order, and both have to come out right.
+    var present = {};
+    idx.forEach(function(eid) { present[eid] = true; });
+    var restored = edgeOrder.filter(function(eid) { return present[eid]; });
+    var known = {};
+    restored.forEach(function(eid) { known[eid] = true; });
+    idx.forEach(function(eid) { if (!known[eid]) restored.push(eid); });
+    setEdgeIndices(restored);
+    edgeOrder = null;
+    try { network.redraw(); } catch (e) {}
+}
+
 // Restore every ringed node to exactly what it looked like before.
 //
 // The saved values are written back explicitly rather than by passing the
@@ -494,6 +550,7 @@ function clearNeighbourHighlight() {
     }
     hlSource = null;
     hlSaved = null;
+    restoreEdgeOrder();
 }
 
 // Ring `id`'s neighbours: dashed for the ones pointing at it, solid for the ones
@@ -542,6 +599,10 @@ function applyNeighbourHighlight(id) {
     incoming.forEach(function(nid) { ringNode(nid, true); });
     outgoing.forEach(function(nid) { ringNode(nid, false); });
     if (updates.length) { try { ds.update(updates); } catch (e) {} }
+    // Ride along with the ring: every path that selects a node goes through
+    // here (issue #224), so the links follow the selection without each of
+    // those paths having to remember to say so.
+    raiseEdgesOf(id);
 }
 
 // --- Shortest-path ring (issues #176, #357) ---------------------------------

--- a/tests/test_viz_edge_order.py
+++ b/tests/test_viz_edge_order.py
@@ -1,0 +1,74 @@
+"""The selected node's links are drawn in front (issue #385).
+
+vis draws the edges in one pass and their arrowheads in a second, both walking
+``body.edgeIndices`` in order — so which arrowhead lands on top of which comes
+down to the order the builder happened to emit them in, and a restriction's was
+always over a relation's because restrictions are assembled last. Nothing about
+the ontology says one is above the other, so the fix is not to reorder the
+builder but to raise what the user is looking at: selecting a class puts its
+links over everything they cross, and dropping the selection puts the order
+back.
+
+Canvas behaviour, so none of it is observable from Python; the invariants that
+would silently break it are pinned at the source level, the way the neighbour
+ring's are in test_viz_neighbour_highlight.py.
+"""
+
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+_VIEWER = _PKG / "lib" / "graph_viewer" / "index.html"
+
+
+def _viewer():
+    return _VIEWER.read_text(encoding="utf-8")
+
+
+def _function(src, name):
+    return src[src.index(f"function {name}(") :].split("\n}", 1)[0]
+
+
+def test_selecting_a_node_raises_its_links():
+    """It rides along with the neighbour ring, which every path that selects a
+    node already goes through (issue #224) — so a new selection path cannot
+    forget to raise the links without also forgetting to ring the neighbours,
+    which its own test already forbids."""
+    fn = _function(_viewer(), "applyNeighbourHighlight")
+    assert "raiseEdgesOf(" in fn, fn
+
+
+def test_dropping_the_selection_puts_the_order_back():
+    fn = _function(_viewer(), "clearNeighbourHighlight")
+    assert "restoreEdgeOrder()" in fn, fn
+
+
+def test_the_draw_order_is_mutated_in_place():
+    """vis hands the same ``edgeIndices`` array around its renderer, so a fresh
+    one would leave those holders pointing at the order before the raise."""
+    src = _viewer()
+    assert "body.edgeIndices =" not in src, "the array is shared; reorder it in place"
+    assert "idx.length = 0" in _function(src, "setEdgeIndices")
+
+
+def test_the_raise_keeps_the_builder_s_order_within_each_group():
+    """A stable partition, not a sort: the order the edges were emitted in is
+    what the parallel-edge curves (issue #245) and the legend are built around,
+    and the only thing this changes is which side of the line they sit on."""
+    fn = _function(_viewer(), "raiseEdgesOf")
+    assert "back.concat(front)" in fn, fn
+    assert "sort(" not in fn, fn
+
+
+def test_the_edges_themselves_are_left_alone():
+    """The DataSet is not touched: this is a view concern, and an edge update
+    would ripple into the selection and the ring restore that read it back."""
+    fn = _function(_viewer(), "raiseEdgesOf")
+    assert "data.edges" not in fn and ".update(" not in fn, fn
+
+
+def test_a_rebuild_between_the_raise_and_the_restore_is_survivable():
+    """Ids that have gone since the order was taken must not come back, and ids
+    that arrived after it must not be dropped."""
+    fn = _function(_viewer(), "restoreEdgeOrder")
+    assert "present[eid]" in fn, fn
+    assert "known[eid]" in fn, fn


### PR DESCRIPTION
Closes #385.

## Why the restriction was always on top

vis draws the edges in one pass and their arrowheads in a second (`_drawEdges`, then `_drawArrows`), both walking `body.edgeIndices` in order. So which arrowhead lands over which is decided by the order the builder happened to emit the edges in - and a restriction's was always over a relation's because restrictions are assembled last. Nothing about the ontology says one is above the other, so reordering the builder would only move the arbitrariness around.

## What it does instead

The issue's own suggestion: put what you are looking at in front. Selecting a class raises its links - lines and arrowheads - over everything they cross, and dropping the selection puts the order back.

Measured live on the Organization template:

```
edges 17, connected to the selected class 7
draw slots before   [2, 3, 4, 6, 7, 13, 14]
draw slots after    [10, 11, 12, 13, 14, 15, 16]   all at the back of the draw
same edge set       true
restored exactly    true                            after deselecting
```

Three things worth saying about the implementation:

- **The DataSet is untouched.** Draw order is a view concern; an edge update would ripple into the selection and the ring restore that read it back.
- **`edgeIndices` is mutated in place**, not reassigned - vis hands that same array around its renderer, and a fresh one would leave those holders pointing at the order before the raise.
- **It rides along with the neighbour ring** (issue #224), which every path that selects a node already goes through, so a new selection path cannot forget to raise the links without also forgetting to ring the neighbours - which that feature's own test already forbids.

The partition is stable, so within each group the builder's order survives: the parallel-edge curves (issue #245) and the legend are built around it, and the only thing that changes is which side of the line an edge sits on.

## Tests

`tests/test_viz_edge_order.py` - six source-level guards, in the style of the neighbour-ring ones since none of this is observable from Python: the raise is wired to the selection, the restore to the deselection, the array is mutated in place, the partition is stable rather than sorted, the edges themselves are left alone, and a rebuild between raise and restore neither resurrects a gone edge nor drops a new one. All six fail on `main`.

Full suite green (1967 passed), plus ruff 0.16.5 format/check and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)