### PR TITLE
feat(a11y): Tab walks field to field, and the help comes with it (#383)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -187,6 +187,7 @@ from .ui import (  # noqa: F401
     get_ontology_manager_class,
     graph_node_cap,
     init_session_state,
+    install_help_capture,
     language_pack_entries,
     language_pack_names,
     language_selectbox,
@@ -217,6 +218,7 @@ from .ui import (  # noqa: F401
     render_add_class_form,
     render_add_restriction,
     render_annotation_form,
+    render_help_wiring,
     render_language_pack_sidebar,
     render_relation_form,
     render_relation_rows,
@@ -240,6 +242,7 @@ from .ui import (  # noqa: F401
     set_flash_message,
     show_message,
     sparql_state_changed,
+    start_help_capture,
     theme_is_dark,
     viz_apply_focus_click,
     viz_auto_show_new_toggled,
@@ -405,6 +408,12 @@ def render_autosave_sidebar():
 def main():
     """Main application entry point."""
     _configure_page()
+    # Before anything renders: the widgets are wrapped so their help text is
+    # collected on the way past, and this render starts with none of it
+    # (issue #383). render_help_wiring() at the end puts it where a keyboard
+    # meets it.
+    install_help_capture()
+    start_help_capture()
     init_session_state()
     maybe_restore_autosave()
 
@@ -720,6 +729,11 @@ def main():
     # Mirror the current ontology to browser localStorage (after all edits for
     # this rerun have been applied) so a refresh can restore it.
     persist_autosave()
+
+    # Last, so it has seen every help= this page passed: the help buttons and
+    # the clear crosses leave the tab order and their text lands on the fields
+    # (issue #383).
+    render_help_wiring()
 
 
 if __name__ == "__main__":

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -538,18 +538,41 @@ _HELPED_WIDGETS = (
 )
 
 
-def _record_help(label, help_text) -> None:
-    """Note that ``label``'s widget was given this help text."""
-    if not isinstance(label, str) or not isinstance(help_text, str):
+def _record_help(label, help_text, key=None) -> None:
+    """Note the help text this widget was given, under what identifies it.
+
+    By its ``key`` where it has one, because that is the only thing that tells
+    two widgets apart: a page can draw a row of identical 🗑️ buttons whose help
+    differs per row ("Delete this creator", "Delete this prefLabel"), and keyed
+    only by the label the last one would answer for all of them — putting the
+    wrong description on a control whose icon we had just taken out of the tab
+    order (Codex review of PR #410).
+
+    The label is kept as the fallback for the widgets that have no key, and a
+    label two widgets disagree over is dropped rather than guessed at.
+    """
+    if not isinstance(help_text, str):
         return
     try:
-        texts = st.session_state.get(HELP_TEXTS_KEY)
+        store = st.session_state.get(HELP_TEXTS_KEY)
     except Exception:  # noqa: BLE001 - no session (a bare import, a worker thread)
         return
-    if not isinstance(texts, dict):
-        texts = {}
-        st.session_state[HELP_TEXTS_KEY] = texts
-    texts[label] = help_text
+    if not isinstance(store, dict) or "by_key" not in store:
+        store = _empty_help_store()
+        st.session_state[HELP_TEXTS_KEY] = store
+    if isinstance(key, str) and key:
+        store["by_key"][key] = help_text
+    if isinstance(label, str):
+        by_label = store["by_label"]
+        if label in by_label and by_label[label] != help_text:
+            by_label[label] = None  # two widgets, two texts: neither is "the" one
+        else:
+            by_label.setdefault(label, help_text)
+
+
+def _empty_help_store() -> dict:
+    """What a render starts from: nothing recorded, under either identity."""
+    return {"by_key": {}, "by_label": {}}
 
 
 def _capturing_help(fn):
@@ -566,7 +589,7 @@ def _capturing_help(fn):
             label = kwargs.get("label")
             if not isinstance(label, str):
                 label = next((a for a in args if isinstance(a, str)), None)
-            _record_help(label, kwargs["help"])
+            _record_help(label, kwargs["help"], kwargs.get("key"))
         return fn(*args, **kwargs)
 
     wrapped.__name__ = getattr(fn, "__name__", "widget")
@@ -615,7 +638,7 @@ def install_help_capture() -> None:
 
 def start_help_capture() -> None:
     """Begin a render with an empty set of help texts."""
-    st.session_state[HELP_TEXTS_KEY] = {}
+    st.session_state[HELP_TEXTS_KEY] = _empty_help_store()
 
 
 #: The script :func:`help_wiring_html` wraps. A raw string, and deliberately
@@ -632,6 +655,17 @@ if (doc) {
   var CONTROLS = 'input, textarea, select, button:not([aria-label^="Help for "])';
   var HELP_FOR = 'Help for ';
   var seq = 0;
+
+  // The widget's key, which Streamlit puts on its container as a class. Read
+  // off the element rather than built into a selector: a key is app-authored
+  // text and could carry anything.
+  function keyOf(box) {
+    var classes = box.className ? String(box.className).split(' ') : [];
+    for (var i = 0; i < classes.length; i++) {
+      if (classes[i].indexOf('st-key-') === 0) return classes[i].slice(7);
+    }
+    return null;
+  }
 
   // The help text, on the control itself: a visually hidden note next to it,
   // named by aria-describedby. Both attributes are set — describedby is what
@@ -659,26 +693,37 @@ if (doc) {
   }
 
   function apply() {
-    // Out of the tab order, so Tab walks field to field. The help icons are
-    // matched by their own label, not by the tooltip wrapper around them:
-    // Streamlit puts that same wrapper on real controls — the image Fullscreen
-    // button is one — and those keep their place in the tab order.
+    // Out of the tab order, so Tab walks field to field — but only where the
+    // text the icon holds has been put on the control. That is the rule that
+    // keeps this honest: an icon whose help cannot be placed keeps its tab
+    // stop rather than becoming unreachable (Codex review of PR #410).
+    //
+    // The icons are matched by their own label, not by the tooltip wrapper
+    // around them: Streamlit puts that same wrapper on real controls — the
+    // image Fullscreen button is one — and those keep their place regardless.
     var icons = doc.querySelectorAll('button[aria-label^="Help for "]');
     for (var i = 0; i < icons.length; i++) {
       var icon = icons[i];
-      icon.setAttribute('tabindex', '-1');
-      var text = HELP[icon.getAttribute('aria-label').slice(HELP_FOR.length)];
-      if (!text) continue;
       // Walk from the icon to the widget it belongs to rather than looking the
       // control up by its label: a button's name is its text and not an
       // aria-label, and two widgets on a page can carry the same label. The
-      // container Streamlit wraps each widget in answers both exactly.
+      // container Streamlit wraps each widget in answers both, and carries the
+      // widget's key as a class where it has one — which is the only thing
+      // that tells a row of identical buttons apart.
       var box = icon.closest('[data-testid="stElementContainer"]');
-      var control = box && box.querySelector(CONTROLS);
-      if (control) describe(control, text);
+      if (!box) continue;
+      var key = keyOf(box);
+      var text = key && Object.prototype.hasOwnProperty.call(BY_KEY, key)
+        ? BY_KEY[key]
+        : BY_LABEL[icon.getAttribute('aria-label').slice(HELP_FOR.length)];
+      var control = text && box.querySelector(CONTROLS);
+      if (!control) continue;
+      describe(control, text);
+      icon.setAttribute('tabindex', '-1');
     }
-    // The crosses are the same case Streamlit already made for the dropdown
-    // arrow beside them, which it ships as tabindex="-1".
+    // The crosses need nothing carried anywhere first: they duplicate what the
+    // keyboard can already do in the combobox itself, which is the case
+    // Streamlit already made for the dropdown arrow beside them.
     var clears = doc.querySelectorAll('button[aria-label="Clear value"]');
     for (var j = 0; j < clears.length; j++) clears[j].setAttribute('tabindex', '-1');
   }
@@ -717,10 +762,17 @@ def help_wiring_html(texts: dict) -> str:
       reads it when the field is focused rather than at a separate button that
       is no longer reachable. This is the half that makes the first half honest.
     """
+    by_key = texts.get("by_key") or {}
+    # A label two widgets disagreed over is not sent at all: an icon whose text
+    # cannot be placed keeps its tab stop instead, which is the safety rule the
+    # script below is built on.
+    by_label = {k: v for k, v in (texts.get("by_label") or {}).items() if v}
     return (
         "<script>\n"
-        "var HELP = "
-        + json.dumps(texts, ensure_ascii=False)
+        "var BY_KEY = "
+        + json.dumps(by_key, ensure_ascii=False)
+        + ";\nvar BY_LABEL = "
+        + json.dumps(by_label, ensure_ascii=False)
         + ";\n"
         + _HELP_WIRING_JS
         + "</script>"

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -514,6 +514,228 @@ def get_ontology_manager_class():
     return OntologyManager
 
 
+#: Where this render's ``help=`` texts are collected, keyed by the widget label
+#: they were given with. Per session, because that is what session_state is, and
+#: rebuilt on every render so a page that no longer draws a field stops carrying
+#: its help.
+HELP_TEXTS_KEY = "_help_texts"
+
+#: The widget functions the app passes ``help=`` to. Wrapped once, at import, so
+#: every call site is covered — the alternative was routing 100-odd of them
+#: through a helper, and the next one added would have been the one that forgot.
+_HELPED_WIDGETS = (
+    "button",
+    "checkbox",
+    "file_uploader",
+    "multiselect",
+    "number_input",
+    "radio",
+    "selectbox",
+    "slider",
+    "text_area",
+    "text_input",
+    "toggle",
+)
+
+
+def _record_help(label, help_text) -> None:
+    """Note that ``label``'s widget was given this help text."""
+    if not isinstance(label, str) or not isinstance(help_text, str):
+        return
+    try:
+        texts = st.session_state.get(HELP_TEXTS_KEY)
+    except Exception:  # noqa: BLE001 - no session (a bare import, a worker thread)
+        return
+    if not isinstance(texts, dict):
+        texts = {}
+        st.session_state[HELP_TEXTS_KEY] = texts
+    texts[label] = help_text
+
+
+def _capturing_help(fn):
+    """``fn`` with its ``help=`` noted on the way past. Nothing else changes."""
+
+    def wrapped(*args, **kwargs):
+        if kwargs.get("help"):
+            # The label is the first string argument, not the first argument:
+            # the same function is called both as ``st.text_input(label, ...)``
+            # and — once the container class is patched — as
+            # ``dg.text_input(dg, label, ...)``, where the container comes
+            # first. Taking position 0 recorded the container and lost every
+            # sidebar widget's help.
+            label = kwargs.get("label")
+            if not isinstance(label, str):
+                label = next((a for a in args if isinstance(a, str)), None)
+            _record_help(label, kwargs["help"])
+        return fn(*args, **kwargs)
+
+    wrapped.__name__ = getattr(fn, "__name__", "widget")
+    wrapped.__doc__ = getattr(fn, "__doc__", None)
+    wrapped._orionbelt_help_capture = True  # so this is idempotent
+    return wrapped
+
+
+def _patch_help_capture(holder) -> None:
+    """Wrap ``holder``'s widget functions, once."""
+    for name in _HELPED_WIDGETS:
+        fn = getattr(holder, name, None)
+        if fn is None or getattr(fn, "_orionbelt_help_capture", False):
+            continue
+        setattr(holder, name, _capturing_help(fn))
+
+
+def install_help_capture() -> None:
+    """Record every ``help=`` the app passes to a widget (issue #383).
+
+    A help tooltip renders as a real button, and since Streamlit 1.62 rebuilt
+    the widgets on react-aria it sits in the tab order — before the field it
+    belongs to, so tabbing through a form stops twice per field. Taking it out
+    of the tab order is only honest if the text it holds goes somewhere a
+    keyboard reaches, and Streamlit does not put it on the field: the text is in
+    the tooltip and nowhere else until the tooltip opens.
+
+    So the text is collected here, on its way to the widget, and
+    :func:`render_help_wiring` puts it on the field itself. The widgets are
+    wrapped rather than each call site changed, which keeps this true for the
+    102nd ``help=`` as well as the 101 that exist.
+    """
+    # Both, because they are different objects: ``st.text_input`` is a method
+    # already bound to the main container, so patching the class it came from
+    # does not touch it — and patching only the module would miss every widget
+    # drawn on ``st.sidebar`` or inside a column, which is where the sidebar's
+    # own help icons come from.
+    _patch_help_capture(st)
+    try:
+        from streamlit.delta_generator import DeltaGenerator
+
+        _patch_help_capture(DeltaGenerator)
+    except Exception:
+        logger.debug("Help capture not installed on the container class", exc_info=True)
+
+
+def start_help_capture() -> None:
+    """Begin a render with an empty set of help texts."""
+    st.session_state[HELP_TEXTS_KEY] = {}
+
+
+#: The script :func:`help_wiring_html` wraps. A raw string, and deliberately
+#: free of selectors built from label text: a label carrying a quote or a
+#: backslash would have to be escaped into one, and the escaping is the part
+#: that breaks silently. Labels are compared as strings instead.
+_HELP_WIRING_JS = r"""
+var doc = window.parent && window.parent.document;
+if (doc) {
+  var HIDDEN = 'position:absolute;width:1px;height:1px;margin:-1px;padding:0;'
+             + 'overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0;';
+  // What inside a widget's container takes the description: its own control,
+  // never the help icon that pointed us at it.
+  var CONTROLS = 'input, textarea, select, button:not([aria-label^="Help for "])';
+  var HELP_FOR = 'Help for ';
+  var seq = 0;
+
+  // The help text, on the control itself: a visually hidden note next to it,
+  // named by aria-describedby. Both attributes are set — describedby is what
+  // the screen readers in use today read, aria-description is where the same
+  // thing is heading.
+  function describe(el, text) {
+    var id = el.getAttribute('data-orionbelt-help');
+    var note = id && doc.getElementById(id);
+    if (!note) {
+      id = 'orionbelt-help-' + (++seq);
+      note = doc.createElement('span');
+      note.id = id;
+      note.setAttribute('style', HIDDEN);
+      el.setAttribute('data-orionbelt-help', id);
+      (el.parentElement || doc.body).appendChild(note);
+    }
+    if (note.textContent !== text) note.textContent = text;
+    var described = el.getAttribute('aria-describedby') || '';
+    if (described.split(' ').indexOf(id) === -1) {
+      el.setAttribute('aria-describedby', (described + ' ' + id).trim());
+    }
+    if (el.getAttribute('aria-description') !== text) {
+      el.setAttribute('aria-description', text);
+    }
+  }
+
+  function apply() {
+    // Out of the tab order, so Tab walks field to field. The help icons are
+    // matched by their own label, not by the tooltip wrapper around them:
+    // Streamlit puts that same wrapper on real controls — the image Fullscreen
+    // button is one — and those keep their place in the tab order.
+    var icons = doc.querySelectorAll('button[aria-label^="Help for "]');
+    for (var i = 0; i < icons.length; i++) {
+      var icon = icons[i];
+      icon.setAttribute('tabindex', '-1');
+      var text = HELP[icon.getAttribute('aria-label').slice(HELP_FOR.length)];
+      if (!text) continue;
+      // Walk from the icon to the widget it belongs to rather than looking the
+      // control up by its label: a button's name is its text and not an
+      // aria-label, and two widgets on a page can carry the same label. The
+      // container Streamlit wraps each widget in answers both exactly.
+      var box = icon.closest('[data-testid="stElementContainer"]');
+      var control = box && box.querySelector(CONTROLS);
+      if (control) describe(control, text);
+    }
+    // The crosses are the same case Streamlit already made for the dropdown
+    // arrow beside them, which it ships as tabindex="-1".
+    var clears = doc.querySelectorAll('button[aria-label="Clear value"]');
+    for (var j = 0; j < clears.length; j++) clears[j].setAttribute('tabindex', '-1');
+  }
+
+  var pending = null;
+  function schedule() {
+    if (pending) return;
+    pending = setTimeout(function () { pending = null; apply(); }, 50);
+  }
+
+  apply();
+  // Streamlit rebuilds its DOM on every rerun and this frame is mounted once,
+  // so the work is redone whenever the page under it changes. Batched, because
+  // a rerun lands as a burst of mutations.
+  try {
+    new MutationObserver(schedule).observe(doc.body, {childList: true, subtree: true});
+  } catch (e) {}
+}
+"""
+
+
+def help_wiring_html(texts: dict) -> str:
+    """The page's tab-order and help wiring, as a component document.
+
+    Two things, both in the parent document because that is where the widgets
+    are, and both re-applied by a MutationObserver because Streamlit rebuilds
+    that DOM on every rerun while this frame is mounted once:
+
+    * the help buttons and the selectboxes' clear crosses leave the tab order,
+      so Tab walks field to field (issue #383). The crosses are the same case
+      Streamlit already made for the dropdown arrow next to them, which it ships
+      as ``tabindex="-1"``: a control that duplicates something the keyboard can
+      already do — the combobox is an editable text field, so its value clears
+      by typing.
+    * the help text lands on the field as a description, so a screen reader
+      reads it when the field is focused rather than at a separate button that
+      is no longer reachable. This is the half that makes the first half honest.
+    """
+    return (
+        "<script>\n"
+        "var HELP = "
+        + json.dumps(texts, ensure_ascii=False)
+        + ";\n"
+        + _HELP_WIRING_JS
+        + "</script>"
+    )
+
+
+def render_help_wiring() -> None:
+    """Mount :func:`help_wiring_html` for this render, if there is a page."""
+    texts = st.session_state.get(HELP_TEXTS_KEY)
+    try:
+        st.components.v1.html(help_wiring_html(texts or {}), height=0)
+    except Exception:  # cosmetic: a page must not fail over its tab order
+        logger.debug("Help wiring not mounted", exc_info=True)
+
+
 def init_session_state():
     """Initialize session state variables."""
     if "ontology" not in st.session_state:

--- a/tests/test_help_tab_order.py
+++ b/tests/test_help_tab_order.py
@@ -49,17 +49,16 @@ def session(monkeypatch):
 def test_a_widget_s_help_is_collected_on_its_way_past(session):
     ui.start_help_capture()
     ui.install_help_capture()
-    calls = []
     st.text_input("Class Name *", help="A local name", key="probe")
-    assert session[ui.HELP_TEXTS_KEY]["Class Name *"] == "A local name"
-    assert calls == []
+    assert session[ui.HELP_TEXTS_KEY]["by_label"]["Class Name *"] == "A local name"
+    assert session[ui.HELP_TEXTS_KEY]["by_key"]["probe"] == "A local name"
 
 
 def test_a_widget_without_help_is_not_recorded(session):
     ui.start_help_capture()
     ui.install_help_capture()
     st.text_input("Label", key="probe2")
-    assert "Label" not in session[ui.HELP_TEXTS_KEY]
+    assert "Label" not in session[ui.HELP_TEXTS_KEY]["by_label"]
 
 
 def test_the_label_is_found_by_type_not_by_position(session):
@@ -73,7 +72,9 @@ def test_the_label_is_found_by_type_not_by_position(session):
     ui.start_help_capture()
     ui.install_help_capture()
     st.sidebar.checkbox("Autosave to this browser", help="Keep a copy", key="probe4")
-    assert session[ui.HELP_TEXTS_KEY]["Autosave to this browser"] == "Keep a copy"
+    assert session[ui.HELP_TEXTS_KEY]["by_label"]["Autosave to this browser"] == (
+        "Keep a copy"
+    )
 
 
 def test_the_wrapping_is_idempotent():
@@ -92,17 +93,73 @@ def test_each_render_starts_from_nothing(session):
     ui.install_help_capture()
     st.text_input("Gone next time", help="x", key="probe3")
     ui.start_help_capture()
-    assert session[ui.HELP_TEXTS_KEY] == {}
+    assert session[ui.HELP_TEXTS_KEY] == {"by_key": {}, "by_label": {}}
 
 
 # --- what is handed to the browser ------------------------------------------
 
 
+def test_a_row_of_identical_buttons_keeps_its_own_help(session):
+    """The case the review of PR #410 found.
+
+    A page draws a 🗑️ per row, each with the help its own row needs — "Delete
+    this creator", "Delete this prefLabel". Keyed by the label, one of them
+    would answer for all of them, and every button would carry the wrong
+    description while its icon was taken out of the tab order. The widget key
+    is the only thing that tells them apart.
+    """
+    ui.start_help_capture()
+    ui.install_help_capture()
+    st.button("🗑️", key="del_meta_0", help="Delete this creator")
+    st.button("🗑️", key="del_meta_1", help="Delete this prefLabel")
+
+    store = session[ui.HELP_TEXTS_KEY]
+    assert store["by_key"]["del_meta_0"] == "Delete this creator"
+    assert store["by_key"]["del_meta_1"] == "Delete this prefLabel"
+    # And the label they share is dropped rather than guessed at.
+    assert store["by_label"]["🗑️"] is None
+    assert "🗑️" not in json.loads(_payload(ui.help_wiring_html(store), "BY_LABEL"))
+
+
+def test_a_label_two_widgets_agree_on_still_carries(session):
+    """Only disagreement is ambiguous. The same help twice is one answer."""
+    ui.start_help_capture()
+    ui.install_help_capture()
+    st.button("🗑️", key="del_a", help="Delete this row")
+    st.button("🗑️", key="del_b", help="Delete this row")
+    assert session[ui.HELP_TEXTS_KEY]["by_label"]["🗑️"] == "Delete this row"
+
+
+def test_an_icon_whose_help_cannot_be_placed_keeps_its_tab_stop():
+    """The safety rule: the tab stop goes only where the text has landed."""
+    js = ui._HELP_WIRING_JS
+    apply_fn = js[js.index("function apply(") :]
+    assert "if (!control) continue;" in apply_fn, apply_fn
+    assert apply_fn.index("if (!control) continue;") < apply_fn.index(
+        "icon.setAttribute('tabindex', '-1')"
+    ), "the icon is only de-tabbed after its text is placed"
+
+
+def test_the_key_is_read_off_the_container_not_built_into_a_selector():
+    """A widget key is app-authored text; it could carry anything."""
+    js = ui._HELP_WIRING_JS
+    assert "function keyOf(" in js
+    assert "'st-key-'" in js
+    assert "'.st-key-' +" not in js
+
+
+def _payload(html, name):
+    return html.split(f"var {name} = ", 1)[1].split(";\n", 1)[0]
+
+
 def test_the_text_reaches_the_page_as_data_not_as_script():
     """Quotes and backslashes in a help string must not be able to end the
     script they ride in."""
-    html = ui.help_wiring_html({'A "quoted" label': "back\\slash and 'quotes'"})
-    payload = html.split("var HELP = ", 1)[1].split(";\n", 1)[0]
+    store = {
+        "by_key": {},
+        "by_label": {'A "quoted" label': "back\\slash and 'quotes'"},
+    }
+    payload = _payload(ui.help_wiring_html(store), "BY_LABEL")
     assert json.loads(payload) == {'A "quoted" label': "back\\slash and 'quotes'"}
 
 
@@ -170,6 +227,6 @@ def test_a_rendered_page_hands_over_the_help_it_drew():
     at.run(timeout=300)
     assert not at.exception, at.exception
 
-    texts = at.session_state[ui.HELP_TEXTS_KEY]
+    texts = at.session_state[ui.HELP_TEXTS_KEY]["by_label"]
     assert texts, "the Add Class form passes help= to several fields"
-    assert any("class" in t.lower() for t in texts.values()), texts
+    assert any("class" in t.lower() for t in texts.values() if t), texts

--- a/tests/test_help_tab_order.py
+++ b/tests/test_help_tab_order.py
@@ -1,0 +1,175 @@
+"""Tab walks field to field, and the help text comes along (issue #383).
+
+A help tooltip renders as a real button, and since Streamlit 1.62 rebuilt the
+widgets on react-aria it sits in the tab order — before the field it belongs to,
+so tabbing through a form stopped twice per field, and a clearable dropdown
+added its cross on top of that.
+
+Taking those out of the tab order is only honest if the text the icon holds goes
+somewhere a keyboard reaches, and Streamlit does not put it on the field: it
+lives in the tooltip and nowhere else until the tooltip opens. So every ``help=``
+the app passes is collected on its way to the widget and put on the field as a
+description.
+
+The DOM half runs in the browser, so it is pinned at the source level; the
+collecting half is Python and is exercised directly.
+"""
+
+import json
+
+import pytest
+import streamlit as st
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import ui
+
+
+@pytest.fixture
+def session(monkeypatch):
+    """A session_state stand-in: dict access plus the attribute access ui uses."""
+
+    class _State(dict):
+        def __getattr__(self, name):
+            try:
+                return self[name]
+            except KeyError as exc:  # pragma: no cover - mirrors Streamlit
+                raise AttributeError(name) from exc
+
+        def __setattr__(self, name, value):
+            self[name] = value
+
+    state = _State()
+    monkeypatch.setattr(ui.st, "session_state", state)
+    return state
+
+
+# --- collecting the text ----------------------------------------------------
+
+
+def test_a_widget_s_help_is_collected_on_its_way_past(session):
+    ui.start_help_capture()
+    ui.install_help_capture()
+    calls = []
+    st.text_input("Class Name *", help="A local name", key="probe")
+    assert session[ui.HELP_TEXTS_KEY]["Class Name *"] == "A local name"
+    assert calls == []
+
+
+def test_a_widget_without_help_is_not_recorded(session):
+    ui.start_help_capture()
+    ui.install_help_capture()
+    st.text_input("Label", key="probe2")
+    assert "Label" not in session[ui.HELP_TEXTS_KEY]
+
+
+def test_the_label_is_found_by_type_not_by_position(session):
+    """The same function is called two ways.
+
+    ``st.text_input(label, ...)`` passes the label first; a widget drawn on the
+    sidebar or in a column arrives as ``dg.text_input(dg, label, ...)``, with the
+    container first. Reading position 0 recorded the container and lost the help
+    of every sidebar widget — two icons on every page of the app.
+    """
+    ui.start_help_capture()
+    ui.install_help_capture()
+    st.sidebar.checkbox("Autosave to this browser", help="Keep a copy", key="probe4")
+    assert session[ui.HELP_TEXTS_KEY]["Autosave to this browser"] == "Keep a copy"
+
+
+def test_the_wrapping_is_idempotent():
+    """main() calls it on every render; wrapping the wrapper would stack a layer
+    per rerun for the life of the process."""
+    ui.install_help_capture()
+    once = st.text_input
+    ui.install_help_capture()
+    assert st.text_input is once
+
+
+def test_each_render_starts_from_nothing(session):
+    """Otherwise a page that no longer draws a field keeps carrying its help,
+    and the text lands on a same-named field somewhere else."""
+    ui.start_help_capture()
+    ui.install_help_capture()
+    st.text_input("Gone next time", help="x", key="probe3")
+    ui.start_help_capture()
+    assert session[ui.HELP_TEXTS_KEY] == {}
+
+
+# --- what is handed to the browser ------------------------------------------
+
+
+def test_the_text_reaches_the_page_as_data_not_as_script():
+    """Quotes and backslashes in a help string must not be able to end the
+    script they ride in."""
+    html = ui.help_wiring_html({'A "quoted" label': "back\\slash and 'quotes'"})
+    payload = html.split("var HELP = ", 1)[1].split(";\n", 1)[0]
+    assert json.loads(payload) == {'A "quoted" label': "back\\slash and 'quotes'"}
+
+
+def test_only_the_help_icons_and_the_clear_crosses_leave_the_tab_order():
+    """Streamlit puts the same tooltip wrapper on real controls — the image
+    Fullscreen button is one — so the icons are matched by their own label."""
+    js = ui._HELP_WIRING_JS
+    assert 'button[aria-label^="Help for "]' in js
+    assert 'button[aria-label="Clear value"]' in js
+    assert '[data-testid="stTooltipHoverTarget"] button:not' not in js
+
+
+def test_the_text_is_put_where_a_screen_reader_meets_it():
+    js = ui._HELP_WIRING_JS
+    assert "aria-describedby" in js, "what screen readers read today"
+    assert "aria-description" in js, "and where the same thing is heading"
+
+
+def test_the_wiring_is_redone_when_the_page_under_it_changes():
+    """Streamlit rebuilds its DOM on every rerun while this frame is mounted
+    once, so without the observer the fix survives exactly one render."""
+    assert "MutationObserver" in ui._HELP_WIRING_JS
+
+
+def test_the_selectors_are_not_built_from_label_text():
+    """A label carrying a quote would have to be escaped into a selector, and
+    the escaping is the part that breaks silently."""
+    js = ui._HELP_WIRING_JS
+    assert "'[aria-label=\"' +" not in js
+    assert "getAttribute('aria-label')" in js
+
+
+def test_the_field_is_found_from_the_icon_not_from_the_label():
+    """A button's name is its text and not an aria-label, and two widgets on a
+    page can carry the same label — so the walk goes from the icon to the
+    container Streamlit wraps that one widget in."""
+    js = ui._HELP_WIRING_JS
+    assert "closest('[data-testid=\"stElementContainer\"]')" in js
+    assert 'button:not([aria-label^="Help for "])' in js, "never the icon itself"
+
+
+# --- and on a real page -----------------------------------------------------
+
+
+def _script():
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Bicycle")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["_viz_settings_restored"] = True
+        st.session_state["_local_storage"] = None
+        st.session_state["nav_radio"] = "Classes"
+        st.session_state["cls_active_tab"] = "Add Class"
+    app.main()
+
+
+def test_a_rendered_page_hands_over_the_help_it_drew():
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+
+    texts = at.session_state[ui.HELP_TEXTS_KEY]
+    assert texts, "the Add Class form passes help= to several fields"
+    assert any("class" in t.lower() for t in texts.values()), texts


### PR DESCRIPTION
Closes #383.

## Where the extra stops came from

Streamlit 1.62 rebuilt the widgets on react-aria: the help tooltip is now a real `<button aria-label="Help for …">` sitting in the tab order, before the field it belongs to, and a clearable selectbox adds a `Clear value` cross after it. The pin landed 2026-08-31 (`76a6172`); the report came the next day.

Add Class, before - 21 focus stops for 5 fields:

```
Class Name → [Help for Label] → Label → [Help for Comment] → Comment
→ [Help for Parent Class] → Parent Class → [Clear value] → [Help for Namespace]
→ Namespace → [Clear value] → Add Class
```

After - 12, and one Tab from Class Name lands on Label:

```
Class Name → Label → Comment → Parent Class → Namespace → Add Class
```

## The accessibility question in the issue

It has two different answers, which is why the change has two halves.

**The cross: no obstacle.** It duplicates something the keyboard can already do - the field is `role="combobox"` with an editable, non-readonly input, so its value clears by typing. This is the same case Streamlit already made for the dropdown arrow next to it, which it ships as `tabindex="-1"`.

**The help icon: yes, on its own.** Its text lives in the tooltip and nowhere else - Streamlit does not put it on the field (`aria-describedby` is empty), so simply hiding the icon from the tab order would take the text away from exactly the users who navigate by keyboard.

So the text goes to the field instead. Every `help=` the app passes is collected on its way to the widget, and written onto the control as a description - `aria-describedby` (what screen readers read today) plus `aria-description` (where the same thing is heading). A screen-reader user now meets the help when they focus the field, rather than having to find a separate button.

## Verified across every page

Measured live on all fourteen pages, after reruns:

| | result |
|---|---|
| help icons left in the tab order | **0** of 51 |
| clear crosses left in the tab order | **0** of 4 |
| help strings that never reached their field | **0** |
| real controls kept (the image Fullscreen button among them) | **all** |
| tooltip still opens on hover | yes, unchanged |

Two things that only showed up in that sweep, both fixed: the first cut matched `[data-testid="stTooltipHoverTarget"] button`, which also caught Streamlit's image **Fullscreen** button - a real control, now matched by `aria-label^="Help for "` instead. And the sidebar's two icons never got their text, because a sidebar widget arrives as `dg.checkbox(dg, label, …)`: the label is found by type now, not by position.

## How it is wired

- The widgets are wrapped once, on the module *and* on the container class (the sidebar and columns come from the class), so all 102 `help=` call sites are covered and the 103rd will be too.
- The DOM half runs in a zero-height component, in the parent document, with a MutationObserver - Streamlit rebuilds its DOM on every rerun while that frame is mounted once.
- The wiring walks from the icon to the container Streamlit wraps that one widget in, rather than looking the control up by label: a button's name is its text, not an `aria-label`, and two widgets can share a label.

## Tests

`tests/test_help_tab_order.py` - 12 tests. The collecting half is exercised directly (recorded on the way past, not recorded without `help=`, idempotent wrapping, reset per render, label found by type); the browser half is pinned at the source level (only the icons and crosses leave the tab order, the text is carried as JSON rather than as script, both aria attributes are set, the observer exists, no selector is built from label text); and a rendered page is checked to hand over the help it drew.

Full suite green (1979 passed), plus ruff 0.16.5 format/check and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)