### PR TITLE
feat(viz): add a class above the selected one, from the graph (#327)

### DIFF
--- a/orionbelt_ontology_builder/app.py
+++ b/orionbelt_ontology_builder/app.py
@@ -135,6 +135,7 @@ from .ui import (  # noqa: F401
     _render_panel_add_individual_form,
     _render_panel_add_relation_form,
     _render_panel_add_restriction_form,
+    _render_panel_add_superclass_form,
     _render_panel_annotation_editor,
     _render_panel_entity_editor,
     _render_panel_relation_editor,

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -3687,7 +3687,16 @@ def parent_option_index(parent_options, parent_lookup, parent_uri) -> int:
     return 0
 
 
-def render_add_class_form(ont, classes, form_key, parent_uri=None, on_close=None):
+def render_add_class_form(
+    ont,
+    classes,
+    form_key,
+    parent_uri=None,
+    on_close=None,
+    after_add=None,
+    checkpoint_label="Add class",
+    exclude_uri=None,
+):
     """Render the "add a class" form. Returns True when a class was created.
 
     Shared by the Classes page and the Visualization details panel, so both
@@ -3698,8 +3707,18 @@ def render_add_class_form(ont, classes, form_key, parent_uri=None, on_close=None
     for you. ``on_close`` is what dismissing the form means; the page has no such
     thing (the tab is the form) so it passes None and gets no Cancel button.
 
+    ``after_add`` is called with the new class's name once it exists and before
+    the checkpoint, so a caller that has more to write — the panel's "Add
+    superclass", which then hangs the selected class under it (issue #327) — is
+    one entry in the undo history rather than two. ``checkpoint_label`` is what
+    that entry is called, and ``exclude_uri`` drops a class from the parent
+    picker: offering the class that is about to become the new one's *child*
+    would make a cycle out of one dropdown.
+
     The caller owns the rerun: the panel has to drop its open flag first.
     """
+    if exclude_uri:
+        classes = [c for c in classes if c["uri"] != exclude_uri]
     parent_options, parent_lookup = build_class_options(classes, include_none=True)
     parent_index = parent_option_index(parent_options, parent_lookup, parent_uri)
 
@@ -3755,7 +3774,9 @@ def render_add_class_form(ont, classes, form_key, parent_uri=None, on_close=None
                     comment=comment,
                     namespace=ns_val,
                 )
-                save_checkpoint("Add class")
+                if after_add is not None:
+                    after_add(name)
+                save_checkpoint(checkpoint_label)
                 show_message(f"Class '{name}' added successfully!", "success")
                 return True
     return False
@@ -4338,6 +4359,11 @@ def _render_panel_add_buttons(classes, ntype, ename, subject_uri):
     ]
     if parent_uri:
         actions += [
+            (
+                "Add superclass",
+                "super",
+                f"Add a class above '{parent_name}', alongside its parents.",
+            ),
             ("Add relation", "crel", "Then click the class this one points at."),
             ("Add restriction", "rest", "Then click the class it restricts to."),
             ("Add individual", "ind", f"Add an instance of '{parent_name}'."),
@@ -4388,6 +4414,44 @@ def _render_panel_add_class_form(ont, classes, ntype, ename):
         "panel_add_class_form",
         parent_uri=parent_uri,
         on_close=_panel_close_add,
+    ):
+        _panel_close_add()
+        st.rerun()
+
+
+def _render_panel_add_superclass_form(ont, classes, ntype, ename):
+    """Add a class *above* the selected one, from the graph (issue #327).
+
+    The panel could only ever grow a hierarchy downwards: everything it creates
+    hangs under the class you clicked. Realising a level is missing above one is
+    just as ordinary, and doing it meant leaving the graph, adding the class on
+    the Classes page and coming back to re-parent the first one.
+
+    The new class is added alongside whatever parents the selected class already
+    has, rather than being spliced between it and them. That is what the reporter
+    asked for and it matches the button next to this one: "Add subclass" writes
+    one ``rdfs:subClassOf`` and rewires nothing, so this writes one too. Moving a
+    class from one parent to another is a different act, and belongs to a control
+    that says so.
+    """
+    child_uri = _panel_add_parent(classes, ntype, ename)
+    child_name = next((c["name"] for c in classes if c["uri"] == child_uri), None)
+    if not child_uri:
+        # Nothing selected to hang under it: the button is only offered with a
+        # class selected, but a rerun can arrive after the selection is gone.
+        _panel_close_add()
+        st.rerun()
+    st.markdown(f"**New superclass of {child_name}**")
+    st.caption(f"'{child_name}' keeps the parents it has; this one is added alongside.")
+    if render_add_class_form(
+        ont,
+        classes,
+        "panel_add_superclass_form",
+        on_close=_panel_close_add,
+        after_add=lambda name: ont.update_class(child_uri, new_parent=name),
+        checkpoint_label="Add superclass",
+        # The class about to become its child cannot also be its parent.
+        exclude_uri=child_uri,
     ):
         _panel_close_add()
         st.rerun()

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -3695,7 +3695,7 @@ def render_add_class_form(
     on_close=None,
     after_add=None,
     checkpoint_label="Add class",
-    exclude_uri=None,
+    exclude_uris=None,
 ):
     """Render the "add a class" form. Returns True when a class was created.
 
@@ -3707,18 +3707,23 @@ def render_add_class_form(
     for you. ``on_close`` is what dismissing the form means; the page has no such
     thing (the tab is the form) so it passes None and gets no Cancel button.
 
-    ``after_add`` is called with the new class's name once it exists and before
+    ``after_add`` is called with the new class's *URI* once it exists and before
     the checkpoint, so a caller that has more to write — the panel's "Add
     superclass", which then hangs the selected class under it (issue #327) — is
-    one entry in the undo history rather than two. ``checkpoint_label`` is what
-    that entry is called, and ``exclude_uri`` drops a class from the parent
-    picker: offering the class that is about to become the new one's *child*
-    would make a cycle out of one dropdown.
+    one entry in the undo history rather than two. The URI and not the name it
+    was typed under: the class can be created in any bound namespace, and a
+    caller given the local name would resolve it through the base one and link
+    to a URI nothing declares (Codex review of PR #411).
+
+    ``checkpoint_label`` is what that undo entry is called, and ``exclude_uris``
+    drops classes from the parent picker: the class about to become the new
+    one's child, and everything already under it, would each close a cycle if
+    picked as its parent.
 
     The caller owns the rerun: the panel has to drop its open flag first.
     """
-    if exclude_uri:
-        classes = [c for c in classes if c["uri"] != exclude_uri]
+    if exclude_uris:
+        classes = [c for c in classes if c["uri"] not in exclude_uris]
     parent_options, parent_lookup = build_class_options(classes, include_none=True)
     parent_index = parent_option_index(parent_options, parent_lookup, parent_uri)
 
@@ -3767,7 +3772,7 @@ def render_add_class_form(
             elif taken := ont.name_conflict_reason(name, "class", ns_val):
                 show_message(taken, "error")
             else:
-                ont.add_class(
+                new_uri = ont.add_class(
                     name,
                     parent=parent_lookup.get(parent_display),
                     label=label,
@@ -3775,7 +3780,7 @@ def render_add_class_form(
                     namespace=ns_val,
                 )
                 if after_add is not None:
-                    after_add(name)
+                    after_add(str(new_uri))
                 save_checkpoint(checkpoint_label)
                 show_message(f"Class '{name}' added successfully!", "success")
                 return True
@@ -4419,6 +4424,29 @@ def _render_panel_add_class_form(ont, classes, ntype, ename):
         st.rerun()
 
 
+def class_descendant_uris(ont, root_uri) -> set:
+    """Every class under ``root_uri``, however deep.
+
+    Read from the ``rdfs:subClassOf`` edges by URI rather than from the local
+    names ``get_classes`` reports, which two namespaces can share. Walked with a
+    seen-set, so a hierarchy that already contains a cycle — an imported one can
+    — is answered rather than looped over.
+    """
+    children: dict = {}
+    for relation in ont.get_class_relations():
+        if relation.get("relation") != "subClassOf":
+            continue
+        children.setdefault(relation["object_uri"], []).append(relation["subject_uri"])
+    found: set = set()
+    stack = [root_uri]
+    while stack:
+        for child in children.get(stack.pop(), ()):
+            if child not in found:
+                found.add(child)
+                stack.append(child)
+    return found
+
+
 def _render_panel_add_superclass_form(ont, classes, ntype, ename):
     """Add a class *above* the selected one, from the graph (issue #327).
 
@@ -4448,10 +4476,15 @@ def _render_panel_add_superclass_form(ont, classes, ntype, ename):
         classes,
         "panel_add_superclass_form",
         on_close=_panel_close_add,
-        after_add=lambda name: ont.update_class(child_uri, new_parent=name),
+        # By URI: the new class can be created in any bound namespace, and the
+        # link has to point at the class that was actually made. add_class_
+        # relation resolves both ends through the same URI handling, so a
+        # namespace with an unusual scheme works here too.
+        after_add=lambda uri: ont.add_class_relation(child_uri, "subClassOf", uri),
         checkpoint_label="Add superclass",
-        # The class about to become its child cannot also be its parent.
-        exclude_uri=child_uri,
+        # Neither the class about to become its child nor anything already under
+        # that class: picking one as this class's parent closes a cycle.
+        exclude_uris={child_uri} | class_descendant_uris(ont, child_uri),
     ):
         _panel_close_add()
         st.rerun()

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -34,6 +34,7 @@ from ..ui import (
     _render_panel_add_individual_form,
     _render_panel_add_relation_form,
     _render_panel_add_restriction_form,
+    _render_panel_add_superclass_form,
     _render_panel_entity_editor,
     _restore_viz_file_state,
     _restore_viz_settings,
@@ -3140,6 +3141,12 @@ def render_visualization():
                         # The add form owns the whole panel while it is open, so
                         # its fields can't be confused with the editor's.
                         _render_panel_add_class_form(
+                            ont, classes, _sel_ntype, _sel_ename
+                        )
+                    elif _add_kind == "super":
+                        # Same reason as the class form: it owns the panel while
+                        # it is open (issue #327).
+                        _render_panel_add_superclass_form(
                             ont, classes, _sel_ntype, _sel_ename
                         )
                     elif _add_kind == "crel":

--- a/tests/test_mutation_checkpoints.py
+++ b/tests/test_mutation_checkpoints.py
@@ -49,6 +49,11 @@ CHECKPOINTED_BY_CALLER = {
     # rollback path returns False having restored the graph, so there is nothing
     # to checkpoint there either (issue #223).
     "_apply_annotation_edit",
+    # Hands its write to render_add_class_form as the ``after_add`` callback,
+    # which that function calls immediately before its own save_checkpoint — on
+    # purpose, so creating a superclass and hanging the selected class under it
+    # is one entry in the undo history rather than two (issue #327).
+    "_render_panel_add_superclass_form",
     # Both hand their delete to _panel_delete_edge as a callback, and that is
     # where the checkpoint sits — the axiom has no URI, so the panel resolves it
     # and the shared helper confirms, deletes and checkpoints (issue #222).

--- a/tests/test_viz_add_superclass.py
+++ b/tests/test_viz_add_superclass.py
@@ -54,18 +54,79 @@ def test_a_class_with_no_parent_simply_gains_one(ont):
     assert _parents(ont, "Vehicle") == ["Machine"]
 
 
+def test_a_superclass_made_in_another_namespace_is_linked_to_by_its_own_uri(ont):
+    """The first thing the review of PR #411 found.
+
+    The form can create the class in any bound namespace. Handing the caller
+    the local name it was typed under resolved it through the *base* namespace,
+    so the selected class was linked to a URI nothing declares.
+    """
+    ont.add_prefix("other", "http://other.example/")
+    made = ont.add_class("Parent", namespace="http://other.example/")
+    assert str(made) == "http://other.example/Parent"
+
+    ont.add_class_relation(NS + "Bicycle", "subClassOf", str(made))
+
+    relations = [
+        r
+        for r in ont.get_class_relations()
+        if r["relation"] == "subClassOf" and r["subject_uri"] == NS + "Bicycle"
+    ]
+    assert "http://other.example/Parent" in [r["object_uri"] for r in relations]
+    assert NS + "Parent" not in [r["object_uri"] for r in relations], (
+        "the base namespace must not be where the link points"
+    )
+
+
+def test_the_form_hands_over_the_uri_it_made():
+    """Pinned at the source, since the namespace is chosen inside the form."""
+    import inspect
+
+    src = inspect.getsource(ui.render_add_class_form)
+    assert "after_add(str(new_uri))" in src, src[-400:]
+
+
 # --- what the form is given -------------------------------------------------
 
 
 def test_the_child_is_not_offered_as_the_new_class_s_own_parent(ont):
     """Otherwise one dropdown makes a cycle: the class about to become the new
     one's child, picked as its parent."""
-    classes = ont.get_classes()
-    kept = [c for c in classes if c["uri"] != NS + "Bicycle"]
+    excluded = {NS + "Bicycle"} | ui.class_descendant_uris(ont, NS + "Bicycle")
+    kept = [c for c in ont.get_classes() if c["uri"] not in excluded]
     options, lookup = ui.build_class_options(kept, include_none=True)
 
     assert not any(lookup.get(o) == NS + "Bicycle" for o in options)
     assert any(lookup.get(o) == NS + "Vehicle" for o in options), "the rest remain"
+
+
+def test_everything_under_the_class_is_kept_out_of_the_parent_picker(ont):
+    """The second thing the review found.
+
+    Excluding only the selected class is not enough: choosing one of its own
+    descendants as the new class's parent closes the loop, and
+    ``Bicycle -> New -> Tandem -> Bicycle`` is a cycle made from one dropdown.
+    """
+    ont.add_class("Tandem", parent="Bicycle")
+    ont.add_class("Roadster", parent="Tandem")
+
+    under = ui.class_descendant_uris(ont, NS + "Bicycle")
+    assert under == {NS + "Tandem", NS + "Roadster"}, under
+
+    excluded = {NS + "Bicycle"} | under
+    kept = [c["uri"] for c in ont.get_classes() if c["uri"] not in excluded]
+    assert kept == [NS + "Vehicle"], "everything above stays available"
+
+
+def test_a_hierarchy_that_already_loops_is_answered_not_looped_over(ont):
+    """An imported ontology can contain a cycle; the walk must still return."""
+    ont.add_class("Tandem", parent="Bicycle")
+    ont.add_class_relation(NS + "Bicycle", "subClassOf", NS + "Tandem")
+
+    assert ui.class_descendant_uris(ont, NS + "Bicycle") == {
+        NS + "Tandem",
+        NS + "Bicycle",
+    }
 
 
 def test_the_form_takes_the_write_before_the_checkpoint():
@@ -74,8 +135,8 @@ def test_the_form_takes_the_write_before_the_checkpoint():
     import inspect
 
     src = inspect.getsource(ui.render_add_class_form)
-    assert "after_add(name)" in src
-    assert src.index("after_add(name)") < src.index("save_checkpoint(")
+    assert "after_add(str(new_uri))" in src
+    assert src.index("after_add(str(new_uri))") < src.index("save_checkpoint(")
 
 
 # --- and through the page ---------------------------------------------------

--- a/tests/test_viz_add_superclass.py
+++ b/tests/test_viz_add_superclass.py
@@ -1,0 +1,134 @@
+"""Adding a class *above* the selected one, from the graph (issue #327).
+
+The panel could only ever grow a hierarchy downwards: everything it creates
+hangs under the class you clicked. Realising a level is missing above one is
+just as ordinary, and doing it meant leaving the graph, adding the class on the
+Classes page and coming back to re-parent the first one.
+
+What the new class does to the parents the selected class already has was the
+open question, and the reporter answered it: nothing. It is added alongside
+them, the way "Add subclass" writes one ``rdfs:subClassOf`` and rewires nothing.
+Moving a class from one parent to another is a different act.
+"""
+
+import os
+
+import pytest
+from streamlit.testing.v1 import AppTest
+
+from orionbelt_ontology_builder import ui
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+NS = "http://example.org/ontology#"
+
+
+@pytest.fixture
+def ont():
+    om = OntologyManager()
+    om.add_class("Vehicle")
+    om.add_class("Bicycle", parent="Vehicle")
+    return om
+
+
+def _parents(om, name):
+    return sorted(next(c["parents"] for c in om.get_classes() if c["name"] == name))
+
+
+# --- what the write does ----------------------------------------------------
+
+
+def test_the_new_class_joins_the_parents_the_class_already_had(ont):
+    """The reporter's answer: alongside, not spliced in between."""
+    ont.add_class("WheeledThing")
+    ont.update_class(NS + "Bicycle", new_parent="WheeledThing")
+
+    assert _parents(ont, "Bicycle") == ["Vehicle", "WheeledThing"]
+    # And nothing was moved under the new class but the one that was selected.
+    assert _parents(ont, "WheeledThing") == []
+
+
+def test_a_class_with_no_parent_simply_gains_one(ont):
+    """Where the two readings of "add a superclass" agree."""
+    ont.add_class("Machine")
+    ont.update_class(NS + "Vehicle", new_parent="Machine")
+    assert _parents(ont, "Vehicle") == ["Machine"]
+
+
+# --- what the form is given -------------------------------------------------
+
+
+def test_the_child_is_not_offered_as_the_new_class_s_own_parent(ont):
+    """Otherwise one dropdown makes a cycle: the class about to become the new
+    one's child, picked as its parent."""
+    classes = ont.get_classes()
+    kept = [c for c in classes if c["uri"] != NS + "Bicycle"]
+    options, lookup = ui.build_class_options(kept, include_none=True)
+
+    assert not any(lookup.get(o) == NS + "Bicycle" for o in options)
+    assert any(lookup.get(o) == NS + "Vehicle" for o in options), "the rest remain"
+
+
+def test_the_form_takes_the_write_before_the_checkpoint():
+    """Creating the class and hanging the old one under it is one action, so it
+    is one entry in the undo history: the hook runs before save_checkpoint."""
+    import inspect
+
+    src = inspect.getsource(ui.render_add_class_form)
+    assert "after_add(name)" in src
+    assert src.index("after_add(name)") < src.index("save_checkpoint(")
+
+
+# --- and through the page ---------------------------------------------------
+
+
+def _script():
+    import os
+
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    ns = "http://example.org/ontology#"
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Vehicle")
+        om.add_class("Bicycle", parent="Vehicle")
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["_viz_settings_restored"] = True
+        st.session_state["_local_storage"] = None
+        st.session_state["_viz_cfg_details_panel"] = True
+        st.session_state["_viz_last_selection"] = {
+            "selected": True,
+            "ntype": "Class",
+            "ename": app._uid(ns + "Bicycle"),
+            "label": "Bicycle",
+            "flabel": "Bicycle",
+            "title": "Class: Bicycle",
+        }
+        if os.environ.get("OPEN_SUPERCLASS") == "1":
+            st.session_state["_viz_add_kind"] = "super"
+    app.render_visualization()
+
+
+def test_the_panel_offers_the_button_with_a_class_selected():
+    os.environ["OPEN_SUPERCLASS"] = "0"
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    assert any(b.key == "panel_add_open_super" for b in at.button), [
+        b.key for b in at.button
+    ]
+
+
+def test_the_form_says_what_it_will_do():
+    os.environ["OPEN_SUPERCLASS"] = "1"
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    said = " ".join(m.value for m in at.markdown) + " ".join(
+        c.value for c in at.caption
+    )
+    assert "New superclass of Bicycle" in said, said
+    assert "keeps the parents it has" in said, said


### PR DESCRIPTION
Closes #327.

## What was missing

With a class selected, the panel offers `Add subclass`, `Add relation`, `Add restriction`, `Add individual`, `Add annotation`. Everything it creates hangs *below* the selection: the class you picked becomes the parent, the subject, the type. There was no way to go the other way, so inserting a class above an existing one meant leaving the graph, adding it on the Classes page, and coming back to re-parent the first one.

## What it does to the parents already there

That was the open question on the issue, and the reporter answered it: nothing. The new class is added **alongside** whatever parents the selected class has, not spliced between them.

> I would keep it consistent with how add subclass works, so option 2. I feel like a modification that 'ripples through' classes may deserve its own button, if wanted, as it potentially creates more havoc.

Which is right: `Add subclass` writes one `rdfs:subClassOf` and rewires nothing, so this writes one too. Multiple inheritance is already supported in the engine (issue #157). Moving a class from one parent to another is a different act and belongs to a control that says so.

## How it is built

The shared add-class form grew two hooks rather than being copied:

- **`after_add`** is called with the new class's name once it exists and before the checkpoint, so creating the class and hanging the old one under it is *one* entry in the undo history rather than two.
- **`exclude_uri`** keeps the class about to become the new one's child out of its parent picker. Offering it there would let one dropdown make a cycle.

`tests/test_mutation_checkpoints.py` flagged the write inside that callback, correctly: the checkpoint is one frame up, in the form. It is added to `CHECKPOINTED_BY_CALLER`, which is exactly the exemption that set exists for, with a comment saying where the checkpoint sits.

## Verified in the running app

On the Organization template, with `Person` selected:

| step | result |
|---|---|
| the button | `Add superclass` appears next to `Add subclass` |
| the form | "New superclass of Person", "'Person' keeps the parents it has; this one is added alongside." |
| submitting `Agent` | `Agent` drawn, `Person -> Agent` drawn exactly as the template's own `Department -> Organization` is |
| one Undo | classes 5 back to 4, `Agent` gone, `Person` back to no parent |

(The graph draws each `subClassOf` twice, once as a hierarchy edge and once as a class relation - that is pre-existing, visible on `Department -> Organization` in the untouched template, and left alone here.)

## Tests

`tests/test_viz_add_superclass.py` - six: the new class joins the parents the class already had rather than replacing them, a parentless class simply gains one, the child is kept out of the parent picker, the write lands before the checkpoint, the button is offered with a class selected, and the form says what it is about to do.

Full suite green (1989 passed), plus ruff 0.16.5 format/check and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)