### PR TITLE
fix(viz): the Triples layer stops redrawing edges the graph already has

### DIFF
--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -1804,8 +1804,10 @@ def render_visualization():
         # now also reports the annotations a focus at the node cap left no room
         # for (issue #405) — the same reasoning as 22, since the notice travels
         # with the payload: a cached v23 focus graph would go on showing the one
-        # that says nothing about them.
-        _graph_ver = 24
+        # that says nothing about them. 25: the Triples layer no longer redraws
+        # an edge another layer already drew, so a cached v24 payload is a graph
+        # with those duplicates still in it.
+        _graph_ver = 25
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.
@@ -2474,6 +2476,19 @@ def render_visualization():
                         if concept.get("uri") and _skos_node in skos_node_ids:
                             _uri_to_node[concept["uri"]] = _skos_node
 
+                # What the layers above already drew, as (from, to, label). A
+                # triple whose edge is already on the canvas is not drawn again:
+                # "Show all RDF triples" means the ones nothing else shows, not
+                # a second subClassOf beside the first. Read off the edges
+                # themselves rather than from a list of predicates, so it stays
+                # true to what is actually on screen — turn Classes off and the
+                # subClassOf triple is drawn, because then nothing else is
+                # drawing it.
+                _already_drawn = {
+                    (edge["from"], edge["to"], edge.get("label") or "")
+                    for edge in net.edges
+                }
+
                 # Query only triples with visible subjects (avoid full graph scan)
                 _triple_new = 0
                 _max_triple_new = 200
@@ -2490,6 +2505,8 @@ def render_visualization():
                             o_str = str(o)
                             if o_str in _uri_to_node:
                                 o_node = _uri_to_node[o_str]
+                                if (s_node, o_node, p_label) in _already_drawn:
+                                    continue
                             else:
                                 if _triple_new >= _max_triple_new:
                                     continue

--- a/tests/test_viz_triples_no_duplicates.py
+++ b/tests/test_viz_triples_no_duplicates.py
@@ -1,0 +1,112 @@
+"""The Triples layer draws what nothing else draws.
+
+"Show all RDF triples for visible nodes" used to mean *all* of them, including
+the ones the graph was already showing: `rdfs:subClassOf` came out twice, once
+as the green class-hierarchy edge and again as a grey triple edge beside it, and
+`rdf:type` the same. The layer now skips a triple whose edge is already on the
+canvas.
+
+Read off the edges that were built rather than from a list of predicates, so it
+follows what is actually drawn: with Classes switched off nothing else draws the
+hierarchy, and the triple is the only thing left to show it.
+"""
+
+import json
+import os
+
+from streamlit.testing.v1 import AppTest
+
+
+def _script():
+    import os
+
+    import streamlit as st
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        om.add_class("Organization")
+        om.add_class("Department", parent="Organization")
+        # A raw triple between the same two classes that no layer draws: same
+        # pair, different predicate.
+        from rdflib import URIRef
+
+        om.graph.add(
+            (
+                URIRef(om.namespace + "Department"),
+                URIRef(om.namespace + "reportsTo"),
+                URIRef(om.namespace + "Organization"),
+            )
+        )
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["_viz_settings_restored"] = True
+        st.session_state["_local_storage"] = None
+        st.session_state["_viz_cfg_show_triples"] = os.environ["TRIPLES"] == "1"
+        st.session_state["_viz_cfg_show_classes"] = os.environ["CLASSES"] == "1"
+    app.render_visualization()
+
+
+def _edges(triples=True, classes=True):
+    os.environ["TRIPLES"] = "1" if triples else "0"
+    os.environ["CLASSES"] = "1" if classes else "0"
+    at = AppTest.from_function(_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    data = at.session_state["last_graph_data"]
+    nodes = {n["id"]: n.get("label") for n in json.loads(data["nodes"])}
+    return [
+        (nodes.get(e["from"]), nodes.get(e["to"]), e.get("label"))
+        for e in json.loads(data["edges"])
+    ]
+
+
+def _subclass(edges):
+    return [e for e in edges if e[2] == "subClassOf"]
+
+
+def test_the_hierarchy_edge_is_drawn_once_without_the_triples_layer():
+    """The baseline: one axiom, one edge."""
+    assert _subclass(_edges(triples=False)) == [
+        ("Department", "Organization", "subClassOf")
+    ]
+
+
+def test_the_triples_layer_does_not_draw_it_a_second_time():
+    """The report: with Triples on it used to come out twice, the same pair and
+    the same label, once green and once grey."""
+    assert _subclass(_edges(triples=True)) == [
+        ("Department", "Organization", "subClassOf")
+    ]
+
+
+def test_the_triples_layer_still_draws_what_nothing_else_does():
+    """It is not simply suppressing subClassOf: the type and label triples that
+    no other layer draws are still there."""
+    labels = {e[2] for e in _edges(triples=True)}
+    assert "type" in labels, labels
+
+
+def test_a_different_predicate_between_the_same_pair_is_still_drawn():
+    """The guard is (from, to, label), not (from, to): a triple that says
+    something else about the same two classes is not what is already on screen,
+    and is drawn."""
+    edges = _edges(triples=True)
+    pair = [e for e in edges if e[0] == "Department" and e[1] == "Organization"]
+    labels = sorted(label for _, _, label in pair)
+
+    assert labels == ["reportsTo", "subClassOf"], labels
+
+
+def test_the_docstring_rule_is_what_the_code_does():
+    """Read off the edges already built rather than from a list of predicates,
+    so the layer follows what is on screen rather than a guess about it."""
+    import inspect
+
+    from orionbelt_ontology_builder.views import visualization
+
+    src = inspect.getsource(visualization.render_visualization)
+    assert "_already_drawn = {" in src
+    assert 'edge.get("label")' in src, "keyed by the label the edge draws"


### PR DESCRIPTION
Noticed while showing the graph in #327, and worth correcting first: this is **not** a duplicate-drawing bug. With the Triples layer off, every `subClassOf` is drawn exactly once. The second edge comes from `Show all RDF triples for visible nodes`, doing what it says.

The trouble is that what it says includes the triples the graph is already showing:

```
Department -> Organization [Class Relation, #81C784]   the axiom, green, clickable
Department -> Organization [no ntype,       #90A4AE]   the same fact, grey, not clickable
```

`rdf:type` and `rdfs:label` are restated the same way. The layer exists to show what nothing else shows, and those were the hardest edges to pick out of the ones it repeated.

## The rule

A triple whose edge is already on the canvas is skipped. Read off the edges that were built rather than from a list of predicates, so it follows what is actually drawn rather than a guess about it. The key is `(from, to, label)` and not `(from, to)`: a triple that says something *else* about the same two classes is not a duplicate, and is still drawn.

The grey duplicate carried no `ename`, so it was never clickable - nothing that could be selected is lost.

`_graph_ver` goes to 25, since the edges travel in the cached payload and a cached v24 graph is one with the duplicates still in it.

## Measured, Organization template, Triples on

| | before | after |
|---|---|---|
| `subClassOf` edges for one axiom | 2 | **1** |
| `type` edges | 6 | 6 |
| edges in total | 19 | 18 |

## Tests

`tests/test_viz_triples_no_duplicates.py` - five: the baseline with the layer off, the reported doubling, that the layer still draws the `type` triples nothing else draws, that a different predicate between the same pair is still drawn, and that the rule is read off the built edges rather than a predicate list. Three fail on `main`.

Full suite green (2005 passed), plus ruff 0.16.5 format/check and mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)