### PR TITLE
fix(viz): the node tooltip was rendering invisibly

### DIFF
--- a/orionbelt_ontology_builder/lib/graph_viewer/index.html
+++ b/orionbelt_ontology_builder/lib/graph_viewer/index.html
@@ -11,6 +11,30 @@ html, body { margin: 0; padding: 0; overflow: hidden; background: #fff; }
     html, body { background: #0e1117; }
 }
 #graph { width: 100%; }
+/* The node tooltip, which vis creates on hover and fills from a node's title.
+   vis ships its styling in vis-network.css, and only the script is vendored
+   here, so the element arrived with no box at all: black text on a transparent
+   background over a near-black canvas, and `position: static`, which meant the
+   top/left vis writes inline did nothing and it sat in the document flow rather
+   than beside the pointer. Visible in the DOM, invisible on screen.
+   Given the panel look the legend and the toolbar buttons already have. */
+.vis-tooltip {
+    position: absolute;
+    z-index: 20;
+    max-width: 340px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    background: var(--node-tip-bg, rgba(255,255,255,0.96));
+    color: var(--node-tip-fg, #333333);
+    border: 1px solid rgba(127,127,127,0.35);
+    box-shadow: 0 4px 14px rgba(0,0,0,0.35);
+    font: 12px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
+    /* A title carries newlines (Class, Label, Comment on their own lines) and
+       a comment can be long, so it wraps rather than running off the canvas. */
+    white-space: pre-wrap;
+    pointer-events: none;
+}
 #legend {
     position: absolute; top: 8px; left: 8px; background: rgba(255,255,255,0.92);
     padding: 8px 12px; border-radius: 6px; font-size: 12px; color: #333;
@@ -152,6 +176,11 @@ function themeToolbarButtons(theme) {
     var root = document.documentElement;
     root.style.setProperty('--tip-bg', theme.text);
     root.style.setProperty('--tip-fg', theme.bg);
+    // The node tooltip reads the other way round, as a panel rather than a
+    // chip, so it matches the legend beside it. Set as variables because vis
+    // creates that element on the first hover, long after this runs.
+    root.style.setProperty('--node-tip-bg', theme.panel);
+    root.style.setProperty('--node-tip-fg', theme.text);
 }
 
 // What a toolbar button says on hover. The tooltip is drawn from data-tip (see

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -708,14 +708,17 @@ def render_visualization():
                     on_change=viz_sync,
                     args=("_viz_cfg_show_annotations", "viz_show_annotations"),
                     # Labels and comments are the annotations most entities
-                    # carry, and they are the two this does not draw — they are
-                    # in the tooltip instead. Without saying so, a graph of
-                    # entities annotated with nothing else looks like the
-                    # toggle does nothing (issue #405).
+                    # carry, and they are the two this does not draw. Without
+                    # saying so, a graph of entities annotated with nothing else
+                    # looks like the toggle does nothing (issue #405). Where to
+                    # read them is named as well, and named twice: the tooltip
+                    # was the only answer here until it turned out to be
+                    # rendering invisibly, and the details panel is the one that
+                    # cannot go quiet on us.
                     help=(
                         "Draw each annotation as a node hanging off what it "
-                        "annotates. Labels and comments are not drawn: they are "
-                        "already in the node's tooltip."
+                        "annotates. Labels and comments are not drawn: hover a "
+                        "node, or open the details panel, to read them."
                     ),
                 )
             with _cols[4]:

--- a/tests/test_viz_node_tooltip.py
+++ b/tests/test_viz_node_tooltip.py
@@ -1,0 +1,70 @@
+"""The node tooltip has to be styled here, because vis's stylesheet is not vendored.
+
+The viewer loads `vis-network.min.js` and nothing else. vis puts `.vis-tooltip`
+styling in `vis-network.css`, so without a rule of our own the element arrived
+with no box at all: black text on a transparent background over a near-black
+canvas, and `position: static`, which meant the top/left vis writes inline did
+nothing and it sat in the document flow instead of beside the pointer. It was in
+the DOM, reporting `visibility: visible`, and invisible on screen. Measured
+before and after:
+
+    colour      rgb(0,0,0)     ->  rgb(250,250,250)
+    background  rgba(0,0,0,0)  ->  rgb(38,39,48)
+    position    static         ->  absolute
+    z-index     auto           ->  20
+
+None of it is observable from Python, so it is pinned at the source level like
+the viewer's other invariants.
+"""
+
+from pathlib import Path
+
+_PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+_VIEWER = _PKG / "lib" / "graph_viewer" / "index.html"
+
+
+def _viewer():
+    return _VIEWER.read_text(encoding="utf-8")
+
+
+def _rule(src, selector):
+    start = src.index(selector + " {")
+    return src[start : src.index("}", start)]
+
+
+def test_the_tooltip_is_styled_at_all():
+    """vis ships no CSS here, so every property it needs comes from this rule."""
+    src = _viewer()
+    assert ".vis-tooltip {" in src, "no rule at all is what made it invisible"
+    rule = _rule(src, ".vis-tooltip")
+    for prop in ("position", "background", "color", "padding", "z-index"):
+        assert prop in rule, (prop, rule)
+
+
+def test_it_is_positioned_where_vis_puts_it():
+    """vis writes top/left inline; `position: static` ignores both, which is how
+    it ended up in the document flow rather than beside the node."""
+    assert "position: absolute" in _rule(_viewer(), ".vis-tooltip")
+
+
+def test_it_follows_the_theme_rather_than_a_fixed_colour():
+    """The canvas is near-black in dark mode and white in light, so a fixed
+    colour is invisible in one of them. The variables are set beside the ones
+    the toolbar chips use."""
+    src = _viewer()
+    rule = _rule(src, ".vis-tooltip")
+    assert "var(--node-tip-bg" in rule
+    assert "var(--node-tip-fg" in rule
+    assert "setProperty('--node-tip-bg', theme.panel)" in src
+    assert "setProperty('--node-tip-fg', theme.text)" in src
+
+
+def test_a_long_comment_wraps_instead_of_running_off():
+    """A title carries newlines and a comment can be a paragraph."""
+    rule = _rule(_viewer(), ".vis-tooltip")
+    assert "white-space: pre-wrap" in rule
+    assert "max-width" in rule
+
+
+def test_it_cannot_swallow_a_click_on_the_node_under_it():
+    assert "pointer-events: none" in _rule(_viewer(), ".vis-tooltip")


### PR DESCRIPTION
Found because the Annotations help text added in #407 tells you labels and comments are "already in the node's tooltip", and the tooltip could not be found.

## What was wrong

Hovering a node builds a tooltip from its `title`, and it was there the whole time: right text, `visibility: visible`, nothing on screen.

The viewer vendors `vis-network.min.js` and nothing else. vis keeps `.vis-tooltip` styling in `vis-network.css`, which was never vendored, so the element arrived with no rule at all. Measured on a class with a comment:

| | before | after |
|---|---|---|
| `color` | `rgb(0, 0, 0)` | **`rgb(250, 250, 250)`** |
| `background-color` | `rgba(0, 0, 0, 0)` | **`rgb(38, 39, 48)`** |
| `position` | `static` | **`absolute`** |
| `z-index` | `auto` | **20** |

Canvas background is `rgb(14, 17, 23)`, so it was black on near-black. And `position: static` ignores the `top`/`left` vis writes inline, so it sat in the document flow rather than beside the pointer, which is why one reading found it pinned to the left edge.

## The fix

A `.vis-tooltip` rule in the viewer's own CSS, taking the panel look the legend and the toolbar buttons already have. Themed through `--node-tip-bg` / `--node-tip-fg`, set beside the variables the toolbar chips use, because vis creates the element on the first hover and a fixed colour is invisible in one theme or the other. A long comment wraps rather than running off the canvas, and `pointer-events: none` keeps it from swallowing a click meant for the node beneath it.

**And the help text is corrected.** "Labels and comments are not drawn: they are already in the node's tooltip" was a promise the app was not keeping. It now reads "hover a node, or open the details panel, to read them", so it names something visible either way.

## Verified

Live, dark theme, on a class with a comment: hovering shows a dark panel beside the node reading `Class: Contractor` / `Comment: Someone engaged for a fixed term rather than employed.`, wrapped over two lines. The computed values are the "after" column above.

## Tests

`tests/test_viz_node_tooltip.py` - five source-level guards, in the style of the viewer's other invariants since none of this is observable from Python: there is a rule at all, it is positioned absolutely, it follows the theme rather than a fixed colour, long text wraps, and it cannot take a click. All five fail on `main`.

Full suite green (2010 passed), plus ruff 0.16.5 format/check and mypy.

## Worth noting

`test_third_party_notices.py` covers the vendored bundle; this adds no new dependency, only a rule for a class that bundle creates. If the viewer ever vendors `vis-network.css`, this rule should be re-checked against it rather than left to fight it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)