### PR TITLE
feat(validation): report a subClassOf cycle (#413)

### DIFF
--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -4760,8 +4760,18 @@ class OntologyManager:
         the cycles its own way could break an edge the check never complained
         about, or leave the one it did.
         """
+        return self._cycles_in(self._skos_parent_map(concepts))
+
+    @staticmethod
+    def _cycles_in(parents: dict[str, list[str]]) -> list[list[str]]:
+        """Every distinct cycle in a ``child -> parents`` map, as a list of keys.
+
+        Lifted out of the SKOS check so the class hierarchy can be walked the
+        same way (issue #413). The walk is the part worth sharing: both are
+        "follow every parent and notice when the path meets itself", and a
+        second implementation would be a second set of edge cases.
+        """
         cycles: list[list[str]] = []
-        parents = self._skos_parent_map(concepts)
         WHITE, GREY, BLACK = 0, 1, 2
         colour = dict.fromkeys(parents, WHITE)
         seen_cycles: set[frozenset] = set()
@@ -4794,6 +4804,49 @@ class OntologyManager:
                     stack.pop()
                     path.pop()
         return cycles
+
+    def _class_parent_map(self) -> dict[str, list[str]]:
+        """``child URI -> parent URIs`` over ``rdfs:subClassOf``.
+
+        Named classes only: a restriction is written as a subClassOf a blank
+        node, and following those would report a "cycle" through anonymous
+        classes that says nothing to anyone.
+        """
+        parents: dict[str, list[str]] = {}
+        for child, parent in self.graph.subject_objects(RDFS.subClassOf):
+            if isinstance(child, BNode) or isinstance(parent, BNode):
+                continue
+            parents.setdefault(str(child), []).append(str(parent))
+            parents.setdefault(str(parent), [])
+        return {uri: sorted(set(ps)) for uri, ps in parents.items()}
+
+    def _class_cycle_issues(self) -> list[dict[str, str]]:
+        """One issue per ``rdfs:subClassOf`` cycle (issue #413).
+
+        A warning and not an error, because a cycle is legal OWL: ``A ⊑ B`` with
+        ``B ⊑ A`` says the two classes are equivalent, and a reasoner reads it
+        that way. It is usually a modelling slip and occasionally deliberate, so
+        the app says so rather than refusing it — and says what it means, since
+        "equivalent" is the part that surprises people who wrote it by accident.
+        """
+        cycles = self._cycles_in(self._class_parent_map())
+        issues = []
+        for cycle in cycles:
+            names = [self._local_name(URIRef(uri)) for uri in [*cycle, cycle[0]]]
+            issues.append(
+                {
+                    "severity": "warning",
+                    "type": "class_cycle",
+                    "subject": self._local_name(URIRef(cycle[0])),
+                    "message": (
+                        "subClassOf cycle: "
+                        + " -> ".join(names)
+                        + ". Classes in a cycle are equivalent to one another, "
+                        "which is valid OWL but rarely what was meant."
+                    ),
+                }
+            )
+        return issues
 
     def _skos_cycle_issues(
         self, concepts: list[dict[str, Any]]
@@ -6307,6 +6360,11 @@ class OntologyManager:
     def validate(self, check_missing_domain_range: bool = True) -> list[dict[str, str]]:
         """Validate the ontology and return issues."""
         issues = []
+        # A subClassOf cycle, which nothing used to mention: the tree view marks
+        # the back-edge it walks into and the graph survives one, so an
+        # ontology could carry a loop with only its own hierarchy view to say
+        # so (issue #413).
+        issues += self._class_cycle_issues()
         # ``pred`` is reused across loops that bind it to both predicate URIRefs
         # and arbitrary graph terms; declare the broader rdflib type up front.
         pred: Node

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -4808,13 +4808,18 @@ class OntologyManager:
     def _class_parent_map(self) -> dict[str, list[str]]:
         """``child URI -> parent URIs`` over ``rdfs:subClassOf``.
 
-        Named classes only: a restriction is written as a subClassOf a blank
+        Named classes only, on both ends, and tested for what they are rather
+        than what they are not: a restriction is written as a subClassOf a blank
         node, and following those would report a "cycle" through anonymous
-        classes that says nothing to anyone.
+        classes that says nothing to anyone — while a malformed graph can carry
+        a *literal* whose text happens to read like a class URI, and skipping
+        only blank nodes let that literal stand in for the class it spells
+        (Codex review of PR #416). Every other hierarchy reader here requires a
+        URIRef; so does this one.
         """
         parents: dict[str, list[str]] = {}
         for child, parent in self.graph.subject_objects(RDFS.subClassOf):
-            if isinstance(child, BNode) or isinstance(parent, BNode):
+            if not isinstance(child, URIRef) or not isinstance(parent, URIRef):
                 continue
             parents.setdefault(str(child), []).append(str(parent))
             parents.setdefault(str(parent), [])

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -4820,6 +4820,26 @@ class OntologyManager:
             parents.setdefault(str(parent), [])
         return {uri: sorted(set(ps)) for uri, ps in parents.items()}
 
+    def _display_names(self, uris) -> dict[str, str]:
+        """URI -> the shortest form that still identifies it.
+
+        The local name where it is unique among ``uris``, the full URI where it
+        is not. Two namespaces can hold a class of the same name, and a message
+        that called both of them "A" would name nothing: a cross-namespace cycle
+        read "A -> A -> A" (Codex review of PR #416).
+
+        The same idea as :meth:`_skos_display_names`, which does it over concept
+        dicts that already carry their name; this one starts from URIs, which is
+        what the class hierarchy is keyed by.
+        """
+        names = {str(uri): self._local_name(URIRef(str(uri))) for uri in uris}
+        counts: dict[str, int] = {}
+        for name in names.values():
+            counts[name] = counts.get(name, 0) + 1
+        return {
+            uri: (name if counts[name] == 1 else uri) for uri, name in names.items()
+        }
+
     def _class_cycle_issues(self) -> list[dict[str, str]]:
         """One issue per ``rdfs:subClassOf`` cycle (issue #413).
 
@@ -4829,18 +4849,25 @@ class OntologyManager:
         the app says so rather than refusing it — and says what it means, since
         "equivalent" is the part that surprises people who wrote it by accident.
         """
-        cycles = self._cycles_in(self._class_parent_map())
+        parents = self._class_parent_map()
+        cycles = self._cycles_in(parents)
+        # Named over the whole hierarchy, not over each cycle: a class outside
+        # the loop can share a local name with one inside it, and the reader has
+        # the whole ontology in front of them, not the cycle.
+        shown = self._display_names(parents)
         issues = []
         for cycle in cycles:
-            names = [self._local_name(URIRef(uri)) for uri in [*cycle, cycle[0]]]
             issues.append(
                 {
                     "severity": "warning",
                     "type": "class_cycle",
-                    "subject": self._local_name(URIRef(cycle[0])),
+                    "subject": shown[cycle[0]],
+                    # The URI as well, since the name may not be unique and this
+                    # is what navigating to the class has to go on.
+                    "subject_uri": cycle[0],
                     "message": (
                         "subClassOf cycle: "
-                        + " -> ".join(names)
+                        + " -> ".join(shown[uri] for uri in [*cycle, cycle[0]])
                         + ". Classes in a cycle are equivalent to one another, "
                         "which is valid OWL but rarely what was meant."
                     ),

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -4861,9 +4861,13 @@ class OntologyManager:
                 {
                     "severity": "warning",
                     "type": "class_cycle",
-                    "subject": shown[cycle[0]],
-                    # The URI as well, since the name may not be unique and this
-                    # is what navigating to the class has to go on.
+                    # The local name, like every other issue this method
+                    # returns: a consumer matching on it should not have to
+                    # learn that one type sometimes answers with a URI instead
+                    # (Codex review of PR #416). Where that name is ambiguous
+                    # the URI below says which class is meant, and the message
+                    # spells the whole cycle out.
+                    "subject": self._local_name(URIRef(cycle[0])),
                     "subject_uri": cycle[0],
                     "message": (
                         "subClassOf cycle: "

--- a/orionbelt_ontology_builder/ontology_manager.py
+++ b/orionbelt_ontology_builder/ontology_manager.py
@@ -4851,10 +4851,20 @@ class OntologyManager:
         """
         parents = self._class_parent_map()
         cycles = self._cycles_in(parents)
-        # Named over the whole hierarchy, not over each cycle: a class outside
-        # the loop can share a local name with one inside it, and the reader has
-        # the whole ontology in front of them, not the cycle.
-        shown = self._display_names(parents)
+        if not cycles:
+            return []
+        # Named over every class in the ontology, not over the cycle and not
+        # over the hierarchy: a class outside the loop can share a local name
+        # with one inside it, and a *declared* class with no subClassOf edge at
+        # all is absent from the hierarchy while being just as present on screen
+        # (Codex review of PR #416). Both are the reader's ontology, so both
+        # decide whether a name identifies anything.
+        declared = {
+            str(uri)
+            for uri in self.graph.subjects(RDF.type, OWL.Class)
+            if not isinstance(uri, BNode)
+        }
+        shown = self._display_names(set(parents) | declared)
         issues = []
         for cycle in cycles:
             issues.append(

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -799,10 +799,20 @@ def render_visualization():
         highlight_issues = _cfg["_viz_cfg_highlight_issues"]
         auto_show_new = _cfg["_viz_cfg_auto_show_new"]
 
-        validation_subjects = set()
+        # Two sets, because an issue names its subject two ways. Most carry a
+        # local name only, and two classes in different namespaces can share
+        # one — so an issue that also carries a URI is matched by that instead,
+        # and rings the class it actually means rather than both of them.
+        validation_subjects: set = set()
+        validation_subject_uris: set = set()
         if highlight_issues:
             issues = ont.validate()
-            validation_subjects = {i["subject"] for i in issues}
+            validation_subject_uris = {
+                i["subject_uri"] for i in issues if i.get("subject_uri")
+            }
+            validation_subjects = {
+                i["subject"] for i in issues if not i.get("subject_uri")
+            }
 
         # Class filter — reconcile the selection with the current class set
         # instead of resetting it on every ontology mutation, which used to wipe
@@ -2021,7 +2031,10 @@ def render_visualization():
                     if cls["comment"]:
                         title += f"\nComment: {cls['comment'][:100]}"
 
-                    has_issue = cls["name"] in validation_subjects
+                    has_issue = (
+                        cls["uri"] in validation_subject_uris
+                        or cls["name"] in validation_subjects
+                    )
                     node_color = (
                         {
                             "background": "#4CAF50",
@@ -2227,7 +2240,10 @@ def render_visualization():
                     if ind["classes"]:
                         title += f"\nType: {', '.join(ind['classes'])}"
 
-                    has_issue = ind["name"] in validation_subjects
+                    has_issue = (
+                        ind["uri"] in validation_subject_uris
+                        or ind["name"] in validation_subjects
+                    )
                     ind_color = (
                         {
                             "background": "#FF9800",

--- a/tests/test_class_cycles.py
+++ b/tests/test_class_cycles.py
@@ -221,6 +221,22 @@ def test_a_restriction_is_not_a_cycle(om):
     assert _cycles(om) == []
 
 
+def test_a_literal_that_spells_a_class_uri_is_not_an_edge(om):
+    """A malformed graph can carry `A subClassOf "…#B"` as a *literal*. Skipping
+    only blank nodes let that string stand in for the class it spells, and the
+    pair was reported as a cycle (Codex review of PR #416)."""
+    from rdflib import RDFS, Literal, URIRef
+
+    om.graph.add(
+        (
+            URIRef(NS + "Vehicle"),
+            RDFS.subClassOf,
+            Literal(NS + "Tandem"),
+        )
+    )
+    assert _cycles(om) == []
+
+
 def test_a_diamond_is_not_a_cycle(om):
     """Two paths to one ancestor is multiple inheritance, not a loop."""
     om.add_class("Machine")

--- a/tests/test_class_cycles.py
+++ b/tests/test_class_cycles.py
@@ -115,7 +115,67 @@ def test_the_issue_carries_the_uri_to_navigate_by():
     issue = _cycles(o)[0]
 
     assert issue["subject_uri"] in {base_a, other_a}
-    assert issue["subject"] == issue["subject_uri"], "an ambiguous name shows in full"
+
+
+def test_the_subject_stays_a_local_name_like_every_other_issue():
+    """It briefly became a URI when the name was ambiguous, and the graph's
+    "Highlight issues" matches subjects against class names: nothing was marked
+    at all (Codex review of PR #416). The URI belongs in subject_uri."""
+    o, _base_a, _other_a = _cross_namespace_loop()
+    issue = _cycles(o)[0]
+
+    assert issue["subject"] == "A"
+    assert issue["subject_uri"].startswith("http")
+
+
+def test_the_graph_marks_the_class_a_cycle_names():
+    """Through the builder's own matching, which is where the regression was."""
+    import json
+    import os
+
+    from streamlit.testing.v1 import AppTest
+
+    os.environ["CYCLE_NAMESPACES"] = "cross"
+    at = AppTest.from_function(_viz_script)
+    at.run(timeout=300)
+    assert not at.exception, at.exception
+    nodes = json.loads(at.session_state["last_graph_data"]["nodes"])
+    ringed = [n for n in nodes if (n.get("color") or {}).get("border") == "#F44336"]
+
+    assert ringed, [
+        (n.get("label"), (n.get("color") or {}).get("border")) for n in nodes
+    ]
+
+
+def _viz_script():
+    import os
+
+    import streamlit as st
+    from rdflib import OWL, RDF, RDFS, Literal, URIRef
+
+    from orionbelt_ontology_builder import app
+    from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+    if "ontology" not in st.session_state:
+        om = OntologyManager()
+        other = "http://other.example/"
+        cross = os.environ.get("CYCLE_NAMESPACES") == "cross"
+        first = om.namespace + "A"
+        second = (other if cross else om.namespace) + ("A" if cross else "B")
+        for uri in (first, second):
+            om.graph.add((URIRef(uri), RDF.type, OWL.Class))
+            # Labelled, so the cycle is the only issue: an unlabelled class
+            # raises missing_label, whose subject is the local name, and that
+            # would ring the node whatever the cycle issue said.
+            om.graph.add((URIRef(uri), RDFS.label, Literal(uri.rsplit("/", 1)[-1])))
+        om.graph.add((URIRef(first), RDFS.subClassOf, URIRef(second)))
+        om.graph.add((URIRef(second), RDFS.subClassOf, URIRef(first)))
+        st.session_state.ontology = om
+        st.session_state["_autosave_restored"] = True
+        st.session_state["_viz_settings_restored"] = True
+        st.session_state["_local_storage"] = None
+        st.session_state["_viz_cfg_highlight_issues"] = True
+    app.render_visualization()
 
 
 def test_names_are_disambiguated_against_the_whole_hierarchy(om):

--- a/tests/test_class_cycles.py
+++ b/tests/test_class_cycles.py
@@ -1,0 +1,126 @@
+"""validate() reports a subClassOf cycle (issue #413).
+
+Nothing used to mention one. The tree view marks the back-edge it walks into
+and `ui.class_descendant_uris` walks with a seen-set, so a loop breaks nothing
+and says nothing either: an ontology could carry one with only its own
+hierarchy view to show it.
+
+A warning rather than an error, because a cycle is legal OWL. `A ⊑ B` with
+`B ⊑ A` says the two classes are equivalent, and a reasoner reads it that way.
+It is usually a modelling slip, occasionally deliberate, so the app says so
+rather than refusing it.
+"""
+
+import pytest
+
+from orionbelt_ontology_builder.ontology_manager import OntologyManager
+
+NS = "http://example.org/ontology#"
+
+
+@pytest.fixture
+def om():
+    o = OntologyManager()
+    o.add_class("Vehicle")
+    o.add_class("Bicycle", parent="Vehicle")
+    o.add_class("Tandem", parent="Bicycle")
+    return o
+
+
+def _cycles(o):
+    return [i for i in o.validate() if i["type"] == "class_cycle"]
+
+
+def test_a_plain_hierarchy_reports_nothing(om):
+    assert _cycles(om) == []
+
+
+def test_a_two_class_loop_is_reported(om):
+    om.update_class(NS + "Bicycle", new_parent="Tandem")
+    found = _cycles(om)
+
+    assert len(found) == 1
+    assert found[0]["severity"] == "warning", "a cycle is legal OWL, not an error"
+    assert "Bicycle" in found[0]["message"] and "Tandem" in found[0]["message"]
+
+
+def test_the_message_says_what_a_cycle_means(om):
+    """ "Equivalent" is the part that surprises whoever wrote one by accident."""
+    om.update_class(NS + "Bicycle", new_parent="Tandem")
+    assert "equivalent" in _cycles(om)[0]["message"].lower()
+
+
+def test_a_longer_loop_is_reported_once_with_its_members(om):
+    """Not once per class in it."""
+    om.update_class(NS + "Vehicle", new_parent="Tandem")
+    found = _cycles(om)
+
+    assert len(found) == 1, [i["message"] for i in found]
+    for name in ("Vehicle", "Bicycle", "Tandem"):
+        assert name in found[0]["message"]
+
+
+def test_a_class_that_is_its_own_parent_counts(om):
+    om.update_class(NS + "Vehicle", new_parent="Vehicle")
+    assert len(_cycles(om)) == 1
+
+
+def test_two_separate_loops_are_two_issues(om):
+    om.update_class(NS + "Bicycle", new_parent="Tandem")
+    om.add_class("Left")
+    om.add_class("Right", parent="Left")
+    om.update_class(NS + "Left", new_parent="Right")
+
+    assert len(_cycles(om)) == 2
+
+
+# --- what must not be mistaken for a cycle ----------------------------------
+
+
+def test_a_restriction_is_not_a_cycle(om):
+    """A restriction is a subClassOf a blank node, and following those would
+    report a loop through anonymous classes that says nothing to anyone."""
+    om.add_object_property("hasPart")
+    om.add_restriction("Bicycle", "hasPart", "someValuesFrom", "Vehicle")
+    assert _cycles(om) == []
+
+
+def test_a_diamond_is_not_a_cycle(om):
+    """Two paths to one ancestor is multiple inheritance, not a loop."""
+    om.add_class("Machine")
+    om.update_class(NS + "Tandem", new_parent="Machine")
+    om.update_class(NS + "Machine", new_parent="Vehicle")
+    assert _cycles(om) == []
+
+
+def test_every_bundled_ontology_is_clean():
+    """The samples are real vocabularies (FOAF, GoodRelations, Pizza, Wine,
+    PROV-O), which is the sharpest available check against false positives."""
+    from pathlib import Path
+
+    import orionbelt_ontology_builder as pkg
+    from orionbelt_ontology_builder.ui import _rdf_format_for_path
+
+    checked = 0
+    for path in sorted((Path(pkg.__file__).parent / "samples").glob("*")):
+        if path.suffix.lower() not in {".ttl", ".owl", ".rdf", ".xml", ".nt"}:
+            continue
+        loaded = OntologyManager()
+        loaded.load_from_file(str(path), format=_rdf_format_for_path(path))
+        assert _cycles(loaded) == [], f"{path.name}: {_cycles(loaded)}"
+        checked += 1
+    assert checked >= 5, checked
+
+
+# --- the walk is shared with the SKOS check ---------------------------------
+
+
+def test_both_hierarchies_are_walked_by_the_same_code():
+    """A second implementation would be a second set of edge cases."""
+    import inspect
+
+    src = inspect.getsource(OntologyManager._skos_cycles)
+    assert "_cycles_in(" in src
+
+    parents = {"a": ["b"], "b": ["a"], "c": []}
+    assert OntologyManager._cycles_in(parents) == [["a", "b"]]

--- a/tests/test_class_cycles.py
+++ b/tests/test_class_cycles.py
@@ -74,6 +74,64 @@ def test_two_separate_loops_are_two_issues(om):
     assert len(_cycles(om)) == 2
 
 
+# --- naming the classes in the loop -----------------------------------------
+
+
+def _cross_namespace_loop():
+    """``base#A ⊑ other#A`` and back: one local name, two classes."""
+    from rdflib import OWL, RDF, RDFS, URIRef
+
+    o = OntologyManager()
+    other = "http://other.example/"
+    for uri in (o.namespace + "A", other + "A"):
+        o.graph.add((URIRef(uri), RDF.type, OWL.Class))
+    o.graph.add((URIRef(o.namespace + "A"), RDFS.subClassOf, URIRef(other + "A")))
+    o.graph.add((URIRef(other + "A"), RDFS.subClassOf, URIRef(o.namespace + "A")))
+    return o, o.namespace + "A", other + "A"
+
+
+def test_a_cross_namespace_cycle_names_both_classes():
+    """The local name alone read "A -> A -> A", which identifies nothing
+    (Codex review of PR #416)."""
+    o, base_a, other_a = _cross_namespace_loop()
+    message = _cycles(o)[0]["message"]
+
+    assert base_a in message and other_a in message, message
+    assert "A -> A -> A" not in message
+
+
+def test_a_cycle_within_one_namespace_still_reads_short(om):
+    """The URI is the fallback, not the default: unique names stay names."""
+    om.update_class(NS + "Vehicle", new_parent="Bicycle")
+    message = _cycles(om)[0]["message"]
+
+    assert "Bicycle -> Vehicle -> Bicycle" in message
+    assert "http://" not in message
+
+
+def test_the_issue_carries_the_uri_to_navigate_by():
+    """A name may not be unique; this is what a click has to go on."""
+    o, base_a, other_a = _cross_namespace_loop()
+    issue = _cycles(o)[0]
+
+    assert issue["subject_uri"] in {base_a, other_a}
+    assert issue["subject"] == issue["subject_uri"], "an ambiguous name shows in full"
+
+
+def test_names_are_disambiguated_against_the_whole_hierarchy(om):
+    """Not against the cycle alone: a class outside the loop can share a local
+    name with one inside it, and the reader has the ontology in front of them."""
+    from rdflib import OWL, RDF, RDFS, URIRef
+
+    other = "http://other.example/"
+    om.graph.add((URIRef(other + "Bicycle"), RDF.type, OWL.Class))
+    om.graph.add((URIRef(other + "Bicycle"), RDFS.subClassOf, URIRef(NS + "Vehicle")))
+    om.update_class(NS + "Vehicle", new_parent="Bicycle")
+
+    message = _cycles(om)[0]["message"]
+    assert NS + "Bicycle" in message, message
+
+
 # --- what must not be mistaken for a cycle ----------------------------------
 
 

--- a/tests/test_class_cycles.py
+++ b/tests/test_class_cycles.py
@@ -178,6 +178,24 @@ def _viz_script():
     app.render_visualization()
 
 
+def test_a_declared_class_with_no_hierarchy_edge_still_counts(om):
+    """It is absent from the parent map and just as present on screen.
+
+    Naming the cycle against the hierarchy alone left the loop reading
+    "Bicycle -> Vehicle -> Bicycle" while a second Bicycle sat elsewhere in the
+    ontology (Codex review of PR #416).
+    """
+    from rdflib import OWL, RDF, URIRef
+
+    om.graph.add((URIRef("http://other.example/Bicycle"), RDF.type, OWL.Class))
+    om.update_class(NS + "Vehicle", new_parent="Bicycle")
+
+    message = _cycles(om)[0]["message"]
+    assert NS + "Bicycle" in message, message
+    # And the member whose name is still unique is still readable.
+    assert "-> Vehicle ->" in message, message
+
+
 def test_names_are_disambiguated_against_the_whole_hierarchy(om):
     """Not against the cycle alone: a class outside the loop can share a local
     name with one inside it, and the reader has the ontology in front of them."""


### PR DESCRIPTION
Closes #413.

## What was missing

Point a class at one of its own descendants from the Classes page and the triple is written with nothing said anywhere. `validate()` reported three missing labels and no loop.

Nothing breaks, which is why it stayed quiet: the tree view already walks cycles on purpose (issue #171) and marks the back-edge, and `ui.class_descendant_uris` walks with a seen-set. So a loop could sit in an ontology with only the hierarchy view to show it, and only if you opened it.

## A warning, not an error

A `subClassOf` cycle is legal OWL: `A ⊑ B` with `B ⊑ A` asserts the two classes are equivalent, and a reasoner reads it that way. Usually a modelling slip, occasionally deliberate, so the app says so rather than refusing it. The message says what it means, since "equivalent" is the part that surprises whoever wrote one by accident:

> subClassOf cycle: Department → Organization → Department. Classes in a cycle are equivalent to one another, which is valid OWL but rarely what was meant.

## How

The walk is the SKOS cycle finder's, lifted out of `_skos_cycles` into `_cycles_in(parents)` rather than written twice: both are "follow every parent and notice when the path meets itself", and a second implementation would be a second set of edge cases. The SKOS tests cover that refactor (30 of them pass unchanged).

`_class_parent_map` reads `rdfs:subClassOf` between **named** classes only. A restriction is a subClassOf a blank node, and following those would report a loop through anonymous classes that means nothing to anyone.

## Verified against real vocabularies

The sharpest available check against false positives is the bundled samples, all of which are real:

```
foaf.rdf                classes=15   cycles=0
goodrelations.owl       classes=37   cycles=0
pizza.owl               classes=99   cycles=0
prov-o.ttl              classes=31   cycles=0
wine.owl                classes=74   cycles=0
geography-thesaurus.ttl / skos-showcase.ttl        cycles=0
```

And end to end in the app: Classes → Edit `Organization` → parent `Department` (its own child) → Update, then Validation reads `Warnings (2)` with the cycle line above.

## Tests

`tests/test_class_cycles.py` - ten: a plain hierarchy is silent, a two-class loop is one warning naming both, the message explains equivalence, a longer loop is reported once with all its members, a self-parent counts, two loops are two issues, a restriction is not a cycle, a diamond is not a cycle, every bundled ontology is clean, and both hierarchies go through the one walk.

Full suite green (2020 passed), plus ruff 0.16.5 format/check and mypy.

## Not included

Hiding descendants in the Classes page's Parent field, as #411 does in the superclass form. That form creates the relationship in one gesture with an obviously wrong answer; the Parent field is a general editor, and silently dropping valid options from a dropdown is more surprising than a warning. `ui.class_descendant_uris` is public if that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)