### PR TITLE
fix(ui): the page shims' frame no longer claims 150px of every page

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -861,15 +861,45 @@ def page_shim_html(texts: dict) -> str:
     )
 
 
+#: Container key for the page shims' frame (see :func:`render_page_shims`).
+PAGE_SHIM_KEY = "page_shim"
+
+#: Collapses that container to nothing. Out of the flow rather than
+#: ``display: none``: the frame is script, and hiding it outright is a stronger
+#: claim on how a browser treats a frame than this needs to make. Absolute also
+#: takes it out of the block's gap grid, which a zero-height child in the flow
+#: would still claim a slot in.
+PAGE_SHIM_CSS = f"""<style>
+.st-key-{PAGE_SHIM_KEY},
+[data-testid="stLayoutWrapper"]:has(> .st-key-{PAGE_SHIM_KEY}) {{
+    position: absolute !important;
+    height: 0 !important;
+    min-height: 0 !important;
+    overflow: hidden !important;
+    pointer-events: none !important;
+}}
+</style>"""
+
+
 def render_page_shims() -> None:
     """Mount :func:`page_shim_html` for this render.
 
     One frame for both, rather than one each: they are mounted on every page and
     every rerun, and a component is an iframe.
+
+    The frame carries script and draws nothing, but ``height=0`` does not keep
+    it out of the page: Streamlit 1.62 reads a falsy height as "no height given"
+    and falls back to the component default of 150px, which put an empty block
+    that tall at the foot of every page — and, on Visualization, took the same
+    150px off the graph, which sizes itself to the room left below it. So it is
+    mounted in a keyed container that :data:`PAGE_SHIM_CSS` collapses to
+    nothing, rather than trusting the height alone.
     """
     texts = st.session_state.get(HELP_TEXTS_KEY)
     try:
-        st.components.v1.html(page_shim_html(texts or {}), height=0)
+        st.markdown(PAGE_SHIM_CSS, unsafe_allow_html=True)
+        with st.container(key=PAGE_SHIM_KEY):
+            st.components.v1.html(page_shim_html(texts or {}), height=1)
     except Exception:  # cosmetic: a page must not fail over its keyboard wiring
         logger.debug("Page shims not mounted", exc_info=True)
 

--- a/tests/test_help_tab_order.py
+++ b/tests/test_help_tab_order.py
@@ -299,3 +299,41 @@ def test_a_rendered_page_hands_over_the_help_it_drew():
     texts = at.session_state[ui.HELP_TEXTS_KEY]["by_label"]
     assert texts, "the Add Class form passes help= to several fields"
     assert any("class" in t.lower() for t in texts.values() if t), texts
+
+
+def test_the_frame_claims_no_page_height(session, monkeypatch):
+    """The shims draw nothing, so they must cost the page nothing.
+
+    ``height=0`` does not say that: Streamlit 1.62 reads a falsy height as "no
+    height given" and falls back to the component default of 150px, which left
+    an empty block that tall at the foot of every page — and took the same 150px
+    off the graph, which sizes itself to the room left below it. The frame goes
+    in a keyed container the CSS collapses instead.
+    """
+    import contextlib
+
+    mounted = {}
+    styles = []
+
+    @contextlib.contextmanager
+    def _container(*, key=None, **kwargs):
+        mounted["key"] = key
+        yield
+
+    monkeypatch.setattr(ui.st, "container", _container)
+    monkeypatch.setattr(ui.st, "markdown", lambda body, **kw: styles.append(body))
+    monkeypatch.setattr(
+        ui.st.components.v1,
+        "html",
+        lambda html, height=None, **kw: mounted.update(height=height),
+    )
+
+    ui.render_page_shims()
+
+    assert mounted["height"], "a falsy height is read as the 150px default"
+    assert mounted["key"] == ui.PAGE_SHIM_KEY
+    assert f".st-key-{ui.PAGE_SHIM_KEY}" in ui.PAGE_SHIM_CSS
+    assert "height: 0 !important" in ui.PAGE_SHIM_CSS
+    assert ui.PAGE_SHIM_CSS in styles, (
+        "the container is only collapsed if the CSS is on the page"
+    )


### PR DESCRIPTION
## What

The help and Enter shims added in #412 ride in one component frame that draws nothing, and it was mounted with `height=0`. That does not give a zero-height frame: Streamlit 1.62 reads a falsy height as "no height given" and falls back to the component default of 150px.

So every page carried an empty 150px block at its foot (visible as an empty `stIFrame` with two `<script>` tags and an empty `<body>`), and Visualization paid for it twice: the canvas fits itself to the room left below the controls, and `autofitReserve()` counted the phantom block.

Measured at 1600x1000 with gUFO loaded, in headless Chromium and Firefox alike:

| | before | after |
| --- | --- | --- |
| `autofitReserve()` | 217px | 44px |
| graph height | 329px | 508px |
| blank strip under the status bar | ~173px | none |

## How

The frame goes in a keyed container with a truthy height, and `PAGE_SHIM_CSS` collapses that container with `position: absolute; height: 0; overflow: hidden`.

Absolute rather than `display: none`: hiding it outright is a stronger claim on how a browser treats a frame than this needs to make, and the frame is script that has to keep running. Absolute positioning also takes it out of the block's 16px gap grid, which a zero-height child still in the flow would claim a slot in.

## Tests

`tests/test_help_tab_order.py` gains a case that the mounted height is truthy and that the collapsing CSS is on the page.

Full suite: 2029 passed. `ruff format`, `ruff check` and `mypy` clean. Also verified live against the running app in headless Chromium and Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)