### PR TITLE
chore: bump to 1.27.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.27.2` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.27.3` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -33,7 +33,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.27.2"
+APP_VERSION = "1.27.3"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.27.2"
+version = "1.27.3"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 # SPDX. Business Source License 1.1 is BUSL-1.1; BSL-1.0 is the Boost Software

--- a/uv.lock
+++ b/uv.lock
@@ -891,7 +891,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.27.2"
+version = "1.27.3"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },


### PR DESCRIPTION
Version bump only. Thirteen commits since v1.27.2, mostly Visualization fixes; six are typed `feat:` but are refinements to what was already there, so this ships as a patch.

Bumped in `pyproject.toml`, `README.md` (Docker pin hint), `orionbelt_ontology_builder/ui.py` (`APP_VERSION`) and `uv.lock`. A repo-wide grep for the old string comes back empty, and `tests/test_version_consistency.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)