### PR TITLE
fix(ui): an edit confirmation clears in two seconds, not four

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -3020,6 +3020,13 @@ def show_message(message: str, type: str = "info"):
 #: Icons for the toast form of a flash message, by message type.
 _FLASH_TOAST_ICON = {"success": "✅", "warning": "⚠️", "error": "🚫", "info": "ℹ️"}
 
+#: How long a confirmation toast stays up, in seconds. Streamlit's default is
+#: four, and these carry one piece of news each: the edit landed. That is read
+#: at a glance, and the rest of the four seconds is a message about the last
+#: edit sitting over the next one (issue #419). Only the confirmations are cut
+#: back; a warning or an error keeps the default, since neither is read as fast.
+_FLASH_TOAST_SECONDS = 2
+
 
 def set_flash_message(message: str, type: str = "info", toast: bool = False):
     """Set a flash message to be displayed after rerun.
@@ -3043,7 +3050,13 @@ def display_flash_message():
     if st.session_state.get("flash_message"):
         msg = st.session_state.flash_message
         if msg.get("toast"):
-            st.toast(msg["message"], icon=_FLASH_TOAST_ICON.get(msg["type"]))
+            st.toast(
+                msg["message"],
+                icon=_FLASH_TOAST_ICON.get(msg["type"]),
+                duration=(
+                    _FLASH_TOAST_SECONDS if msg["type"] == "success" else "short"
+                ),
+            )
         else:
             show_message(msg["message"], msg["type"])
         st.session_state.flash_message = None

--- a/tests/test_flash_toast.py
+++ b/tests/test_flash_toast.py
@@ -29,7 +29,11 @@ def flash(monkeypatch):
     shown: list[tuple[str, str]] = []
     monkeypatch.setattr(ui.st, "session_state", state)
     monkeypatch.setattr(
-        ui.st, "toast", lambda message, icon=None: shown.append(("toast", message))
+        ui.st,
+        "toast",
+        lambda message, icon=None, duration=None: shown.append(
+            ("toast", message, duration)
+        ),
     )
     for kind in ("success", "warning", "error", "info"):
         monkeypatch.setattr(
@@ -54,7 +58,7 @@ def test_a_toast_flash_floats_over_the_page(flash):
 
     ui.display_flash_message()
 
-    assert shown == [("toast", "Relation updated!")]
+    assert shown == [("toast", "Relation updated!", ui._FLASH_TOAST_SECONDS)]
     assert state["flash_message"] is None
 
 
@@ -82,3 +86,27 @@ def test_the_editor_confirmations_are_the_ones_that_float():
         'set_flash_message(f"This {label} is no longer in the ontology.", "error")'
         in src
     )
+
+
+def test_a_confirmation_does_not_outstay_the_edit(flash):
+    """Two seconds, not Streamlit's four (issue #419).
+
+    The confirmation carries one piece of news, read at a glance. What is left
+    of the default is a message about the last edit sitting over the next one.
+    """
+    _state, shown = flash
+    ui.set_flash_message("Relation updated!", "success", toast=True)
+
+    ui.display_flash_message()
+
+    assert shown[0][2] == 2
+
+
+def test_a_warning_toast_keeps_the_default(flash):
+    """Only the confirmations are cut back: a warning is not read that fast."""
+    _state, shown = flash
+    ui.set_flash_message("Saved, but the label was dropped", "warning", toast=True)
+
+    ui.display_flash_message()
+
+    assert shown[0][2] == "short"


### PR DESCRIPTION
Closes #419.

## The report

"Relation updated!" stays on screen too long. Two seconds is more than enough.

## The change

`display_flash_message()` passes `duration=2` to `st.toast` for the success confirmations. Streamlit's default is `"short"`, which is four seconds.

These carry one piece of news each: the edit landed. That is read at a glance, and what is left of the four seconds is a message about the last edit sitting over the next one. All six toast call sites that go through the flash are of that kind (`Relation updated!`, `Restriction updated!`, `Annotation updated!`, `Annotation deleted!`, and the two entity deletions).

A warning or an error given as a toast keeps the default, since neither is read that fast. Nothing today sends one, so this is a guard on the next one rather than a behaviour change.

`duration` is a Streamlit 1.62 parameter, which the pin is already on.

## Tests

`tests/test_flash_toast.py` gains two cases: a confirmation asks for two seconds, and a warning keeps the default. The fixture's `st.toast` stand-in now records the duration.

Full suite: 2031 passed. `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)