### PR TITLE
chore(deps): take the streamlit pin to 1.63.0

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -759,13 +759,30 @@ if (doc) {
 #: Enter, and is left alone. Only where Enter does nothing today, too — with the
 #: list open, something typed, and no option highlighted — so nothing that works
 #: is taken over, form submission included.
+# SELECT_ALL_NOTE
+# Why a few multiselects are drawn without their "Select N matches" row.
+#
+# Streamlit 1.63 made Enter commit the first visible row, and with two or more
+# matches that row is the bulk one, so type-and-Enter selects every match
+# (streamlit/streamlit#16841). The shim below takes the first real option
+# instead, on every multiselect, which leaves the row safe to keep wherever
+# selecting everything is a coherent thing to want: the three bulk delete pages,
+# and the graph's entity filters, whose own help text points at it by name.
+#
+# `select_all=False` is passed at the pickers where it is not coherent - a focus
+# on every node, a property chain of every property, a key of every property, a
+# concept under every parent - since there the row is only something to hit by
+# accident. It is a 1.63 parameter, which is part of why the pin moved.
 _ENTER_INSERTS_JS = r"""
 var doc = window.parent && window.parent.document;
 if (doc) {
   // The bulk rows, which select every option or every match at once. One of
   // them is always first, so it is what an unqualified "first option" would
   // take, and inserting five classes when one was asked for is worse than doing
-  // nothing. They are matched by the shape of the key they carry, not by the
+  // nothing. Since 1.63 that is also what Streamlit's own Enter does, so this
+  // is a deliberate override of an upstream default and not only a fix for a
+  // gap: keeping it is what lets the bulk pages keep their row (SELECT_ALL_NOTE
+  // above, and streamlit/streamlit#16841). They are matched by the shape of the key they carry, not by the
   // words they show and not by either key literally: with the box empty it is
   // "__select_all__" and with a query typed it is "__select_matches__", and
   // taking one for the other is exactly the bug this comment exists to stop

--- a/orionbelt_ontology_builder/views/advanced.py
+++ b/orionbelt_ontology_builder/views/advanced.py
@@ -147,6 +147,9 @@ def render_advanced():
                     "Chain Properties (in order)",
                     options=obj_prop_names,
                     help="Select properties in the order they should be followed",
+                    # The order is the point, and a row that inserts every
+                    # property at once has none (see SELECT_ALL_NOTE in ui.py).
+                    select_all=False,
                 )
 
                 submitted = st.form_submit_button("Add Property Chain")
@@ -283,6 +286,9 @@ def render_advanced():
                     "Key Properties",
                     options=all_prop_names,
                     help="Properties that together uniquely identify instances",
+                    # A key is a handful of properties, never all of them
+                    # (see SELECT_ALL_NOTE in ui.py).
+                    select_all=False,
                 )
 
                 submitted = st.form_submit_button("Add hasKey")

--- a/orionbelt_ontology_builder/views/skos.py
+++ b/orionbelt_ontology_builder/views/skos.py
@@ -544,6 +544,9 @@ def render_skos_vocabulary():
                                 _broader_opts,
                                 default=_cur_broader_disp,
                                 key=f"broader_{_ck}",
+                                # Every concept as this one's parent is never
+                                # the intent (see SELECT_ALL_NOTE in ui.py).
+                                select_all=False,
                                 format_func=_pad_option,
                                 help="A concept may have several parents. An "
                                 "edge that would make this concept its own "

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -1252,6 +1252,9 @@ def render_visualization():
                         options=focus_labels,
                         format_func=_picker_caption,
                         key="viz_focus_seeds",
+                        # A focus on everything is not a focus, so the row that
+                        # would offer it is not drawn (see SELECT_ALL_NOTE in ui.py).
+                        select_all=False,
                         on_change=viz_focus_seeds_changed,
                         help="Classes, individuals or SKOS concepts to centre on. "
                         "The neighbourhood grows from all of them. Starts from "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "streamlit==1.62.0",
+    "streamlit==1.63.0",
     "rdflib>=7.0.0",
     "owlrl>=6.0.2",
     "networkx>=3.0",

--- a/tests/test_multiselect_select_all.py
+++ b/tests/test_multiselect_select_all.py
@@ -1,0 +1,71 @@
+"""Which multiselects keep their "Select N matches" row (streamlit/streamlit#16841).
+
+Streamlit 1.63 made Enter commit the first visible row of a multiselect, and
+with two or more matches that row is the bulk one. ``_ENTER_INSERTS_JS`` takes
+the first real option instead, on every multiselect, so the row itself stays
+harmless and is kept wherever selecting everything is a coherent thing to want:
+the three bulk delete pages, and the graph's entity filters, whose help text
+points at it by name.
+
+``select_all=False`` is passed only where selecting everything is not coherent.
+These are source-level checks: the parameter is a rendering detail Streamlit's
+test API does not report, and what is worth pinning is the decision per picker.
+"""
+
+import re
+from pathlib import Path
+
+VIEWS = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder" / "views"
+
+
+def _call(path: str, label: str) -> str:
+    """The ``st.multiselect(...)`` call whose first argument is ``label``."""
+    src = (VIEWS / path).read_text(encoding="utf-8")
+    start = src.find("st.multiselect(")
+    while start != -1:
+        depth, i = 0, src.index("(", start)
+        for j in range(i, len(src)):
+            if src[j] == "(":
+                depth += 1
+            elif src[j] == ")":
+                depth -= 1
+                if depth == 0:
+                    call = src[start : j + 1]
+                    if label in call.split("\n")[1 if "\n" in call else 0]:
+                        return call
+                    break
+        start = src.find("st.multiselect(", start + 1)
+    raise AssertionError(f"no multiselect labelled {label!r} in {path}")
+
+
+def test_a_picker_that_cannot_mean_all_hides_the_row():
+    for path, label in (
+        ("visualization.py", "Focus node(s)"),
+        ("advanced.py", "Chain Properties (in order)"),
+        ("advanced.py", "Key Properties"),
+        ("skos.py", "Broader Concepts"),
+    ):
+        assert "select_all=False" in _call(path, label), f"{path}: {label}"
+
+
+def test_the_bulk_pages_keep_the_row():
+    """Selecting every match is the point of a bulk page, so the row stays."""
+    for path, label in (
+        ("classes.py", "Select classes to delete"),
+        ("properties.py", "Select properties to delete"),
+        ("individuals.py", "Select individuals to delete"),
+    ):
+        assert "select_all" not in _call(path, label), f"{path}: {label}"
+
+
+def test_the_graph_filter_keeps_the_row_its_help_names():
+    call = _call("visualization.py", "Select {_plural} to display")
+    assert "select_all" not in call
+    assert "'Select all'" in call, "the help text points at the row by name"
+
+
+def test_the_shim_is_what_makes_the_row_safe_to_keep():
+    """Every kept row is only harmless while Enter skips it."""
+    ui = (VIEWS.parent / "ui.py").read_text(encoding="utf-8")
+    assert "SELECT_ALL_NOTE" in ui
+    assert re.search(r"var SENTINEL = /\^__\.\*__\$/", ui), "the bulk rows are skipped"

--- a/uv.lock
+++ b/uv.lock
@@ -118,15 +118,6 @@ wheels = [
 ]
 
 [[package]]
-name = "blinker"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
-]
-
-[[package]]
 name = "bottle"
 version = "0.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -940,7 +931,7 @@ requires-dist = [
     { name = "pywebview", extras = ["pyside6"], marker = "sys_platform != 'darwin' and extra == 'qt'" },
     { name = "rdflib", specifier = ">=7.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.16.5" },
-    { name = "streamlit", specifier = "==1.62.0" },
+    { name = "streamlit", specifier = "==1.63.0" },
     { name = "streamlit-ace", specifier = ">=0.1.1" },
     { name = "streamlit-desktop-app", marker = "extra == 'desktop'", specifier = ">=0.3.3" },
     { name = "streamlit-desktop-app", marker = "extra == 'gtk'", specifier = ">=0.3.3" },
@@ -1743,12 +1734,11 @@ wheels = [
 
 [[package]]
 name = "streamlit"
-version = "1.62.0"
+version = "1.63.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "altair" },
     { name = "anyio" },
-    { name = "blinker" },
     { name = "click" },
     { name = "httptools" },
     { name = "itsdangerous" },
@@ -1768,9 +1758,9 @@ dependencies = [
     { name = "watchdog", marker = "sys_platform != 'darwin'" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/94/928c44a8b7bcd602fc4a16025e9868bcdb88b92bcdb2e53dec188d034fc4/streamlit-1.62.0.tar.gz", hash = "sha256:9d2571da6e6799cbaf0f59548f5773926260a87a69807cf3e2f0f68f9f5e4d45", size = 9883501, upload-time = "2026-08-19T18:31:22.864Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/8a/ccd27f3d5fb05734659a3c188b2c4014454d263e30ae31bb93445290b9cb/streamlit-1.63.0.tar.gz", hash = "sha256:1ea0121884d5606cf055b8c42600528daf07d0401eaabfc8e22f00e235ea53eb", size = 9911883, upload-time = "2026-09-01T17:12:32.456Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/57/78864764c53885db8a378cc1c47329b4b6e095f7ebd89cd1ffcca4027c89/streamlit-1.62.0-py3-none-any.whl", hash = "sha256:294dbcfe0d6531b0d8593a095e6872dcc6ec4b731723fbb318a0f8102e69162e", size = 10490146, upload-time = "2026-08-19T18:31:19.957Z" },
+    { url = "https://files.pythonhosted.org/packages/18/60/2acf1a5cac2b2fa6b09fea362abf81f210cf25cee40082ab11beb754cf70/streamlit-1.63.0-py3-none-any.whl", hash = "sha256:c24fd38170543ffb749321c801627aaa09068219539d7b81ef77633ea2408b36", size = 10497212, upload-time = "2026-09-01T17:12:30.021Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

1.63 carries the multiselect fixes that came out of the react-aria migration this app has been working around ([#16650](https://github.com/streamlit/streamlit/pull/16650) restores Ctrl/Cmd+A in the filter, [#16673](https://github.com/streamlit/streamlit/pull/16673) adds `select_all`), and it stops markdown lists overflowing a narrow container, which is what the graph's details panel is.

## The Enter shim stays

1.63 changed Enter in a multiselect from a no-op to "commit the first visible row". With two or more matches that row is the bulk one, so on the defaults it selects every match. Measured against gUFO in Bulk Delete Classes, typing `Ev` then Enter:

| | "Select N matches" row | Enter inserts | armed warning |
| --- | --- | --- | --- |
| 1.62 + shim (before) | present | `Event` | 1 class |
| 1.63, no shim, defaults | present | `Event`, `EventType`, `ConcreteIndividual`, `ConcreteIndividualType` | 4 classes |
| 1.63, no shim, `select_all=False` | gone | `Event` | 1 class |
| **1.63 + shim (this PR)** | present | `Event` | 1 class |

The last two of those four are reached because the filter matches on subsequence: the `E` in "Concrete" and the `v` in "Individual". Nothing is deleted without pressing Delete Selected, and a checkpoint means Undo restores it, but staging four deletions for two keystrokes that used to mean one is not a default this app should adopt quietly.

`_ENTER_INSERTS_JS` already skips the bulk rows and takes the first real option, on every multiselect, so it keeps the old behaviour on the new pin. What changes is its standing: it now overrides an upstream default deliberately rather than filling a gap, and its comment says so.

## Where the row is dropped

`select_all=False` at the four pickers where selecting everything is not a coherent thing to want: a focus on every node, a property chain of every property, a key of every property, a concept under every parent.

The three bulk delete pages keep it, since selecting every match is the point of a bulk page, and so does the graph's entity filter, whose help text points at the row by name. The reasoning lives in one place, `SELECT_ALL_NOTE` in `ui.py`, next to the shim it depends on.

## Verification

- Live on both pins: bulk delete still draws the row and Enter still inserts one class; Chain Properties draws no row and Enter inserts one property.
- Every `[data-testid=]` / `[data-baseweb=]` hook in `ui.py` counted across all thirteen pages on 1.62 and on 1.63: **no drift**. This is the check that 1.62 taught us to run, since that pin broke five selectors in silence (#368).
- Suite 2035 passed (four new), `ruff` and `mypy` clean.

## Noticed, not fixed here

Four selectors in `ui.py` match nothing on either version, across all thirteen pages: `[data-baseweb="tab"]`, `[data-baseweb="tab-list"]` (there is no `st.tabs` left in the app, the pages use `st.segmented_control`), `[data-testid="stAppViewBlockContainer"]` (renamed to `stMainBlockContainer`) and `[data-testid="stBottom"]`. Dead CSS rather than a regression, so it is left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)