### PR TITLE
chore(ui): drop four CSS hooks that cannot match

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -123,12 +123,6 @@ PKG_DIR = _Path(__file__).resolve().parent
 _FAVICON = PKG_DIR / "favicon.png"
 _CUSTOM_CSS = """
 <style>
-    .stTabs [data-baseweb="tab-list"] {
-        gap: 8px;
-    }
-    .stTabs [data-baseweb="tab"] {
-        padding: 8px 16px;
-    }
     .metric-card {
         background-color: #f0f2f6;
         border-radius: 8px;
@@ -194,15 +188,11 @@ _CUSTOM_CSS = """
        and looked fine only because the CSS blocks above the title were each
        taking a 16px slot in the column; once those went out of the flow, the
        first line of the page slid under the header. */
-    .block-container, .stMainBlockContainer,
-    [data-testid="stAppViewBlockContainer"] {
+    .block-container, .stMainBlockContainer {
         padding-top: 4rem !important;
         padding-bottom: 0 !important;
         padding-left: 2rem !important;
         padding-right: 2rem !important;
-    }
-    footer, [data-testid="stBottom"] {
-        display: none !important;
     }
     .main .block-container { min-height: 0 !important; }
     /* Reduce iframe and element spacing */

--- a/tests/test_css_hooks_are_live.py
+++ b/tests/test_css_hooks_are_live.py
@@ -1,0 +1,44 @@
+"""The stylesheet names no hook that cannot match (issue #368 follow-up).
+
+Streamlit's DOM is internal and moves: the 1.62 pin rebuilt the widgets on
+react-aria and five ``[data-baseweb=...]`` selectors in :mod:`ui` stopped
+matching in silence. The audit for that is to count each hook against a rendered
+page, and it only works if a zero means something. Four selectors matched
+nothing on any of the app's pages on either pin, so a zero was ambiguous:
+
+* ``.stTabs [data-baseweb="tab"]`` and ``.stTabs [data-baseweb="tab-list"]``,
+  for a widget the app stopped using (the sections are ``st.segmented_control``)
+* ``[data-testid="stAppViewBlockContainer"]``, the old name for the element the
+  same rule already selects as ``.stMainBlockContainer``
+* ``footer, [data-testid="stBottom"]``, a footer Streamlit no longer renders and
+  a bottom container this app never mounts
+
+These check the ones that can be checked from the source. The rest is the live
+count, which is a step in the pin-bump routine rather than a test.
+"""
+
+from pathlib import Path
+
+PKG = Path(__file__).resolve().parent.parent / "orionbelt_ontology_builder"
+UI = (PKG / "ui.py").read_text(encoding="utf-8")
+
+
+def _package_source() -> str:
+    return "\n".join(p.read_text(encoding="utf-8") for p in sorted(PKG.rglob("*.py")))
+
+
+def test_the_tab_rules_are_gone_while_the_widget_is():
+    """A rule for ``st.tabs`` is only earned by rendering one."""
+    if "st.tabs(" in _package_source():
+        return  # the widget is back: the rules may come with it
+    assert ".stTabs" not in UI
+
+
+def test_the_block_container_is_named_once_and_currently():
+    assert ".stMainBlockContainer" in UI, "the name the element carries today"
+    assert "stAppViewBlockContainer" not in UI, "the name it carried before"
+
+
+def test_no_rule_hides_chrome_that_is_no_longer_drawn():
+    assert "stBottom" not in UI
+    assert "\n    footer" not in UI


### PR DESCRIPTION
Found while auditing the hooks for the 1.63 pin (#422). Four selectors in `ui.py` matched nothing on any of the app's fourteen pages, on 1.62 and on 1.63 alike:

| selector | why it cannot match |
| --- | --- |
| `.stTabs [data-baseweb="tab-list"]` | no `st.tabs` left in the app; the sections are `st.segmented_control` |
| `.stTabs [data-baseweb="tab"]` | same |
| `[data-testid="stAppViewBlockContainer"]` | the old name for the element the same rule already selects as `.stMainBlockContainer` |
| `footer, [data-testid="stBottom"]` | a footer Streamlit no longer renders, and a bottom container this app never mounts (both halves measured at zero, so the rule goes whole) |

Nothing here is a regression and removing it changes no pixel. The point is the audit: a selector that has never matched is indistinguishable from one that has just stopped matching, which is exactly the failure 1.62 caused when it rebuilt the widgets and five `[data-baseweb=...]` hooks died in silence (#368). Clearing the permanent zeroes is what makes the next audit's zeroes mean something.

## Verification

- Measured, not assumed: every selector in both rules counted across all fourteen pages before removal. `.block-container` and `.stMainBlockContainer` are live (1 each, the same element) and stay; the other six are zero.
- After the strip, the main block container still computes `padding: 64px 32px 0` and the page still has no `footer` element, so the surviving rule does the whole job.
- `tests/test_css_hooks_are_live.py` pins the three that can be checked from source, and the tab rule is allowed back if `st.tabs` ever returns.
- Suite 2038 passed, `ruff` and `mypy` clean.

## Left alone

Four rules in the same block name classes this app never emits: `.metric-card`, `.success-message`, `.warning-message`, `.error-message`. Dead too, but they are app-authored classes rather than Streamlit hooks, so they are not part of the audit this PR is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)