### PR TITLE
fix(viz): Find and centre no longer leaves a focus seed behind

### DIFF
--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -6562,6 +6562,7 @@ def viz_hidden_caption(
     focus_hidden,
     hidden_by_filter,
     focusable_drawn=True,
+    find_kept=None,
 ) -> str:
     """One line saying what is not on screen, or "" when everything is.
 
@@ -6571,6 +6572,12 @@ def viz_hidden_caption(
 
     Seeds are listed by name up to five, then counted, so a focus on half the
     ontology stays one short line.
+
+    ``find_kept`` is the entity picked in "Find and centre" when a focus is
+    running and the pick is not one of its seeds. The graph holds it anyway, so
+    the line has to account for it: the seeds no longer describe everything on
+    the canvas, and a node the focus does not explain otherwise reads as the
+    focus leaking (issue #423).
 
     ``focusable_drawn`` is False when Classes, Individuals and SKOS are all
     switched off: focus mode is still on and still holding its seeds, but there
@@ -6592,6 +6599,8 @@ def viz_hidden_caption(
             names += f", … (+{len(focus_seeds) - 5})"
         hops = "hop" if focus_depth == 1 else "hops"
         parts.append(f"Focused on {names} · {focus_depth} {hops}")
+        if find_kept:
+            parts.append(f"{find_kept.split(': ', 1)[-1]} kept by Find")
     if focus_hidden:
         parts.append(f"{focus_hidden} hidden by focus")
     if hidden_by_filter:

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -1107,6 +1107,9 @@ def render_visualization():
         # sits beside the Filter Classes expander so it doesn't cost the graph a
         # whole row; the empty state is a placeholder (clearable), not a "—" row.
         _find_id: str | None = None
+        # The picked entity's display label, for the note that says the graph is
+        # holding it (see viz_hidden_caption).
+        _find_label: str | None = None
         focus_seed_ids: list = []
         # Declared with the rest, not left to the branch that draws the picker:
         # with focus mode on and every focusable type switched off, that branch
@@ -1146,31 +1149,23 @@ def render_visualization():
                 )
                 if _find_choice:
                     _find_id = focus_targets.get(_find_choice)
-                    # The target may currently be hidden — by one of the display
-                    # filters, or pruned away in focus mode — in which case its
-                    # node isn't in the graph and the JS focus() would silently
-                    # no-op (PR #144 review P2). On a fresh pick, reveal it:
-                    # restore a filtered-out entity and, in focus mode, add it as
-                    # a seed so the prune keeps it. Guarded by the find seq so
-                    # this runs once per pick.
-                    _cur_seq = st.session_state.get("_viz_find_seq", 0)
-                    if st.session_state.get("_viz_find_revealed_seq") != _cur_seq:
-                        st.session_state["_viz_find_revealed_seq"] = _cur_seq
-                        _reveal_rerun = False
-                        # A node filter hiding the target is handled where the
-                        # graph is built, against the live filter, so nothing is
-                        # written back here. Un-hiding it once per pick both
-                        # rewrote a filter the user had set and went stale the
-                        # moment a later filter change hid it again (issue #234).
-                        if st.session_state.get("_viz_cfg_focus_mode"):
-                            _seeds = list(
-                                st.session_state.get("_viz_cfg_focus_seeds") or []
-                            )
-                            if _find_choice not in _seeds:
-                                viz_set_focus_seeds(_seeds + [_find_choice])
-                                _reveal_rerun = True
-                        if _reveal_rerun:
-                            st.rerun()
+                    _find_label = _find_choice
+                    # Nothing is written back. The target may well be hidden —
+                    # by one of the display filters, or pruned away in focus
+                    # mode — in which case its node isn't in the graph and the
+                    # JS focus() would silently no-op (PR #144 review P2), but
+                    # that is the graph's problem to solve while it builds, not
+                    # a reason to edit the settings the user chose.
+                    #
+                    # It was solved that way for the node filter first: un-hiding
+                    # the entity once per pick both rewrote a filter the user had
+                    # set and went stale the moment a later filter change hid it
+                    # again (issue #234), so the builder exempts it instead.
+                    # Focus mode kept its own answer, adding the pick as a seed,
+                    # which left it in `Focus node(s)` for good — a saved setting
+                    # grown by an act of looking (issue #423). The prune takes
+                    # `_find_id` as a seed for the render instead, so clearing
+                    # the picker forgets it.
         # What the view is holding back, on the expander's own label: it costs
         # no vertical space there, and it sits on the control that causes it.
         # Written by the run that built the graph (below), because the numbers
@@ -2620,6 +2615,18 @@ def render_visualization():
                 _before_prune = len(net.nodes)
                 present_ids = {n["id"] for n in net.nodes}
                 seeds = {sid for sid in focus_seed_ids if sid in present_ids}
+                # The Find target grows the neighbourhood too, for this render
+                # only. It is the last gate that used to drop the entity the user
+                # just picked, and the one the builder's pin (see _pinned_ids)
+                # could not reach: the node is assembled, then pruned away again
+                # unless the focus happens to reach it. Adding it here is what
+                # lets the pick stay out of the saved seeds (issue #423).
+                #
+                # Only alongside seeds that are actually present: with none, the
+                # prune does not run at all, and a Find pick is not a reason to
+                # start narrowing a graph that was not being narrowed.
+                if seeds and _find_id and _find_id in present_ids:
+                    seeds.add(_find_id)
                 if seeds:
                     adj: dict = {}
                     for edge in net.edges:
@@ -2902,6 +2909,12 @@ def render_visualization():
             (len(filters["class"]["uris"]) - len(filters["class"]["selected_uris"]))
             + (len(filters["ind"]["uris"]) - len(filters["ind"]["selected_uris"])),
             focusable_drawn=bool(focus_targets),
+            # Only when the focus is not already explaining it.
+            find_kept=(
+                _find_label
+                if focus_mode and _find_label and _find_label not in focus_seeds
+                else None
+            ),
         )
         if _note_now != st.session_state.get("_viz_hidden_note", ""):
             st.session_state["_viz_hidden_note"] = _note_now

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -2660,21 +2660,8 @@ def render_visualization():
                         f"shown. Pick fewer focus nodes, or a lower depth, to "
                         f"see it in full."
                     )
-                    # One node of the budget is held back for the Find target,
-                    # so a focus that fills the cap on its own cannot spend the
-                    # room the pick needs. Without the reservation the seeds ate
-                    # the whole allowance, the pin below found room == 0, and the
-                    # viewer was handed a focus_node for a node that is not in
-                    # the payload — the silent no-op this whole arrangement
-                    # exists to prevent (PR #428 review, PR #144 review P2). The
-                    # assembly reserves for the same pin the same way, one node
-                    # over the cap (see _pinned_ids); here it comes out of the
-                    # focus instead, so the browser is never handed more than the
-                    # cap allows.
                     _pin_find = bool(_find_id and _find_id in present_ids)
-                    keep, _cut_short = _grow(
-                        seeds, set(), GRAPH_MAX_NODES - (1 if _pin_find else 0)
-                    )
+                    keep, _cut_short = _grow(seeds, set(), GRAPH_MAX_NODES)
 
                     # The Find target, but only when the focus does not already
                     # hold it. It is the last gate that used to drop the entity
@@ -2695,9 +2682,24 @@ def render_visualization():
                     # reason to start narrowing a graph that was not narrowed.
                     focus_find_kept = False
                     if _pin_find and _find_id not in keep:
-                        # The full cap here: the slot held back above is what it
-                        # spends, so the target lands even when the focus filled
-                        # everything else.
+                        # A focus that fills the cap on its own leaves the pin
+                        # nothing: it would find room == 0, add nothing, and the
+                        # viewer would be handed a focus_node for a node that is
+                        # not in the payload — the silent no-op this arrangement
+                        # exists to prevent (PR #428 review, PR #144 review P2).
+                        # So the walk is run again one node short, and the pin
+                        # spends what that leaves. The assembly reserves for the
+                        # same pin the same way, one node over the cap (see
+                        # _pinned_ids); here it comes out of the focus instead,
+                        # so the browser is never handed more than the cap.
+                        #
+                        # Re-walked rather than reserved up front, because the
+                        # reservation is only owed when the focus would drop the
+                        # target: charging it always left a capped focus one node
+                        # short of what it can draw for a pick already on the
+                        # canvas (PR #428 review).
+                        if len(keep) >= GRAPH_MAX_NODES:
+                            keep, _cut_short = _grow(seeds, set(), GRAPH_MAX_NODES - 1)
                         keep, _find_cut = _grow({_find_id}, keep, GRAPH_MAX_NODES)
                         focus_find_kept = _find_id in keep
                         _cut_short = _cut_short or _find_cut

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -1817,8 +1817,12 @@ def render_visualization():
         # with the payload: a cached v23 focus graph would go on showing the one
         # that says nothing about them. 25: the Triples layer no longer redraws
         # an edge another layer already drew, so a cached v24 payload is a graph
-        # with those duplicates still in it.
-        _graph_ver = 25
+        # with those duplicates still in it. 26: the focus prune keeps the Find
+        # target for the render instead of the pick being written into the saved
+        # seeds (issue #423), so the same key can now mean a different graph — a
+        # cached v25 payload for a focus plus a find is one the pick was pruned
+        # out of, and nothing about the settings would evict it.
+        _graph_ver = 26
         # Include a mutation counter that bumps on every checkpoint / undo / redo,
         # so any change to the ontology — even one that preserves triple count —
         # invalidates the cached graph data and the iframe re-renders.
@@ -2611,54 +2615,78 @@ def render_visualization():
             # types, so depth counts real graph links rather than class hops).
             # Several seeds grow the neighbourhood from all of them at once.
             focus_hidden = 0
+            # Whether the Find target is on the canvas because the prune was told
+            # to keep it, rather than because the focus reaches it. The note says
+            # so, and only then (issue #423).
+            focus_find_kept = False
             if focus_pruning:
                 _before_prune = len(net.nodes)
                 present_ids = {n["id"] for n in net.nodes}
                 seeds = {sid for sid in focus_seed_ids if sid in present_ids}
-                # The Find target grows the neighbourhood too, for this render
-                # only. It is the last gate that used to drop the entity the user
-                # just picked, and the one the builder's pin (see _pinned_ids)
-                # could not reach: the node is assembled, then pruned away again
-                # unless the focus happens to reach it. Adding it here is what
-                # lets the pick stay out of the saved seeds (issue #423).
-                #
-                # Only alongside seeds that are actually present: with none, the
-                # prune does not run at all, and a Find pick is not a reason to
-                # start narrowing a graph that was not being narrowed.
-                if seeds and _find_id and _find_id in present_ids:
-                    seeds.add(_find_id)
                 if seeds:
                     adj: dict = {}
                     for edge in net.edges:
                         adj.setdefault(edge["from"], set()).add(edge["to"])
                         adj.setdefault(edge["to"], set()).add(edge["from"])
-                    # Ring by ring, starting with the seeds themselves, and never
-                    # past what can be drawn — the assembly was allowed over that
-                    # only because this holds the line. The seeds alone can
-                    # already overflow it: they default to every selected class.
-                    # Truncating mid-ring keeps the nearer hops, which are the
-                    # ones that were asked for.
-                    keep: set = set()
-                    ring = set(seeds)
-                    for _ in range(focus_depth + 1):
-                        if not ring:
-                            break
-                        room = GRAPH_MAX_NODES - len(keep)
-                        if len(ring) > room:
-                            keep |= set(sorted(ring)[:room])
-                            graph_notice = (
-                                f"This focus covers more than the "
-                                f"{GRAPH_MAX_NODES} nodes the graph can draw, so "
-                                f"only part of it is shown. Pick fewer focus "
-                                f"nodes, or a lower depth, to see it in full."
-                            )
-                            _notice_is_the_cap_line = False
-                            break
-                        keep |= ring
-                        nxt: set = set()
-                        for nid in ring:
-                            nxt |= adj.get(nid, set())
-                        ring = nxt - keep
+
+                    def _grow(from_ids, keep, _adj=adj, _depth=focus_depth):
+                        """Ring by ring from *from_ids*, into *keep*.
+
+                        Never past what can be drawn — the assembly was allowed
+                        over that only because this holds the line. The seeds
+                        alone can already overflow it: they default to every
+                        selected class. Truncating mid-ring keeps the nearer
+                        hops, which are the ones that were asked for. Returns
+                        the keep set and whether it had to stop short.
+                        """
+                        ring = set(from_ids) - keep
+                        for _ in range(_depth + 1):
+                            if not ring:
+                                break
+                            room = GRAPH_MAX_NODES - len(keep)
+                            if len(ring) > room:
+                                keep |= set(sorted(ring)[:room])
+                                return keep, True
+                            keep |= ring
+                            nxt: set = set()
+                            for nid in ring:
+                                nxt |= _adj.get(nid, set())
+                            ring = nxt - keep
+                        return keep, False
+
+                    _cap_line = (
+                        f"This focus covers more than the {GRAPH_MAX_NODES} "
+                        f"nodes the graph can draw, so only part of it is "
+                        f"shown. Pick fewer focus nodes, or a lower depth, to "
+                        f"see it in full."
+                    )
+                    keep, _cut_short = _grow(seeds, set())
+
+                    # The Find target, but only when the focus does not already
+                    # hold it. It is the last gate that used to drop the entity
+                    # the user just picked, and the one the builder's pin (see
+                    # _pinned_ids) could not reach: the node is assembled, then
+                    # pruned away again unless the focus happens to reach it.
+                    # Growing it here is what lets the pick stay out of the
+                    # saved seeds (issue #423).
+                    #
+                    # Growing from it unconditionally would make Find widen the
+                    # graph even when it changed nothing about what is on it:
+                    # find a node one hop from the seed and the ring beyond it
+                    # came along, for a pick that only meant "show me where this
+                    # is" (PR #428 review). A target already drawn is left alone.
+                    #
+                    # Only alongside seeds that are actually present: with none,
+                    # the prune does not run at all, and a Find pick is not a
+                    # reason to start narrowing a graph that was not narrowed.
+                    focus_find_kept = False
+                    if _find_id and _find_id in present_ids and _find_id not in keep:
+                        keep, _find_cut = _grow({_find_id}, keep)
+                        focus_find_kept = _find_id in keep
+                        _cut_short = _cut_short or _find_cut
+                    if _cut_short:
+                        graph_notice = _cap_line
+                        _notice_is_the_cap_line = False
                     net.nodes = [n for n in net.nodes if n["id"] in keep]
                     net.edges = [
                         e for e in net.edges if e["from"] in keep and e["to"] in keep
@@ -2851,6 +2879,9 @@ def render_visualization():
                     # produced so the caption below survives the reruns that
                     # reuse it (issue #222 follow-up).
                     "focus_hidden": focus_hidden,
+                    # Same reasoning: the note that names the Find target has to
+                    # survive the reruns that reuse this payload.
+                    "focus_find_kept": focus_find_kept,
                 }
                 # NB: don't bump viz_render_seq here. The component re-renders on
                 # its own whenever nodes/edges change, and seq is the layout-cache
@@ -2910,11 +2941,7 @@ def render_visualization():
             + (len(filters["ind"]["uris"]) - len(filters["ind"]["selected_uris"])),
             focusable_drawn=bool(focus_targets),
             # Only when the focus is not already explaining it.
-            find_kept=(
-                _find_label
-                if focus_mode and _find_label and _find_label not in focus_seeds
-                else None
-            ),
+            find_kept=(_find_label if (gdata or {}).get("focus_find_kept") else None),
         )
         if _note_now != st.session_state.get("_viz_hidden_note", ""):
             st.session_state["_viz_hidden_note"] = _note_now

--- a/orionbelt_ontology_builder/views/visualization.py
+++ b/orionbelt_ontology_builder/views/visualization.py
@@ -2629,21 +2629,21 @@ def render_visualization():
                         adj.setdefault(edge["from"], set()).add(edge["to"])
                         adj.setdefault(edge["to"], set()).add(edge["from"])
 
-                    def _grow(from_ids, keep, _adj=adj, _depth=focus_depth):
+                    def _grow(from_ids, keep, budget, _adj=adj, _depth=focus_depth):
                         """Ring by ring from *from_ids*, into *keep*.
 
-                        Never past what can be drawn — the assembly was allowed
-                        over that only because this holds the line. The seeds
-                        alone can already overflow it: they default to every
-                        selected class. Truncating mid-ring keeps the nearer
-                        hops, which are the ones that were asked for. Returns
-                        the keep set and whether it had to stop short.
+                        Never past *budget* nodes — the assembly was allowed over
+                        the render cap only because this holds the line. The
+                        seeds alone can already overflow it: they default to
+                        every selected class. Truncating mid-ring keeps the
+                        nearer hops, which are the ones that were asked for.
+                        Returns the keep set and whether it had to stop short.
                         """
                         ring = set(from_ids) - keep
                         for _ in range(_depth + 1):
                             if not ring:
                                 break
-                            room = GRAPH_MAX_NODES - len(keep)
+                            room = budget - len(keep)
                             if len(ring) > room:
                                 keep |= set(sorted(ring)[:room])
                                 return keep, True
@@ -2660,7 +2660,21 @@ def render_visualization():
                         f"shown. Pick fewer focus nodes, or a lower depth, to "
                         f"see it in full."
                     )
-                    keep, _cut_short = _grow(seeds, set())
+                    # One node of the budget is held back for the Find target,
+                    # so a focus that fills the cap on its own cannot spend the
+                    # room the pick needs. Without the reservation the seeds ate
+                    # the whole allowance, the pin below found room == 0, and the
+                    # viewer was handed a focus_node for a node that is not in
+                    # the payload — the silent no-op this whole arrangement
+                    # exists to prevent (PR #428 review, PR #144 review P2). The
+                    # assembly reserves for the same pin the same way, one node
+                    # over the cap (see _pinned_ids); here it comes out of the
+                    # focus instead, so the browser is never handed more than the
+                    # cap allows.
+                    _pin_find = bool(_find_id and _find_id in present_ids)
+                    keep, _cut_short = _grow(
+                        seeds, set(), GRAPH_MAX_NODES - (1 if _pin_find else 0)
+                    )
 
                     # The Find target, but only when the focus does not already
                     # hold it. It is the last gate that used to drop the entity
@@ -2680,8 +2694,11 @@ def render_visualization():
                     # the prune does not run at all, and a Find pick is not a
                     # reason to start narrowing a graph that was not narrowed.
                     focus_find_kept = False
-                    if _find_id and _find_id in present_ids and _find_id not in keep:
-                        keep, _find_cut = _grow({_find_id}, keep)
+                    if _pin_find and _find_id not in keep:
+                        # The full cap here: the slot held back above is what it
+                        # spends, so the target lands even when the focus filled
+                        # everything else.
+                        keep, _find_cut = _grow({_find_id}, keep, GRAPH_MAX_NODES)
                         focus_find_kept = _find_id in keep
                         _cut_short = _cut_short or _find_cut
                     if _cut_short:

--- a/tests/test_viz_delete.py
+++ b/tests/test_viz_delete.py
@@ -283,6 +283,22 @@ def test_many_seeds_stay_one_short_line():
     )
 
 
+def test_the_line_names_a_find_target_the_focus_does_not_explain():
+    """The graph holds the picked entity whatever the focus says (issue #423),
+    so a node the seeds do not account for is on the canvas. Unexplained, that
+    reads as the focus leaking."""
+    assert app.viz_hidden_caption(
+        True, ["Class: Person"], 1, 6, 0, find_kept="Class: Endurant"
+    ) == ("Focused on Person · 1 hop · Endurant kept by Find · 6 hidden by focus")
+
+
+def test_a_find_target_among_the_seeds_is_not_named_twice():
+    """The caller passes it only when the focus is not already explaining it."""
+    assert app.viz_hidden_caption(True, ["Class: Person"], 1, 6, 0) == (
+        "Focused on Person · 1 hop · 6 hidden by focus"
+    )
+
+
 def test_a_focus_with_nothing_focusable_says_so():
     """Switch Classes, Individuals and SKOS all off and focus mode is still on,
     still holding its seeds, with nothing it can act on. The page says so inside

--- a/tests/test_viz_node_cap.py
+++ b/tests/test_viz_node_cap.py
@@ -524,6 +524,34 @@ def test_a_full_focus_still_leaves_room_for_the_find_target(monkeypatch, patch_u
     assert "more than the 10 nodes the graph can draw" in notice
 
 
+def test_a_capped_focus_draws_its_full_cap_when_the_target_is_a_seed(
+    monkeypatch, patch_ui
+):
+    """The room for the pin is only owed when the focus would drop the target.
+
+    Holding it back for every pick cost a capped focus one of the nodes it can
+    draw, for an entity that was already on the canvas (PR #428 review).
+    """
+    patch_ui("GRAPH_MAX_NODES", 10)
+    nodes, _, _ = _graph(40, seed="Class: Hub", shape="star", find="Class: Hub")
+
+    assert len(nodes) == 10
+
+
+def test_a_capped_focus_draws_its_full_cap_for_a_target_it_already_keeps(
+    monkeypatch, patch_ui
+):
+    """Same, for a target the focus reaches rather than one that is a seed."""
+    patch_ui("GRAPH_MAX_NODES", 10)
+    kept, _, _ = _graph(40, seed="Class: Hub", shape="star")
+    already = min(n.get("label") for n in kept if n.get("label") != "Hub")
+
+    nodes, _, _ = _graph(40, seed="Class: Hub", shape="star", find=f"Class: {already}")
+
+    assert len(nodes) == 10
+    assert {n.get("label") for n in nodes} == {n.get("label") for n in kept}
+
+
 def test_a_capped_focus_says_the_find_target_is_why_it_is_there(monkeypatch, patch_ui):
     """It is on the canvas for no reason the seeds explain, so the note says so."""
     patch_ui("GRAPH_MAX_NODES", 10)

--- a/tests/test_viz_node_cap.py
+++ b/tests/test_viz_node_cap.py
@@ -88,10 +88,9 @@ def _script():
             # What picking an entity in "Find and centre" leaves behind.
             st.session_state["viz_find_entity"] = os.environ["FIND"]
         if os.environ.get("HIDE"):
-            # A narrowed node filter that does *not* include the Find target,
-            # and a find-seq already marked as revealed: the state left behind
-            # when an entity was visible at the moment it was picked and a later
-            # filter change hid it (issue #234).
+            # A narrowed node filter that does *not* include the Find target:
+            # the state left behind when an entity was visible at the moment it
+            # was picked and a later filter change hid it (issue #234).
             keep = set(os.environ["HIDE"].split())
             st.session_state["_viz_cfg_selected_class_uris"] = [
                 c["uri"] for c in om.get_classes() if c["name"] in keep
@@ -100,15 +99,13 @@ def _script():
                 c["uri"] for c in om.get_classes()
             }
             st.session_state["_viz_find_seq"] = 1
-            st.session_state["_viz_find_revealed_seq"] = 1
         if os.environ.get("HIDE_ALL"):
-            # The filter emptied completely, with the reveal already marked done.
+            # The filter emptied completely, after the pick.
             st.session_state["_viz_cfg_selected_class_uris"] = []
             st.session_state["_viz_cfg_known_class_uris"] = {
                 c["uri"] for c in om.get_classes()
             }
             st.session_state["_viz_find_seq"] = 1
-            st.session_state["_viz_find_revealed_seq"] = 1
 
     app.render_visualization()
 
@@ -423,31 +420,76 @@ def test_a_find_target_survives_an_emptied_class_filter():
     assert {n.get("label") for n in nodes} == {"C0007"}
 
 
-def test_find_does_not_rewrite_the_users_node_filter():
-    """Picking an entity used to un-hide it by editing the filter, which both
-    changed a setting the user had chosen and went stale as soon as a later
-    filter change hid it again. The graph exempts it at build time instead, so
-    the filter is left exactly as it was found."""
+def test_a_find_pick_writes_no_setting_at_all():
+    """Picking an entity used to edit whatever was hiding it: the node filter
+    first, which went stale the moment a later filter change hid the entity
+    again (issue #234), and then the focus seeds, which kept the pick in
+    `Focus node(s)` for good (issue #423). Both are settings the user chose.
+    The graph holds the target while it builds instead, so a pick changes
+    nothing that outlives it."""
     import ast
 
-    src = sources.viz_text()
-    tree = ast.parse(src)
-    handlers = [
+    tree = ast.parse(sources.viz_text())
+    picked = [
         node
         for node in ast.walk(tree)
-        if isinstance(node, ast.If) and "_viz_find_revealed_seq" in ast.dump(node.test)
+        if isinstance(node, ast.If)
+        and ast.dump(node.test) == ast.dump(ast.Name(id="_find_choice", ctx=ast.Load()))
     ]
-    assert handlers, "the Find reveal handler was not found"
-    for handler in handlers:
-        for node in ast.walk(handler):
-            if not isinstance(node, ast.Assign):
-                continue
-            for target in node.targets:
-                dumped = ast.dump(target)
-                assert not ("_viz_cfg_selected_" in dumped and "_uris" in dumped), (
-                    f"line {node.lineno}: Find must not write the node filter; "
-                    "the graph exempts the target at build time instead"
+    assert picked, "the branch that runs on a Find pick was not found"
+    for branch in picked:
+        for node in ast.walk(branch):
+            if isinstance(node, ast.Call):
+                assert getattr(node.func, "id", "") != "viz_set_focus_seeds", (
+                    f"line {node.lineno}: a Find pick must not write the focus "
+                    "seeds; the prune takes the target for the render instead"
                 )
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    assert "_viz_cfg_" not in ast.dump(target), (
+                        f"line {node.lineno}: a Find pick must not write a saved "
+                        "setting; the graph exempts the target while it builds"
+                    )
+
+
+# --- Find and centre under a focus (issue #423) ------------------------------
+
+
+def test_the_focus_prune_keeps_the_find_target():
+    """The prune was the last gate that dropped the picked entity.
+
+    Everything else the builder does is exempted for the Find target, but focus
+    mode assembles the whole graph and then cuts it back to the seeds' reach, so
+    a target outside that reach was assembled and then thrown away again. It
+    joins the seeds for the render, which is why it survives.
+    """
+    nodes, _, _ = _graph(40, seed="Class: C0000", depth=1, find="Class: C0007")
+
+    drawn = {n.get("label") for n in nodes}
+    assert "C0007" in drawn, "the entity the user asked to see was pruned away"
+    # The seed keeps its own neighbourhood, and the target brings the same one
+    # hop the focus is set to, so it arrives in context rather than alone.
+    assert drawn == {"C0000", "C0001", "C0006", "C0007", "C0008"}
+
+
+def test_the_find_target_does_not_join_the_saved_seeds():
+    """What the issue is about: a pick is an act of looking, not a setting.
+
+    Adding it to `Focus node(s)` was how the prune used to be persuaded to keep
+    it, and it stayed there afterwards - through a cleared picker, and through a
+    reload, since the seeds are saved.
+    """
+    at = _render(40, seed="Class: C0000", depth=1, find="Class: C0007")
+
+    assert at.session_state["_viz_cfg_focus_seeds"] == ["Class: C0000"]
+
+
+def test_a_find_pick_does_not_start_a_prune_of_its_own():
+    """With no seeds present there is nothing to narrow, and looking something
+    up is not a reason to start narrowing."""
+    nodes, _, _ = _graph(6, seed="", find="Class: C0003")
+
+    assert len({n.get("label") for n in nodes}) == 6
 
 
 # --- what the pickers show ---------------------------------------------------

--- a/tests/test_viz_node_cap.py
+++ b/tests/test_viz_node_cap.py
@@ -161,6 +161,17 @@ def _render(n_classes, **kw):
     return at
 
 
+def _hidden_note(at):
+    """The Node options note, or "" when the page wrote none.
+
+    ``AppTest``'s session_state raises rather than returning a default, and a
+    render that hides nothing never writes the key at all.
+    """
+    if "_viz_hidden_note" not in at.session_state:
+        return ""
+    return at.session_state["_viz_hidden_note"] or ""
+
+
 def _notice_shown(at):
     return [c.value for c in at.caption if "are not drawn" in c.value]
 
@@ -470,6 +481,27 @@ def test_the_focus_prune_keeps_the_find_target():
     # The seed keeps its own neighbourhood, and the target brings the same one
     # hop the focus is set to, so it arrives in context rather than alone.
     assert drawn == {"C0000", "C0001", "C0006", "C0007", "C0008"}
+
+
+def test_a_find_target_the_focus_already_holds_widens_nothing():
+    """Centring on something already drawn must not change what is drawn.
+
+    Growing from the target unconditionally made a pick one hop from the seed
+    drag the ring beyond it onto the canvas, for an act that only meant "show me
+    where this is" (PR #428 review).
+    """
+    nodes, _, _ = _graph(6, seed="Class: C0000", depth=1, find="Class: C0001")
+
+    assert {n.get("label") for n in nodes} == {"C0000", "C0001"}
+
+
+def test_the_note_names_only_a_target_the_focus_does_not_reach():
+    """The line explains what the seeds do not, so it stays quiet otherwise."""
+    at = _render(6, seed="Class: C0000", depth=1, find="Class: C0001")
+    assert "kept by Find" not in _hidden_note(at)
+
+    at = _render(40, seed="Class: C0000", depth=1, find="Class: C0007")
+    assert "C0007 kept by Find" in at.session_state["_viz_hidden_note"]
 
 
 def test_the_find_target_does_not_join_the_saved_seeds():

--- a/tests/test_viz_node_cap.py
+++ b/tests/test_viz_node_cap.py
@@ -504,6 +504,34 @@ def test_the_note_names_only_a_target_the_focus_does_not_reach():
     assert "C0007 kept by Find" in at.session_state["_viz_hidden_note"]
 
 
+def test_a_full_focus_still_leaves_room_for_the_find_target(monkeypatch, patch_ui):
+    """A focus that fills the cap on its own must not spend the pick's room.
+
+    The seeds used to take the whole allowance, leaving the pin nothing, so the
+    viewer was handed a focus_node for a node that is not in the payload: the
+    silent no-op the pin exists to prevent (PR #428 review).
+    """
+    patch_ui("GRAPH_MAX_NODES", 10)
+    nodes, edges, notice = _graph(
+        40, seed="Class: Hub", shape="star", find="Class: C0039"
+    )
+
+    labels = {n.get("label") for n in nodes}
+    assert "C0039" in labels, "the entity the user asked to see was cut by the cap"
+    assert len(nodes) == 10, "and the cap still holds"
+    kept = {n["id"] for n in nodes}
+    assert all(e["from"] in kept and e["to"] in kept for e in edges)
+    assert "more than the 10 nodes the graph can draw" in notice
+
+
+def test_a_capped_focus_says_the_find_target_is_why_it_is_there(monkeypatch, patch_ui):
+    """It is on the canvas for no reason the seeds explain, so the note says so."""
+    patch_ui("GRAPH_MAX_NODES", 10)
+    at = _render(40, seed="Class: Hub", shape="star", find="Class: C0039")
+
+    assert "C0039 kept by Find" in _hidden_note(at)
+
+
 def test_the_find_target_does_not_join_the_saved_seeds():
     """What the issue is about: a pick is an act of looking, not a setting.
 

--- a/tests/test_viz_shortest_path.py
+++ b/tests/test_viz_shortest_path.py
@@ -220,7 +220,6 @@ def test_a_path_is_drawn_when_the_class_filter_is_empty():
     at.session_state["_viz_cfg_selected_class_uris"] = []
     at.session_state["_viz_cfg_known_class_uris"] = uris
     at.session_state["_viz_find_seq"] = 1
-    at.session_state["_viz_find_revealed_seq"] = 1
     at.run(timeout=300)
     assert not at.exception, at.exception
 


### PR DESCRIPTION
Closes #423.

## The report

> don't persist entities that were 'find and centred on' when Focus on one node is enabled. This is already the default behaviour when Focus on one node is disabled.

Reproduced live, gUFO loaded, focus narrowed to a single seed:

```
focus ON, narrowed to one seed     seeds=1  ['Class: AbstractIndividual']
after find 'Endurant'              seeds=2  ['Class: AbstractIndividual', 'Class: Endurant']
after clearing the Find picker     seeds=2  ['Class: AbstractIndividual', 'Class: Endurant']
```

Every pick appended a seed, clearing the picker did not take it back, and the seeds are saved config, so it survived a reload too.

## Why it was there

Focus mode assembles the whole graph and then prunes it to the seeds' reach. A target outside that reach was assembled and thrown away again, so the viewer's `focus()` no-oped on a node that was not in the payload (PR #144 review P2). Making the pick a seed was the cheapest way to guarantee the node existed. The cost was that an act of looking edited a setting the user had chosen.

## The change

The prune takes the Find target as a seed for that render only, and the write-back goes. The target keeps the neighbourhood the focus is set to, so it arrives in context rather than as a lone node with its edges cut, and clearing the picker forgets it.

This is the last of the gates that used to drop the Find target. The others were exempted at build time in #234; this one could not be reached from there because it runs after assembly, which is exactly why it kept its own answer.

It is only added alongside seeds that are actually present: with none, the prune does not run at all, and looking something up is not a reason to start narrowing a graph that was not being narrowed.

The Node options note names it, since the seeds no longer describe everything on the canvas:

```
Focused on AbstractIndividual · 1 hop · Endurant kept by Find · 34 hidden by focus
```

## Verification

Live, focused on one class at depth 1: the graph goes from 5 nodes to 16 on the pick (`Endurant` plus its one hop), `Focus node(s)` stays at one seed through the pick and through clearing the picker, and the note reads as above.

New tests: the prune keeps the target and draws it in context, a pick leaves `_viz_cfg_focus_seeds` untouched, and a pick with no seeds present starts no prune. `test_find_does_not_rewrite_the_users_node_filter` becomes `test_a_find_pick_writes_no_setting_at_all`, which now walks the whole pick branch and rejects both a node-filter write and a focus-seed write. Suite 2043 passed, `ruff` and `mypy` clean.

Note the interaction the suite still cannot cover: `AppTest` renders the Visualization page once, so build-then-pick is pinned at source level and in the browser, not in the harness. That is how #234's regressions escaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)