### PR TITLE
chore: bump to 1.27.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ A prebuilt image is published to Docker Hub. No local Python setup required:
 docker run --rm -p 8501:8501 ralforion/orionbelt-ontology-builder
 ```
 
-Then open http://localhost:8501. Use `:1.27.3` to pin a specific version instead of `latest`.
+Then open http://localhost:8501. Use `:1.27.4` to pin a specific version instead of `latest`.
 
 To build the image yourself from a checkout:
 

--- a/orionbelt_ontology_builder/ui.py
+++ b/orionbelt_ontology_builder/ui.py
@@ -33,7 +33,7 @@ OrionBelt Ontology Builder - A Streamlit application for building, editing,
 and managing OWL ontologies.
 """
 APP_NAME = "OrionBelt Ontology Builder"
-APP_VERSION = "1.27.3"
+APP_VERSION = "1.27.4"
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 GITHUB_ISSUES_URL = "https://github.com/ralforion/orionbelt-ontology-builder/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.27.3"
+version = "1.27.4"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 # SPDX. Business Source License 1.1 is BUSL-1.1; BSL-1.0 is the Boost Software

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-ontology-builder"
-version = "1.27.3"
+version = "1.27.4"
 source = { editable = "." }
 dependencies = [
     { name = "networkx" },


### PR DESCRIPTION
Version bump only. Eight commits since v1.27.3: the edit-confirmation timing (#421), the Streamlit 1.63 pin (#422), the dead CSS (#424), two dependency bumps (#426, #427), the Find-and-centre focus seed (#428), and the edge curve setting (#431), plus the screenshots that came and went with #430 and #432.

One of the eight is typed `feat:`, and it does add a control that was not there before, so the generated notes will list it as a feature. Shipping as a patch: nothing was removed or changed incompatibly, and the rest is fixes and chores.

Bumped in `pyproject.toml`, `README.md` (Docker pin hint), `orionbelt_ontology_builder/ui.py` (`APP_VERSION`) and `uv.lock`. A repo-wide grep for the old string comes back empty, and `tests/test_version_consistency.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)